### PR TITLE
Rename the 'Events' primary navigation link to 'Timeline'.

### DIFF
--- a/betty/assets/templates/base.html.j2
+++ b/betty/assets/templates/base.html.j2
@@ -62,7 +62,7 @@
         <div class="nav-primary-expanded">
             <ul class="nav-secondary">
                 <li><a href="{{ '/person/index.html' | url }}">{% trans %}People{% endtrans %}</a></li>
-                <li><a href="{{ '/event/index.html' | url }}">{% trans %}Events{% endtrans %}</a></li>
+                <li><a href="{{ '/event/index.html' | url }}">{% trans %}Timeline{% endtrans %}</a></li>
                 <li><a href="{{ '/place/index.html' | url }}">{% trans %}Places{% endtrans %}</a></li>
                 <li><a href="{{ '/file/index.html' | url }}">{% trans %}Media{% endtrans %}</a></li>
                 <li><a href="{{ '/source/index.html' | url }}">{% trans %}Sources{% endtrans %}</a></li>


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/445