### PR TITLE
Remove support for Node.js 8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,6 @@ matrix:
           python: '3.8'
           env:
               - NODE_VERSION=10
-        - name: 'Node.js 8'
-          dist: xenial
-          python: '3.8'
-          env:
-              - NODE_VERSION=8
         - name: 'Mac OS'
           dist: osx
           python: '3.8'


### PR DESCRIPTION
Node.js 8 will be EOL by the end of this month (December 32, 2019), so there's no need for us to continue supporting it.