### PR TITLE
Fix a bug where the Dockerized nginx server could only be run one at a time

### DIFF
--- a/betty/extension/nginx/serve.py
+++ b/betty/extension/nginx/serve.py
@@ -26,7 +26,7 @@ class DockerizedNginxServer(Server):
         async with self._app:
             await generate_configuration_file(self._app, destination_file_path=nginx_configuration_file_path, https=False, www_directory_path='/var/www/betty')
             await generate_dockerfile_file(self._app, destination_file_path=dockerfile_file_path)
-        self._container = Container(self._app.configuration.www_directory_path, docker_directory_path, nginx_configuration_file_path, 'betty-serve')
+        self._container = Container(self._app.configuration.www_directory_path, docker_directory_path, nginx_configuration_file_path)
         self._container.start()
 
     async def stop(self) -> None:

--- a/betty/serve.py
+++ b/betty/serve.py
@@ -68,9 +68,10 @@ class AppServer(Server):
         self._server = None
 
     def _get_server(self) -> Server:
-        servers = (server for extension in self._app.extensions.flatten() if isinstance(extension, ServerProvider) for server in extension.servers)
-        with contextlib.suppress(StopIteration):
-            return next(servers)
+        for extension in self._app.extensions.flatten():
+            if isinstance(extension, ServerProvider):
+                for server in extension.servers:
+                    return server
         return BuiltinServer(self._app.configuration.www_directory_path)
 
     async def start(self) -> None:


### PR DESCRIPTION
Fix a bug where the Dockerized nginx server could only be run one at a time, because further instances would cause name conflicts, and would stop and remove earlier instances.

This fixes https://github.com/bartfeenstra/betty/issues/776