### PR TITLE
Ensure map controls are not visible through the dropped down navigation.

### DIFF
--- a/betty/resources/public/betty.css.j2
+++ b/betty/resources/public/betty.css.j2
@@ -299,7 +299,7 @@ ul.file-controls li a:hover {
   position: absolute;
   top: 3rem;
   width: calc(100% - 6rem);
-  z-index: 999;
+  z-index: 9999;
 }
 
 #nav-primary:target ul {


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/195