### PR TITLE
Add citations to files

### DIFF
--- a/betty/assets/templates/label/file.html.j2
+++ b/betty/assets/templates/label/file.html.j2
@@ -1,0 +1,9 @@
+{% set file = file | default(resource) %}
+{% set embedded = embedded | default(False) %}
+{% if not embedded -%}
+    <a href="{{ file | url }}">
+{%- endif -%}
+{{ file.description }}
+{%- if not embedded -%}
+    </a>
+{%- endif %}

--- a/betty/assets/templates/page/file.html.j2
+++ b/betty/assets/templates/page/file.html.j2
@@ -40,25 +40,20 @@
             </ul>
         </section>
     {% endif %}
-    {% set sources = file.sources | list %}
-    {% if sources | length  > 0 %}
+    {% set citations = file.citations | list %}
+    {% if citations | length  > 0 %}
         <section id="sources">
-            {% if sources | length == 1 %}
             <h2>
-                {% trans %}Source{% endtrans %}
+                {% trans %}Sources{% endtrans %}
                 {% with url = page_resource | url ~ '#sources'%}
                     {% include 'permalink.html.j2' %}
                 {% endwith %}
             </h2>
-                <p>{% with source=sources | first %}{% include 'label/source.html.j2' %}{% endwith %}</p>
-            {% elif sources | length  > 1 %}
-                <h2>{% trans %}Sources{% endtrans %}</h2>
-                <ul>
-                    {% for source in sources %}
-                        <li>{% include 'label/source.html.j2' %}</li>
-                    {% endfor %}
-                </ul>
-            {% endif %}
+            <ul>
+            {% for citation in citations %}
+                <li>{% include 'label/citation.html.j2' %}</li>
+            {% endfor %}
+            </ul>
         </section>
     {% endif %}
 {% endblock %}

--- a/betty/assets/templates/page/file.html.j2
+++ b/betty/assets/templates/page/file.html.j2
@@ -42,10 +42,12 @@
     {% endif %}
     {% set citations = file.citations | list %}
     {% if citations | length  > 0 %}
-        <section id="sources">
+        {# These are the citations for the file itself. This assumes no other citations are tracked on the page and #}
+        {# rendered by base.html.j2. #}
+        <section id="references">
             <h2>
-                {% trans %}Sources{% endtrans %}
-                {% with url = page_resource | url ~ '#sources'%}
+                {% trans %}References{% endtrans %}
+                {% with url = page_resource | url ~ '#references'%}
                     {% include 'permalink.html.j2' %}
                 {% endwith %}
             </h2>

--- a/betty/extension/cleaner/__init__.py
+++ b/betty/extension/cleaner/__init__.py
@@ -91,6 +91,9 @@ def _clean_file(ancestry: Ancestry, file: File) -> None:
     if len(file.resources) > 0:
         return
 
+    if len(file.citations) > 0:
+        return
+
     del ancestry.files[file.id]
 
 

--- a/betty/tests/test_ancestry.py
+++ b/betty/tests/test_ancestry.py
@@ -271,27 +271,11 @@ class FileTest(TestCase):
         sut.resources = resources
         self.assertCountEqual(resources, sut.resources)
 
-    def test_sources(self) -> None:
-        file_id = 'BETTY01'
-        file_path = '/tmp/betty'
-        sut = File(file_id, file_path)
-        self.assertCountEqual([], sut.resources)
-        source = Mock(Source)
-        citation_source = Mock(Source)
-        citation = Citation(citation_source)
-        resources = [citation, source, Mock(HasFiles)]
-        sut.resources = resources
-        self.assertCountEqual([citation_source, source], sut.sources)
-
     def test_citations(self) -> None:
         file_id = 'BETTY01'
         file_path = '/tmp/betty'
         sut = File(file_id, file_path)
-        self.assertCountEqual([], sut.resources)
-        citation = Mock(Citation)
-        resources = [citation, Mock(HasFiles)]
-        sut.resources = resources
-        self.assertCountEqual([citation], sut.citations)
+        self.assertCountEqual([], sut.citations)
 
     def test_name(self) -> None:
         file_id = 'BETTY01'


### PR DESCRIPTION
- This allows users to document and credit media files. That's important, because often files come from a different source than the information they represent, e.g. a third party digitizes and publishes a public institution's records.
- This also fixes a problem where it looked like files were credited, but instead Betty listed all citations and sources that a file was attached to.
- To do so, this breaks BC by removing the shortcut property methods `File.citations` and `File.sources`, and makes `File` extend `HasCitations` (which comes with `HasCitations.citations`).