### PR TITLE
Unify all configuration paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ optional arguments:
 Configuration files are written in JSON:
 ```json
 {
-	"outputDirectoryPath": "/var/www/betty",
+	"output": "/var/www/betty",
 	"url": "https://ancestry.example.com",
 	"title": "Betty's ancestry",
-	"resourcesPath": "./resources",
+	"resources": "./resources",
 	"plugins": {
 		"betty.plugins.gramps.Gramps": {
 			"file": "./gramps.gpkg"
@@ -70,10 +70,10 @@ Configuration files are written in JSON:
 	}
 }
 ```
-- `outputDirectoryPath` (required); The path to the directory in which to place the generated site.
+- `output` (required); The path to the directory in which to place the generated site.
 - `url` (required); The absolute, public URL at which the site will be published.
 - `title` (optional); The site's title.
-- `resourcesPath` (optional); The path to a directory containing overrides for any of Betty's [resources](./betty/resources).
+- `resources` (optional); The path to a directory containing overrides for any of Betty's [resources](./betty/resources).
 - `plugins` (optional): The plugins to enable. Keys are plugin names, and values are objects containing each plugin's configuration.
     - `betty.plugin.gramps.Gramps`: Parses a Gramps genealogy. Configuration:
         - `file`: the path to the *Gramps XML* or *Gramps XML Package* file.

--- a/betty/config.py
+++ b/betty/config.py
@@ -15,7 +15,7 @@ class Configuration:
         self._title = 'Betty'
         self._plugins = {}
         self._mode = 'production'
-        self._resources_path = None
+        self._resources_directory_path = None
 
     @property
     def working_directory_path(self) -> str:
@@ -27,7 +27,7 @@ class Configuration:
 
     @property
     def output_directory_path(self) -> str:
-        return self._output_directory_path
+        return self._abspath(self._output_directory_path)
 
     @property
     def url(self):
@@ -54,12 +54,12 @@ class Configuration:
         return self._plugins
 
     @property
-    def resources_path(self) -> Optional[str]:
-        return self._resources_path
+    def resources_directory_path(self) -> Optional[str]:
+        return self._abspath(self._resources_directory_path) if self._resources_directory_path else None
 
-    @resources_path.setter
-    def resources_path(self, resources_path: str) -> None:
-        self._resources_path = self._abspath(resources_path)
+    @resources_directory_path.setter
+    def resources_directory_path(self, resources_directory_path: str) -> None:
+        self._resources_directory_path = resources_directory_path
 
     def _abspath(self, path: str):
         return abspath(join(self._working_directory_path, path))
@@ -67,7 +67,7 @@ class Configuration:
 
 def _from_dict(working_directory_path: str, config_dict: Dict) -> Configuration:
     configuration = Configuration(
-        config_dict['outputDirectoryPath'], config_dict['url'])
+        config_dict['output'], config_dict['url'])
     configuration.working_directory_path = working_directory_path
 
     if 'title' in config_dict:
@@ -76,8 +76,8 @@ def _from_dict(working_directory_path: str, config_dict: Dict) -> Configuration:
     if 'mode' in config_dict:
         configuration.mode = config_dict['mode']
 
-    if 'resourcesPath' in config_dict:
-        configuration.resources_path = config_dict['resourcesPath']
+    if 'resources' in config_dict:
+        configuration.resources_directory_path = config_dict['resources']
 
     if 'plugins' in config_dict:
         for plugin_type_name, plugin_configuration in config_dict['plugins'].items():

--- a/betty/config.schema.json
+++ b/betty/config.schema.json
@@ -1,10 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "properties": {
-    "outputDirectoryPath": {
+    "output": {
       "type": "string"
     },
-    "tile": {
+    "title": {
       "type": "string"
     },
     "url": {
@@ -13,7 +13,7 @@
     "mode": {
       "enum": ["development", "production"]
     },
-    "resources_path": {
+    "resources": {
       "type": "string"
     },
     "plugins": {
@@ -24,7 +24,8 @@
     }
   },
   "required": [
-    "outputDirectoryPath",
+    "output",
     "url"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/betty/site.py
+++ b/betty/site.py
@@ -16,8 +16,8 @@ class Site:
         self._ancestry = Ancestry()
         self._configuration = configuration
         self._resources = FileSystem(join(dirname(abspath(__file__)), 'resources'))
-        if configuration.resources_path:
-            self._resources.paths.appendleft(configuration.resources_path)
+        if configuration.resources_directory_path:
+            self._resources.paths.appendleft(configuration.resources_directory_path)
         self._event_dispatcher = EventDispatcher()
         self._plugins = {}
         self._init_plugins()

--- a/betty/tests/test_cli.py
+++ b/betty/tests/test_cli.py
@@ -26,7 +26,7 @@ class MainTest(TestCase):
             with TemporaryDirectory() as output_directory_path:
                 url = 'https://example.com'
                 config_dict = {
-                    'outputDirectoryPath': output_directory_path,
+                    'output': output_directory_path,
                     'url': url,
                 }
                 dump(config_dict, config_file)

--- a/betty/tests/test_config.py
+++ b/betty/tests/test_config.py
@@ -11,34 +11,50 @@ from betty.plugin import Plugin
 
 
 class ConfigurationTest(TestCase):
-    def test_working_directory_path(self):
+    def test_working_directory_path_with_cwd(self):
         sut = Configuration('/tmp/betty', 'https://example.com')
-
         self.assertEquals(getcwd(), sut.working_directory_path)
 
+    def test_working_directory_path_with_path(self):
+        sut = Configuration('/tmp/betty', 'https://example.com')
         working_directory_path = '/tmp/betty-working-directory'
         sut.working_directory_path = working_directory_path
         self.assertEquals(working_directory_path, sut.working_directory_path)
 
-    def test_resources_path(self):
-        sut = Configuration('/tmp/betty', 'https://example.com')
+    def test_output_directory_path_with_absolute_path(self):
+        output_directory_path = '/tmp/betty'
+        sut = Configuration(output_directory_path, 'https://example.com')
+        self.assertEquals(output_directory_path, sut.output_directory_path)
 
-        self.assertIsNone(sut.resources_path)
-
-        absolute_resources_directory_path = '/tmp/betty-resources'
-        sut.working_directory_path = absolute_resources_directory_path
-        self.assertEquals(absolute_resources_directory_path, sut.working_directory_path)
-
+    def test_output_directory_path_with_relative_path(self):
+        output_directory_path = './betty'
+        sut = Configuration(output_directory_path, 'https://example.com')
         working_directory_path = '/tmp/betty-working-directory'
         sut.working_directory_path = working_directory_path
-        relative_resources_directory_path = './betty-resources'
-        sut.resources_path = relative_resources_directory_path
-        self.assertEquals('/tmp/betty-working-directory/betty-resources', sut.resources_path)
+        self.assertEquals('/tmp/betty-working-directory/betty', sut.output_directory_path)
+
+    def test_resources_directory_path_without_path(self):
+        sut = Configuration('/tmp/betty', 'https://example.com')
+        self.assertIsNone(sut.resources_directory_path)
+
+    def test_resources_directory_path_with_absolute_path(self):
+        sut = Configuration('/tmp/betty', 'https://example.com')
+        resources_directory_path = '/tmp/betty-resources'
+        sut.resources_directory_path = resources_directory_path
+        self.assertEquals(resources_directory_path, sut.resources_directory_path)
+
+    def test_resources_directory_path_with_relative_path(self):
+        sut = Configuration('/tmp/betty', 'https://example.com')
+        working_directory_path = '/tmp/betty-working-directory'
+        sut.working_directory_path = working_directory_path
+        resources_directory_path = './betty-resources'
+        sut.resources_directory_path = resources_directory_path
+        self.assertEquals('/tmp/betty-working-directory/betty-resources', sut.resources_directory_path)
 
 
 class FromTest(TestCase):
     _MINIMAL_CONFIG_DICT = {
-        'outputDirectoryPath': '/tmp/path/to/site',
+        'output': '/tmp/path/to/site',
         'url': 'https://example.com',
     }
 
@@ -55,7 +71,7 @@ class FromTest(TestCase):
         with self._write(self._MINIMAL_CONFIG_DICT) as f:
             configuration = from_file(f)
         self.assertEquals(
-            self._MINIMAL_CONFIG_DICT['outputDirectoryPath'], configuration.output_directory_path)
+            self._MINIMAL_CONFIG_DICT['output'], configuration.output_directory_path)
         self.assertEquals(self._MINIMAL_CONFIG_DICT['url'], configuration.url)
         self.assertEquals('Betty', configuration.title)
         self.assertEquals('production', configuration.mode)
@@ -79,13 +95,13 @@ class FromTest(TestCase):
             configuration = from_file(f)
             self.assertEquals(mode, configuration.mode)
 
-    def test_from_file_should_parse_resources_path(self):
-        resources_path = '/tmp/betty'
+    def test_from_file_should_parse_resources_directory_path(self):
+        resources_directory_path = '/tmp/betty'
         config_dict = dict(**self._MINIMAL_CONFIG_DICT)
-        config_dict['resourcesPath'] = resources_path
+        config_dict['resources'] = resources_directory_path
         with self._write(config_dict) as f:
             configuration = from_file(f)
-            self.assertEquals(resources_path, configuration.resources_path)
+            self.assertEquals(resources_directory_path, configuration.resources_directory_path)
 
     def test_from_file_should_parse_one_plugin_with_configuration(self):
         config_dict = dict(**self._MINIMAL_CONFIG_DICT)

--- a/betty/tests/test_render.py
+++ b/betty/tests/test_render.py
@@ -108,12 +108,12 @@ class RenderTest(TestCase):
 
     def test_resource_override(self):
         with TemporaryDirectory() as output_directory_path:
-            with TemporaryDirectory() as resources_path:
-                makedirs(join(resources_path, 'public'))
-                with open(join(resources_path, 'public', 'index.html.j2'), 'w') as f:
+            with TemporaryDirectory() as resources_directory_path:
+                makedirs(join(resources_directory_path, 'public'))
+                with open(join(resources_directory_path, 'public', 'index.html.j2'), 'w') as f:
                     f.write('{% block content %}Betty was here{% endblock %}')
                 configuration = Configuration(output_directory_path, 'https://ancestry.example.com')
-                configuration.resources_path = resources_path
+                configuration.resources_directory_path = resources_directory_path
                 site = Site(configuration)
                 render(site)
                 with open(join(output_directory_path, 'index.html')) as f:

--- a/betty/tests/test_site.py
+++ b/betty/tests/test_site.py
@@ -192,15 +192,15 @@ class SiteTest(TestCase):
         self.assertEquals(ComesAfterNonConfigurablePluginPlugin,
                           type(event.tracker[0]))
 
-    def test_resources_without_resources_path(self):
+    def test_resources_without_resources_directory_path(self):
         configuration = Configuration(**self._MINIMAL_CONFIGURATION_ARGS)
         sut = Site(configuration)
         self.assertEquals(1, len(sut.resources.paths))
 
-    def test_resources_with_resources_path(self):
-        resources_path = '/tmp/betty'
+    def test_resources_with_resources_directory_path(self):
+        resources_directory_path = '/tmp/betty'
         configuration = Configuration(**self._MINIMAL_CONFIGURATION_ARGS)
-        configuration.resources_path = resources_path
+        configuration.resources_directory_path = resources_directory_path
         sut = Site(configuration)
         self.assertEquals(2, len(sut.resources.paths))
-        self.assertEquals(resources_path, sut.resources.paths[0])
+        self.assertEquals(resources_directory_path, sut.resources.paths[0])


### PR DESCRIPTION
Unify all configuration paths: allow output paths to be relative, rename 'resources path' to 'resources directory path', and simplify the configuration file keys.