### PR TITLE
Reduce noise in test output

### DIFF
--- a/betty/subprocess.py
+++ b/betty/subprocess.py
@@ -1,13 +1,10 @@
 import subprocess as stdsubprocess
-from tempfile import TemporaryFile
 
 
-def run(*args, **kwargs) -> stdsubprocess.CompletedProcess:
-    with TemporaryFile() as f:
-        kwargs['stdout'] = f
-        kwargs['stderr'] = f
-        process = stdsubprocess.run(*args, **kwargs)
-        if process.returncode != 0:
-            f.seek(0)
-            raise RuntimeError(f.read().decode('utf-8'))
-        return process
+def run(args, *remaining_args, **kwargs) -> stdsubprocess.CompletedProcess:
+    kwargs['stdout'] = stdsubprocess.PIPE
+    kwargs['stderr'] = stdsubprocess.PIPE
+    process = stdsubprocess.run(args, *remaining_args, **kwargs)
+    if process.returncode != 0:
+        raise stdsubprocess.CalledProcessError(process.returncode, args, process.stdout, process.stderr)
+    return process

--- a/betty/tests/__init__.py
+++ b/betty/tests/__init__.py
@@ -36,7 +36,7 @@ class TestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        logging.disable()
+        logging.disable(logging.CRITICAL)
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/betty/tests/__init__.py
+++ b/betty/tests/__init__.py
@@ -1,3 +1,4 @@
+import logging
 from contextlib import suppress
 try:
     from contextlib import asynccontextmanager
@@ -5,7 +6,7 @@ except ImportError:
     from async_generator import asynccontextmanager
 from tempfile import TemporaryDirectory
 from typing import Optional, Dict, Callable, Tuple
-from unittest import TestCase
+import unittest
 
 from jinja2 import Environment, Template
 
@@ -28,6 +29,18 @@ def patch_cache(f):
                 cache_directory.cleanup()
 
     return _patch_cache
+
+
+class TestCase(unittest.TestCase):
+    _logging_handler = logging.NullHandler()
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        logging.disable()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        logging.disable(logging.NOTSET)
 
 
 class TemplateTestCase(TestCase):

--- a/betty/tests/plugin/anonymizer/test__init__.py
+++ b/betty/tests/plugin/anonymizer/test__init__.py
@@ -1,6 +1,5 @@
 import gettext
 from tempfile import TemporaryDirectory
-from unittest import TestCase
 from unittest.mock import patch, ANY
 
 from betty.ancestry import Ancestry, Person, File, Source, Citation, PersonName, Presence, Event, IdentifiableEvent, \
@@ -11,6 +10,7 @@ from betty.parse import parse
 from betty.plugin.anonymizer import Anonymizer, anonymize, anonymize_person, anonymize_event, anonymize_file, \
     anonymize_citation, anonymize_source, AnonymousSource, AnonymousCitation
 from betty.site import Site
+from betty.tests import TestCase
 
 
 class AnonymizeTest(TestCase):

--- a/betty/tests/plugin/cleaner/test__init__.py
+++ b/betty/tests/plugin/cleaner/test__init__.py
@@ -1,5 +1,4 @@
 from tempfile import TemporaryDirectory
-from unittest import TestCase
 
 from betty.ancestry import Ancestry, Person, Place, Presence, PlaceName, IdentifiableEvent, File, PersonName, \
     IdentifiableSource, IdentifiableCitation, Subject, Birth, Enclosure
@@ -8,6 +7,7 @@ from betty.functools import sync
 from betty.parse import parse
 from betty.plugin.cleaner import Cleaner, clean
 from betty.site import Site
+from betty.tests import TestCase
 
 
 class CleanerTest(TestCase):

--- a/betty/tests/plugin/deriver/test__init__.py
+++ b/betty/tests/plugin/deriver/test__init__.py
@@ -1,6 +1,5 @@
 from tempfile import TemporaryDirectory
 from typing import Optional, Set, Type
-from unittest import TestCase
 from parameterized import parameterized
 
 from betty.ancestry import Person, Presence, Subject, EventType, CreatableDerivableEventType, \
@@ -11,6 +10,7 @@ from betty.locale import DateRange, Date, Datey
 from betty.parse import parse
 from betty.plugin.deriver import derive, Deriver
 from betty.site import Site
+from betty.tests import TestCase
 
 
 class Ignored(EventType):

--- a/betty/tests/plugin/gramps/test__init__.py
+++ b/betty/tests/plugin/gramps/test__init__.py
@@ -1,7 +1,6 @@
 from os.path import join, dirname, abspath
 from tempfile import TemporaryDirectory, NamedTemporaryFile
 from typing import Optional
-from unittest import TestCase
 
 from parameterized import parameterized
 
@@ -12,12 +11,14 @@ from betty.locale import Date
 from betty.parse import parse
 from betty.plugin.gramps import parse_xml, Gramps
 from betty.site import Site
+from betty.tests import TestCase
 
 
 class ParseXmlTest(TestCase):
     @classmethod
     @sync
     async def setUpClass(cls) -> None:
+        TestCase.setUpClass()
         # @todo Convert each test method to use self._parse(), so we can remove this shared XML file.
         with TemporaryDirectory() as output_directory_path:
             configuration = Configuration(output_directory_path, 'https://example.com')

--- a/betty/tests/plugin/maps/test__init__.py
+++ b/betty/tests/plugin/maps/test__init__.py
@@ -1,13 +1,12 @@
 from os.path import join
 from tempfile import TemporaryDirectory
-from unittest import TestCase
 
 from betty.config import Configuration
 from betty.functools import sync
 from betty.generate import generate
 from betty.plugin.maps import Maps
 from betty.site import Site
-from betty.tests import patch_cache
+from betty.tests import patch_cache, TestCase
 
 
 class MapsTest(TestCase):

--- a/betty/tests/plugin/nginx/test__init__.py
+++ b/betty/tests/plugin/nginx/test__init__.py
@@ -2,13 +2,13 @@ import re
 from os.path import join
 from tempfile import TemporaryDirectory
 from typing import Optional
-from unittest import TestCase
 
 from betty.config import Configuration, LocaleConfiguration
 from betty.functools import sync
 from betty.generate import generate
 from betty.plugin.nginx import Nginx
 from betty.site import Site
+from betty.tests import TestCase
 
 
 class NginxTest(TestCase):

--- a/betty/tests/plugin/nginx/test_integration.py
+++ b/betty/tests/plugin/nginx/test_integration.py
@@ -1,18 +1,19 @@
 import json
-import subprocess
+import subprocess as stdsubprocess
 import sys
 import unittest
 from contextlib import suppress
 from os import path
 from tempfile import TemporaryDirectory
-from unittest import TestCase
 
 import html5lib
 import jsonschema
 import requests
 from requests import Response
 
+from betty import subprocess
 from betty.plugin.nginx import DOCKER_PATH
+from betty.tests import TestCase
 
 CONTAINER_NAME = IMAGE_NAME = 'betty-test-nginx'
 
@@ -38,15 +39,14 @@ class NginxTest(TestCase):
                 self._working_directory.name, 'betty.json')
             with open(configuration_file_path, 'w') as f:
                 json.dump(configuration, f)
-            subprocess.check_call(
-                ['betty', '-c', configuration_file_path, 'generate'])
-            subprocess.check_call(['docker', 'run', '--rm', '--name', CONTAINER_NAME, '-d', '-v',
-                                   '%s:/etc/nginx/conf.d/betty.conf:ro' % path.join(output_directory_path,
-                                                                                    'nginx', 'nginx.conf'), '-v',
-                                   '%s:/var/www/betty:ro' % path.join(output_directory_path, 'www'), IMAGE_NAME])
-            self.address = 'http://%s' % subprocess.check_output(
+            subprocess.run(['betty', '-c', configuration_file_path, 'generate'])
+            subprocess.run(['docker', 'run', '--rm', '--name', CONTAINER_NAME, '-d', '-v',
+                            '%s:/etc/nginx/conf.d/betty.conf:ro' % path.join(output_directory_path, 'nginx',
+                                                                             'nginx.conf'), '-v',
+                            '%s:/var/www/betty:ro' % path.join(output_directory_path, 'www'), IMAGE_NAME])
+            self.address = 'http://%s' % subprocess.run(
                 ['docker', 'inspect', '-f', '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}',
-                 CONTAINER_NAME]).decode('utf-8').strip()
+                 CONTAINER_NAME]).stdout.decode('utf-8').strip()
             return self
 
         def __exit__(self, exc_type, exc_val, exc_tb):
@@ -56,12 +56,12 @@ class NginxTest(TestCase):
 
         def _cleanup_environment(self):
             # Maybe the container wasn't running, and that is fine.
-            with suppress(subprocess.CalledProcessError):
-                subprocess.check_call(['docker', 'stop', CONTAINER_NAME], stderr=subprocess.DEVNULL)
+            with suppress(stdsubprocess.CalledProcessError):
+                subprocess.run(['docker', 'stop', CONTAINER_NAME])
 
     @classmethod
     def setUpClass(cls) -> None:
-        subprocess.check_call(
+        subprocess.run(
             ['docker', 'build', '-t', IMAGE_NAME, DOCKER_PATH])
 
     def assert_betty_html(self, response: Response) -> None:

--- a/betty/tests/plugin/privatizer/test__init__.py
+++ b/betty/tests/plugin/privatizer/test__init__.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from tempfile import TemporaryDirectory
 from typing import Optional
-from unittest import TestCase
 
 from parameterized import parameterized
 
@@ -13,6 +12,7 @@ from betty.locale import Date, DateRange
 from betty.parse import parse
 from betty.plugin.privatizer import Privatizer, privatize_event, privatize_source, privatize_citation, privatize_person
 from betty.site import Site
+from betty.tests import TestCase
 
 
 def _expand_person(generation: int):

--- a/betty/tests/plugin/test__init__.py
+++ b/betty/tests/plugin/test__init__.py
@@ -1,8 +1,8 @@
-from unittest import TestCase
 from unittest.mock import Mock
 
 from betty.plugin import Plugin
 from betty.site import Site
+from betty.tests import TestCase
 
 
 class PluginTest(TestCase):

--- a/betty/tests/plugin/trees/test__init__.py
+++ b/betty/tests/plugin/trees/test__init__.py
@@ -1,13 +1,12 @@
 from os.path import join
 from tempfile import TemporaryDirectory
-from unittest import TestCase
 
 from betty.config import Configuration
 from betty.functools import sync
 from betty.generate import generate
 from betty.plugin.trees import Trees
 from betty.site import Site
-from betty.tests import patch_cache
+from betty.tests import patch_cache, TestCase
 
 
 class TreesTest(TestCase):

--- a/betty/tests/plugin/wikipedia/test__init__.py
+++ b/betty/tests/plugin/wikipedia/test__init__.py
@@ -1,8 +1,10 @@
 from tempfile import TemporaryDirectory
 from time import sleep
 from typing import Tuple, Optional
-from unittest import TestCase
 from unittest.mock import patch, call
+
+from betty.tests import TestCase
+
 try:
     from unittest.mock import AsyncMock
 except ImportError:

--- a/betty/tests/test_ancestry.py
+++ b/betty/tests/test_ancestry.py
@@ -1,5 +1,4 @@
 from tempfile import TemporaryFile, NamedTemporaryFile
-from unittest import TestCase
 from unittest.mock import Mock
 
 from parameterized import parameterized
@@ -7,6 +6,7 @@ from parameterized import parameterized
 from betty.ancestry import EventHandlingSetList, Person, Event, Place, File, Note, Presence, PlaceName, PersonName, \
     IdentifiableEvent, Subject, Birth, Enclosure
 from betty.locale import Date
+from betty.tests import TestCase
 
 
 class EventHandlingSetListTest(TestCase):

--- a/betty/tests/test_cli.py
+++ b/betty/tests/test_cli.py
@@ -2,7 +2,6 @@ from json import dump
 from os import path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import Callable, Dict
-from unittest import TestCase
 from unittest.mock import patch
 
 import click
@@ -11,7 +10,7 @@ from click.testing import CliRunner
 import betty
 from betty import os
 from betty.plugin import Plugin
-from betty.tests import patch_cache
+from betty.tests import patch_cache, TestCase
 
 try:
     from unittest.mock import AsyncMock

--- a/betty/tests/test_concurrent.py
+++ b/betty/tests/test_concurrent.py
@@ -1,7 +1,7 @@
 from concurrent.futures.thread import ThreadPoolExecutor
-from unittest import TestCase
 
 from betty.concurrent import ExceptionRaisingExecutor
+from betty.tests import TestCase
 
 
 class ExceptionRaisingExecutorTest(TestCase):

--- a/betty/tests/test_config.py
+++ b/betty/tests/test_config.py
@@ -3,7 +3,6 @@ from collections import OrderedDict
 from os.path import join
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import Any, Dict
-from unittest import TestCase
 
 import yaml
 from parameterized import parameterized
@@ -12,6 +11,7 @@ from voluptuous import Schema, Required
 from betty.config import from_file, Configuration, ConfigurationError, LocaleConfiguration, PluginsConfiguration
 from betty.plugin import Plugin
 from betty.site import Site
+from betty.tests import TestCase
 
 
 class NonConfigurablePlugin(Plugin):

--- a/betty/tests/test_error.py
+++ b/betty/tests/test_error.py
@@ -1,6 +1,5 @@
-from unittest import TestCase
-
 from betty.error import ExternalContextError
+from betty.tests import TestCase
 
 
 class ExternalContextErrorTest(TestCase):

--- a/betty/tests/test_fs.py
+++ b/betty/tests/test_fs.py
@@ -2,10 +2,10 @@ import os
 from os import mkdir
 from os.path import join, dirname
 from tempfile import TemporaryDirectory
-from unittest import TestCase
 
 from betty.fs import iterfiles, FileSystem, hashfile
 from betty.functools import sync
+from betty.tests import TestCase
 
 
 class IterfilesTest(TestCase):

--- a/betty/tests/test_functools.py
+++ b/betty/tests/test_functools.py
@@ -1,6 +1,5 @@
-from unittest import TestCase
-
 from betty.functools import sync
+from betty.tests import TestCase
 
 
 class SyncTest(TestCase):

--- a/betty/tests/test_generate.py
+++ b/betty/tests/test_generate.py
@@ -2,7 +2,6 @@ import json as stdjson
 from os import makedirs, path
 from os.path import join, exists
 from tempfile import TemporaryDirectory, NamedTemporaryFile
-from unittest import TestCase
 
 import html5lib
 from lxml import etree
@@ -14,6 +13,7 @@ from betty.config import Configuration, LocaleConfiguration
 from betty.functools import sync
 from betty.generate import generate
 from betty.site import Site
+from betty.tests import TestCase
 
 
 class GenerateTestCase(TestCase):

--- a/betty/tests/test_graph.py
+++ b/betty/tests/test_graph.py
@@ -1,6 +1,5 @@
-from unittest import TestCase
-
 from betty.graph import tsort, CyclicGraphError
+from betty.tests import TestCase
 
 
 class TSortTest(TestCase):

--- a/betty/tests/test_importlib.py
+++ b/betty/tests/test_importlib.py
@@ -1,8 +1,7 @@
-from unittest import TestCase
-
 from parameterized import parameterized
 
 from betty.importlib import import_any
+from betty.tests import TestCase
 
 
 class ImportAnyTest(TestCase):

--- a/betty/tests/test_json.py
+++ b/betty/tests/test_json.py
@@ -1,6 +1,5 @@
 import json as stdjson
 from tempfile import TemporaryDirectory, NamedTemporaryFile
-from unittest import TestCase
 
 from geopy import Point
 
@@ -11,6 +10,7 @@ from betty.config import Configuration, LocaleConfiguration
 from betty.json import JSONEncoder
 from betty.locale import Date, DateRange
 from betty.site import Site
+from betty.tests import TestCase
 
 
 class JSONEncoderTest(TestCase):

--- a/betty/tests/test_locale.py
+++ b/betty/tests/test_locale.py
@@ -1,11 +1,11 @@
 import gettext
 from typing import List, Optional
-from unittest import TestCase
 
 from parameterized import parameterized
 
 from betty.locale import Localized, negotiate_localizeds, Date, format_datey, DateRange, Translations, negotiate_locale, \
     Datey
+from betty.tests import TestCase
 
 
 class DateTest(TestCase):

--- a/betty/tests/test_lock.py
+++ b/betty/tests/test_lock.py
@@ -1,7 +1,6 @@
-from unittest import TestCase
-
 from betty.functools import sync
 from betty.lock import Locks, AcquiredError
+from betty.tests import TestCase
 
 
 class LocksTest(TestCase):

--- a/betty/tests/test_media_type.py
+++ b/betty/tests/test_media_type.py
@@ -1,9 +1,9 @@
 from typing import Optional, List, Dict
-from unittest import TestCase
 
 from parameterized import parameterized
 
 from betty.media_type import MediaType
+from betty.tests import TestCase
 
 
 class MediaTypeTest(TestCase):

--- a/betty/tests/test_openapi.py
+++ b/betty/tests/test_openapi.py
@@ -1,7 +1,6 @@
 import json as stdjson
 from os import path
 from tempfile import TemporaryDirectory
-from unittest import TestCase
 
 import jsonschema
 from parameterized import parameterized
@@ -10,6 +9,7 @@ from betty.config import Configuration
 from betty.functools import sync
 from betty.openapi import build_specification
 from betty.site import Site
+from betty.tests import TestCase
 
 
 class BuildSpecificationTest(TestCase):

--- a/betty/tests/test_readme.py
+++ b/betty/tests/test_readme.py
@@ -1,10 +1,9 @@
 import json
 from os import path
-from subprocess import check_output
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
-from betty import os
+from betty import os, subprocess
 
 
 class ReadmeTest(TestCase):
@@ -17,7 +16,7 @@ class ReadmeTest(TestCase):
             with open(path.join(betty_site_path, 'betty.json'), 'w') as f:
                 json.dump(configuration, f)
             with os.chdir(betty_site_path):
-                expected = check_output(['betty', '--help'])
+                expected = subprocess.run(['betty', '--help']).stdout
             with open('README.md') as f:
                 actual = f.read().encode()
             self.assertIn(expected, actual)

--- a/betty/tests/test_scheduler.py
+++ b/betty/tests/test_scheduler.py
@@ -3,10 +3,10 @@ from asyncio import sleep
 from concurrent.futures.thread import ThreadPoolExecutor
 from os import path
 from tempfile import TemporaryDirectory
-from unittest import TestCase
 
 from betty.functools import sync
 from betty.scheduler import ExecutorScheduler, JoiningError
+from betty.tests import TestCase
 
 
 def _executor_scheduler_test_task(carrier_file_path: str, *args, **kwargs):

--- a/betty/tests/test_search.py
+++ b/betty/tests/test_search.py
@@ -1,5 +1,4 @@
 from tempfile import TemporaryDirectory
-from unittest import TestCase
 
 from parameterized import parameterized
 
@@ -8,6 +7,7 @@ from betty.config import Configuration, LocaleConfiguration
 from betty.functools import sync
 from betty.search import Index
 from betty.site import Site
+from betty.tests import TestCase
 
 
 class IndexTest(TestCase):

--- a/betty/tests/test_site.py
+++ b/betty/tests/test_site.py
@@ -1,5 +1,4 @@
 from typing import Dict, List, Tuple, Type, Callable, Set
-from unittest import TestCase
 
 from voluptuous import Schema, Required
 
@@ -10,6 +9,7 @@ from betty.functools import sync
 from betty.graph import CyclicGraphError
 from betty.plugin import Plugin
 from betty.site import Site
+from betty.tests import TestCase
 
 
 class TrackingEvent(Event):

--- a/betty/tests/test_subprocess.py
+++ b/betty/tests/test_subprocess.py
@@ -1,7 +1,7 @@
-from subprocess import CompletedProcess
-from unittest import TestCase
+from subprocess import CompletedProcess, CalledProcessError
 
 from betty import subprocess
+from betty.tests import TestCase
 
 
 class RunTest(TestCase):
@@ -10,5 +10,5 @@ class RunTest(TestCase):
         self.assertIsInstance(process, CompletedProcess)
 
     def test_with_errors(self):
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(CalledProcessError):
             subprocess.run(['false'])

--- a/betty/tests/test_url.py
+++ b/betty/tests/test_url.py
@@ -1,11 +1,11 @@
 from typing import Any
-from unittest import TestCase
 
 from parameterized import parameterized
 
 from betty.ancestry import Person, Place, File, Source, Identifiable, PlaceName, IdentifiableEvent, \
     IdentifiableSource, IdentifiableCitation, Death
 from betty.config import Configuration, LocaleConfiguration
+from betty.tests import TestCase
 from betty.url import LocalizedPathUrlGenerator, IdentifiableResourceUrlGenerator, SiteUrlGenerator
 
 

--- a/betty/tests/test_voluptuous.py
+++ b/betty/tests/test_voluptuous.py
@@ -1,10 +1,10 @@
 from os import path
-from unittest import TestCase
 
 from parameterized import parameterized
 from voluptuous import Invalid
 
 from betty import os
+from betty.tests import TestCase
 from betty.voluptuous import Path, Importable
 
 


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/550 by disabling logging and hiding subprocess output.