### PR TITLE
Add configuration error handling.

### DIFF
--- a/betty/cli.py
+++ b/betty/cli.py
@@ -6,6 +6,7 @@ from typing import Callable, Optional, List
 
 from betty import parse, render
 from betty.config import from_file, Configuration
+from betty.error import ExternalContextError
 from betty.logging import CliHandler
 from betty.site import Site
 
@@ -105,3 +106,11 @@ def main(args=None):
     except KeyboardInterrupt:
         # Quit gracefully.
         logger.info('Quitting...')
+    except ExternalContextError as e:
+        logger.error(str(e))
+        exit(1)
+    except SystemExit as e:
+        raise e
+    except BaseException as e:
+        logger.exception(str(e))
+        exit(1)

--- a/betty/error.py
+++ b/betty/error.py
@@ -1,0 +1,28 @@
+from textwrap import indent
+
+
+class ExternalContextError(RuntimeError):
+    """
+    An error depending on Betty's external context, e.g. not caused by internal failure.
+
+    This type of error is fatal, but fixing it does not require knowledge of Betty's internals or the stack trace
+    leading to the error. Instead, the error message must provide contextual information, and the error may be caught,
+    its description extended using wrap(), and re-raised.
+    """
+
+    def __init__(self, *args, **kwargs):
+        RuntimeError.__init__(self, *args, **kwargs)
+        self._contexts = []
+
+    def __str__(self):
+        return RuntimeError.__str__(self) + '\n' + indent('\n'.join(self._contexts), '- ')
+
+    def add_context(self, context: str):
+        """
+        Add a message describing the error's context.
+
+        :param context: str
+        :return: ExternalContextError
+        """
+        self._contexts.append(context)
+        return self

--- a/betty/logging.py
+++ b/betty/logging.py
@@ -1,3 +1,4 @@
+import sys
 from logging import CRITICAL, ERROR, WARNING, INFO, DEBUG, NOTSET, StreamHandler
 
 
@@ -12,7 +13,7 @@ class CliHandler(StreamHandler):
     ]
 
     def __init__(self):
-        StreamHandler.__init__(self)
+        StreamHandler.__init__(self, sys.stderr)
 
     def format(self, record):
         s = StreamHandler.format(self, record)

--- a/betty/tests/test_cli.py
+++ b/betty/tests/test_cli.py
@@ -46,22 +46,21 @@ class TestPlugin(Plugin, CommandProvider):
         ]
 
 
+@patch('sys.stderr')
+@patch('sys.stdout')
 class MainTest(TestCase):
     def assertExit(self, *args):
         return AssertExit(self, *args)
 
-    @patch('sys.stdout')
-    def test_without_arguments(self, _):
+    def test_without_arguments(self, _, __):
         with self.assertExit(2):
             main()
 
-    @patch('sys.stdout')
-    def test_help_without_configuration(self, _):
+    def test_help_without_configuration(self, _, __):
         with self.assertExit(0):
             main(['--help'])
 
-    @patch('sys.stdout')
-    def test_configuration_without_help(self, _):
+    def test_configuration_without_help(self, _, __):
         with NamedTemporaryFile(mode='w') as config_file:
             with TemporaryDirectory() as output_directory_path:
                 url = 'https://example.com'
@@ -75,8 +74,7 @@ class MainTest(TestCase):
                 with self.assertExit(2):
                     main(['--config', config_file.name])
 
-    @patch('sys.stdout')
-    def test_help_with_configuration(self, _):
+    def test_help_with_configuration(self, _, __):
         with NamedTemporaryFile(mode='w') as config_file:
             with TemporaryDirectory() as output_directory_path:
                 url = 'https://example.com'
@@ -93,8 +91,7 @@ class MainTest(TestCase):
                 with self.assertExit(0):
                     main(['--config', config_file.name, '--help'])
 
-    @patch('sys.stdout')
-    def test_with_discovered_configuration(self, _):
+    def test_with_discovered_configuration(self, _, __):
         with TemporaryDirectory() as cwd:
             with TemporaryDirectory() as output_directory_path:
                 with open(join(cwd, 'betty.json'), 'w') as config_file:
@@ -110,14 +107,13 @@ class MainTest(TestCase):
                 original_cwd = getcwd()
                 try:
                     chdir(cwd)
-                    with self.assertRaises(TestCommandError):
+                    with self.assertExit(1):
                         main(['test'])
                 finally:
                     chdir(original_cwd)
 
     @patch('argparse.ArgumentParser')
-    @patch('sys.stderr')
-    def test_with_keyboard_interrupt(self, _, parser):
+    def test_with_keyboard_interrupt(self, parser, _, __):
         parser.side_effect = KeyboardInterrupt
         main()
 

--- a/betty/tests/test_cli.py
+++ b/betty/tests/test_cli.py
@@ -91,6 +91,15 @@ class MainTest(TestCase):
                 with self.assertExit(0):
                     main(['--config', config_file.name, '--help'])
 
+    def test_help_with_invalid_configuration(self, _, __):
+        with NamedTemporaryFile(mode='w') as config_file:
+            config_dict = {}
+            dump(config_dict, config_file)
+            config_file.seek(0)
+
+            with self.assertExit(1):
+                main(['--config', config_file.name, '--help'])
+
     def test_with_discovered_configuration(self, _, __):
         with TemporaryDirectory() as cwd:
             with TemporaryDirectory() as output_directory_path:

--- a/betty/tests/test_config.py
+++ b/betty/tests/test_config.py
@@ -7,7 +7,7 @@ from unittest import TestCase
 
 from parameterized import parameterized
 
-from betty.config import from_file, Configuration
+from betty.config import from_file, Configuration, ConfigurationError
 from betty.plugin import Plugin
 
 
@@ -194,11 +194,11 @@ class FromTest(TestCase):
 
     def test_from_file_should_error_if_invalid_json(self):
         with self._writes('') as f:
-            with self.assertRaises(ValueError):
+            with self.assertRaises(ConfigurationError):
                 from_file(f)
 
     def test_from_file_should_error_if_invalid_config(self):
         config_dict = {}
         with self._write(config_dict) as f:
-            with self.assertRaises(ValueError):
+            with self.assertRaises(ConfigurationError):
                 from_file(f)

--- a/betty/tests/test_error.py
+++ b/betty/tests/test_error.py
@@ -1,0 +1,13 @@
+from unittest import TestCase
+
+from betty.error import ExternalContextError
+
+
+class ExternalContextErrorTest(TestCase):
+    def test__str__(self):
+        message = 'Something went wrong!'
+        context = 'Somewhere, at some point...'
+        expected = 'Something went wrong!\n- Somewhere, at some point...'
+        sut = ExternalContextError(message)
+        sut.add_context(context)
+        self.assertEquals(expected, str(sut))


### PR DESCRIPTION
This *partly* fixes https://github.com/bartfeenstra/betty/issues/199. It introduces a configuration error API, but doesn't yet make it easy for plugins to validate their configuration.