### PR TITLE
Fix whitespace between meta labels and values.

### DIFF
--- a/betty/assets/public/static/betty.scss
+++ b/betty/assets/public/static/betty.scss
@@ -176,7 +176,7 @@ footer {
   }
 
   .meta dt::after {
-    content: ':';
+    content: ': ';
   }
 
   .meta dd {


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/451