### PR TITLE
Prevent end-of-life events in person meta from wrapping under start-of-life events.

### DIFF
--- a/betty/assets/public/static/css/meta.scss
+++ b/betty/assets/public/static/css/meta.scss
@@ -2,27 +2,4 @@
   color: #777;
   display: block;
   font-size: 0.9rem;
-
-  & dt {
-    font-weight: bold;
-  }
-}
-
-@media (min-width: 768px) {
-  .meta dl {
-    margin: 0;
-  }
-
-  .meta dt,
-  .meta dd {
-    display: inline;
-  }
-
-  .meta dt::after {
-    content: ': ';
-  }
-
-  .meta dd {
-    margin: 0 3em 0 0;
-  }
 }

--- a/betty/assets/public/static/css/person.scss
+++ b/betty/assets/public/static/css/person.scss
@@ -8,6 +8,29 @@
   font-style: italic;
 }
 
+.person-meta {
+  dl {
+    margin: 0;
+  }
+
+  dt {
+    font-weight: bold;
+
+    &::after {
+      content: ': ';
+    }
+  }
+
+  dt,
+  dd {
+    display: inline;
+  }
+
+  dd {
+    margin: 0 3em 0 0;
+  }
+}
+
 .family {
   margin: 3rem 0;
 }

--- a/betty/assets/templates/meta/person.html.j2
+++ b/betty/assets/templates/meta/person.html.j2
@@ -6,7 +6,7 @@
 {%- if not embedded is defined -%}
     {%- set embedded = False -%}
 {%- endif -%}
-<div class="meta">
+<div class="meta person-meta">
     {%- if person.private -%}
         <p>{%- trans -%}This person's details are unavailable to protect their privacy.{%- endtrans -%}</p>
     {%- else -%}
@@ -30,10 +30,14 @@
         {%- if formatted_start or formatted_end -%}
             <dl>
                 {%- if formatted_start -%}
-                    <dt>{{ person.start.type.label }}</dt><dd>{{ formatted_start }}</dd>
+                    <div>
+                        <dt>{{ person.start.type.label }}</dt><dd>{{ formatted_start }}</dd>
+                    </div>
                 {%- endif -%}
                 {%- if formatted_end -%}
-                    <dt>{{ person.end.type.label }}</dt><dd>{{ formatted_end }}</dd>
+                    <div>
+                        <dt>{{ person.end.type.label }}</dt><dd>{{ formatted_end }}</dd>
+                    </div>
                 {%- endif -%}
             </dl>
         {%- endif -%}

--- a/betty/assets/templates/meta/person.html.j2
+++ b/betty/assets/templates/meta/person.html.j2
@@ -30,14 +30,10 @@
         {%- if formatted_start or formatted_end -%}
             <dl>
                 {%- if formatted_start -%}
-                    <div>
-                        <dt>{{ person.start.type.label }}</dt><dd>{{ formatted_start }}</dd>
-                    </div>
+                    <div><dt>{{ person.start.type.label }}</dt><dd>{{ formatted_start }}</dd></div>
                 {%- endif -%}
                 {%- if formatted_end -%}
-                    <div>
-                        <dt>{{ person.end.type.label }}</dt><dd>{{ formatted_end }}</dd>
-                    </div>
+                    <div><dt>{{ person.end.type.label }}</dt><dd>{{ formatted_end }}</dd></div>
                 {%- endif -%}
             </dl>
         {%- endif -%}

--- a/betty/tests/assets/templates/meta/test_person_html_j2.py
+++ b/betty/tests/assets/templates/meta/test_person_html_j2.py
@@ -10,7 +10,7 @@ class Test(TemplateTestCase):
     @sync
     async def test_without_meta(self):
         person = Person('P0')
-        expected = '<div class="meta"></div>'
+        expected = '<div class="meta person-meta"></div>'
         async with self._render(data={
             'person': person,
         }) as (actual, _):
@@ -20,7 +20,7 @@ class Test(TemplateTestCase):
     async def test_private(self):
         person = Person('P0')
         person.private = True
-        expected = '<div class="meta"><p>This person\'s details are unavailable to protect their privacy.</p></div>'
+        expected = '<div class="meta person-meta"><p>This person\'s details are unavailable to protect their privacy.</p></div>'
         async with self._render(data={
             'person': person,
         }) as (actual, _):
@@ -33,7 +33,7 @@ class Test(TemplateTestCase):
         name = PersonName('Janet', 'Doughnut')
         name.citations.append(Citation(Source('The Source')))
         person.names.append(name)
-        expected = '<div class="meta"><span class="aka">Also known as <span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Janet</span> <span property="foaf:familyName">Doughnut</span></span><a href="#reference-1" class="citation">[1]</a></span></div>'
+        expected = '<div class="meta person-meta"><span class="aka">Also known as <span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Janet</span> <span property="foaf:familyName">Doughnut</span></span><a href="#reference-1" class="citation">[1]</a></span></div>'
         async with self._render(data={
             'person': person,
         }) as (actual, _):
@@ -45,7 +45,7 @@ class Test(TemplateTestCase):
         person.names.append(PersonName('Jane', 'Dough'))
         person.names.append(PersonName('Janet', 'Doughnut'))
         person.names.append(PersonName('Janetar', 'Of Doughnuton'))
-        expected = '<div class="meta"><span class="aka">Also known as <span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Janet</span> <span property="foaf:familyName">Doughnut</span></span>, <span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Janetar</span> <span property="foaf:familyName">Of Doughnuton</span></span></span></div>'
+        expected = '<div class="meta person-meta"><span class="aka">Also known as <span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Janet</span> <span property="foaf:familyName">Doughnut</span></span>, <span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Janetar</span> <span property="foaf:familyName">Of Doughnuton</span></span></span></div>'
         async with self._render(data={
             'person': person,
         }) as (actual, _):
@@ -55,7 +55,7 @@ class Test(TemplateTestCase):
     async def test_with_start(self):
         person = Person('P0')
         Presence(person, Subject(), Event(Birth(), Date(1970)))
-        expected = '<div class="meta"><dl><dt>Birth</dt><dd>1970</dd></dl></div>'
+        expected = '<div class="meta person-meta"><dl><div><dt>Birth</dt><dd>1970</dd></div></dl></div>'
         async with self._render(data={
             'person': person,
         }) as (actual, _):
@@ -65,7 +65,7 @@ class Test(TemplateTestCase):
     async def test_with_end(self):
         person = Person('P0')
         Presence(person, Subject(), Event(Death(), Date(1970)))
-        expected = '<div class="meta"><dl><dt>Death</dt><dd>1970</dd></dl></div>'
+        expected = '<div class="meta person-meta"><dl><div><dt>Death</dt><dd>1970</dd></div></dl></div>'
         async with self._render(data={
             'person': person,
         }) as (actual, _):
@@ -79,7 +79,7 @@ class Test(TemplateTestCase):
         name = PersonName('Janet', 'Doughnut')
         name.citations.append(Citation(Source('The Source')))
         person.names.append(name)
-        expected = '<div class="meta"><span class="aka">Also known as <span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Janet</span> <span property="foaf:familyName">Doughnut</span></span></span><dl><dt>Birth</dt><dd>1970</dd></dl></div>'
+        expected = '<div class="meta person-meta"><span class="aka">Also known as <span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Janet</span> <span property="foaf:familyName">Doughnut</span></span></span><dl><div><dt>Birth</dt><dd>1970</dd></div></dl></div>'
         async with self._render(data={
             'person': person,
             'embedded': True,


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/605

This breaks some of the CSS classes, as they're no longer generic to meta elements, but specific to person meta.