### PR TITLE
Create file hashes based on metadata

### DIFF
--- a/betty/fs.py
+++ b/betty/fs.py
@@ -2,7 +2,7 @@ import hashlib
 import os
 from collections import deque
 from os import walk
-from os.path import join, dirname, exists, relpath
+from os.path import join, dirname, exists, relpath, getmtime
 from shutil import copy2
 from typing import Iterable
 
@@ -15,18 +15,8 @@ def makedirs(path: str) -> None:
     os.makedirs(path, 0o755, True)
 
 
-BLOCK_SIZE = 65536
-
-
 def hashfile(path: str) -> str:
-    hasher = hashlib.md5()
-    with open(path, 'rb') as file:
-        while True:
-            buffer = file.read(BLOCK_SIZE)
-            if len(buffer) == 0:
-                break
-            hasher.update(buffer)
-    return hasher.hexdigest()
+    return hashlib.md5(':'.join([str(getmtime(path)), path]).encode('utf-8')).hexdigest()
 
 
 class FileSystem:

--- a/betty/tests/test_fs.py
+++ b/betty/tests/test_fs.py
@@ -26,11 +26,17 @@ class IterfilesTest(TestCase):
 
 
 class HashfileTest(TestCase):
-    def test_hashfile(self):
+    def test_hashfile_with_identical_file(self):
         file_path = join(dirname(dirname(__file__)),
-                         'resources/public/betty-512x512.png')
-        self.assertEquals('699fbf62d4e694646151cb78eef2e146',
-                          hashfile(file_path))
+                         'resources/public/betty-16x16.png')
+        self.assertEquals(hashfile(file_path), hashfile(file_path))
+
+    def test_hashfile_with_different_files(self):
+        file_path_1 = join(dirname(dirname(__file__)),
+                           'resources/public/betty-16x16.png')
+        file_path_2 = join(dirname(dirname(__file__)),
+                           'resources/public/betty-512x512.png')
+        self.assertNotEquals(hashfile(file_path_1), hashfile(file_path_2))
 
 
 class FileSystemTest(TestCase):


### PR DESCRIPTION
Create file hashes based on metadata instead of file contents to improve performance.