### PR TITLE
Privatize, anonymize, and clean events, files, sources, and citations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Betty is a static site generator for [Gramps](https://gramps-project.org/) XML f
 - [Usage](#usage)
   - [The command line](#the-command-line)
   - [Configuration files](#configuration-files)
+  - [Gramps](#gramps)
   - [The Python API](#the-python-api)
 - [Development](#development)
 - [Contributions](#contributions)
@@ -118,6 +119,13 @@ plugins:
     - `betty.plugin.privatizer.Privatizer`: Marks living people private. Configuration: `{}`.
     - `betty.plugin.trees.Trees`: Renders interactive ancestry trees using [Cytoscape.js](http://js.cytoscape.org/).
     - `betty.plugin.wikipedia.Wikipedia`: Lets templates and other plugins retrieve complementary Wikipedia entries.
+
+### Gramps
+#### Privacy
+Gramps has built-in support for person privacy. To control privacy for events, files, sources, and citations, add a
+`betty:privacy` attribute to any of these types, with a value of `private` to explicitly declare the data always
+private or `public` to declare the data always public. Any other value will leave the privacy undecided. In such cases,
+the `betty.plugin.privatizer.Privatizer` may decide if the data is public or private.
 
 ### The Python API
 ```python

--- a/betty/ancestry.py
+++ b/betty/ancestry.py
@@ -213,7 +213,7 @@ class HasLinks:
 @many_to_many('resources', 'files')
 class File(Resource, Identifiable, Described, HasPrivacy):
     resource_type_name = 'file'
-    resources: ManyAssociation
+    resources: ManyAssociation[Resource]
     notes: List[Note]
 
     def __init__(self, file_id: str, path: str):
@@ -275,6 +275,9 @@ class HasFiles:
 class Source(Resource, Identifiable, Dated, HasFiles, HasLinks, HasPrivacy):
     resource_type_name = 'source'
     name: str
+    contained_by: 'Source'
+    contains: ManyAssociation['Source']
+    citations: ManyAssociation['Citation']
 
     def __init__(self, source_id: str, name: str):
         Identifiable.__init__(self, source_id)
@@ -308,6 +311,7 @@ class Source(Resource, Identifiable, Dated, HasFiles, HasLinks, HasPrivacy):
 class Citation(Resource, Identifiable, Dated, HasFiles, HasPrivacy):
     resource_type_name = 'citation'
     source: Source
+    facts: ManyAssociation[Resource]
 
     def __init__(self, citation_id: str, source: Source):
         Identifiable.__init__(self, citation_id)

--- a/betty/ancestry.py
+++ b/betty/ancestry.py
@@ -124,7 +124,7 @@ def many_to_one(self_name: str, associated_name: str):
         setattr(cls, self_name, property(
             lambda self: getattr(self, _decorated_self_name),
             _set,
-            lambda self: setattr(self, _decorated_self_name, None),
+            lambda self: _set(self, None),
         ))
         return cls
     return decorator

--- a/betty/locale.py
+++ b/betty/locale.py
@@ -9,16 +9,10 @@ from babel import dates, Locale, parse_locale, negotiate_locale
 
 
 class Localized:
+    locale: Optional[str]
+
     def __init__(self, locale: Optional[str] = None):
-        self._locale = locale
-
-    @property
-    def locale(self) -> Optional[str]:
-        return self._locale
-
-    @locale.setter
-    def locale(self, locale: Optional[str]) -> None:
-        self._locale = locale
+        self.locale = locale
 
 
 class IncompleteDateError(ValueError):

--- a/betty/plugins/gramps/__init__.py
+++ b/betty/plugins/gramps/__init__.py
@@ -11,7 +11,7 @@ from lxml.etree import XMLParser, Element
 from voluptuous import Schema, IsFile
 
 from betty.ancestry import Ancestry, Place, File, Note, PersonName, Presence, Event, LocalizedName, Person, Source, \
-    Link, HasFiles, Citation, HasLinks, HasCitations, IdentifiableEvent
+    Link, HasFiles, Citation, HasLinks, HasCitations, IdentifiableEvent, HasPrivacy
 from betty.config import validate_configuration
 from betty.fs import makedirs
 from betty.locale import DateRange, Datey, Date
@@ -58,7 +58,7 @@ def _xpath(element, selector: str) -> []:
     return element.xpath(selector, namespaces=_NS)
 
 
-def _xpath1(element, selector: str) -> []:
+def _xpath1(element, selector: str) -> Optional:
     elements = element.xpath(selector, namespaces=_NS)
     if elements:
         return elements[0]
@@ -176,6 +176,7 @@ def _parse_object(ancestry: _IntermediateAncestry, element: Element, gramps_file
     note_handles = _xpath(element, './ns:noteref/@hlink')
     for note_handle in note_handles:
         file.notes.append(ancestry.notes[note_handle])
+    _parse_attribute_privacy(file, element)
     ancestry.files[handle] = file
 
 
@@ -379,6 +380,7 @@ def _parse_event(ancestry: _IntermediateAncestry, element: Element):
 
     _parse_objref(ancestry, event, element)
     _parse_citationref(ancestry, event, element)
+    _parse_attribute_privacy(event, element)
     ancestry.events[handle] = event
 
 
@@ -424,6 +426,7 @@ def _parse_source(ancestry: _IntermediateAncestry, element: Element) -> None:
         source.publisher = spubinfo_element.text
 
     _parse_objref(ancestry, source, element)
+    _parse_attribute_privacy(source, element)
 
     ancestry.sources[handle] = source
 
@@ -442,6 +445,7 @@ def _parse_citation(ancestry: _IntermediateAncestry, element: Element) -> None:
 
     citation.date = _parse_date(element)
     _parse_objref(ancestry, citation, element)
+    _parse_attribute_privacy(citation, element)
 
     page = _xpath1(element, './ns:page')
     if page is not None:
@@ -468,6 +472,23 @@ def _parse_urls(owner: HasLinks, element: Element):
         uri = str(_xpath1(url_element, './@href'))
         label = str(_xpath1(url_element, './@description'))
         owner.links.add(Link(uri, label))
+
+
+def _parse_attribute_privacy(resource: HasPrivacy, element: Element) -> None:
+    privacy_value = _parse_attribute('privacy', element)
+    if privacy_value is None:
+        return
+    if privacy_value == 'private':
+        resource.private = True
+        return
+    if privacy_value == 'public':
+        resource.private = False
+        return
+    logging.getLogger().warning('The betty:privacy Gramps attribute must have a value of "public" or "private", but "%s" was given, which was ignored.' % privacy_value)
+
+
+def _parse_attribute(name: str, element: Element) -> Optional[str]:
+    return _xpath1(element, './ns:attribute[@type="betty:%s"]/@value' % name)
 
 
 GrampsConfigurationSchema = Schema({

--- a/betty/tests/plugins/cleaner/test__init__.py
+++ b/betty/tests/plugins/cleaner/test__init__.py
@@ -2,7 +2,7 @@ from tempfile import TemporaryDirectory
 from unittest import TestCase
 
 from betty.ancestry import Ancestry, Person, Event, Place, Presence, LocalizedName, IdentifiableEvent, Citation, Source, \
-    File
+    File, PersonName
 from betty.config import Configuration
 from betty.parse import parse
 from betty.plugins.cleaner import Cleaner, clean
@@ -76,20 +76,67 @@ class CleanTest(TestCase):
         file = File('F1', __file__)
         ancestry.files[file.id] = file
 
-        event = IdentifiableEvent('E0', Event.Type.BIRTH)
+        place = Place('P0', [LocalizedName('The Place')])
+        ancestry.places[place.id] = place
+
         presence = Presence(Presence.Role.SUBJECT)
+
+        event = IdentifiableEvent('E0', Event.Type.BIRTH)
         event.presences.append(presence)
         event.citations.append(citation)
         event.files.append(file)
+        event.place = place
         ancestry.events[event.id] = event
 
         clean(ancestry)
 
         self.assertNotIn(event.id, ancestry.events)
+        self.assertIsNone(event.place)
+        self.assertNotIn(event, place.events)
+        self.assertNotIn(place.id, ancestry.places)
         self.assertNotIn(event, citation.facts)
+        self.assertNotIn(citation.id, ancestry.citations)
         self.assertNotIn(event, file.resources)
+        self.assertNotIn(file.id, ancestry.files)
 
-    def test_clean_should_clean_private_people_without_descendants(self) -> None:
+    def test_clean_should_not_clean_event_with_presences_with_people(self) -> None:
+        ancestry = Ancestry()
+
+        source = Source('S1', 'The Source')
+        ancestry.sources[source.id] = source
+
+        citation = Citation('C1', source)
+        ancestry.citations[citation.id] = citation
+
+        file = File('F1', __file__)
+        ancestry.files[file.id] = file
+
+        place = Place('P0', [LocalizedName('The Place')])
+        ancestry.places[place.id] = place
+
+        person = Person('P0')
+
+        presence = Presence(Presence.Role.SUBJECT)
+        presence.person = person
+
+        event = IdentifiableEvent('E0', Event.Type.BIRTH)
+        event.presences.append(presence)
+        event.citations.append(citation)
+        event.files.append(file)
+        event.place = place
+        ancestry.events[event.id] = event
+
+        clean(ancestry)
+
+        self.assertEqual(event, ancestry.events[event.id])
+        self.assertIn(event, place.events)
+        self.assertEqual(place, ancestry.places[place.id])
+        self.assertIn(event, citation.facts)
+        self.assertEqual(citation, ancestry.citations[citation.id])
+        self.assertIn(event, file.resources)
+        self.assertEqual(file, ancestry.files[file.id])
+
+    def test_clean_should_clean_private_people(self) -> None:
         ancestry = Ancestry()
 
         person = Person('P0')
@@ -108,3 +155,155 @@ class CleanTest(TestCase):
         clean(ancestry)
 
         self.assertEquals(1, len(ancestry.people))
+
+    def test_clean_should_clean_file(self) -> None:
+        ancestry = Ancestry()
+
+        file = File('F0', __file__)
+        ancestry.files[file.id] = file
+
+        clean(ancestry)
+
+        self.assertNotIn(file.id, ancestry.files)
+
+    def test_clean_should_not_clean_file_with_resources(self) -> None:
+        ancestry = Ancestry()
+
+        person = Person('P0')
+        ancestry.people[person.id] = person
+
+        file = File('F0', __file__)
+        file.resources.append(person)
+        ancestry.files[file.id] = file
+
+        clean(ancestry)
+
+        self.assertEqual(file, ancestry.files[file.id])
+        self.assertIn(person, file.resources)
+        self.assertEqual(person, ancestry.people[person.id])
+
+    def test_clean_should_clean_source(self) -> None:
+        ancestry = Ancestry()
+
+        source = Source('S0', 'The source')
+        ancestry.sources[source.id] = source
+
+        clean(ancestry)
+
+        self.assertNotIn(source.id, ancestry.sources)
+
+    def test_clean_should_not_clean_source_with_citations(self) -> None:
+        ancestry = Ancestry()
+
+        source = Source('S0', 'The Source')
+        ancestry.sources[source.id] = source
+
+        citation = Citation('C0', source)
+        citation.facts.append(PersonName('Jane'))
+        ancestry.citations[citation.id] = citation
+
+        clean(ancestry)
+
+        self.assertEqual(source, ancestry.sources[source.id])
+        self.assertEqual(source, citation.source)
+        self.assertEqual(citation, ancestry.citations[citation.id])
+
+    def test_clean_should_not_clean_source_with_contained_by(self) -> None:
+        ancestry = Ancestry()
+
+        source = Source('S0', 'The Source')
+        ancestry.sources[source.id] = source
+
+        contained_by = Source('S1', 'The Source')
+        contained_by.contains.append(source)
+        ancestry.sources[contained_by.id] = contained_by
+
+        clean(ancestry)
+
+        self.assertEqual(source, ancestry.sources[source.id])
+        self.assertIn(source, contained_by.contains)
+        self.assertEqual(contained_by, ancestry.sources[contained_by.id])
+
+    def test_clean_should_not_clean_source_with_contains(self) -> None:
+        ancestry = Ancestry()
+
+        source = Source('S0', 'The Source')
+        ancestry.sources[source.id] = source
+
+        contains = Source('S1', 'The Source')
+        contains.contained_by = source
+        ancestry.sources[contains.id] = contains
+
+        clean(ancestry)
+
+        self.assertEqual(source, ancestry.sources[source.id])
+        self.assertEqual(source, contains.contained_by)
+        self.assertEqual(contains, ancestry.sources[contains.id])
+
+    def test_clean_should_not_clean_source_with_files(self) -> None:
+        ancestry = Ancestry()
+
+        source = Source('S0', 'The Source')
+        ancestry.sources[source.id] = source
+
+        file = File('F0', __file__)
+        file.resources.append(source)
+        ancestry.files[file.id] = file
+
+        clean(ancestry)
+
+        self.assertEqual(source, ancestry.sources[source.id])
+        self.assertIn(source, file.sources)
+        self.assertEqual(file, ancestry.files[file.id])
+
+    def test_clean_should_clean_citation(self) -> None:
+        ancestry = Ancestry()
+
+        source = Source('S0', 'The source')
+        ancestry.sources[source.id] = source
+
+        citation = Citation('C0', source)
+        ancestry.citations[citation.id] = citation
+
+        clean(ancestry)
+
+        self.assertNotIn(citation.id, ancestry.citations)
+
+    def test_clean_should_not_clean_citation_with_facts(self) -> None:
+        ancestry = Ancestry()
+
+        source = Source('S0', 'The Source')
+        ancestry.sources[source.id] = source
+
+        citation = Citation('C0', source)
+        citation.facts.append(PersonName('Jane'))
+        ancestry.citations[citation.id] = citation
+
+        fact = Person('P0')
+        fact.citations.append(citation)
+        ancestry.people[fact.id] = fact
+
+        clean(ancestry)
+
+        self.assertEqual(citation, ancestry.citations[citation.id])
+        self.assertIn(citation, fact.citations)
+        self.assertEqual(fact, ancestry.people[fact.id])
+
+    def test_clean_should_not_clean_citation_with_files(self) -> None:
+        ancestry = Ancestry()
+
+        source = Source('S0', 'The Source')
+        ancestry.sources[source.id] = source
+
+        citation = Citation('C0', source)
+        ancestry.citations[citation.id] = citation
+
+        file = File('F0', __file__)
+        file.resources.append(citation)
+        ancestry.files[file.id] = file
+
+        clean(ancestry)
+
+        self.assertEqual(source, ancestry.sources[source.id])
+        self.assertIn(source, file.sources)
+        self.assertEqual(file, ancestry.files[file.id])

--- a/betty/tests/test_locale.py
+++ b/betty/tests/test_locale.py
@@ -206,10 +206,10 @@ class ValidateLocaleTest(TestCase):
 class NegotiateLocalizedsTest(TestCase):
     class DummyLocalized(Localized):
         def __eq__(self, other):
-            return self._locale == other._locale
+            return self.locale == other.locale
 
         def __repr__(self):
-            return '%s(%s)' % (self.__class__.__name__, self._locale)
+            return '%s(%s)' % (self.__class__.__name__, self.locale)
 
     @parameterized.expand([
         (DummyLocalized('nl'), 'nl', [DummyLocalized('nl')]),


### PR DESCRIPTION
Privatize, anonymize, and clean events, files, sources, and citations. To support this, introduce a `betty:privacy` Gramps attribute to support privacy for events, files, sources, and citations.

This fixes https://github.com/bartfeenstra/betty/issues/320
This fixes https://github.com/bartfeenstra/betty/issues/350