### PR TITLE
Fix a bug where Nginx configuration overrides wouldn't make it into the generated configuration

### DIFF
--- a/betty/extension/nginx/__init__.py
+++ b/betty/extension/nginx/__init__.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from typing import Optional, Iterable, Dict
-from urllib.parse import urlparse
 
 from PyQt5.QtWidgets import QFormLayout, QButtonGroup, QRadioButton, QWidget, QHBoxLayout, QLineEdit, \
     QFileDialog, QPushButton
@@ -76,8 +75,8 @@ class Nginx(ConfigurableExtension, Generator, ServerProvider, GuiBuilder):
         return []
 
     async def generate(self) -> None:
-        await self.generate_configuration_file()
-        await self._generate_dockerfile_file()
+        await generate_configuration_file(self._app)
+        await generate_dockerfile_file(self._app)
 
     @property
     def assets_directory_path(self) -> Optional[Path]:
@@ -94,17 +93,6 @@ class Nginx(ConfigurableExtension, Generator, ServerProvider, GuiBuilder):
         if self._configuration.www_directory_path is None:
             return self._app.configuration.www_directory_path
         return self._configuration.www_directory_path
-
-    async def generate_configuration_file(self, destination_file_path: Optional[str] = None, **kwargs) -> None:
-        kwargs = dict({
-            'server_name': urlparse(self._app.configuration.base_url).netloc,
-        }, **kwargs)
-        if destination_file_path is None:
-            destination_file_path = self._app.configuration.output_directory_path / 'nginx' / 'nginx.conf'
-        await generate_configuration_file(destination_file_path, self._app.jinja2_environment, **kwargs)
-
-    async def _generate_dockerfile_file(self) -> None:
-        await generate_dockerfile_file(self._app.configuration.output_directory_path / 'nginx' / 'docker' / 'Dockerfile')
 
     @classmethod
     def gui_name(cls) -> str:

--- a/betty/extension/nginx/artifact.py
+++ b/betty/extension/nginx/artifact.py
@@ -1,20 +1,34 @@
 from pathlib import Path
 from shutil import copyfile
+from typing import Optional
+from urllib.parse import urlparse
 
-from jinja2 import FileSystemLoader, Environment
+from jinja2 import FileSystemLoader
 
+from betty.app import App
 from betty.path import rootname
 
 
-async def generate_configuration_file(destination_file_path: Path, jinja2_environment: Environment, **kwargs) -> None:
+async def generate_configuration_file(app: App, destination_file_path: Optional[str] = None, www_directory_path: Optional[str] = None, https: Optional[bool] = None) -> None:
+    from betty.extension.nginx import Nginx
+
+    kwargs = {
+        'server_name': urlparse(app.configuration.base_url).netloc,
+        'www_directory_path': app.extensions[Nginx].www_directory_path if www_directory_path is None else www_directory_path,
+        'https': app.extensions[Nginx].https if https is None else https,
+    }
+    if destination_file_path is None:
+        destination_file_path = app.configuration.output_directory_path / 'nginx' / 'nginx.conf'
     root_path = rootname(__file__)
     configuration_file_template_name = '/'.join((Path(__file__).parent / 'assets' / 'nginx.conf.j2').relative_to(root_path).parts)
-    template = FileSystemLoader(root_path).load(jinja2_environment, configuration_file_template_name, jinja2_environment.globals)
+    template = FileSystemLoader(root_path).load(app.jinja2_environment, configuration_file_template_name, app.jinja2_environment.globals)
     destination_file_path.parent.mkdir(exist_ok=True, parents=True)
     with open(destination_file_path, 'w', encoding='utf-8') as f:
         f.write(template.render(kwargs))
 
 
-async def generate_dockerfile_file(destination_file_path: Path) -> None:
+async def generate_dockerfile_file(app: App, destination_file_path: Optional[str] = None) -> None:
+    if destination_file_path is None:
+        destination_file_path = app.configuration.output_directory_path / 'nginx' / 'docker' / 'Dockerfile'
     destination_file_path.parent.mkdir(exist_ok=True, parents=True)
     copyfile(Path(__file__).parent / 'assets' / 'docker' / 'Dockerfile', destination_file_path)

--- a/betty/extension/nginx/assets/nginx.conf.j2
+++ b/betty/extension/nginx/assets/nginx.conf.j2
@@ -1,4 +1,4 @@
-{% if extensions['betty.extension.nginx.Nginx'].https %}
+{% if https %}
     server {
         listen 80;
         server_name {{ server_name }};
@@ -6,10 +6,10 @@
     }
 {% endif %}
 server {
-	listen {% if extensions['betty.extension.nginx.Nginx'].https %}443 ssl http2{% else %}80{% endif %};
+	listen {% if https %}443 ssl http2{% else %}80{% endif %};
 	server_name {{ server_name }};
-	root {{ extensions['betty.extension.nginx.Nginx'].www_directory_path }};
-    {% if extensions['betty.extension.nginx.Nginx'].https %}
+	root {{ www_directory_path }};
+    {% if https %}
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     {% endif %}
     {% if app.debug %}

--- a/betty/extension/nginx/serve.py
+++ b/betty/extension/nginx/serve.py
@@ -5,7 +5,7 @@ from tempfile import TemporaryDirectory
 import docker
 from docker.errors import DockerException
 
-from betty.extension.nginx import Nginx, generate_dockerfile_file
+from betty.extension.nginx import generate_dockerfile_file, generate_configuration_file
 from betty.extension.nginx.docker import Container
 from betty.serve import Server, NoPublicUrlBecauseServerNotStartedError
 from betty.app import App
@@ -24,8 +24,8 @@ class DockerizedNginxServer(Server):
         docker_directory_path = Path(self._output_directory.name) / 'docker'
         dockerfile_file_path = docker_directory_path / 'Dockerfile'
         async with self._app:
-            await self._app.extensions[Nginx].generate_configuration_file(destination_file_path=nginx_configuration_file_path, https=False, www_directory_path='/var/www/betty')
-            await generate_dockerfile_file(destination_file_path=dockerfile_file_path)
+            await generate_configuration_file(self._app, destination_file_path=nginx_configuration_file_path, https=False, www_directory_path='/var/www/betty')
+            await generate_dockerfile_file(self._app, destination_file_path=dockerfile_file_path)
         self._container = Container(self._app.configuration.www_directory_path, docker_directory_path, nginx_configuration_file_path, 'betty-serve')
         self._container.start()
 


### PR DESCRIPTION
Fix a bug where Nginx configuration overrides wouldn't make it into the generated configuration.

## Change log
- `betty.extension.nginx.Nginx.generate_configuration_file()` was removed in favor of `betty.extension.nginx.artifact.generate_configuration_file()`
- `betty.extension.nginx.artifact.generate_configuration_file()` and `betty.extension.nginx.artifact.generate_dockerfile_file()` changed signatures, primarily requiring a `betty.app.App` argument.