### PR TITLE
Replace os.path usage with pathlib.Path

### DIFF
--- a/betty/__init__.py
+++ b/betty/__init__.py
@@ -1,3 +1,0 @@
-from os import path
-
-_CACHE_DIRECTORY_PATH = path.join(path.expanduser('~'), '.betty')

--- a/betty/about.py
+++ b/betty/about.py
@@ -1,8 +1,8 @@
-from os import path
+from pathlib import Path
 
 
 def version() -> str:
-    with open(path.join(path.dirname(path.dirname(__file__)), 'VERSION')) as f:
+    with open(Path(__file__).parents[1] / 'VERSION') as f:
         release_version = f.read().strip()
     if release_version == '0.0.0':
         return 'development'

--- a/betty/ancestry.py
+++ b/betty/ancestry.py
@@ -1,13 +1,13 @@
 from functools import total_ordering
 from itertools import chain
-from os.path import splitext, basename
+from pathlib import Path
 from typing import Dict, Optional, List, Iterable, Set, Union, TypeVar, Generic, Callable, Sequence, Type
 
 from geopy import Point
 
 from betty.locale import Localized, Datey
 from betty.media_type import MediaType
-from betty.path import extension
+from betty.os import PathLike
 
 T = TypeVar('T')
 
@@ -247,14 +247,14 @@ class File(Resource, Identifiable, Described, HasPrivacy, HasMediaType, HasNotes
     resources: ManyAssociation['HasFiles']
     notes: List[Note]
 
-    def __init__(self, file_id: str, path: str, media_type: Optional[MediaType] = None):
+    def __init__(self, file_id: str, path: PathLike, media_type: Optional[MediaType] = None):
         Identifiable.__init__(self, file_id)
         Described.__init__(self)
         HasPrivacy.__init__(self)
         HasMediaType.__init__(self)
         HasNotes.__init__(self)
         HasCitations.__init__(self)
-        self._path = path
+        self._path = Path(path)
         self.media_type = media_type
 
     @classmethod
@@ -262,20 +262,8 @@ class File(Resource, Identifiable, Described, HasPrivacy, HasMediaType, HasNotes
         return 'file'
 
     @property
-    def path(self) -> str:
+    def path(self) -> Path:
         return self._path
-
-    @property
-    def name(self) -> str:
-        return basename(self._path)
-
-    @property
-    def basename(self) -> str:
-        return splitext(self._path)[0]
-
-    @property
-    def extension(self) -> Optional[str]:
-        return extension(self._path)
 
 
 @many_to_many('files', 'resources')

--- a/betty/app.py
+++ b/betty/app.py
@@ -2,6 +2,7 @@ import gettext
 from collections import defaultdict, OrderedDict
 from concurrent.futures._base import Executor
 from concurrent.futures.thread import ThreadPoolExecutor
+from pathlib import Path
 
 from jinja2 import Environment
 
@@ -16,7 +17,6 @@ try:
 except ImportError:
     from async_exit_stack import AsyncExitStack
 from copy import copy
-from os.path import abspath, dirname, join
 from typing import Type, Dict
 
 from betty.ancestry import Ancestry
@@ -32,8 +32,7 @@ class App:
         self._app_stack = []
         self._ancestry = Ancestry()
         self._configuration = configuration
-        self._assets = FileSystem(
-            join(dirname(abspath(__file__)), 'assets'))
+        self._assets = FileSystem(Path(__file__).parent / 'assets')
         self._dispatcher = None
         self._localized_url_generator = AppUrlGenerator(configuration)
         self._static_url_generator = StaticPathUrlGenerator(configuration)

--- a/betty/assets/templates/file.html.j2
+++ b/betty/assets/templates/file.html.j2
@@ -29,7 +29,7 @@
     <div id="file-extended-{{ file.id }}" class="file-extended">
         <ul class="file-controls">
             <li><a href="{{ file | file | static_url }}" title="View original in full">⇔</a></li>
-            <li><a href="{{ file | file | static_url }}" download="{{ file.name | escape }}" title="Download this file">⇓</a></li>
+            <li><a href="{{ file | file | static_url }}" download="{{ file.path.name | escape }}" title="Download this file">⇓</a></li>
             <li><a href="{{ file | url }}" title="More details">ℹ</a></li>
             <li class="file-extended-close"><a href="#file-{{ file.id }}" title="Close this file">×</a></li>
             {% if previous_file is defined %}

--- a/betty/cli.py
+++ b/betty/cli.py
@@ -12,8 +12,7 @@ from typing import Callable, Dict, Optional
 import click
 from click import get_current_context, Context, Option
 
-import betty
-from betty import generate, load, serve, about, demo
+from betty import generate, load, serve, about, demo, fs
 from betty.config import from_file
 from betty.error import UserFacingError
 from betty.asyncio import sync
@@ -154,7 +153,7 @@ def main(app):
 @global_command
 async def _clear_caches():
     with suppress(FileNotFoundError):
-        shutil.rmtree(betty._CACHE_DIRECTORY_PATH)
+        shutil.rmtree(fs.CACHE_DIRECTORY_PATH)
     logging.getLogger().info('All caches cleared.')
 
 

--- a/betty/extension/__init__.py
+++ b/betty/extension/__init__.py
@@ -1,5 +1,6 @@
 import asyncio
 from collections import defaultdict
+from pathlib import Path
 from typing import Type, Set, Optional, Any, List, Dict
 
 from betty.dispatch import Dispatcher, TargetedDispatcher
@@ -38,7 +39,7 @@ class Extension:
         return set()
 
     @property
-    def assets_directory_path(self) -> Optional[str]:
+    def assets_directory_path(self) -> Optional[Path]:
         return None
 
 

--- a/betty/extension/nginx/__init__.py
+++ b/betty/extension/nginx/__init__.py
@@ -1,4 +1,4 @@
-from os import path
+from pathlib import Path
 from typing import Optional, Iterable, Dict
 from urllib.parse import urlparse
 
@@ -18,7 +18,7 @@ class Nginx(ConfigurableExtension, AppAwareFactory, Generator, ServerProvider):
         'https': bool,
     })
 
-    def __init__(self, app: App, www_directory_path: Optional[str] = None, https: Optional[bool] = None):
+    def __init__(self, app: App, www_directory_path: Optional[Path] = None, https: Optional[bool] = None):
         self._https = https
         self._www_directory_path = www_directory_path
         self._app = app
@@ -49,8 +49,8 @@ class Nginx(ConfigurableExtension, AppAwareFactory, Generator, ServerProvider):
         await self._generate_dockerfile_file()
 
     @property
-    def assets_directory_path(self) -> Optional[str]:
-        return '%s/assets' % path.dirname(__file__)
+    def assets_directory_path(self) -> Optional[Path]:
+        return Path(__file__).parent / 'assets'
 
     @property
     def https(self) -> bool:
@@ -59,7 +59,7 @@ class Nginx(ConfigurableExtension, AppAwareFactory, Generator, ServerProvider):
         return self._https
 
     @property
-    def www_directory_path(self) -> str:
+    def www_directory_path(self) -> Path:
         if self._www_directory_path is None:
             return self._app.configuration.www_directory_path
         return self._www_directory_path
@@ -75,8 +75,8 @@ class Nginx(ConfigurableExtension, AppAwareFactory, Generator, ServerProvider):
             'www_directory_path': self._app.extensions[Nginx].www_directory_path,
         }, **kwargs)
         if destination_file_path is None:
-            destination_file_path = path.join(self._app.configuration.output_directory_path, 'nginx', 'nginx.conf')
+            destination_file_path = self._app.configuration.output_directory_path / 'nginx' / 'nginx.conf'
         await generate_configuration_file(destination_file_path, self._app.jinja2_environment, **kwargs)
 
     async def _generate_dockerfile_file(self) -> None:
-        await generate_dockerfile_file(path.join(self._app.configuration.output_directory_path, 'nginx', 'docker', 'Dockerfile'))
+        await generate_dockerfile_file(self._app.configuration.output_directory_path / 'nginx' / 'docker' / 'Dockerfile')

--- a/betty/extension/nginx/artifact.py
+++ b/betty/extension/nginx/artifact.py
@@ -1,22 +1,20 @@
-from os import path
 from pathlib import Path
 from shutil import copyfile
 
 from jinja2 import FileSystemLoader, Environment
 
-from betty.fs import makedirs
 from betty.path import rootname
 
 
-async def generate_configuration_file(destination_file_path: str, jinja2_environment: Environment, **kwargs) -> None:
+async def generate_configuration_file(destination_file_path: Path, jinja2_environment: Environment, **kwargs) -> None:
     root_path = rootname(__file__)
-    configuration_file_template_name = '/'.join(Path(path.relpath(path.join(path.dirname(__file__), 'assets', 'nginx.conf.j2'), root_path)).parts)
+    configuration_file_template_name = '/'.join((Path(__file__).parent / 'assets' / 'nginx.conf.j2').relative_to(root_path).parts)
     template = FileSystemLoader(root_path).load(jinja2_environment, configuration_file_template_name, jinja2_environment.globals)
-    makedirs(path.dirname(destination_file_path))
+    destination_file_path.parent.mkdir(exist_ok=True, parents=True)
     with open(destination_file_path, 'w') as f:
         f.write(template.render(kwargs))
 
 
-async def generate_dockerfile_file(destination_file_path: str) -> None:
-    makedirs(path.dirname(destination_file_path))
-    copyfile(path.join(path.dirname(__file__), 'assets', 'docker', 'Dockerfile'), destination_file_path)
+async def generate_dockerfile_file(destination_file_path: Path) -> None:
+    destination_file_path.parent.mkdir(exist_ok=True, parents=True)
+    copyfile(Path(__file__).parent / 'assets' / 'docker' / 'Dockerfile', destination_file_path)

--- a/betty/extension/nginx/assets/nginx.conf.j2
+++ b/betty/extension/nginx/assets/nginx.conf.j2
@@ -18,6 +18,15 @@ server {
     gzip_vary on;
     gzip_types text/css application/javascript application/json application/xml;
 
+    {% if app.ancestry.files | length > 0 %}
+        # Redirect Betty <0.3 file paths to Betty 0.3 file paths.
+        {% for file in app.ancestry.files.values() %}
+            location /file/{{ file.id }}{{ file.path.suffix }} {
+                return 301 /file/{{ file.id }}/file/{{ file.path.name }};
+            }
+        {% endfor %}
+    {% endif %}
+
     {% if content_negotiation %}
         set_by_lua_block $media_type_extension {
             local available_media_types = {'text/html', 'application/json'}

--- a/betty/extension/nginx/docker.py
+++ b/betty/extension/nginx/docker.py
@@ -4,9 +4,11 @@ import docker
 from docker.errors import NotFound
 from docker.models.containers import Container as DockerContainer
 
+from betty.os import PathLike
+
 
 class Container:
-    def __init__(self, www_directory_path: str, docker_directory_path: str, nginx_configuration_file_path: str, name: str):
+    def __init__(self, www_directory_path: PathLike, docker_directory_path: PathLike, nginx_configuration_file_path: PathLike, name: str):
         self._name = name
         self._docker_directory_path = docker_directory_path
         self._nginx_configuration_file_path = nginx_configuration_file_path
@@ -23,7 +25,7 @@ class Container:
         # Stop any containers that may have been left over.
         self.stop()
 
-        self._client.images.build(path=self._docker_directory_path, tag=self._name)
+        self._client.images.build(path=str(self._docker_directory_path), tag=self._name)
         self._client.containers.run(self._name, name=self._name, auto_remove=True, detach=True, volumes={
             self._nginx_configuration_file_path: {
                 'bind': '/etc/nginx/conf.d/betty.conf',

--- a/betty/extension/nginx/serve.py
+++ b/betty/extension/nginx/serve.py
@@ -1,5 +1,5 @@
 import logging
-from os import path
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import docker
@@ -20,9 +20,9 @@ class DockerizedNginxServer(Server):
     async def start(self) -> None:
         logging.getLogger().info('Starting a Dockerized nginx web server...')
         self._output_directory = TemporaryDirectory()
-        nginx_configuration_file_path = path.join(self._output_directory.name, 'nginx.conf')
-        docker_directory_path = path.join(self._output_directory.name, 'docker')
-        dockerfile_file_path = path.join(docker_directory_path, 'Dockerfile')
+        nginx_configuration_file_path = Path(self._output_directory.name) / 'nginx.conf'
+        docker_directory_path = Path(self._output_directory.name) / 'docker'
+        dockerfile_file_path = docker_directory_path / 'Dockerfile'
         async with self._app:
             await self._app.extensions[Nginx].generate_configuration_file(destination_file_path=nginx_configuration_file_path, https=False, www_directory_path='/var/www/betty')
             await generate_dockerfile_file(destination_file_path=dockerfile_file_path)

--- a/betty/extension/redoc/__init__.py
+++ b/betty/extension/redoc/__init__.py
@@ -3,8 +3,7 @@ import logging
 import shutil
 import sys
 from contextlib import suppress
-from os import path
-from os.path import dirname
+from pathlib import Path
 from typing import Optional
 
 from betty import subprocess
@@ -26,29 +25,28 @@ class ReDoc(Extension, AppAwareFactory, Generator):
         await self._render()
 
     @property
-    def assets_directory_path(self) -> Optional[str]:
-        return '%s/assets' % dirname(__file__)
+    def assets_directory_path(self) -> Optional[Path]:
+        return Path(__file__).parent / 'assets'
 
     async def _render(self) -> None:
-        build_directory_path = path.join(self._app.configuration.cache_directory_path, self.name(),
-                                         hashlib.md5(self.assets_directory_path.encode()).hexdigest(), 'build')
+        build_directory_path = self._app.configuration.cache_directory_path / self.name() / hashlib.md5(str(self.assets_directory_path).encode()).hexdigest() / 'build'
 
         async with DirectoryBackup(build_directory_path, 'node_modules'):
             with suppress(FileNotFoundError):
                 shutil.rmtree(build_directory_path)
-            shutil.copytree(path.join(self.assets_directory_path, 'js'), build_directory_path)
+            shutil.copytree(self.assets_directory_path / 'js', build_directory_path)
         await self._app.renderer.render_tree(build_directory_path)
 
         self._app.executor.submit(_do_render, build_directory_path, self._app.configuration.www_directory_path)
 
 
-def _do_render(build_directory_path: str, www_directory_path: str) -> None:
+def _do_render(build_directory_path: Path, www_directory_path: Path) -> None:
     # Use a shell on Windows so subprocess can find the executables it needs (see https://bugs.python.org/issue17023).
     shell = sys.platform.startswith('win32')
 
     # Install third-party dependencies.
     subprocess.run(['npm', 'install', '--production'], cwd=build_directory_path, shell=shell)
 
-    shutil.copy2(path.join(build_directory_path, 'node_modules', 'redoc', 'bundles', 'redoc.standalone.js'), path.join(www_directory_path, 'redoc.js'))
+    shutil.copy2(build_directory_path / 'node_modules' / 'redoc' / 'bundles' / 'redoc.standalone.js', www_directory_path / 'redoc.js')
 
     logging.getLogger().info('Built the ReDoc API documentation.')

--- a/betty/extension/trees/__init__.py
+++ b/betty/extension/trees/__init__.py
@@ -3,8 +3,7 @@ import logging
 import shutil
 import sys
 from contextlib import suppress
-from os import path
-from os.path import dirname
+from pathlib import Path
 from typing import Optional, Iterable
 
 from betty import subprocess
@@ -27,17 +26,16 @@ class Trees(Extension, AppAwareFactory, HtmlProvider, Generator):
         await self._render()
 
     @property
-    def assets_directory_path(self) -> Optional[str]:
-        return '%s/assets' % dirname(__file__)
+    def assets_directory_path(self) -> Optional[Path]:
+        return Path(__file__).parent / 'assets'
 
     async def _render(self) -> None:
-        build_directory_path = path.join(self._app.configuration.cache_directory_path, self.name(),
-                                         hashlib.md5(self.assets_directory_path.encode()).hexdigest(), 'build')
+        build_directory_path = self._app.configuration.cache_directory_path / self.name() / hashlib.md5(str(self.assets_directory_path).encode()).hexdigest() / 'build'
 
         async with DirectoryBackup(build_directory_path, 'node_modules'):
             with suppress(FileNotFoundError):
                 shutil.rmtree(build_directory_path)
-            shutil.copytree(path.join(self.assets_directory_path, 'js'), build_directory_path)
+            shutil.copytree(self.assets_directory_path / 'js', build_directory_path)
         await self._app.renderer.render_tree(build_directory_path)
 
         self._app.executor.submit(_do_render, build_directory_path, self._app.configuration.www_directory_path)
@@ -55,7 +53,7 @@ class Trees(Extension, AppAwareFactory, HtmlProvider, Generator):
         }
 
 
-def _do_render(build_directory_path: str, www_directory_path: str) -> None:
+def _do_render(build_directory_path: Path, www_directory_path: Path) -> None:
     # Use a shell on Windows so subprocess can find the executables it needs (see https://bugs.python.org/issue17023).
     shell = sys.platform.startswith('win32')
 
@@ -64,8 +62,8 @@ def _do_render(build_directory_path: str, www_directory_path: str) -> None:
 
     # Run Webpack.
     subprocess.run(['npm', 'run', 'webpack'], cwd=build_directory_path, shell=shell)
-    output_directory_path = path.join(path.dirname(build_directory_path), 'output')
-    shutil.copy2(path.join(output_directory_path, 'trees.css'), path.join(www_directory_path, 'trees.css'))
-    shutil.copy2(path.join(output_directory_path, 'trees.js'), path.join(www_directory_path, 'trees.js'))
+    output_directory_path = build_directory_path.parent / 'output'
+    shutil.copy2(output_directory_path / 'trees.css', www_directory_path / 'trees.css')
+    shutil.copy2(output_directory_path / 'trees.js', www_directory_path / 'trees.js')
 
     logging.getLogger().info('Built the interactive family trees.')

--- a/betty/fs.py
+++ b/betty/fs.py
@@ -3,74 +3,76 @@ import os
 import shutil
 from collections import deque
 from contextlib import suppress
-from os import walk, path
-from os.path import join, dirname, exists, relpath, getmtime
+from os.path import getmtime
+from pathlib import Path
 from shutil import copy2
 from tempfile import mkdtemp
 from typing import AsyncIterable
 
+from betty.os import PathLike
 
-async def iterfiles(path: str) -> AsyncIterable[str]:
-    for dir_path, _, filenames in walk(path):
+ROOT_DIRECTORY_PATH = Path(__file__).resolve().parents[1]
+
+
+CACHE_DIRECTORY_PATH = Path.home() / '.betty'
+
+
+async def iterfiles(path: PathLike) -> AsyncIterable[Path]:
+    for dir_path, _, filenames in os.walk(path):
         for filename in filenames:
-            yield join(dir_path, filename)
+            yield Path(dir_path) / filename
 
 
-def makedirs(path: str) -> None:
-    os.makedirs(path, 0o755, True)
-
-
-def hashfile(path: str) -> str:
-    return hashlib.md5(':'.join([str(getmtime(path)), path]).encode('utf-8')).hexdigest()
+def hashfile(path: PathLike) -> str:
+    return hashlib.md5(':'.join([str(getmtime(path)), str(path)]).encode('utf-8')).hexdigest()
 
 
 class FileSystem:
-    def __init__(self, *paths):
-        self._paths = deque(paths)
+    def __init__(self, *paths: PathLike):
+        self._paths = deque(map(Path, paths))
 
     @property
     def paths(self) -> deque:
         return self._paths
 
-    async def open(self, *file_paths: str):
-        for file_path in file_paths:
+    async def open(self, *file_paths: PathLike):
+        for file_path in map(Path, file_paths):
             for fs_path in self._paths:
                 with suppress(FileNotFoundError):
-                    return open(join(fs_path, file_path))
+                    return open(fs_path / file_path)
         raise FileNotFoundError
 
-    async def copy2(self, source_path: str, destination_path: str) -> str:
+    async def copy2(self, source_path: PathLike, destination_path: PathLike) -> Path:
         for fs_path in self._paths:
             with suppress(FileNotFoundError):
-                return copy2(join(fs_path, source_path), destination_path)
-        tried_paths = [join(fs_path, source_path) for fs_path in self._paths]
-        raise FileNotFoundError('Could not find any of %s.' %
-                                ', '.join(tried_paths))
+                return copy2(fs_path / source_path, destination_path)
+        tried_paths = [str(fs_path / source_path) for fs_path in self._paths]
+        raise FileNotFoundError('Could not find any of %s.' % ', '.join(tried_paths))
 
-    async def copytree(self, source_path: str, destination_path: str) -> str:
+    async def copytree(self, source_path: PathLike, destination_path: PathLike) -> Path:
+        source_path = Path(source_path)
+        destination_path = Path(destination_path)
         for fs_path in self._paths:
-            async for file_source_path in iterfiles(join(fs_path, source_path)):
-                file_destination_path = join(destination_path, relpath(
-                    file_source_path, join(fs_path, source_path)))
-                if not exists(file_destination_path):
-                    makedirs(dirname(file_destination_path))
+            async for file_source_path in iterfiles(fs_path / source_path):
+                file_destination_path = destination_path / file_source_path.relative_to(fs_path / source_path)
+                if not file_destination_path.exists():
+                    file_destination_path.parent.mkdir(exist_ok=True, parents=True)
                     copy2(file_source_path, file_destination_path)
         return destination_path
 
 
 class DirectoryBackup:
-    def __init__(self, root_path: str, backup_path: str):
-        self._root_path = root_path
-        self._backup_path = backup_path
+    def __init__(self, root_path: PathLike, backup_path: PathLike):
+        self._root_path = Path(root_path)
+        self._backup_path = Path(backup_path)
 
     async def __aenter__(self):
         self._tmp = mkdtemp()
         with suppress(FileNotFoundError):
-            shutil.move(path.join(self._root_path, self._backup_path), self._tmp)
+            shutil.move(str(self._root_path / self._backup_path), self._tmp)
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         with suppress(FileNotFoundError):
-            shutil.move(path.join(self._tmp, self._backup_path),
-                        path.join(self._root_path, self._backup_path))
+            shutil.move(str(self._tmp / self._backup_path), str(self._root_path / self._backup_path))
         shutil.rmtree(self._tmp)

--- a/betty/os.py
+++ b/betty/os.py
@@ -1,8 +1,11 @@
 import os
 import shutil
+from typing import Union
+
+PathLike = Union[str, os.PathLike]
 
 
-def link_or_copy(source_path: str, destination_path: str) -> None:
+def link_or_copy(source_path: PathLike, destination_path: PathLike) -> None:
     try:
         os.link(source_path, destination_path)
     except OSError:
@@ -10,7 +13,7 @@ def link_or_copy(source_path: str, destination_path: str) -> None:
 
 
 class ChDir:
-    def __init__(self, directory_path: str):
+    def __init__(self, directory_path: PathLike):
         self._directory_path = directory_path
         self._owd = None
 

--- a/betty/path.py
+++ b/betty/path.py
@@ -1,17 +1,13 @@
-from os import path
-from os.path import splitext
-from typing import Optional
+from pathlib import Path
+
+from betty.os import PathLike
 
 
-def rootname(source_path: str) -> str:
+def rootname(source_path: PathLike) -> Path:
+    source_path = Path(source_path)
     root = source_path
     while True:
-        possible_root = path.dirname(root)
+        possible_root = root.parent
         if possible_root == root:
             return root
         root = possible_root
-
-
-def extension(path: str) -> Optional[str]:
-    extension = splitext(path)[1][1:]
-    return extension if extension else None

--- a/betty/render.py
+++ b/betty/render.py
@@ -1,11 +1,13 @@
 from typing import List
 
+from betty.os import PathLike
+
 
 class Renderer:
-    async def render_file(self, file_path: str) -> None:
+    async def render_file(self, file_path: PathLike) -> None:
         raise NotImplementedError
 
-    async def render_tree(self, tree_path: str) -> None:
+    async def render_tree(self, tree_path: PathLike) -> None:
         raise NotImplementedError
 
 
@@ -13,10 +15,10 @@ class SequentialRenderer(Renderer):
     def __init__(self, renderers: List[Renderer]):
         self._renderers = renderers
 
-    async def render_file(self, file_path: str) -> None:
+    async def render_file(self, file_path: PathLike) -> None:
         for renderer in self._renderers:
             await renderer.render_file(file_path)
 
-    async def render_tree(self, tree_path: str) -> None:
+    async def render_tree(self, tree_path: PathLike) -> None:
         for renderer in self._renderers:
             await renderer.render_tree(tree_path)

--- a/betty/serve.py
+++ b/betty/serve.py
@@ -7,7 +7,7 @@ from io import StringIO
 from typing import Iterable
 
 from betty.error import UserFacingError
-from betty.os import ChDir
+from betty.os import ChDir, PathLike
 from betty.app import App
 
 DEFAULT_PORT = 8000
@@ -79,7 +79,7 @@ class AppServer(Server):
 
 
 class BuiltinServer(Server):
-    def __init__(self, www_directory_path: str):
+    def __init__(self, www_directory_path: PathLike):
         self._www_directory_path = www_directory_path
         self._http_server = None
         self._cwd = None

--- a/betty/tests/__init__.py
+++ b/betty/tests/__init__.py
@@ -1,5 +1,9 @@
 import logging
 from contextlib import suppress
+from pathlib import Path
+
+from betty import fs
+
 try:
     from contextlib import asynccontextmanager
 except ImportError:
@@ -10,20 +14,19 @@ import unittest
 
 from jinja2 import Environment, Template
 
-import betty
 from betty.config import Configuration
 from betty.app import App
 
 
 def patch_cache(f):
     def _patch_cache(*args, **kwargs):
-        original_cache_directory_path = betty._CACHE_DIRECTORY_PATH
+        original_cache_directory_path = fs.CACHE_DIRECTORY_PATH
         cache_directory = TemporaryDirectory()
-        betty._CACHE_DIRECTORY_PATH = cache_directory.name
+        fs.CACHE_DIRECTORY_PATH = Path(cache_directory.name)
         try:
             f(*args, **kwargs)
         finally:
-            betty._CACHE_DIRECTORY_PATH = original_cache_directory_path
+            fs.CACHE_DIRECTORY_PATH = original_cache_directory_path
             # Pythons 3.6 and 3.7 do not allow the temporary directory to have been removed already.
             with suppress(FileNotFoundError):
                 cache_directory.cleanup()

--- a/betty/tests/assets/locale/test_translations.py
+++ b/betty/tests/assets/locale/test_translations.py
@@ -1,14 +1,14 @@
 import gettext
-from os import path, listdir
+from os import listdir
+from pathlib import Path
 
 from betty.locale import open_translations
 from betty.tests import TestCase
 
-_ASSETS_DIRECTORY_PATH = path.join(path.dirname(path.dirname(path.dirname(path.dirname(__file__)))), 'assets')
-
 
 class TranslationsTest(TestCase):
     def test(self) -> None:
-        for locale_path_name in listdir(path.join(_ASSETS_DIRECTORY_PATH, 'locale')):
+        assets_directory_path = Path(__file__).parents[3] / 'assets'
+        for locale_path_name in listdir(assets_directory_path / 'locale'):
             locale = locale_path_name.replace('_', '-')
-            self.assertIsInstance(open_translations(locale, _ASSETS_DIRECTORY_PATH), gettext.NullTranslations)
+            self.assertIsInstance(open_translations(locale, assets_directory_path), gettext.NullTranslations)

--- a/betty/tests/extension/gramps/test__init__.py
+++ b/betty/tests/extension/gramps/test__init__.py
@@ -1,4 +1,4 @@
-from os.path import join, dirname, abspath
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Optional, Any, Dict
 
@@ -34,7 +34,7 @@ class LoadXmlTest(TestCase):
             configuration = Configuration(output_directory_path, 'https://example.com')
             async with App(configuration) as app:
                 cls.ancestry = app.ancestry
-                xml_file_path = join(dirname(abspath(__file__)), 'assets', 'data.xml')
+                xml_file_path = Path(__file__).parent / 'assets' / 'data.xml'
                 with open(xml_file_path) as f:
                     load_xml(app.ancestry, f.read(), rootname(xml_file_path))
 
@@ -44,7 +44,7 @@ class LoadXmlTest(TestCase):
             configuration = Configuration(output_directory_path, 'https://example.com')
             async with App(configuration) as app:
                 with TemporaryDirectory() as tree_directory_path:
-                    load_xml(app.ancestry, xml.strip(), tree_directory_path)
+                    load_xml(app.ancestry, xml.strip(), Path(tree_directory_path))
                     return app.ancestry
 
     def _load_partial(self, xml: str) -> Ancestry:
@@ -67,7 +67,7 @@ class LoadXmlTest(TestCase):
         with TemporaryDirectory() as output_directory_path:
             configuration = Configuration(output_directory_path, 'https://example.com')
             async with App(configuration) as app:
-                gramps_file_path = join(dirname(abspath(__file__)), 'assets', 'minimal.xml')
+                gramps_file_path = Path(__file__).parent / 'assets' / 'minimal.xml'
                 with open(gramps_file_path) as f:
                     load_xml(app.ancestry, f.read(), rootname(gramps_file_path))
 
@@ -76,7 +76,7 @@ class LoadXmlTest(TestCase):
         with TemporaryDirectory() as output_directory_path:
             configuration = Configuration(output_directory_path, 'https://example.com')
             async with App(configuration) as app:
-                gramps_file_path = join(dirname(abspath(__file__)), 'assets', 'minimal.xml')
+                gramps_file_path = Path(__file__).parent / 'assets' / 'minimal.xml'
                 load_xml(app.ancestry, gramps_file_path, rootname(gramps_file_path))
 
     @sync
@@ -84,7 +84,7 @@ class LoadXmlTest(TestCase):
         with TemporaryDirectory() as output_directory_path:
             configuration = Configuration(output_directory_path, 'https://example.com')
             async with App(configuration) as app:
-                gramps_file_path = join(dirname(abspath(__file__)), 'assets', 'minimal.gramps')
+                gramps_file_path = Path(__file__).parent / 'assets' / 'minimal.gramps'
                 load_gramps(app.ancestry, gramps_file_path)
 
     @sync
@@ -92,7 +92,7 @@ class LoadXmlTest(TestCase):
         with TemporaryDirectory() as output_directory_path:
             configuration = Configuration(output_directory_path, 'https://example.com')
             async with App(configuration) as app:
-                gramps_file_path = join(dirname(abspath(__file__)), 'assets', 'minimal.gpkg')
+                gramps_file_path = Path(__file__).parent / 'assets' / 'minimal.gpkg'
                 load_gpkg(app.ancestry, gramps_file_path)
 
     def test_place_should_include_name(self):
@@ -657,12 +657,13 @@ class GrampsTest(TestCase):
   </notes>
 </database>
 """.strip()
-        with TemporaryDirectory() as working_directory:
-            gramps_family_tree_one_path = join(working_directory, 'one.xml')
+        with TemporaryDirectory() as working_directory_path_str:
+            working_directory_path = Path(working_directory_path_str)
+            gramps_family_tree_one_path = working_directory_path / 'one.xml'
             with open(gramps_family_tree_one_path, mode='w') as f:
                 f.write(family_tree_one_xml)
 
-            gramps_family_tree_two_path = join(working_directory, 'two.xml')
+            gramps_family_tree_two_path = working_directory_path / 'two.xml'
             with open(gramps_family_tree_two_path, mode='w') as f:
                 f.write(family_tree_two_xml)
 

--- a/betty/tests/extension/maps/test__init__.py
+++ b/betty/tests/extension/maps/test__init__.py
@@ -1,4 +1,3 @@
-from os.path import join
 from tempfile import TemporaryDirectory
 
 from betty.config import Configuration
@@ -14,16 +13,15 @@ class MapsTest(TestCase):
     @sync
     async def test_post_render_event(self):
         with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(
-                output_directory_path, 'https://ancestry.example.com')
+            configuration = Configuration(output_directory_path, 'https://ancestry.example.com')
             configuration.mode = 'development'
             configuration.extensions[Maps] = None
             async with App(configuration) as app:
                 await generate(app)
-            with open(join(configuration.www_directory_path, 'maps.js')) as f:
+            with open(configuration.www_directory_path / 'maps.js') as f:
                 betty_js = f.read()
             self.assertIn('maps.js', betty_js)
             self.assertIn('maps.css', betty_js)
-            with open(join(configuration.www_directory_path, 'maps.css')) as f:
+            with open(configuration.www_directory_path / 'maps.css') as f:
                 betty_css = f.read()
             self.assertIn('.map', betty_css)

--- a/betty/tests/extension/nginx/test__init__.py
+++ b/betty/tests/extension/nginx/test__init__.py
@@ -1,5 +1,4 @@
 import re
-from os.path import join
 from tempfile import TemporaryDirectory
 from typing import Optional
 
@@ -26,7 +25,7 @@ class NginxTest(TestCase):
     async def _assert_configuration_equals(self, expected: str, configuration: Configuration):
         async with App(configuration) as app:
             await generate(app)
-        with open(join(configuration.output_directory_path, 'nginx', 'nginx.conf')) as f:
+        with open(configuration.output_directory_path / 'nginx' / 'nginx.conf') as f:
             actual = f.read()
         self.assertEqual(self._normalize_configuration(expected), self._normalize_configuration(actual))
 

--- a/betty/tests/extension/nginx/test_serve.py
+++ b/betty/tests/extension/nginx/test_serve.py
@@ -1,6 +1,5 @@
 import sys
 import unittest
-from os import path, makedirs
 from tempfile import TemporaryDirectory
 from time import sleep
 
@@ -22,8 +21,8 @@ class DockerizedNginxServerTest(TestCase):
         with TemporaryDirectory() as output_directory_path:
             configuration = Configuration(output_directory_path, 'https://example.com')
             configuration.extensions[Nginx] = Nginx.configuration_schema({})
-            makedirs(configuration.www_directory_path)
-            with open(path.join(configuration.www_directory_path, 'index.html'), 'w') as f:
+            configuration.www_directory_path.mkdir(parents=True)
+            with open(configuration.www_directory_path / 'index.html', 'w') as f:
                 f.write(content)
             async with App(configuration) as app:
                 async with DockerizedNginxServer(app) as server:

--- a/betty/tests/extension/redoc/test__init__.py
+++ b/betty/tests/extension/redoc/test__init__.py
@@ -1,4 +1,4 @@
-from os import path
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from betty.config import Configuration
@@ -13,10 +13,11 @@ class ReDocTest(TestCase):
     @patch_cache
     @sync
     async def test(self):
-        with TemporaryDirectory() as output_directory_path:
+        with TemporaryDirectory() as output_directory_path_str:
+            output_directory_path = Path(output_directory_path_str)
             configuration = Configuration(output_directory_path, 'https://ancestry.example.com')
             configuration.extensions[ReDoc] = None
             async with App(configuration) as app:
                 await generate(app)
-            self.assertTrue(path.isfile(path.join(output_directory_path, 'www', 'api', 'index.html')))
-            self.assertTrue(path.isfile(path.join(output_directory_path, 'www', 'redoc.js')))
+            self.assertTrue((output_directory_path / 'www' / 'api' / 'index.html').is_file())
+            self.assertTrue((output_directory_path / 'www' / 'redoc.js').is_file())

--- a/betty/tests/extension/trees/test__init__.py
+++ b/betty/tests/extension/trees/test__init__.py
@@ -1,4 +1,3 @@
-from os.path import join
 from tempfile import TemporaryDirectory
 
 from betty.config import Configuration
@@ -14,16 +13,15 @@ class TreesTest(TestCase):
     @sync
     async def test_post_render_event(self):
         with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(
-                output_directory_path, 'https://ancestry.example.com')
+            configuration = Configuration(output_directory_path, 'https://ancestry.example.com')
             configuration.mode = 'development'
             configuration.extensions[Trees] = None
             async with App(configuration) as app:
                 await generate(app)
-            with open(join(configuration.www_directory_path, 'trees.js')) as f:
+            with open(configuration.www_directory_path / 'trees.js') as f:
                 betty_js = f.read()
             self.assertIn('trees.js', betty_js)
             self.assertIn('trees.css', betty_js)
-            with open(join(configuration.www_directory_path, 'trees.css')) as f:
+            with open(configuration.www_directory_path / 'trees.css') as f:
                 betty_css = f.read()
             self.assertIn('.tree', betty_css)

--- a/betty/tests/extension/wikipedia/test__init__.py
+++ b/betty/tests/extension/wikipedia/test__init__.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from time import sleep
 from typing import Tuple, Optional
@@ -96,7 +97,7 @@ class RetrieverTest(TestCase):
         m_aioresponses.get(api_url, payload=api_response_body)
         with TemporaryDirectory() as cache_directory_path:
             async with aiohttp.ClientSession() as session:
-                translations = await _Retriever(session, cache_directory_path).get_translations(entry_language, entry_name)
+                translations = await _Retriever(session, Path(cache_directory_path)).get_translations(entry_language, entry_name)
         self.assertEqual(expected, translations)
 
     @aioresponses()
@@ -110,7 +111,7 @@ class RetrieverTest(TestCase):
         with TemporaryDirectory() as cache_directory_path:
             with self.assertRaises(RetrievalError):
                 async with aiohttp.ClientSession() as session:
-                    await _Retriever(session, cache_directory_path).get_translations(entry_language, entry_name)
+                    await _Retriever(session, Path(cache_directory_path)).get_translations(entry_language, entry_name)
 
     @aioresponses()
     @patch('sys.stderr')
@@ -123,7 +124,7 @@ class RetrieverTest(TestCase):
         with TemporaryDirectory() as cache_directory_path:
             with self.assertRaises(RetrievalError):
                 async with aiohttp.ClientSession() as session:
-                    await _Retriever(session, cache_directory_path).get_translations(entry_language, entry_name)
+                    await _Retriever(session, Path(cache_directory_path)).get_translations(entry_language, entry_name)
 
     @parameterized.expand([
         ({},),
@@ -152,7 +153,7 @@ class RetrieverTest(TestCase):
         with TemporaryDirectory() as cache_directory_path:
             with self.assertRaises(RetrievalError):
                 async with aiohttp.ClientSession() as session:
-                    await _Retriever(session, cache_directory_path).get_translations(entry_language, entry_name)
+                    await _Retriever(session, Path(cache_directory_path)).get_translations(entry_language, entry_name)
 
     @aioresponses()
     @sync
@@ -189,7 +190,7 @@ class RetrieverTest(TestCase):
         m_aioresponses.get(api_url, payload=api_response_body_4)
         with TemporaryDirectory() as cache_directory_path:
             async with aiohttp.ClientSession() as session:
-                retriever = _Retriever(session, cache_directory_path, 1)
+                retriever = _Retriever(session, Path(cache_directory_path), 1)
                 # The first retrieval should make a successful request and set the cache.
                 entry_1 = await retriever.get_entry(entry_language, entry_name)
                 # The second retrieval should hit the cache from the first request.
@@ -220,7 +221,7 @@ class RetrieverTest(TestCase):
         m_aioresponses.get(api_url, exception=aiohttp.ClientError())
         with TemporaryDirectory() as cache_directory_path:
             async with aiohttp.ClientSession() as session:
-                retriever = _Retriever(session, cache_directory_path)
+                retriever = _Retriever(session, Path(cache_directory_path))
                 with self.assertRaises(RetrievalError):
                     await retriever.get_entry(entry_language, entry_name)
 
@@ -502,7 +503,7 @@ class WikipediaTest(TestCase):
             with TemporaryDirectory() as cache_directory_path:
                 configuration = Configuration(
                     output_directory_path, 'https://ancestry.example.com')
-                configuration.cache_directory_path = cache_directory_path
+                configuration.cache_directory_path = Path(cache_directory_path)
                 configuration.extensions[Wikipedia] = None
                 async with App(configuration) as app:
                     actual = app.jinja2_environment.from_string(
@@ -545,7 +546,7 @@ class WikipediaTest(TestCase):
             with TemporaryDirectory() as cache_directory_path:
                 configuration = Configuration(
                     output_directory_path, 'https://example.com')
-                configuration.cache_directory_path = cache_directory_path
+                configuration.cache_directory_path = Path(cache_directory_path)
                 configuration.extensions[Wikipedia] = None
                 async with App(configuration) as app:
                     app.ancestry.sources[resource.id] = resource

--- a/betty/tests/test_ancestry.py
+++ b/betty/tests/test_ancestry.py
@@ -1,5 +1,6 @@
 from gettext import NullTranslations
-from tempfile import TemporaryFile, NamedTemporaryFile
+from pathlib import Path
+from tempfile import NamedTemporaryFile
 from typing import Any
 from unittest.mock import Mock
 
@@ -203,13 +204,13 @@ class FileTest(TestCase):
 
     def test_id(self) -> None:
         file_id = 'BETTY01'
-        file_path = '/tmp/betty'
+        file_path = Path('~')
         sut = File(file_id, file_path)
         self.assertEquals(file_id, sut.id)
 
     def test_private(self) -> None:
         file_id = 'BETTY01'
-        file_path = '/tmp/betty'
+        file_path = Path('~')
         sut = File(file_id, file_path)
         self.assertIsNone(sut.private)
         private = True
@@ -218,35 +219,29 @@ class FileTest(TestCase):
 
     def test_media_type(self) -> None:
         file_id = 'BETTY01'
-        file_path = '/tmp/betty'
+        file_path = Path('~')
         sut = File(file_id, file_path)
         self.assertIsNone(sut.media_type)
         media_type = MediaType('text/plain')
         sut.media_type = media_type
         self.assertEquals(media_type, sut.media_type)
 
-    def test_path(self) -> None:
-        with TemporaryFile() as f:
+    def test_path_with_path(self) -> None:
+        with NamedTemporaryFile() as f:
             file_id = 'BETTY01'
-            sut = File(file_id, f.name)
-            self.assertEquals(f.name, sut.path)
+            file_path = Path(f.name)
+            sut = File(file_id, file_path)
+            self.assertEquals(file_path, sut.path)
 
-    def test_extension_with_extension(self) -> None:
-        extension = 'betty'
-        with NamedTemporaryFile(suffix='.%s' % extension) as f:
-            file_id = 'BETTY01'
-            sut = File(file_id, f.name)
-            self.assertEquals(extension, sut.extension)
-
-    def test_extension_without_extension(self) -> None:
+    def test_path_with_str(self) -> None:
         with NamedTemporaryFile() as f:
             file_id = 'BETTY01'
             sut = File(file_id, f.name)
-            self.assertIsNone(sut.extension)
+            self.assertEquals(Path(f.name), sut.path)
 
     def test_description(self) -> None:
         file_id = 'BETTY01'
-        file_path = '/tmp/betty'
+        file_path = Path('~')
         sut = File(file_id, file_path)
         self.assertIsNone(sut.description)
         description = 'Hi, my name is Betty!'
@@ -255,7 +250,7 @@ class FileTest(TestCase):
 
     def test_notes(self) -> None:
         file_id = 'BETTY01'
-        file_path = '/tmp/betty'
+        file_path = Path('~')
         sut = File(file_id, file_path)
         self.assertCountEqual([], sut.notes)
         notes = [Mock(Note), Mock(Note)]
@@ -264,7 +259,7 @@ class FileTest(TestCase):
 
     def test_resources(self) -> None:
         file_id = 'BETTY01'
-        file_path = '/tmp/betty'
+        file_path = Path('~')
         sut = File(file_id, file_path)
         self.assertCountEqual([], sut.resources)
         resources = [Mock(HasFiles), Mock(HasFiles)]
@@ -273,27 +268,9 @@ class FileTest(TestCase):
 
     def test_citations(self) -> None:
         file_id = 'BETTY01'
-        file_path = '/tmp/betty'
+        file_path = Path('~')
         sut = File(file_id, file_path)
         self.assertCountEqual([], sut.citations)
-
-    def test_name(self) -> None:
-        file_id = 'BETTY01'
-        file_path = '/tmp/betty.png'
-        sut = File(file_id, file_path)
-        self.assertEquals('betty.png', sut.name)
-
-    def test_basename(self) -> None:
-        file_id = 'BETTY01'
-        file_path = '/tmp/betty.png'
-        sut = File(file_id, file_path)
-        self.assertEquals('/tmp/betty', sut.basename)
-
-    def test_extension(self) -> None:
-        file_id = 'BETTY01'
-        file_path = '/tmp/betty.png'
-        sut = File(file_id, file_path)
-        self.assertEquals('png', sut.extension)
 
 
 class HasFilesTest(TestCase):

--- a/betty/tests/test_app.py
+++ b/betty/tests/test_app.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import List, Type, Set, Dict, Optional
 
 from voluptuous import Schema, Required, Invalid
@@ -216,7 +217,7 @@ class AppTest(TestCase):
 
     @sync
     async def test_resources_with_assets_directory_path(self):
-        assets_directory_path = '/tmp/betty'
+        assets_directory_path = Path('/tmp/betty')
         configuration = Configuration(**self._MINIMAL_CONFIGURATION_ARGS)
         configuration.assets_directory_path = assets_directory_path
         async with App(configuration) as sut:

--- a/betty/tests/test_cli.py
+++ b/betty/tests/test_cli.py
@@ -1,6 +1,6 @@
 import unittest
 from json import dump
-from os import path, makedirs
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Callable, Dict
 from unittest.mock import patch
@@ -8,8 +8,7 @@ from unittest.mock import patch
 import click
 from click.testing import CliRunner
 
-import betty
-from betty import os
+from betty import os, fs
 from betty.error import UserFacingError
 from betty.extension import Extension
 from betty.serve import Server
@@ -56,7 +55,7 @@ class MainTest(TestCase):
 
     def test_configuration_without_help(self, _, __):
         with TemporaryDirectory() as working_directory_path:
-            configuration_file_path = path.join(working_directory_path, 'betty.json')
+            configuration_file_path = Path(working_directory_path) / 'betty.json'
             with TemporaryDirectory() as output_directory_path:
                 url = 'https://example.com'
                 config_dict = {
@@ -72,7 +71,7 @@ class MainTest(TestCase):
 
     def test_help_with_configuration(self, _, __):
         with TemporaryDirectory() as working_directory_path:
-            configuration_file_path = path.join(working_directory_path, 'betty.json')
+            configuration_file_path = Path(working_directory_path) / 'betty.json'
             with TemporaryDirectory() as output_directory_path:
                 url = 'https://example.com'
                 config_dict = {
@@ -91,7 +90,7 @@ class MainTest(TestCase):
 
     def test_help_with_invalid_configuration_file_path(self, _, __):
         with TemporaryDirectory() as working_directory_path:
-            configuration_file_path = path.join(working_directory_path, 'non-existent-betty.json')
+            configuration_file_path = Path(working_directory_path) / 'non-existent-betty.json'
 
             runner = CliRunner()
             result = runner.invoke(main, ('-c', configuration_file_path, '--help',), catch_exceptions=False)
@@ -99,7 +98,7 @@ class MainTest(TestCase):
 
     def test_help_with_invalid_configuration(self, _, __):
         with TemporaryDirectory() as working_directory_path:
-            configuration_file_path = path.join(working_directory_path, 'betty.json')
+            configuration_file_path = Path(working_directory_path) / 'betty.json'
             config_dict = {}
             with open(configuration_file_path, 'w') as f:
                 dump(config_dict, f)
@@ -111,7 +110,7 @@ class MainTest(TestCase):
     def test_with_discovered_configuration(self, _, __):
         with TemporaryDirectory() as working_directory_path:
             with TemporaryDirectory() as output_directory_path:
-                with open(path.join(working_directory_path, 'betty.json'), 'w') as config_file:
+                with open(Path(working_directory_path) / 'betty.json', 'w') as config_file:
                     url = 'https://example.com'
                     config_dict = {
                         'output': output_directory_path,
@@ -157,7 +156,7 @@ class VersionTest(TestCase):
 class ClearCachesTest(TestCase):
     @patch_cache
     def test(self):
-        cached_file_path = path.join(betty._CACHE_DIRECTORY_PATH, 'KeepMeAroundPlease')
+        cached_file_path = Path(fs.CACHE_DIRECTORY_PATH) / 'KeepMeAroundPlease'
         open(cached_file_path, 'w').close()
         runner = CliRunner()
         result = runner.invoke(main, ('clear-caches',), catch_exceptions=False)
@@ -179,7 +178,7 @@ class GenerateTest(TestCase):
     @patch('betty.load.load', new_callable=AsyncMock)
     def test(self, m_parse, m_generate):
         with TemporaryDirectory() as working_directory_path:
-            configuration_file_path = path.join(working_directory_path, 'betty.json')
+            configuration_file_path = Path(working_directory_path) / 'betty.json'
             with TemporaryDirectory() as output_directory_path:
                 url = 'https://example.com'
                 config_dict = {
@@ -218,10 +217,10 @@ class ServeTest(TestCase):
     @patch('betty.serve.AppServer', new_callable=lambda: _KeyboardInterruptedServer)
     def test(self, m_server):
         with TemporaryDirectory() as working_directory_path:
-            configuration_file_path = path.join(working_directory_path, 'betty.json')
+            configuration_file_path = Path(working_directory_path) / 'betty.json'
             with TemporaryDirectory() as output_directory_path:
-                www_directory_path = path.join(output_directory_path, 'www')
-                makedirs(www_directory_path)
+                www_directory_path = Path(output_directory_path) / 'www'
+                www_directory_path.mkdir(parents=True)
                 url = 'https://example.com'
                 config_dict = {
                     'output': output_directory_path,
@@ -236,7 +235,7 @@ class ServeTest(TestCase):
 
     def test_without_www_directory_should_error(self):
         with TemporaryDirectory() as working_directory_path:
-            configuration_file_path = path.join(working_directory_path, 'betty.json')
+            configuration_file_path = Path(working_directory_path) / 'betty.json'
             with TemporaryDirectory() as output_directory_path:
                 url = 'https://example.com'
                 config_dict = {

--- a/betty/tests/test_config.py
+++ b/betty/tests/test_config.py
@@ -1,7 +1,7 @@
 import json
 from collections import OrderedDict
 from contextlib import contextmanager
-from os.path import join
+from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import Any, Dict, Optional
 
@@ -55,57 +55,57 @@ class LocaleConfigurationTest(TestCase):
 
 class ConfigurationTest(TestCase):
     def test_output_directory_path(self):
-        output_directory_path = '/tmp/betty'
+        output_directory_path = Path('~')
         sut = Configuration(output_directory_path, 'https://example.com')
         self.assertEquals(output_directory_path, sut.output_directory_path)
 
     def test_www_directory_path_with_absolute_path(self):
-        output_directory_path = '/tmp/betty'
+        output_directory_path = Path('~')
         sut = Configuration(output_directory_path, 'https://example.com')
-        expected = join(output_directory_path, 'www')
+        expected = output_directory_path / 'www'
         self.assertEquals(expected, sut.www_directory_path)
 
     def test_assets_directory_path_without_path(self):
-        sut = Configuration('/tmp/betty', 'https://example.com')
+        sut = Configuration('~', 'https://example.com')
         self.assertIsNone(sut.assets_directory_path)
 
     def test_assets_directory_path_with_path(self):
-        sut = Configuration('/tmp/betty', 'https://example.com')
+        sut = Configuration('~', 'https://example.com')
         assets_directory_path = '/tmp/betty-assets'
         sut.assets_directory_path = assets_directory_path
         self.assertEquals(assets_directory_path,
                           sut.assets_directory_path)
 
     def test_root_path(self):
-        sut = Configuration('/tmp/betty', 'https://example.com')
+        sut = Configuration('~', 'https://example.com')
         configured_root_path = '/betty'
         expected_root_path = '/betty/'
         sut.root_path = configured_root_path
         self.assertEquals(expected_root_path, sut.root_path)
 
     def test_clean_urls(self):
-        sut = Configuration('/tmp/betty', 'https://example.com')
+        sut = Configuration('~', 'https://example.com')
         clean_urls = True
         sut.clean_urls = clean_urls
         self.assertEquals(clean_urls, sut.clean_urls)
 
     def test_content_negotiation(self):
-        sut = Configuration('/tmp/betty', 'https://example.com')
+        sut = Configuration('~', 'https://example.com')
         content_negotiation = True
         sut.content_negotiation = content_negotiation
         self.assertEquals(content_negotiation, sut.content_negotiation)
 
     def test_clean_urls_implied_by_content_negotiation(self):
-        sut = Configuration('/tmp/betty', 'https://example.com')
+        sut = Configuration('~', 'https://example.com')
         sut.content_negotiation = True
         self.assertTrue(sut.clean_urls)
 
     def test_author_without_author(self):
-        sut = Configuration('/tmp/betty', 'https://example.com')
+        sut = Configuration('~', 'https://example.com')
         self.assertIsNone(sut.author)
 
     def test_author_with_author(self):
-        sut = Configuration('/tmp/betty', 'https://example.com')
+        sut = Configuration('~', 'https://example.com')
         author = 'Bart'
         sut.author = author
         self.assertEquals(author, sut.author)
@@ -142,7 +142,7 @@ class FromDictTest(TestCase):
     def test_should_parse_minimal(self, extension, dumper) -> None:
         with _build_minimal_config() as configuration_dict:
             configuration = _from_dict(configuration_dict)
-            self.assertEquals(configuration_dict['output'], configuration.output_directory_path)
+            self.assertEquals(Path(configuration_dict['output']).expanduser().resolve(), configuration.output_directory_path)
             self.assertEquals(configuration_dict['base_url'], configuration.base_url)
             self.assertEquals('Betty', configuration.title)
             self.assertIsNone(configuration.author)
@@ -228,7 +228,7 @@ class FromDictTest(TestCase):
             with _build_minimal_config() as configuration_dict:
                 configuration_dict['assets_directory_path'] = assets_directory_path
                 configuration = _from_dict(configuration_dict)
-                self.assertEquals(assets_directory_path, configuration.assets_directory_path)
+                self.assertEquals(Path(assets_directory_path).expanduser().resolve(), configuration.assets_directory_path)
 
     def test_should_parse_one_extension_with_configuration(self) -> None:
         with _build_minimal_config() as configuration_dict:

--- a/betty/tests/test_fs.py
+++ b/betty/tests/test_fs.py
@@ -1,5 +1,4 @@
-import os
-from os import mkdir, path
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from betty.fs import iterfiles, FileSystem, hashfile
@@ -11,28 +10,28 @@ class IterfilesTest(TestCase):
     @sync
     async def test_iterfiles(self):
         with TemporaryDirectory() as working_directory_path:
-            working_subdirectory_path = path.join(working_directory_path, 'subdir')
-            mkdir(working_subdirectory_path)
-            open(path.join(working_directory_path, 'rootfile'), 'a').close()
-            open(path.join(working_directory_path, '.hiddenrootfile'), 'a').close()
-            open(path.join(working_subdirectory_path, 'subdirfile'), 'a').close()
-            actual = [actualpath[len(working_directory_path) + 1:] async for actualpath in iterfiles(working_directory_path)]
+            working_subdirectory_path = Path(working_directory_path) / 'subdir'
+            working_subdirectory_path.mkdir()
+            open(Path(working_directory_path) / 'rootfile', 'a').close()
+            open(Path(working_directory_path) / '.hiddenrootfile', 'a').close()
+            open(Path(working_subdirectory_path) / 'subdirfile', 'a').close()
+            actual = [str(actualpath)[len(working_directory_path) + 1:] async for actualpath in iterfiles(working_directory_path)]
         expected = [
             '.hiddenrootfile',
             'rootfile',
-            path.join('subdir', 'subdirfile'),
+            str(Path('subdir') / 'subdirfile'),
         ]
         self.assertCountEqual(expected, actual)
 
 
 class HashfileTest(TestCase):
     def test_hashfile_with_identical_file(self):
-        file_path = path.join(path.dirname(path.dirname(__file__)), 'assets', 'public', 'static', 'betty-16x16.png')
+        file_path = Path(__file__).parents[1] / 'assets' / 'public' / 'static' / 'betty-16x16.png'
         self.assertEquals(hashfile(file_path), hashfile(file_path))
 
     def test_hashfile_with_different_files(self):
-        file_path_1 = path.join(path.dirname(path.dirname(__file__)), 'assets', 'public', 'static', 'betty-16x16.png')
-        file_path_2 = path.join(path.dirname(path.dirname(__file__)), 'assets', 'public', 'static', 'betty-512x512.png')
+        file_path_1 = Path(__file__).parents[1] / 'assets' / 'public' / 'static' / 'betty-16x16.png'
+        file_path_2 = Path(__file__).parents[1] / 'assets' / 'public' / 'static' / 'betty-512x512.png'
         self.assertNotEquals(hashfile(file_path_1), hashfile(file_path_2))
 
 
@@ -41,13 +40,13 @@ class FileSystemTest(TestCase):
     async def test_open(self):
         with TemporaryDirectory() as source_path_1:
             with TemporaryDirectory() as source_path_2:
-                with open(path.join(source_path_1, 'apples'), 'w') as f:
+                with open(Path(source_path_1) / 'apples', 'w') as f:
                     f.write('apples')
-                with open(path.join(source_path_2, 'apples'), 'w') as f:
+                with open(Path(source_path_2) / 'apples', 'w') as f:
                     f.write('notapples')
-                with open(path.join(source_path_1, 'oranges'), 'w') as f:
+                with open(Path(source_path_1) / 'oranges', 'w') as f:
                     f.write('oranges')
-                with open(path.join(source_path_2, 'bananas'), 'w') as f:
+                with open(Path(source_path_2) / 'bananas', 'w') as f:
                     f.write('bananas')
 
                 sut = FileSystem(source_path_1, source_path_2)
@@ -67,13 +66,13 @@ class FileSystemTest(TestCase):
     async def test_open_with_first_file_path_alternative_first_source_path(self):
         with TemporaryDirectory() as source_path_1:
             with TemporaryDirectory() as source_path_2:
-                with open(path.join(source_path_1, 'pinkladies'), 'w') as f:
+                with open(Path(source_path_1) / 'pinkladies', 'w') as f:
                     f.write('pinkladies')
-                with open(path.join(source_path_2, 'pinkladies'), 'w') as f:
+                with open(Path(source_path_2) / 'pinkladies', 'w') as f:
                     f.write('notpinkladies')
-                with open(path.join(source_path_1, 'apples'), 'w') as f:
+                with open(Path(source_path_1) / 'apples', 'w') as f:
                     f.write('notpinkladies')
-                with open(path.join(source_path_2, 'apples'), 'w') as f:
+                with open(Path(source_path_2) / 'apples', 'w') as f:
                     f.write('notpinkladies')
 
                 sut = FileSystem(source_path_1, source_path_2)
@@ -85,11 +84,11 @@ class FileSystemTest(TestCase):
     async def test_open_with_first_file_path_alternative_second_source_path(self):
         with TemporaryDirectory() as source_path_1:
             with TemporaryDirectory() as source_path_2:
-                with open(path.join(source_path_2, 'pinkladies'), 'w') as f:
+                with open(Path(source_path_2) / 'pinkladies', 'w') as f:
                     f.write('pinkladies')
-                with open(path.join(source_path_1, 'apples'), 'w') as f:
+                with open(Path(source_path_1) / 'apples', 'w') as f:
                     f.write('notpinkladies')
-                with open(path.join(source_path_2, 'apples'), 'w') as f:
+                with open(Path(source_path_2) / 'apples', 'w') as f:
                     f.write('notpinkladies')
 
                 sut = FileSystem(source_path_1, source_path_2)
@@ -101,9 +100,9 @@ class FileSystemTest(TestCase):
     async def test_open_with_second_file_path_alternative_first_source_path(self):
         with TemporaryDirectory() as source_path_1:
             with TemporaryDirectory() as source_path_2:
-                with open(path.join(source_path_1, 'apples'), 'w') as f:
+                with open(Path(source_path_1) / 'apples', 'w') as f:
                     f.write('apples')
-                with open(path.join(source_path_2, 'apples'), 'w') as f:
+                with open(Path(source_path_2) / 'apples', 'w') as f:
                     f.write('notapples')
 
                 sut = FileSystem(source_path_1, source_path_2)
@@ -115,13 +114,13 @@ class FileSystemTest(TestCase):
     async def test_copy2(self):
         with TemporaryDirectory() as source_path_1:
             with TemporaryDirectory() as source_path_2:
-                with open(path.join(source_path_1, 'apples'), 'w') as f:
+                with open(Path(source_path_1) / 'apples', 'w') as f:
                     f.write('apples')
-                with open(path.join(source_path_2, 'apples'), 'w') as f:
+                with open(Path(source_path_2) / 'apples', 'w') as f:
                     f.write('notapples')
-                with open(path.join(source_path_1, 'oranges'), 'w') as f:
+                with open(Path(source_path_1) / 'oranges', 'w') as f:
                     f.write('oranges')
-                with open(path.join(source_path_2, 'bananas'), 'w') as f:
+                with open(Path(source_path_2) / 'bananas', 'w') as f:
                     f.write('bananas')
 
                 with TemporaryDirectory() as destination_path:
@@ -131,11 +130,11 @@ class FileSystemTest(TestCase):
                     await sut.copy2('oranges', destination_path)
                     await sut.copy2('bananas', destination_path)
 
-                    with await sut.open(path.join(destination_path, 'apples')) as f:
+                    with await sut.open(Path(destination_path) / 'apples') as f:
                         self.assertEquals('apples', f.read())
-                    with await sut.open(path.join(destination_path, 'oranges')) as f:
+                    with await sut.open(Path(destination_path) / 'oranges') as f:
                         self.assertEquals('oranges', f.read())
-                    with await sut.open(path.join(destination_path, 'bananas')) as f:
+                    with await sut.open(Path(destination_path) / 'bananas') as f:
                         self.assertEquals('bananas', f.read())
 
                     with self.assertRaises(FileNotFoundError):
@@ -144,16 +143,16 @@ class FileSystemTest(TestCase):
     @sync
     async def test_copytree(self):
         with TemporaryDirectory() as source_path_1:
-            os.makedirs(path.join(source_path_1, 'basket'))
+            (Path(source_path_1) / 'basket').mkdir()
             with TemporaryDirectory() as source_path_2:
-                os.makedirs(path.join(source_path_2, 'basket'))
-                with open(path.join(source_path_1, 'basket', 'apples'), 'w') as f:
+                (Path(source_path_2) / 'basket').mkdir()
+                with open(Path(source_path_1) / 'basket' / 'apples', 'w') as f:
                     f.write('apples')
-                with open(path.join(source_path_2, 'basket', 'apples'), 'w') as f:
+                with open(Path(source_path_2) / 'basket' / 'apples', 'w') as f:
                     f.write('notapples')
-                with open(path.join(source_path_1, 'basket', 'oranges'), 'w') as f:
+                with open(Path(source_path_1) / 'basket' / 'oranges', 'w') as f:
                     f.write('oranges')
-                with open(path.join(source_path_2, 'basket', 'bananas'), 'w') as f:
+                with open(Path(source_path_2) / 'basket' / 'bananas', 'w') as f:
                     f.write('bananas')
 
                 with TemporaryDirectory() as destination_path:
@@ -161,9 +160,9 @@ class FileSystemTest(TestCase):
 
                     await sut.copytree('', destination_path)
 
-                    with await sut.open(path.join(destination_path, 'basket', 'apples')) as f:
+                    with await sut.open(Path(destination_path) / 'basket' / 'apples') as f:
                         self.assertEquals('apples', f.read())
-                    with await sut.open(path.join(destination_path, 'basket', 'oranges')) as f:
+                    with await sut.open(Path(destination_path) / 'basket' / 'oranges') as f:
                         self.assertEquals('oranges', f.read())
-                    with await sut.open(path.join(destination_path, 'basket', 'bananas')) as f:
+                    with await sut.open(Path(destination_path) / 'basket' / 'bananas') as f:
                         self.assertEquals('bananas', f.read())

--- a/betty/tests/test_locale.py
+++ b/betty/tests/test_locale.py
@@ -1,5 +1,5 @@
 import gettext
-from os import makedirs, path
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import List, Optional
 
@@ -355,9 +355,10 @@ class OpenTranslationsTest(TestCase):
     def test(self) -> None:
         locale = 'nl-NL'
         locale_path_name = 'nl_NL'
-        with TemporaryDirectory() as assets_directory_path:
-            lc_messages_directory_path = path.join(assets_directory_path, 'locale', locale_path_name, 'LC_MESSAGES')
-            makedirs(lc_messages_directory_path)
+        with TemporaryDirectory() as assets_directory_path_str:
+            assets_directory_path = Path(assets_directory_path_str)
+            lc_messages_directory_path = assets_directory_path / 'locale' / locale_path_name / 'LC_MESSAGES'
+            lc_messages_directory_path.mkdir(parents=True)
             po = """
 # Dutch translations for PROJECT.
 # Copyright (C) 2019 ORGANIZATION
@@ -383,6 +384,6 @@ msgstr ""
 msgid "Subject"
 msgstr "Onderwerp"
 """
-            with open(path.join(lc_messages_directory_path, 'betty.po'), 'w') as f:
+            with open(lc_messages_directory_path / 'betty.po', 'w') as f:
                 f.write(po)
             self.assertIsInstance(open_translations(locale, assets_directory_path), gettext.NullTranslations)

--- a/betty/tests/test_openapi.py
+++ b/betty/tests/test_openapi.py
@@ -1,5 +1,5 @@
 import json as stdjson
-from os import path
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import jsonschema
@@ -19,7 +19,7 @@ class BuildSpecificationTest(TestCase):
     ])
     @sync
     async def test(self, content_negotiation: str):
-        with open(path.join(path.dirname(__file__), 'test_openapi_assets', 'schema.json')) as f:
+        with open(Path(__file__).parent / 'test_openapi_assets' / 'schema.json') as f:
             schema = stdjson.load(f)
         with TemporaryDirectory() as output_directory_path:
             configuration = Configuration(

--- a/betty/tests/test_os.py
+++ b/betty/tests/test_os.py
@@ -1,4 +1,4 @@
-from os import path
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
@@ -8,10 +8,11 @@ from betty.tests import TestCase
 
 class LinkOrCopyTest(TestCase):
     def test(self):
-        with TemporaryDirectory() as working_directory_path:
+        with TemporaryDirectory() as working_directory_path_str:
+            working_directory_path = Path(working_directory_path_str)
             content = 'I will say zis only once.'
-            source_path = path.join(working_directory_path, 'source')
-            destination_path = path.join(working_directory_path, 'destination')
+            source_path = working_directory_path / 'source'
+            destination_path = working_directory_path / 'destination'
             with open(source_path, 'a') as f:
                 f.write(content)
             link_or_copy(source_path, destination_path)
@@ -21,10 +22,11 @@ class LinkOrCopyTest(TestCase):
     @patch('os.link')
     def test_with_os_error(self, m_link):
         m_link.side_effect = OSError
-        with TemporaryDirectory() as working_directory_path:
+        with TemporaryDirectory() as working_directory_path_str:
+            working_directory_path = Path(working_directory_path_str)
             content = 'I will say zis only once.'
-            source_path = path.join(working_directory_path, 'source')
-            destination_path = path.join(working_directory_path, 'destination')
+            source_path = working_directory_path / 'source'
+            destination_path = working_directory_path / 'destination'
             with open(source_path, 'a') as f:
                 f.write(content)
             link_or_copy(source_path, destination_path)

--- a/betty/tests/test_readme.py
+++ b/betty/tests/test_readme.py
@@ -1,5 +1,5 @@
 import json
-from os import path
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
@@ -8,12 +8,13 @@ from betty import os, subprocess
 
 class ReadmeTest(TestCase):
     def test_readme_should_contain_cli_help(self):
-        with TemporaryDirectory() as working_directory_path:
+        with TemporaryDirectory() as working_directory_path_str:
+            working_directory_path = Path(working_directory_path_str)
             configuration = {
                 'base_url': 'https://example.com',
-                'output': path.join(working_directory_path, 'output'),
+                'output': str(working_directory_path / 'output'),
             }
-            with open(path.join(working_directory_path, 'betty.json'), 'w') as f:
+            with open(working_directory_path / 'betty.json', 'w') as f:
                 json.dump(configuration, f)
             with os.ChDir(working_directory_path):
                 expected = subprocess.run(['betty', '--help'], universal_newlines=True).stdout

--- a/betty/tests/test_serve.py
+++ b/betty/tests/test_serve.py
@@ -1,4 +1,4 @@
-from os import path
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from time import sleep
 
@@ -14,7 +14,7 @@ class BuiltinServerTest(TestCase):
     async def test(self):
         content = 'Hello, and welcome to my site!'
         with TemporaryDirectory() as www_directory_path:
-            with open(path.join(www_directory_path, 'index.html'), 'w') as f:
+            with open(Path(www_directory_path) / 'index.html', 'w') as f:
                 f.write(content)
             async with BuiltinServer(www_directory_path) as server:
                 # Wait for the server to start.

--- a/betty/tests/test_voluptuous.py
+++ b/betty/tests/test_voluptuous.py
@@ -1,4 +1,4 @@
-from os import path
+import pathlib
 from tempfile import TemporaryDirectory
 
 from parameterized import parameterized
@@ -20,14 +20,14 @@ class PathTest(TestCase):
 
     def test_with_absolute_path(self):
         with TemporaryDirectory() as directory_path:
-            self.assertEqual(directory_path, Path()(directory_path))
+            self.assertEqual(pathlib.Path(directory_path).expanduser().resolve(), Path()(directory_path))
 
     def test_with_expanduser(self):
-        self.assertEqual(path.join(path.expanduser('~'), 'foo', 'bar'), Path()(path.join(path.expanduser('~'), 'foo', 'bar')))
+        self.assertEqual(pathlib.Path.home().resolve() / 'foo' / 'bar', Path()(str(pathlib.Path('~') / 'foo' / 'bar')))
 
     def test_with_relative_path_made_absolute(self):
         with TemporaryDirectory() as directory_path:
-            self.assertEqual(path.join(directory_path, 'sibling'), Path()(path.join(directory_path, 'child', '..', 'sibling', '.')))
+            self.assertEqual((pathlib.Path(directory_path) / 'sibling').expanduser().resolve(), Path()(pathlib.Path(directory_path) / 'child' / '..' / 'sibling' / '.'))
 
 
 class ImportableTest(TestCase):

--- a/betty/voluptuous.py
+++ b/betty/voluptuous.py
@@ -1,4 +1,4 @@
-from os import path
+import pathlib
 
 from voluptuous import Invalid
 
@@ -8,7 +8,7 @@ from betty.importlib import import_any
 def Path():
     def _path(v):
         try:
-            return path.abspath(path.expanduser(v))
+            return pathlib.Path(v).expanduser().resolve()
         except TypeError as e:
             raise Invalid(e)
 

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,13 @@
 """Integrates Betty with Python's setuptools."""
 
-import os
-from glob import glob
-from os.path import abspath, dirname, join
-
 from setuptools import setup, find_packages
 
-ROOT_PATH = os.path.dirname(os.path.abspath(__file__))
+from betty.fs import ROOT_DIRECTORY_PATH
 
-with open('/'.join((ROOT_PATH, 'VERSION'))) as f:
+with open(ROOT_DIRECTORY_PATH / 'VERSION') as f:
     VERSION = f.read()
 
-with open('/'.join((ROOT_PATH, 'README.md'))) as f:
+with open(ROOT_DIRECTORY_PATH / 'README.md') as f:
     long_description = f.read()
 
 SETUP = {
@@ -90,13 +86,11 @@ SETUP = {
     ],
     'include_package_data': True,
     'package_data': {
-        'betty': [
-                     join(dirname(__file__), 'VERSION'),
-                 ]
-                 +
-                 glob(join(dirname(abspath(__file__)), 'betty', 'assets', '**'), recursive=True)
-                 +
-                 glob(join(dirname(abspath(__file__)), 'betty', 'extension', '*', 'assets', '**'), recursive=True),
+        'betty': list(map(str, [
+             ROOT_DIRECTORY_PATH / 'VERSION',
+             *(ROOT_DIRECTORY_PATH / 'betty' / 'assets').glob('**'),
+             *(ROOT_DIRECTORY_PATH / 'betty' / 'extension' / '*' / 'assets').glob('**'),
+        ])),
     },
 }
 


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/622

## Change log
- `betty.path.extension()` was removed. Use `pathlib.Path.suffix` instead.
- `betty.fs.makedirs()` was removed. Use `pathlib.Path.mkdir()` and `os.chmod()` instead.
- `betty.ancestry.File.path` is no longer a `str`, but a `pathlib.Path`.
- `betty.ancestry.File.name`, `betty.ancestry.File.name`, and `betty.ancestry.File.name` were removed. Use `betty.ancestry.File.path.*` instead.
- `betty.extension.Extension.assets_directory_path` no longer returns `str`, but `pathlib.Path`.
- `betty.fs.iterfiles` no longer returns `typing.AsyncIterable[str]` but `typing.AsyncIterable[pathlib.Path]`.
- As a policy, all APIs returning paths no longer return `str`, but `pathlib.Path`.
- As a policy, all APIs accepting paths no longer accept only `str`, but `Union[str, os.PathLike]`.
- `File` entity files have moved from `/file/$file_id$.$file_extension$` to `/file/$file_id$/file/$file_name$` to prevent the file overriding the `File`'s own HTML/JSON directory if it has no extension. The Nginx plugin generates configuration that will respond with HTTP 301 redirects to the new paths in order to preserve existing links or search engine references to the files on your site. If you use another web server configuration than the generated nginx configuration, you must configure your own redirects if you do not wish incoming links to break.

## To-do
- Update the nginx configuration to respond with a permanent redirect to requests for old file URLs.