### PR TITLE
Remove vertical padding from the content area

### DIFF
--- a/betty/resources/public/betty.css
+++ b/betty/resources/public/betty.css
@@ -99,7 +99,7 @@ footer {
 #content {
   background-color: white;
   clear: both;
-  padding: 1rem;
+  padding: 0 1rem;
   display: inline-block;
   min-width: calc(100% - 2rem);
 }


### PR DESCRIPTION
Remove vertical padding from the content area and make content responsible for vertical spacing. This removes some unnecessary spacing for certain types of content.