### PR TITLE
Remove the page drop shadow

### DIFF
--- a/betty/assets/public/static/betty.scss
+++ b/betty/assets/public/static/betty.scss
@@ -45,20 +45,6 @@ body > * {
   width: 100%;
 }
 
-.has-overlay .background {
-  // Some browsers' performance degrades due to our layered background rendering, so disable it when unneeded.
-  display: none;
-}
-
-.has-page-image #page {
-  filter: drop-shadow(0.3rem 0.3rem 2rem #777);
-}
-
-.has-overlay #page {
-  // Some browsers' performance degrades due to our layered background rendering, so disable it when unneeded.
-  filter: none;
-}
-
 /*
  * Text and links.
  */
@@ -360,10 +346,6 @@ figcaption {
   height: 3rem;
   text-indent: -999em;
   width: 3rem;
-}
-
-.has-page-image #site-title {
-  filter: grayscale(0.25);
 }
 
 #site-title:hover {

--- a/betty/assets/templates/base.html.j2
+++ b/betty/assets/templates/base.html.j2
@@ -57,7 +57,7 @@
 {% elif site.configuration.theme.background_image_id and site.configuration.theme.background_image_id in site.ancestry.files %}
     {% set page_image = site.ancestry.files[site.configuration.theme.background_image_id] %}
 {% endif %}
-<body{% if page_image is defined %} class="has-page-image"{% endif %}>
+<body>
 {% if page_image is defined %}
     <div id="background-header" class="background" style="background-image: url({{ page_image | image(600, 600) | static_url }});"></div>
     <div id="background-footer" class="background" style="background-image: url({{ page_image | image(600, 600) | static_url }});"></div>


### PR DESCRIPTION
Remove the page drop shadow, because it caused page rendering performance issues that severely reduced UX in some browsers.