### PR TITLE
Show site generation feedback in the GUI

### DIFF
--- a/betty/asyncio.py
+++ b/betty/asyncio.py
@@ -17,6 +17,7 @@ def sync(f):
             loop = asyncio.get_event_loop()
         except RuntimeError:
             loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
         return loop.run_until_complete(f)
 
     if inspect.iscoroutinefunction(f):

--- a/betty/extension/gramps/__init__.py
+++ b/betty/extension/gramps/__init__.py
@@ -1,5 +1,4 @@
 import gzip
-import logging
 import re
 import tarfile
 from contextlib import suppress
@@ -24,7 +23,7 @@ from betty.error import UserFacingError
 from betty.gui import GuiBuilder, catch_exceptions, BettyWindow, mark_valid, mark_invalid, Text
 from betty.locale import DateRange, Datey, Date
 from betty.media_type import MediaType
-from betty.load import Loader
+from betty.load import Loader, getLogger
 from betty.os import PathLike
 from betty.path import rootname
 from betty.voluptuous import Path as VoluptuousPath
@@ -37,7 +36,7 @@ class GrampsLoadFileError(UserFacingError):
 
 def load_file(ancestry: Ancestry, file_path: PathLike) -> None:
     file_path = Path(file_path)
-    logger = logging.getLogger()
+    logger = getLogger()
     logger.info('Loading %s...' % str(file_path))
 
     with suppress(GrampsLoadFileError):
@@ -143,7 +142,7 @@ class _Loader:
             self._ancestry.notes[note.id] = note
 
     def load(self) -> None:
-        logger = logging.getLogger()
+        logger = getLogger()
 
         database = self._tree.getroot()
 
@@ -456,7 +455,7 @@ def _load_event(loader: _Loader, element: ElementTree.Element):
         event_type = _EVENT_TYPE_MAP[gramps_type.text]
     except KeyError:
         event_type = UnknownEventType()
-        logging.getLogger().warning(
+        getLogger().warning(
             'Betty is unfamiliar with Gramps event "%s"\'s type of "%s". The event was imported, but its type was set to "%s".' % (event_id, gramps_type.text, event_type.label))
 
     event = IdentifiableEvent(event_id, event_type)
@@ -584,7 +583,7 @@ def _load_attribute_privacy(resource: HasPrivacy, element: ElementTree.Element, 
     if privacy_value == 'public':
         resource.private = False
         return
-    logging.getLogger().warning('The betty:privacy Gramps attribute must have a value of "public" or "private", but "%s" was given, which was ignored.' % privacy_value)
+    getLogger().warning('The betty:privacy Gramps attribute must have a value of "public" or "private", but "%s" was given, which was ignored.' % privacy_value)
 
 
 def _load_attribute(name: str, element: ElementTree.Element, tag: str) -> Optional[str]:

--- a/betty/extension/nginx/serve.py
+++ b/betty/extension/nginx/serve.py
@@ -7,7 +7,7 @@ from docker.errors import DockerException
 
 from betty.extension.nginx import Nginx, generate_dockerfile_file
 from betty.extension.nginx.docker import Container
-from betty.serve import Server, ServerNotStartedError
+from betty.serve import Server, NoPublicUrlBecauseServerNotStartedError
 from betty.app import App
 
 
@@ -37,7 +37,7 @@ class DockerizedNginxServer(Server):
     def public_url(self) -> str:
         if self._container is not None:
             return 'http://%s' % self._container.ip
-        raise ServerNotStartedError('Cannot determine the public URL if the server has not started yet.')
+        raise NoPublicUrlBecauseServerNotStartedError()
 
     @classmethod
     def is_available(cls) -> bool:

--- a/betty/generate.py
+++ b/betty/generate.py
@@ -14,6 +14,10 @@ from betty.openapi import build_specification
 from betty.app import App
 
 
+def getLogger() -> logging.Logger:
+    return logging.getLogger(__name__)
+
+
 class Generator:
     async def generate(self) -> None:
         raise NotImplementedError
@@ -34,7 +38,7 @@ async def generate(app: App) -> None:
 
 
 async def _generate(app: App) -> None:
-    logger = logging.getLogger()
+    logger = getLogger()
     await app.assets.copytree(Path('public') / 'static', app.configuration.www_directory_path)
     await app.renderer.render_tree(app.configuration.www_directory_path)
     for locale_configuration in app.configuration.locales:

--- a/betty/load.py
+++ b/betty/load.py
@@ -1,4 +1,10 @@
+import logging
+
 from betty.app import App
+
+
+def getLogger() -> logging.Logger:
+    return logging.getLogger(__name__)
 
 
 class Loader:


### PR DESCRIPTION
This opens a modal window when generating a site. This allows users to see the logs, and there's a convenience button to launch a server to immediately inspect the site that was just generated.

Doing this solves the current UI awkardness of generating the site, the UI possibly freezing (for large enough sites), without any form of feedback.