### PR TITLE
Add Cache-Control: no-cache to responses sent by the development servers

### DIFF
--- a/betty/extension/nginx/assets/nginx.conf.j2
+++ b/betty/extension/nginx/assets/nginx.conf.j2
@@ -12,7 +12,11 @@ server {
     {% if extensions['betty.extension.nginx.Nginx'].https %}
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     {% endif %}
-    add_header Cache-Control "max-age=86400";
+    {% if app.debug %}
+        add_header Cache-Control "no-cache";
+    {% else %}
+	    add_header Cache-Control "max-age=86400";
+    {% endif %}
     gzip on;
     gzip_disable "msie6";
     gzip_vary on;

--- a/betty/serve.py
+++ b/betty/serve.py
@@ -89,6 +89,12 @@ class AppServer(Server):
         await self._server.stop()
 
 
+class _BuiltinServerRequestHandler(SimpleHTTPRequestHandler):
+    def end_headers(self) -> None:
+        self.send_header('Cache-Control', 'no-cache')
+        super().end_headers()
+
+
 class BuiltinServer(Server):
     def __init__(self, www_directory_path: PathLike):
         self._www_directory_path = www_directory_path
@@ -99,7 +105,7 @@ class BuiltinServer(Server):
         logging.getLogger().info('Starting Python\'s built-in web server...')
         for self._port in range(DEFAULT_PORT, 65535):
             with contextlib.suppress(OSError):
-                self._http_server = HTTPServer(('', self._port), SimpleHTTPRequestHandler)
+                self._http_server = HTTPServer(('', self._port), _BuiltinServerRequestHandler)
                 break
         if self._http_server is None:
             raise OsError('Cannot find an available port to bind the web server to.')

--- a/betty/tests/extension/nginx/test_serve.py
+++ b/betty/tests/extension/nginx/test_serve.py
@@ -34,3 +34,4 @@ class DockerizedNginxServerTest(TestCase):
                     response = requests.get(server.public_url)
                     self.assertEquals(200, response.status_code)
                     self.assertEquals(content, response.content.decode('utf-8'))
+                    self.assertEquals('no-cache', response.headers['Cache-Control'])

--- a/betty/tests/test_serve.py
+++ b/betty/tests/test_serve.py
@@ -22,3 +22,4 @@ class BuiltinServerTest(TestCase):
                 response = requests.get(server.public_url)
                 self.assertEquals(200, response.status_code)
                 self.assertEquals(content, response.content.decode('utf-8'))
+                self.assertEquals('no-cache', response.headers['Cache-Control'])


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/779