### PR TITLE
Rename a left-over occurrence of 'entity' to 'resource'.

### DIFF
--- a/betty/assets/templates/page/person.html.j2
+++ b/betty/assets/templates/page/person.html.j2
@@ -30,7 +30,7 @@
                     {% include 'permalink.html.j2' %}
                 {% endwith %}
             </h2>
-            {% with entity=person %}
+            {% with resource=person %}
                 {% include 'wikipedia.html.j2' %}
             {% endwith %}
         </section>

--- a/betty/assets/templates/page/place.html.j2
+++ b/betty/assets/templates/page/place.html.j2
@@ -29,7 +29,7 @@
                     {% include 'permalink.html.j2' %}
                 {% endwith %}
             </h2>
-            {% with entity=place %}
+            {% with resource=place %}
                 {% include 'wikipedia.html.j2' %}
             {% endwith %}
         </section>

--- a/betty/extension/wikipedia/__init__.py
+++ b/betty/extension/wikipedia/__init__.py
@@ -248,7 +248,7 @@ class Wikipedia(Extension, Jinja2Provider, PostLoader, GuiBuilder):
     def gui_description(cls) -> str:
         return _("""
 Display <a href="https://www.wikipedia.org/">Wikipedia</a> summaries for resources with external links. In your custom <a href="https://jinja2docs.readthedocs.io/en/stable/">Jinja2</a> templates, use the following: <pre><code>
-{% with entity=resource_with_links %}
+{% with resource=resource_with_links %}
     {% include 'wikipedia.html.j2' %}
 {% endwith %}
 </code></pre>""")

--- a/betty/extension/wikipedia/assets/templates/wikipedia.html.j2
+++ b/betty/extension/wikipedia/assets/templates/wikipedia.html.j2
@@ -1,4 +1,4 @@
-{% set entries = entity.links | wikipedia | list %}
+{% set entries = resource.links | wikipedia | list %}
 {% if entries | length > 0 %}
     {% for entry in entries %}
         {{ entry.content | safe }}


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/729

## Change log
- The `wikipedia.html.j2` template now takes a `resource` parameter instead of `entity`. The allowed values remain the same.