### PR TITLE
Convert urlparse() from a filter to a global

### DIFF
--- a/betty/jinja2.py
+++ b/betty/jinja2.py
@@ -82,6 +82,7 @@ def create_environment(site: Site):
     )
     environment.globals['site'] = site
     environment.globals['plugins'] = _Plugins(site.plugins)
+    environment.globals['urlparse'] = urlparse
     environment.globals['calendar'] = calendar
     environment.filters['map'] = _filter_map
     environment.filters['flatten'] = _filter_flatten
@@ -98,7 +99,6 @@ def create_environment(site: Site):
     environment.filters['file'] = lambda *args: _filter_file(site, *args)
     environment.filters['image'] = lambda *args, **kwargs: _filter_image(
         site, *args, **kwargs)
-    environment.filters['urlparse'] = urlparse
     for plugin in site.plugins.values():
         if isinstance(plugin, Jinja2Provider):
             environment.filters.update(plugin.filters)

--- a/betty/plugins/nginx/resources/nginx.conf.j2
+++ b/betty/plugins/nginx/resources/nginx.conf.j2
@@ -2,8 +2,7 @@ server {
 	# The port to listen to.
 	listen 80;
 	# The publicly visible hostname.
-    {%- set server_name_parts = site.configuration.base_url | urlparse %}
-	server_name {{ server_name_parts['netloc'] }};
+	server_name {{ urlparse(site.configuration.base_url)['netloc'] }};
 	# The path to the local web root.
 	root {{ site.configuration.www_directory_path }};
 	# The cache lifetime.


### PR DESCRIPTION
Convert urlparse() from a filter to a global in order to simplify calling code.