### PR TITLE
Link instead of copy filtered images to improve performance

### DIFF
--- a/betty/jinja2.py
+++ b/betty/jinja2.py
@@ -306,14 +306,16 @@ def _filter_image(site: Site, file: File, width: Optional[int] = None, height: O
         output_file_path = join(file_directory_path, destination_name)
 
         try:
-            copy2(cache_file_path, output_file_path)
+            os.link(cache_file_path, output_file_path)
+        except FileExistsError:
+            pass
         except FileNotFoundError:
             if exists(output_file_path):
                 return destination_path
             makedirs(cache_directory_path)
             convert(image, size).save(cache_file_path)
             makedirs(file_directory_path)
-            copy2(cache_file_path, output_file_path)
+            os.link(cache_file_path, output_file_path)
 
     return destination_path
 

--- a/betty/jinja2.py
+++ b/betty/jinja2.py
@@ -4,7 +4,6 @@ import re
 from importlib import import_module
 from itertools import takewhile
 from os.path import join, exists
-from shutil import copy2
 from typing import Union, Dict, Type, Optional, Callable, Iterable
 from urllib.parse import urlparse
 

--- a/betty/jinja2.py
+++ b/betty/jinja2.py
@@ -266,7 +266,7 @@ def _filter_file(site: Site, file: File) -> str:
         return destination_path
 
     makedirs(file_directory_path)
-    copy2(file.path, output_destination_path)
+    os.link(file.path, output_destination_path)
 
     return destination_path
 


### PR DESCRIPTION
Link instead of copy filtered images to improve performance by skipping needless I/O.

This fixes https://github.com/bartfeenstra/betty/issues/357