### PR TITLE
Add start- and end-of-life event shortcuts

### DIFF
--- a/betty/ancestry.py
+++ b/betty/ancestry.py
@@ -550,17 +550,19 @@ class Person(Identifiable, HasFiles, HasCitations, HasLinks):
         self._presences.replace(presences)
 
     @property
-    def birth(self) -> Optional[Event]:
-        for presence in self.presences:
-            if presence.event.type == Event.Type.BIRTH and presence.role == Presence.Role.SUBJECT:
-                return presence.event
+    def start(self) -> Optional[Event]:
+        for event_type in [Event.Type.BIRTH, Event.Type.BAPTISM]:
+            for presence in self.presences:
+                if presence.event.type == event_type and presence.role == Presence.Role.SUBJECT:
+                    return presence.event
         return None
 
     @property
-    def death(self) -> Optional[Event]:
-        for presence in self.presences:
-            if presence.event.type == Event.Type.DEATH and presence.role == Presence.Role.SUBJECT:
-                return presence.event
+    def end(self) -> Optional[Event]:
+        for event_type in [Event.Type.DEATH, Event.Type.BURIAL]:
+            for presence in self.presences:
+                if presence.event.type == event_type and presence.role == Presence.Role.SUBJECT:
+                    return presence.event
         return None
 
     @property

--- a/betty/plugins/privatizer/__init__.py
+++ b/betty/plugins/privatizer/__init__.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import List, Tuple, Callable
 
-from betty.ancestry import Ancestry, Person, Event
+from betty.ancestry import Ancestry, Person, Event, Presence
 from betty.functools import walk
 from betty.parse import PostParseEvent
 from betty.plugin import Plugin
@@ -29,7 +29,7 @@ class Privatizer(Plugin):
 
     def _person_is_private(self, person: Person) -> bool:
         # A dead person is not private, regardless of when they died.
-        if person.death is not None:
+        if len([presence for presence in person.presences if presence.event.type == Event.Type.DEATH and presence.role == Presence.Role.SUBJECT]) > 0:
             return False
 
         if self._person_has_expired(person, 1):

--- a/betty/resources/templates/macro/event.html.j2
+++ b/betty/resources/templates/macro/event.html.j2
@@ -12,7 +12,8 @@
 
     {%- if ns.subjects | length > 0 -%}
         {%- if person_context is not none and person_context in (event.presences | selectattr('role', 'equalto', PresenceRole.SUBJECT) | map(attribute='person')) %} with {% else %} of {% endif -%}
-        {{ ns.subjects | sort(attribute='names') | map(personMacros.label) | join(' and ') }}
+        {{ ns.subjects | sort(attribute='name
+        s') | map(personMacros.label) | join(' and ') }}
     {%- endif -%}
 {%- endmacro -%}
 

--- a/betty/resources/templates/person-meta.html.j2
+++ b/betty/resources/templates/person-meta.html.j2
@@ -1,20 +1,21 @@
+{%- import 'macro/event.html.j2' as eventMacros -%}
 <div class="meta">
     {%- if person.private -%}
         <p>This person's details are unavailable to protect their privacy.</p>
-    {%- elif person.birth or person.death %}
+    {%- elif person.start or person.end %}
         <dl>
-            {%- if person.birth %}
-                <dt>Birth</dt>
+            {%- if person.start %}
+                <dt>{{ eventMacros.type_label(person.start) }}</dt>
                 <dd>
-                    {%- with event=person.birth -%}
+                    {%- with event=person.start -%}
                         {% include 'event-dimensions.html.j2' %}
                     {%- endwith -%}
                 </dd>
             {%- endif %}
-            {%- if person.death %}
-                <dt>Death</dt>
+            {%- if person.end %}
+                <dt>{{ eventMacros.type_label(person.end) }}</dt>
                 <dd>
-                    {%- with event=person.death -%}
+                    {%- with event=person.end -%}
                         {% include 'event-dimensions.html.j2' %}
                     {%- endwith -%}
                 </dd>

--- a/betty/tests/plugins/gramps/test__init__.py
+++ b/betty/tests/plugins/gramps/test__init__.py
@@ -62,11 +62,11 @@ class ParseXmlFileTestCase(TestCase):
 
     def test_person_should_include_birth(self):
         person = self.ancestry.people['I0000']
-        self.assertEquals('E0000', person.birth.id)
+        self.assertEquals('E0000', person.start.id)
 
     def test_person_should_include_death(self):
         person = self.ancestry.people['I0003']
-        self.assertEquals('E0002', person.death.id)
+        self.assertEquals('E0002', person.end.id)
 
     def test_person_should_be_private(self):
         person = self.ancestry.people['I0003']


### PR DESCRIPTION
Change Person.birth to Person.start and Person.death to Person.end as generic start- and end-of-life shortcuts. This fixes https://github.com/bartfeenstra/betty/issues/190