### PR TITLE
Add a cache API.

### DIFF
--- a/betty/cache.py
+++ b/betty/cache.py
@@ -1,0 +1,53 @@
+from copy import copy
+from os import path, unlink, makedirs
+from time import time
+from typing import Any, Optional
+
+
+class CacheMissError(RuntimeError):
+    pass
+
+
+class Cache:
+    def with_scope(self, key_prefix: str) -> 'Cache':
+        raise NotImplementedError
+
+    def set(self, key: str, value: Any) -> None:
+        raise NotImplementedError
+
+    def get(self, key: str, ttl: Optional[int] = None) -> Any:
+        raise NotImplementedError
+
+    def delete(self, key: str) -> None:
+        raise NotImplementedError
+
+
+class FileCache(Cache):
+    def __init__(self, cache_directory_path: str):
+        self._cache_directory_path = cache_directory_path
+        makedirs(cache_directory_path, exist_ok=True)
+
+    def with_scope(self, scope: str) -> Cache:
+        cache = copy(self)
+        cache._cache_directory_path = path.join(self._cache_directory_path, scope)
+        makedirs(cache._cache_directory_path, exist_ok=True)
+        return cache
+
+    def set(self, key: str, value: Any) -> None:
+        fpath = path.join(self._cache_directory_path, key)
+        with open(fpath, 'w') as f:
+            f.write(value)
+
+    def get(self, key: str, ttl: Optional[int] = None) -> Any:
+        fpath = path.join(self._cache_directory_path, key)
+        try:
+            if ttl is not None and path.getmtime(fpath) + ttl < time():
+                raise CacheMissError
+            with open(fpath) as f:
+                return f.read()
+        except FileNotFoundError:
+            raise CacheMissError
+
+    def delete(self, key: str) -> None:
+        fpath = path.join(self._cache_directory_path, key)
+        unlink(fpath)

--- a/betty/site.py
+++ b/betty/site.py
@@ -5,6 +5,7 @@ from os.path import abspath, dirname, join
 from typing import Type, Dict
 
 from betty.ancestry import Ancestry
+from betty.cache import Cache, FileCache
 from betty.config import Configuration
 from betty.event import EventDispatcher
 from betty.fs import FileSystem
@@ -22,6 +23,7 @@ class Site:
         self._locale = None
         self._translations = defaultdict(gettext.NullTranslations)
         self._default_translations = None
+        self._cache = FileCache(configuration.cache_directory_path)
         self._plugins = OrderedDict()
         self._init_plugins()
         self._init_event_listeners()
@@ -119,6 +121,10 @@ class Site:
     @property
     def translations(self) -> Dict[str, gettext.NullTranslations]:
         return self._translations
+
+    @property
+    def cache(self) -> Cache:
+        return self._cache
 
     def with_locale(self, locale: str) -> 'Site':
         site = copy(self)

--- a/betty/tests/test_cache.py
+++ b/betty/tests/test_cache.py
@@ -1,0 +1,47 @@
+from os import path
+from tempfile import TemporaryDirectory
+from time import sleep
+from unittest import TestCase
+
+from betty.cache import FileCache, CacheMissError
+
+
+class FileCacheTest(TestCase):
+    _KEY = 'WhatOpensALock'
+    _VALUE = 'YouFoundMe'
+
+    def setUp(self) -> None:
+        self._cache_directory = TemporaryDirectory()
+        # Set the cache directory path to a non-existent directory, to ensure the SUT can lazily create it.
+        cache_directory_path = path.join(self._cache_directory.name, 'SomeSubDirectory')
+        self._sut = FileCache(cache_directory_path)
+
+    def tearDown(self) -> None:
+        self._cache_directory.cleanup()
+
+    def test_get_with_unknown_key_should_raise_error(self) -> None:
+        with self.assertRaises(CacheMissError):
+            self._sut.get(self._KEY)
+
+    def test_get_with_ttl_and_expired_item_should_raise_error(self) -> None:
+        with self.assertRaises(CacheMissError):
+            self._sut.set(self._KEY, self._VALUE)
+            sleep(1)
+            self.assertEqual(self._VALUE, self._sut.get(self._KEY, 0))
+
+    def test_get_without_ttl_should_return(self) -> None:
+        self._sut.set(self._KEY, self._VALUE)
+        self.assertEqual(self._VALUE, self._sut.get(self._KEY))
+
+    def test_delete(self) -> None:
+        self._sut.set(self._KEY, self._VALUE)
+        self._sut.delete(self._KEY)
+        with self.assertRaises(CacheMissError):
+            self._sut.get(self._KEY)
+
+    def test_with_scope(self) -> None:
+        unscoped_value = 'IamNotTheValueYouAreLookingFor'
+        self._sut.set(self._KEY, unscoped_value)
+        sut = self._sut.with_scope('Scope')
+        sut.set(self._KEY, self._VALUE)
+        self.assertEqual(self._VALUE, sut.get(self._KEY))


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/381

## To-dos
- The Jinja2 `image` filter writes to cached files directly, and creates link as well. It cannot use the cache API in its current form.