### PR TITLE
Allow the select_localizeds() Jinja2 filter to include localized data with no or unspecified locales

### DIFF
--- a/betty/assets/templates/base.html.j2
+++ b/betty/assets/templates/base.html.j2
@@ -125,7 +125,7 @@
         {% block page_content %}{% endblock %}
         {% if page_resource is has_links %}
             {% set links = page_resource.links | rejectattr('label', 'none') | list %}
-            {% set links = links | select_localizeds | list + links | selectattr('locale', 'none') | list %}
+            {% set links = links | select_localizeds(include_unspecified=true) | list + links | selectattr('locale', 'none') | list %}
             {% if links | length > 0 %}
                 <section id="external-links">
                     <h2>

--- a/betty/jinja2.py
+++ b/betty/jinja2.py
@@ -430,10 +430,12 @@ def _filter_sort_localizeds(context: Context, localizeds: Iterable[Localized], l
 
 
 @contextfilter
-def _filter_select_localizeds(context: Context, localizeds: Iterable[Localized]) -> Iterable[Localized]:
+def _filter_select_localizeds(context: Context, localizeds: Iterable[Localized], include_unspecified: bool = False) -> Iterable[Localized]:
     locale = resolve_or_missing(context, 'locale')
     for localized in localizeds:
-        if negotiate_locale(locale, [localized.locale]) is not None:
+        if include_unspecified and localized.locale in {None, 'mis', 'mul', 'und', 'zxx'}:
+            yield localized
+        if localized.locale is not None and negotiate_locale(locale, [localized.locale]) is not None:
             yield localized
 
 

--- a/betty/tests/test_jinja2.py
+++ b/betty/tests/test_jinja2.py
@@ -382,6 +382,25 @@ class FilterSelectLocalizedsTest(TemplateTestCase):
         }, update_configuration=_update_configuration) as (actual, _):
             self.assertEquals(expected, actual)
 
+    @sync
+    async def test_include_unspecified(self):
+        template = '{{ data | select_localizeds(include_unspecified=true) | map(attribute="name") | join(", ") }}'
+        data = [
+            PlaceName('Apple', 'zxx'),
+            PlaceName('Apple', 'und'),
+            PlaceName('Apple', 'mul'),
+            PlaceName('Apple', 'mis'),
+            PlaceName('Apple', None),
+        ]
+
+        def _update_configuration(configuration: Configuration) -> None:
+            configuration.locales.clear()
+            configuration.locales['en-US'] = LocaleConfiguration('en-US')
+        async with self._render(template_string=template, data={
+            'data': data,
+        }, update_configuration=_update_configuration) as (actual, _):
+            self.assertEquals('Apple, Apple, Apple, Apple, Apple', actual)
+
 
 class FilterSelectDatedsTest(TemplateTestCase):
     class DatedDummy(Dated):


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/626