### PR TITLE
Rename the `mode` configuration to `debug`

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Configuration files are written in YAML (`*.yaml` or `*.yml`) or JSON (`*.json`)
 ```yaml
 output: /var/www/betty
 base_url: https://ancestry.example.com
+debug: true
 root_path: /betty
 clean_urls: true
 title: Betty's ancestry
@@ -104,6 +105,8 @@ extensions:
 ```
 - `output` (required); The path to the directory in which to place the generated site.
 - `base_url` (required); The absolute, public URL at which the site will be published.
+- `debug` (optional): `true` to output more detailed logs and disable optimizations that make debugging harder. Defaults
+    to `false`.
 - `root_path` (optional); The relative path under the public URL at which the site will be published.
 - `clean_urls` (optional); A boolean indicating whether to use clean URLs, e.g. `/path` instead of `/path/index.html`.
 - `content_negotiation` (optional, defaults to `false`): Enables dynamic content negotiation, but requires a web server

--- a/betty/app.py
+++ b/betty/app.py
@@ -68,6 +68,7 @@ class App:
         self._dispatcher = None
         self._localized_url_generator = AppUrlGenerator(configuration)
         self._static_url_generator = StaticPathUrlGenerator(configuration)
+        self._debug = None
         self._locale = None
         self._translations = defaultdict(gettext.NullTranslations)
         self._default_translations = None
@@ -118,6 +119,12 @@ class App:
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self.exit()
+
+    @property
+    def debug(self) -> bool:
+        if self._debug is not None:
+            return self._debug
+        return self._configuration.debug
 
     @property
     def locale(self) -> str:
@@ -254,5 +261,11 @@ class App:
         # Clear all locale-dependent lazy-loaded attributes.
         app._jinja2_environment = None
         app._renderer = None
+
+        return app
+
+    def with_debug(self, debug: bool) -> 'App':
+        app = copy(self)
+        app._debug = debug
 
         return app

--- a/betty/config.py
+++ b/betty/config.py
@@ -274,7 +274,7 @@ class Configuration:
         self.author = None
         self._extensions = ExtensionsConfiguration()
         self._extensions.react(self)
-        self.mode = 'production'
+        self._debug = False
         self.assets_directory_path = None
         self._locales = LocalesConfiguration()
         self._locales.react(self)
@@ -392,12 +392,12 @@ class Configuration:
 
     @reactive
     @property
-    def mode(self) -> str:
-        return self._mode
+    def debug(self) -> bool:
+        return self._debug
 
-    @mode.setter
-    def mode(self, mode: str):
-        self._mode = mode
+    @debug.setter
+    def debug(self, debug: bool) -> None:
+        self._debug = debug
 
     @reactive
     @property
@@ -470,7 +470,7 @@ _ConfigurationSchema = Schema(All({
     'root_path': str,
     'clean_urls': bool,
     'content_negotiation': bool,
-    'mode': Any('development', 'production'),
+    'debug': bool,
     'assets': All(str, IsDir(), VoluptuousPath()),
     'extensions': All(dict, _extensions_configuration),
     Required('theme', default=dict): All({
@@ -541,8 +541,8 @@ def _to_dict(configuration: Configuration) -> Dict:
         configuration_dict['author'] = configuration.author
     if configuration.content_negotiation is not None:
         configuration_dict['content_negotiation'] = configuration.content_negotiation
-    if configuration.mode is not None:
-        configuration_dict['mode'] = configuration.mode
+    if configuration.debug is not None:
+        configuration_dict['debug'] = configuration.debug
     if configuration.assets_directory_path is not None:
         configuration_dict['assets'] = str(configuration.assets_directory_path)
     if len(configuration.locales) > 0:

--- a/betty/extension/maps/assets/js/webpack.config.js
+++ b/betty/extension/maps/assets/js/webpack.config.js
@@ -6,7 +6,7 @@ const path = require('path')
 const configuration = require('./webpack.config.json')
 
 module.exports = {
-  mode: configuration.mode,
+  mode: configuration.debug ? 'development' : 'production',
   entry: {
     maps: path.resolve(__dirname, 'maps.js')
   },
@@ -15,7 +15,7 @@ module.exports = {
     filename: '[name].js'
   },
   optimization: {
-    minimize: configuration.minimize,
+    minimize: !configuration.debug,
     splitChunks: {
       cacheGroups: {
         styles: {

--- a/betty/extension/maps/assets/js/webpack.config.json.j2
+++ b/betty/extension/maps/assets/js/webpack.config.json.j2
@@ -1,6 +1,4 @@
 {{ {
-    'mode': app.configuration.mode,
-    'minimize': app.configuration.mode == 'production',
-    'debug': app.configuration.mode == 'development',
+    'debug': app.debug,
     'cacheDirectory': path.join(app.configuration.cache_directory_path, 'betty.extension.trees.Trees', 'babel'),
 } | tojson }}

--- a/betty/extension/nginx/assets/nginx.conf.j2
+++ b/betty/extension/nginx/assets/nginx.conf.j2
@@ -12,7 +12,7 @@ server {
     {% if extensions['betty.extension.nginx.Nginx'].https %}
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     {% endif %}
-	add_header Cache-Control "max-age=86400";
+    add_header Cache-Control "max-age=86400";
     gzip on;
     gzip_disable "msie6";
     gzip_vary on;

--- a/betty/extension/nginx/serve.py
+++ b/betty/extension/nginx/serve.py
@@ -13,7 +13,7 @@ from betty.app import App
 
 class DockerizedNginxServer(Server):
     def __init__(self, app: App):
-        self._app = app
+        self._app = app.with_debug(True)
         self._container = None
         self._output_directory = None
 

--- a/betty/extension/trees/assets/js/webpack.config.js
+++ b/betty/extension/trees/assets/js/webpack.config.js
@@ -6,7 +6,7 @@ const path = require('path')
 const configuration = require('./webpack.config.json')
 
 module.exports = {
-  mode: configuration.mode,
+  mode: configuration.debug ? 'development' : 'production',
   entry: {
     trees: path.resolve(__dirname, 'trees.js')
   },
@@ -15,7 +15,7 @@ module.exports = {
     filename: '[name].js'
   },
   optimization: {
-    minimize: configuration.minimize,
+    minimize: !configuration.debug,
     splitChunks: {
       cacheGroups: {
         styles: {

--- a/betty/extension/trees/assets/js/webpack.config.json.j2
+++ b/betty/extension/trees/assets/js/webpack.config.json.j2
@@ -1,6 +1,4 @@
 {{ {
-    'mode': app.configuration.mode,
-    'minimize': app.configuration.mode == 'production',
-    'debug': app.configuration.mode == 'development',
+    'debug': app.debug,
     'cacheDirectory': path.join(app.configuration.cache_directory_path, 'betty.extension.trees.Trees', 'babel'),
 } | tojson }}

--- a/betty/gui.py
+++ b/betty/gui.py
@@ -355,12 +355,12 @@ class _ProjectGeneralConfigurationPane(QWidget):
         self._form.addRow(Caption('Where to search for asset files, such as templates and translations.'))
 
     def _build_mode(self) -> None:
-        def _update_configuration_mode(mode: bool) -> None:
-            self._app.configuration.mode = 'development' if mode else 'production'
-        self._development_mode = QCheckBox('Development mode')
-        self._development_mode.setChecked(self._app.configuration.mode == 'development')
-        self._development_mode.toggled.connect(_update_configuration_mode)
-        self._form.addRow(self._development_mode)
+        def _update_configuration_debug(mode: bool) -> None:
+            self._app.configuration.debug = mode
+        self._development_debug = QCheckBox('Debugging mode')
+        self._development_debug.setChecked(self._app.configuration.debug)
+        self._development_debug.toggled.connect(_update_configuration_debug)
+        self._form.addRow(self._development_debug)
         self._form.addRow(Caption('Output more detailed logs and disable optimizations that make debugging harder.'))
 
     def _build_clean_urls(self) -> None:

--- a/betty/jinja2.py
+++ b/betty/jinja2.py
@@ -106,7 +106,7 @@ class BettyEnvironment(Environment):
 
         self.app = app
 
-        if app.configuration.mode == 'development':
+        if app.debug:
             self.add_extension('jinja2.ext.debug')
 
         self._init_i18n()

--- a/betty/pytests/test_gui.py
+++ b/betty/pytests/test_gui.py
@@ -131,15 +131,15 @@ def test_project_window_general_configuration_lifetime_threshold_with_zero_input
     assert sut._app.configuration.lifetime_threshold == original_lifetime_threshold
 
 
-def test_project_window_general_configuration_mode(qtbot, minimal_configuration_file_path) -> None:
+def test_project_window_general_configuration_debug(qtbot, minimal_configuration_file_path) -> None:
     sut = ProjectWindow(minimal_configuration_file_path)
     qtbot.addWidget(sut)
     sut.show()
 
-    sut._general_configuration_pane._development_mode.setChecked(True)
-    assert sut._app.configuration.mode == 'development'
-    sut._general_configuration_pane._development_mode.setChecked(False)
-    assert sut._app.configuration.mode == 'production'
+    sut._general_configuration_pane._development_debug.setChecked(True)
+    assert sut._app.configuration.debug
+    sut._general_configuration_pane._development_debug.setChecked(False)
+    assert not sut._app.configuration.debug
 
 
 def test_project_window_general_configuration_clean_urls(qtbot, minimal_configuration_file_path) -> None:
@@ -271,7 +271,7 @@ def test_project_window_save_project_as_should_create_duplicate_configuration_fi
         'root_path': '',
         'clean_urls': False,
         'content_negotiation': False,
-        'mode': 'production',
+        'debug': False,
         'locales': [
             {
                 'locale': 'en-US',

--- a/betty/serve.py
+++ b/betty/serve.py
@@ -27,6 +27,10 @@ class OsError(UserFacingError, OSError):
 
 
 class Server:
+    """
+    Provide a development web server.
+    """
+
     async def start(self) -> None:
         """
         Starts the server.

--- a/betty/tests/__init__.py
+++ b/betty/tests/__init__.py
@@ -79,7 +79,7 @@ class TemplateTestCase(TestCase):
             data = {}
         with TemporaryDirectory() as output_directory_path:
             configuration = Configuration(output_directory_path, 'https://example.com')
-            configuration.mode = 'development'
+            configuration.debug = True
             if update_configuration is not None:
                 update_configuration(configuration)
             async with App(configuration) as app:

--- a/betty/tests/extension/maps/test__init__.py
+++ b/betty/tests/extension/maps/test__init__.py
@@ -14,7 +14,7 @@ class MapsTest(TestCase):
     async def test_post_render_event(self):
         with TemporaryDirectory() as output_directory_path:
             configuration = Configuration(output_directory_path, 'https://ancestry.example.com')
-            configuration.mode = 'development'
+            configuration.debug = True
             configuration.extensions.add(ExtensionConfiguration(Maps))
             async with App(configuration) as app:
                 await generate(app)

--- a/betty/tests/extension/trees/test__init__.py
+++ b/betty/tests/extension/trees/test__init__.py
@@ -14,7 +14,7 @@ class TreesTest(TestCase):
     async def test_post_render_event(self):
         with TemporaryDirectory() as output_directory_path:
             configuration = Configuration(output_directory_path, 'https://ancestry.example.com')
-            configuration.mode = 'development'
+            configuration.debug = True
             configuration.extensions.add(ExtensionConfiguration(Trees))
             async with App(configuration) as app:
                 await generate(app)

--- a/betty/tests/test_config.py
+++ b/betty/tests/test_config.py
@@ -378,7 +378,7 @@ class FromDictTest(TestCase):
             self.assertEquals(configuration_dict['base_url'], configuration.base_url)
             self.assertEquals('Betty', configuration.title)
             self.assertIsNone(configuration.author)
-            self.assertEquals('production', configuration.mode)
+            self.assertFalse(configuration.debug)
             self.assertEquals('', configuration.root_path)
             self.assertFalse(configuration.clean_urls)
             self.assertFalse(configuration.content_negotiation)
@@ -442,14 +442,14 @@ class FromDictTest(TestCase):
             self.assertEquals(content_negotiation, configuration.content_negotiation)
 
     @parameterized.expand([
-        ('production',),
-        ('development',),
+        (True,),
+        (False,),
     ])
-    def test_should_load_mode(self, mode: str) -> None:
+    def test_should_load_debug(self, debug: bool) -> None:
         with _build_minimal_configuration_dict() as configuration_dict:
-            configuration_dict['mode'] = mode
+            configuration_dict['debug'] = debug
             configuration = _from_dict(configuration_dict)
-            self.assertEquals(mode, configuration.mode)
+            self.assertEquals(debug, configuration.debug)
 
     def test_should_load_assets_directory_path(self) -> None:
         with TemporaryDirectory() as assets_directory_path:
@@ -563,7 +563,7 @@ class ToDictTest(TestCase):
             self.assertEquals(configuration_dict['base_url'], configuration.base_url)
             self.assertEquals('Betty', configuration.title)
             self.assertIsNone(configuration.author)
-            self.assertEquals('production', configuration.mode)
+            self.assertEquals(False, configuration.debug)
             self.assertEquals('', configuration.root_path)
             self.assertFalse(configuration.clean_urls)
             self.assertFalse(configuration.content_negotiation)
@@ -630,14 +630,14 @@ class ToDictTest(TestCase):
             self.assertEquals(content_negotiation, configuration_dict['content_negotiation'])
 
     @parameterized.expand([
-        ('production',),
-        ('development',),
+        (True,),
+        (False,),
     ])
-    def test_should_dump_mode(self, mode: str) -> None:
+    def test_should_dump_debug(self, debug: bool) -> None:
         with _build_minimal_configuration() as configuration:
-            configuration.mode = mode
+            configuration.debug = debug
             configuration_dict = _to_dict(configuration)
-            self.assertEquals(mode, configuration_dict['mode'])
+            self.assertEquals(debug, configuration_dict['debug'])
 
     def test_should_dump_assets_directory_path(self) -> None:
         with TemporaryDirectory() as assets_directory_path:


### PR DESCRIPTION
The `mode` configuration takes arbitrary strings, which is prone to errors. However, it just enables development/debugging mode, so let's convert it to a boolean.