### PR TITLE
Make events class-based

### DIFF
--- a/betty/event.py
+++ b/betty/event.py
@@ -1,19 +1,21 @@
 from collections import defaultdict
-from typing import Callable
+from typing import Callable, Type
 
-PARSE_EVENT = 'parse'
-POST_PARSE_EVENT = 'parse:post'
+
+class Event:
+    pass
 
 
 class EventDispatcher:
     def __init__(self):
         self._listeners = defaultdict(list)
 
-    def add_listener(self, event_name: str, listener: Callable):
-        self._listeners[event_name].append(listener)
+    def add_listener(self, event_type: Type[Event], listener: Callable):
+        self._listeners[event_type].append(listener)
 
-    def dispatch(self, event_name, *args, **kwargs):
-        if event_name not in self._listeners:
+    def dispatch(self, event: Event):
+        event_type = type(event)
+        if event_type not in self._listeners:
             return
-        for listener in self._listeners[event_name]:
-            listener(*args, **kwargs)
+        for listener in self._listeners[event_type]:
+            listener(event)

--- a/betty/parse.py
+++ b/betty/parse.py
@@ -1,7 +1,26 @@
-from betty.event import PARSE_EVENT, POST_PARSE_EVENT
+from betty.ancestry import Ancestry
+from betty.event import Event
 from betty.site import Site
 
 
+class ParseEvent(Event):
+    def __init__(self, ancestry: Ancestry):
+        self._ancestry = ancestry
+
+    @property
+    def ancestry(self):
+        return self._ancestry
+
+
+class PostParseEvent(Event):
+    def __init__(self, ancestry: Ancestry):
+        self._ancestry = ancestry
+
+    @property
+    def ancestry(self):
+        return self._ancestry
+
+
 def parse(site: Site) -> None:
-    site.event_dispatcher.dispatch(PARSE_EVENT, site.ancestry)
-    site.event_dispatcher.dispatch(POST_PARSE_EVENT, site.ancestry)
+    site.event_dispatcher.dispatch(ParseEvent(site.ancestry))
+    site.event_dispatcher.dispatch(PostParseEvent(site.ancestry))

--- a/betty/plugins/gramps/__init__.py
+++ b/betty/plugins/gramps/__init__.py
@@ -9,7 +9,7 @@ from lxml import etree
 from lxml.etree import XMLParser, Element
 
 from betty.ancestry import Document, Event, Place, Person, Ancestry, Date, Note, File
-from betty.event import PARSE_EVENT
+from betty.parse import ParseEvent
 from betty.plugin import Plugin
 from betty.site import Site
 
@@ -267,9 +267,9 @@ class Gramps(Plugin):
 
     def subscribes_to(self) -> List[Tuple[str, Callable]]:
         return [
-            (PARSE_EVENT, self._parse),
+            (ParseEvent, self._parse),
         ]
 
-    def _parse(self, ancestry: Ancestry) -> None:
+    def _parse(self, event: ParseEvent) -> None:
         xml_file_path = extract_xml_file(self._gramps_file_path, self._working_directory_path)
-        parse_xml_file(ancestry, xml_file_path)
+        parse_xml_file(event.ancestry, xml_file_path)


### PR DESCRIPTION
Make events class-based so they are self-documenting and we can extend their functionality without breaking backwards compatibility.

This fixes https://github.com/bartfeenstra/betty/issues/99.