### PR TITLE
Add an unknown event type.

### DIFF
--- a/betty/ancestry.py
+++ b/betty/ancestry.py
@@ -510,6 +510,14 @@ class EventType:
         return set()
 
 
+class UnknownEventType(EventType):
+    name = 'unknown'
+
+    @property
+    def label(self) -> str:
+        return _('Unknown')
+
+
 class DerivableEventType(EventType):
     pass  # pragma: no cover
 

--- a/betty/tests/plugin/gramps/test__init__.py
+++ b/betty/tests/plugin/gramps/test__init__.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 
 from parameterized import parameterized
 
-from betty.ancestry import Ancestry, PersonName, Birth, Death
+from betty.ancestry import Ancestry, PersonName, Birth, Death, UnknownEventType
 from betty.config import Configuration
 from betty.functools import sync
 from betty.locale import Date
@@ -150,6 +150,17 @@ class ParseXmlTest(TestCase):
 
     def test_event_should_be_death(self):
         self.assertIsInstance(self.ancestry.events['E0002'].type, Death)
+
+    def test_event_should_parse_unknown(self):
+        ancestry = self._parse_partial("""
+<events>
+    <event handle="_e7692ea23775e80643fe4fcf91" change="1590243374" id="E0000">
+        <type>SomeEventThatIUsedToKnow</type>
+        <dateval val="0000-00-00" quality="calculated"/>
+    </event>
+</events>
+""")
+        self.assertIsInstance(ancestry.events['E0000'].type, UnknownEventType)
 
     def test_event_should_include_place(self):
         event = self.ancestry.events['E0000']


### PR DESCRIPTION
This prevents fatal errors when the Gramps plugin encounters an event type it cannot map to any of Betty's types. Instead we now warn the user, and use the newly introduced "Unknown" event type.