### PR TITLE
Allow Gramps family trees to explicitly declare people public.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,11 @@ ory_path: /var/www/betty
 
 ### Gramps
 #### Privacy
-Gramps has built-in support for person privacy. To control privacy for events, files, sources, and citations, add a
-`betty:privacy` attribute to any of these types, with a value of `private` to explicitly declare the data always
-private or `public` to declare the data always public. Any other value will leave the privacy undecided. In such cases,
-the `betty.plugin.privatizer.Privatizer` may decide if the data is public or private.
+Gramps has limited built-in support for people's privacy. To fully control privacy for people, as well as events, files,
+sources, and citations, add a `betty:privacy` attribute to any of these types, with a value of `private` to explicitly
+declare the data always private or `public` to declare the data always public. Any other value will leave the privacy
+undecided, as well as person records marked public using Gramps' built-in privacy selector. In such cases, the
+`betty.plugin.privatizer.Privatizer` may decide if the data is public or private.
 
 ### The Python API
 ```python

--- a/betty/plugin/gramps/__init__.py
+++ b/betty/plugin/gramps/__init__.py
@@ -230,7 +230,7 @@ def _parse_person(ancestry: _IntermediateAncestry, element: Element):
     _parse_citationref(ancestry, person, element)
     _parse_objref(ancestry, person, element)
     _parse_urls(person, element)
-
+    _parse_attribute_privacy(person, element, 'attribute')
     ancestry.people[handle] = person
 
 

--- a/betty/tests/plugin/gramps/test__init__.py
+++ b/betty/tests/plugin/gramps/test__init__.py
@@ -248,6 +248,24 @@ class ParseXmlTest(TestCase):
         (None, 'publi'),
         (None, 'privat'),
     ])
+    def test_person_should_include_privacy_from_attribute(self, expected: Optional[bool], attribute_value: str) -> None:
+        ancestry = self._parse_partial("""
+<people>
+    <person handle="_e1dd3ac2fa22e6fefa18f738bdd" change="1552126811" id="I0000">
+        <gender>U</gender>
+        <attribute type="betty:privacy" value="%s"/>
+    </person>
+</people>
+""" % attribute_value)
+        person = ancestry.people['I0000']
+        self.assertEquals(expected, person.private)
+
+    @parameterized.expand([
+        (True, 'private'),
+        (False, 'public'),
+        (None, 'publi'),
+        (None, 'privat'),
+    ])
     def test_event_should_include_privacy_from_attribute(self, expected: Optional[bool], attribute_value: str) -> None:
         ancestry = self._parse_partial("""
 <events>


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/428.