### PR TITLE
Simplify how ancestries expose resources

### DIFF
--- a/betty/assets/public/static/sitemap.xml.j2
+++ b/betty/assets/public/static/sitemap.xml.j2
@@ -1,16 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
-    {% set identifiables = [] %}
-    {% set identifiables = identifiables + app.ancestry.people.values() | list %}
-    {% set identifiables = identifiables + app.ancestry.events.values() | list %}
-    {% set identifiables = identifiables + app.ancestry.places.values() | list %}
-    {% set identifiables = identifiables + app.ancestry.files.values() | list %}
-    {% set identifiables = identifiables + app.ancestry.sources.values() | list %}
-    {% set identifiables = identifiables + app.ancestry.citations.values() | list %}
     {% for locale_configuration in app.configuration.locales %}
-        {% for identifiable in identifiables %}
+        {% for resource in app.ancestry.resources | select('identifiable') %}
             <url>
-                <loc>{{ identifiable | url(absolute=true, locale=locale_configuration.locale) }}</loc>
+                <loc>{{ resource | url(absolute=true, locale=locale_configuration.locale) }}</loc>
             </url>
         {% endfor %}
     {% endfor %}

--- a/betty/assets/templates/base.html.j2
+++ b/betty/assets/templates/base.html.j2
@@ -67,7 +67,7 @@
                 <span class="overlay-control overlay-close" title="{% trans %}Exit the search{% endtrans %}">{% trans %}Exit the search{% endtrans %}</span>
             </div>
             <form>
-                {% set search_keywords_example_person_name = app.ancestry.people.values() | map(attribute='name') | first | default(none) %}
+                {% set search_keywords_example_person_name = app.ancestry.people | map(attribute='name') | first | default(none) %}
                 {% if search_keywords_example_person_name %}
                     {% set search_keywords_example -%}
                         {% trans example = person_macros.name_label(search_keywords_example_person_name, embedded=True) | striptags -%}

--- a/betty/extension/anonymizer/__init__.py
+++ b/betty/extension/anonymizer/__init__.py
@@ -31,19 +31,19 @@ class AnonymousCitation(Citation):
 def anonymize(ancestry: Ancestry) -> None:
     anonymous_source = AnonymousSource()
     anonymous_citation = AnonymousCitation(anonymous_source)
-    for person in ancestry.people.values():
+    for person in ancestry.people:
         if person.private:
             anonymize_person(person)
-    for event in ancestry.events.values():
+    for event in ancestry.events:
         if event.private:
             anonymize_event(event)
-    for file in ancestry.files.values():
+    for file in ancestry.files:
         if file.private:
             anonymize_file(file)
-    for source in ancestry.sources.values():
+    for source in ancestry.sources:
         if source.private:
             anonymize_source(source, anonymous_source)
-    for citation in ancestry.citations.values():
+    for citation in ancestry.citations:
         if citation.private:
             anonymize_citation(citation, anonymous_citation)
 

--- a/betty/extension/cleaner/__init__.py
+++ b/betty/extension/cleaner/__init__.py
@@ -5,7 +5,7 @@ except ImportError:
     from graphlib_backport import TopologicalSorter
 from typing import Set, Type, Dict
 
-from betty.ancestry import Ancestry, Place, File, IdentifiableEvent, IdentifiableSource, IdentifiableCitation, Person
+from betty.ancestry import Ancestry, Place, File, Person, Event, Source, Citation
 from betty.gui import GuiBuilder
 from betty.load import PostLoader
 from betty.extension import Extension
@@ -22,11 +22,11 @@ def clean(ancestry: Ancestry) -> None:
 
 
 def _clean_events(ancestry: Ancestry) -> None:
-    for event in list(ancestry.events.values()):
+    for event in ancestry.events:
         _clean_event(ancestry, event)
 
 
-def _clean_event(ancestry: Ancestry, event: IdentifiableEvent) -> None:
+def _clean_event(ancestry: Ancestry, event: Event) -> None:
     if len(event.presences) > 0:
         return
 
@@ -34,11 +34,11 @@ def _clean_event(ancestry: Ancestry, event: IdentifiableEvent) -> None:
     del event.place
     del event.citations
     del event.files
-    del ancestry.events[event.id]
+    ancestry.events.remove(event)
 
 
 def _clean_places(ancestry: Ancestry) -> None:
-    places = list(ancestry.places.values())
+    places = list(ancestry.places)
 
     def _extend_place_graph(graph: Dict, enclosing_place: Place) -> None:
         enclosures = enclosing_place.encloses
@@ -67,11 +67,11 @@ def _clean_place(ancestry: Ancestry, place: Place) -> None:
         return
 
     del place.enclosed_by
-    del ancestry.places[place.id]
+    ancestry.places.remove(place)
 
 
 def _clean_people(ancestry: Ancestry) -> None:
-    for person in list(ancestry.people.values()):
+    for person in list(ancestry.people):
         _clean_person(ancestry, person)
 
 
@@ -82,11 +82,11 @@ def _clean_person(ancestry: Ancestry, person: Person) -> None:
     if len(person.children) > 0:
         return
 
-    del ancestry.people[person.id]
+    ancestry.people.remove(person)
 
 
 def _clean_files(ancestry: Ancestry) -> None:
-    for file in list(ancestry.files.values()):
+    for file in list(ancestry.files):
         _clean_file(ancestry, file)
 
 
@@ -97,15 +97,15 @@ def _clean_file(ancestry: Ancestry, file: File) -> None:
     if len(file.citations) > 0:
         return
 
-    del ancestry.files[file.id]
+    ancestry.files.remove(file)
 
 
 def _clean_sources(ancestry: Ancestry) -> None:
-    for source in list(ancestry.sources.values()):
+    for source in list(ancestry.sources):
         _clean_source(ancestry, source)
 
 
-def _clean_source(ancestry: Ancestry, source: IdentifiableSource) -> None:
+def _clean_source(ancestry: Ancestry, source: Source) -> None:
     if len(source.citations) > 0:
         return
 
@@ -118,15 +118,15 @@ def _clean_source(ancestry: Ancestry, source: IdentifiableSource) -> None:
     if len(source.files) > 0:
         return
 
-    del ancestry.sources[source.id]
+    ancestry.sources.remove(source)
 
 
 def _clean_citations(ancestry: Ancestry) -> None:
-    for citation in list(ancestry.citations.values()):
+    for citation in list(ancestry.citations):
         _clean_citation(ancestry, citation)
 
 
-def _clean_citation(ancestry: Ancestry, citation: IdentifiableCitation) -> None:
+def _clean_citation(ancestry: Ancestry, citation: Citation) -> None:
     if len(citation.facts) > 0:
         return
 
@@ -134,7 +134,7 @@ def _clean_citation(ancestry: Ancestry, citation: IdentifiableCitation) -> None:
         return
 
     del citation.source
-    del ancestry.citations[citation.id]
+    ancestry.citations.remove(citation)
 
 
 class Cleaner(Extension, PostLoader, GuiBuilder):

--- a/betty/extension/demo/__init__.py
+++ b/betty/extension/demo/__init__.py
@@ -20,43 +20,43 @@ class Demo(Extension, Loader):
         amsterdam = Place('betty-demo-amsterdam', [PlaceName('Amsterdam')])
         amsterdam.coordinates = Point(52.366667, 4.9)
         amsterdam.links.add(Link('https://nl.wikipedia.org/wiki/Amsterdam'))
-        self._app.ancestry.places[amsterdam.id] = amsterdam
+        self._app.ancestry.places.add(amsterdam)
 
         ilpendam = Place('betty-demo-ilpendam', [PlaceName('Ilpendam')])
         ilpendam.coordinates = Point(52.465556, 4.951111)
         ilpendam.links.add(Link('https://nl.wikipedia.org/wiki/Ilpendam'))
-        self._app.ancestry.places[ilpendam.id] = ilpendam
+        self._app.ancestry.places.add(ilpendam)
 
         personal_accounts = IdentifiableSource('betty-demo-personal-accounts', 'Personal accounts')
-        self._app.ancestry.sources[personal_accounts.id] = personal_accounts
+        self._app.ancestry.sources.add(personal_accounts)
 
         cite_first_person_account = IdentifiableCitation('betty-demo-first-person-account', personal_accounts)
-        self._app.ancestry.citations[cite_first_person_account.id] = cite_first_person_account
+        self._app.ancestry.citations.add(cite_first_person_account)
 
         bevolkingsregister_amsterdam = IdentifiableSource('betty-demo-bevolkingsregister-amsterdam', 'Bevolkingsregister Amsterdam')
         bevolkingsregister_amsterdam.author = 'Gemeente Amsterdam'
         bevolkingsregister_amsterdam.publisher = 'Gemeente Amsterdam'
-        self._app.ancestry.sources[bevolkingsregister_amsterdam.id] = bevolkingsregister_amsterdam
+        self._app.ancestry.sources.add(bevolkingsregister_amsterdam)
 
         david_marinus_lankester = Person('betty-demo-david-marinus-lankester')
         david_marinus_lankester.names.append(PersonName('David Marinus', 'Lankester'))
-        self._app.ancestry.people[david_marinus_lankester.id] = david_marinus_lankester
+        self._app.ancestry.people.add(david_marinus_lankester)
 
         geertruida_van_ling = Person('betty-demo-geertruida-van-ling')
         geertruida_van_ling.names.append(PersonName('Geertruida', 'Van Ling'))
-        self._app.ancestry.people[geertruida_van_ling.id] = geertruida_van_ling
+        self._app.ancestry.people.add(geertruida_van_ling)
 
         marriage_of_dirk_jacobus_lankester_and_jannigje_palsen = IdentifiableEvent('betty-demo-marriage-of-dirk-jacobus-lankester-and-jannigje-palsen', Marriage(), Date(1922, 7, 4))
         marriage_of_dirk_jacobus_lankester_and_jannigje_palsen.place = ilpendam
-        self._app.ancestry.events[marriage_of_dirk_jacobus_lankester_and_jannigje_palsen.id] = marriage_of_dirk_jacobus_lankester_and_jannigje_palsen
+        self._app.ancestry.events.add(marriage_of_dirk_jacobus_lankester_and_jannigje_palsen)
 
         birth_of_dirk_jacobus_lankester = IdentifiableEvent('betty-demo-birth-of-dirk-jacobus-lankester', Birth(), Date(1897, 8, 25))
         birth_of_dirk_jacobus_lankester.place = amsterdam
-        self._app.ancestry.events[birth_of_dirk_jacobus_lankester.id] = birth_of_dirk_jacobus_lankester
+        self._app.ancestry.events.add(birth_of_dirk_jacobus_lankester)
 
         death_of_dirk_jacobus_lankester = IdentifiableEvent('betty-demo-death-of-dirk-jacobus-lankester', Death(), Date(1986, 8, 18))
         death_of_dirk_jacobus_lankester.place = amsterdam
-        self._app.ancestry.events[death_of_dirk_jacobus_lankester.id] = death_of_dirk_jacobus_lankester
+        self._app.ancestry.events.add(death_of_dirk_jacobus_lankester)
 
         dirk_jacobus_lankester = Person('betty-demo-dirk-jacobus-lankester')
         dirk_jacobus_lankester.names.append(PersonName('Dirk Jacobus', 'Lankester'))
@@ -64,55 +64,55 @@ class Demo(Extension, Loader):
         Presence(dirk_jacobus_lankester, Subject(), death_of_dirk_jacobus_lankester)
         Presence(dirk_jacobus_lankester, Subject(), marriage_of_dirk_jacobus_lankester_and_jannigje_palsen)
         dirk_jacobus_lankester.parents.append(david_marinus_lankester, geertruida_van_ling)
-        self._app.ancestry.people[dirk_jacobus_lankester.id] = dirk_jacobus_lankester
+        self._app.ancestry.people.add(dirk_jacobus_lankester)
 
         birth_of_marinus_david_lankester = IdentifiableEvent('betty-demo-birth-of-marinus-david', Birth(), DateRange(Date(1874, 1, 15), Date(1874, 3, 21), start_is_boundary=True, end_is_boundary=True))
         birth_of_marinus_david_lankester.place = amsterdam
-        self._app.ancestry.events[birth_of_marinus_david_lankester.id] = birth_of_marinus_david_lankester
+        self._app.ancestry.events.add(birth_of_marinus_david_lankester)
 
         death_of_marinus_david_lankester = IdentifiableEvent('betty-demo-death-of-marinus-david', Death(), Date(1971))
         death_of_marinus_david_lankester.place = amsterdam
-        self._app.ancestry.events[death_of_marinus_david_lankester.id] = death_of_marinus_david_lankester
+        self._app.ancestry.events.add(death_of_marinus_david_lankester)
 
         marinus_david_lankester = Person('betty-demo-marinus-david-lankester')
         marinus_david_lankester.names.append(PersonName('Marinus David', 'Lankester'))
         Presence(marinus_david_lankester, Subject(), birth_of_marinus_david_lankester)
         Presence(marinus_david_lankester, Subject(), death_of_marinus_david_lankester)
         marinus_david_lankester.parents.append(david_marinus_lankester, geertruida_van_ling)
-        self._app.ancestry.people[marinus_david_lankester.id] = marinus_david_lankester
+        self._app.ancestry.people.add(marinus_david_lankester)
 
         birth_of_jacoba_gesina_lankester = IdentifiableEvent('betty-demo-birth-of-jacoba-gesina', Birth(), Date(1900, 3, 14))
         birth_of_jacoba_gesina_lankester.place = amsterdam
-        self._app.ancestry.events[birth_of_jacoba_gesina_lankester.id] = birth_of_jacoba_gesina_lankester
+        self._app.ancestry.events.add(birth_of_jacoba_gesina_lankester)
 
         jacoba_gesina_lankester = Person('betty-demo-jacoba-gesina-lankester')
         jacoba_gesina_lankester.names.append(PersonName('Jacoba Gesina', 'Lankester'))
         Presence(jacoba_gesina_lankester, Subject(), birth_of_jacoba_gesina_lankester)
         jacoba_gesina_lankester.parents.append(david_marinus_lankester, geertruida_van_ling)
-        self._app.ancestry.people[jacoba_gesina_lankester.id] = jacoba_gesina_lankester
+        self._app.ancestry.people.add(jacoba_gesina_lankester)
 
         jannigje_palsen = Person('betty-demo-jannigje-palsen')
         jannigje_palsen.names.append(PersonName('Jannigje', 'Palsen'))
         Presence(jannigje_palsen, Subject(), marriage_of_dirk_jacobus_lankester_and_jannigje_palsen)
-        self._app.ancestry.people[jannigje_palsen.id] = jannigje_palsen
+        self._app.ancestry.people.add(jannigje_palsen)
 
         marriage_of_johan_de_boer_and_liberta_lankester = IdentifiableEvent('betty-demo-marriage-of-johan-de-boer-and-liberta-lankester', Marriage(), Date(1953, 6, 19))
         marriage_of_johan_de_boer_and_liberta_lankester.place = amsterdam
-        self._app.ancestry.events[marriage_of_johan_de_boer_and_liberta_lankester.id] = marriage_of_johan_de_boer_and_liberta_lankester
+        self._app.ancestry.events.add(marriage_of_johan_de_boer_and_liberta_lankester)
 
         cite_birth_of_liberta_lankester_from_bevolkingsregister_amsterdam = IdentifiableCitation('betty-demo-birth-of-liberta-lankester-from-bevolkingsregister-amsterdam', bevolkingsregister_amsterdam)
         cite_birth_of_liberta_lankester_from_bevolkingsregister_amsterdam.location = 'Amsterdam'
-        self._app.ancestry.citations[cite_birth_of_liberta_lankester_from_bevolkingsregister_amsterdam.id] = cite_birth_of_liberta_lankester_from_bevolkingsregister_amsterdam
+        self._app.ancestry.citations.add(cite_birth_of_liberta_lankester_from_bevolkingsregister_amsterdam)
 
         birth_of_liberta_lankester = IdentifiableEvent('betty-demo-birth-of-liberta-lankester', Birth(), Date(1929, 12, 22))
         birth_of_liberta_lankester.place = amsterdam
         birth_of_liberta_lankester.citations.append(cite_birth_of_liberta_lankester_from_bevolkingsregister_amsterdam)
-        self._app.ancestry.events[birth_of_liberta_lankester.id] = birth_of_liberta_lankester
+        self._app.ancestry.events.add(birth_of_liberta_lankester)
 
         death_of_liberta_lankester = IdentifiableEvent('betty-demo-death-of-liberta-lankester', Death(), Date(2015, 1, 17))
         death_of_liberta_lankester.place = amsterdam
         death_of_liberta_lankester.citations.append(cite_first_person_account)
-        self._app.ancestry.events[death_of_liberta_lankester.id] = death_of_liberta_lankester
+        self._app.ancestry.events.add(death_of_liberta_lankester)
 
         liberta_lankester = Person('betty-demo-liberta-lankester')
         liberta_lankester.names.append(PersonName('Liberta', 'Lankester'))
@@ -121,16 +121,16 @@ class Demo(Extension, Loader):
         Presence(liberta_lankester, Subject(), death_of_liberta_lankester)
         Presence(liberta_lankester, Subject(), marriage_of_johan_de_boer_and_liberta_lankester)
         liberta_lankester.parents.append(dirk_jacobus_lankester, jannigje_palsen)
-        self._app.ancestry.people[liberta_lankester.id] = liberta_lankester
+        self._app.ancestry.people.add(liberta_lankester)
 
         birth_of_johan_de_boer = IdentifiableEvent('betty-demo-birth-of-johan-de-boer', Birth(), Date(1930, 6, 20))
         birth_of_johan_de_boer.place = amsterdam
-        self._app.ancestry.events[birth_of_johan_de_boer.id] = birth_of_johan_de_boer
+        self._app.ancestry.events.add(birth_of_johan_de_boer)
 
         death_of_johan_de_boer = IdentifiableEvent('betty-demo-death-of-johan-de-boer', Death(), Date(1999, 3, 10))
         death_of_johan_de_boer.place = amsterdam
         death_of_johan_de_boer.citations.append(cite_first_person_account)
-        self._app.ancestry.events[death_of_johan_de_boer.id] = death_of_johan_de_boer
+        self._app.ancestry.events.add(death_of_johan_de_boer)
 
         johan_de_boer = Person('betty-demo-johan-de-boer')
         johan_de_boer.names.append(PersonName('Johan', 'De Boer'))
@@ -138,14 +138,14 @@ class Demo(Extension, Loader):
         Presence(johan_de_boer, Subject(), birth_of_johan_de_boer)
         Presence(johan_de_boer, Subject(), death_of_johan_de_boer)
         Presence(johan_de_boer, Subject(), marriage_of_johan_de_boer_and_liberta_lankester)
-        self._app.ancestry.people[johan_de_boer.id] = johan_de_boer
+        self._app.ancestry.people.add(johan_de_boer)
 
         parent_of_bart_feenstra_child_of_liberta_lankester = Person('betty-demo-parent-of-bart-feenstra-child-of-liberta-lankester')
         parent_of_bart_feenstra_child_of_liberta_lankester.names.append(PersonName('Bart\'s parent'))
         parent_of_bart_feenstra_child_of_liberta_lankester.parents.append(johan_de_boer, liberta_lankester)
-        self._app.ancestry.people[parent_of_bart_feenstra_child_of_liberta_lankester.id] = parent_of_bart_feenstra_child_of_liberta_lankester
+        self._app.ancestry.people.add(parent_of_bart_feenstra_child_of_liberta_lankester)
 
         bart_feenstra = Person('betty-demo-bart-feenstra')
         bart_feenstra.names.append(PersonName('Bart', 'Feenstra'))
         bart_feenstra.parents.append(parent_of_bart_feenstra_child_of_liberta_lankester)
-        self._app.ancestry.people[bart_feenstra.id] = bart_feenstra
+        self._app.ancestry.people.add(bart_feenstra)

--- a/betty/extension/deriver/__init__.py
+++ b/betty/extension/deriver/__init__.py
@@ -31,7 +31,7 @@ class Deriver(Extension, PostLoader, GuiBuilder):
             if isinstance(event_type, DerivableEventType):
                 created_derivations = 0
                 updated_derivations = 0
-                for person in ancestry.people.values():
+                for person in ancestry.people:
                     created, updated = derive(person, event_type_type)
                     created_derivations += created
                     updated_derivations += updated

--- a/betty/extension/gramps/__init__.py
+++ b/betty/extension/gramps/__init__.py
@@ -127,19 +127,19 @@ class _Loader:
 
     def _populate_ancestry(self):
         for file in self._files.values():
-            self._ancestry.files[file.file.id] = file.file
+            self._ancestry.files.add(file.file)
         for person in self._people.values():
-            self._ancestry.people[person.id] = person
+            self._ancestry.people.add(person)
         for place in self._places.values():
-            self._ancestry.places[place.id] = place
+            self._ancestry.places.add(place)
         for event in self._events.values():
-            self._ancestry.events[event.id] = event
+            self._ancestry.events.add(event)
         for source in self._sources.values():
-            self._ancestry.sources[source.id] = source
+            self._ancestry.sources.add(source)
         for citation in self._citations.values():
-            self._ancestry.citations[citation.id] = citation
+            self._ancestry.citations.add(citation)
         for note in self._notes.values():
-            self._ancestry.notes[note.id] = note
+            self._ancestry.notes.add(note)
 
     def load(self) -> None:
         logger = getLogger()

--- a/betty/extension/nginx/assets/nginx.conf.j2
+++ b/betty/extension/nginx/assets/nginx.conf.j2
@@ -24,7 +24,7 @@ server {
 
     {% if app.ancestry.files | length > 0 %}
         # Redirect Betty <0.3 file paths to Betty 0.3 file paths.
-        {% for file in app.ancestry.files.values() %}
+        {% for file in app.ancestry.files %}
             location /file/{{ file.id }}{{ file.path.suffix }} {
                 return 301 /file/{{ file.id }}/file/{{ file.path.name }};
             }

--- a/betty/extension/privatizer/__init__.py
+++ b/betty/extension/privatizer/__init__.py
@@ -27,7 +27,7 @@ def privatize(ancestry: Ancestry, lifetime_threshold: int = 125) -> None:
     seen = []
 
     privatized = 0
-    for person in ancestry.people.values():
+    for person in ancestry.people:
         private = person.private
         _privatize_person(person, seen, lifetime_threshold)
         if private is None and person.private is True:
@@ -35,16 +35,16 @@ def privatize(ancestry: Ancestry, lifetime_threshold: int = 125) -> None:
     logger = logging.getLogger()
     logger.info('Privatized %d people because they are likely still alive.' % privatized)
 
-    for citation in ancestry.citations.values():
+    for citation in ancestry.citations:
         _privatize_citation(citation, seen)
 
-    for source in ancestry.sources.values():
+    for source in ancestry.sources:
         _privatize_source(source, seen)
 
-    for event in ancestry.events.values():
+    for event in ancestry.events:
         _privatize_event(event, seen)
 
-    for file in ancestry.files.values():
+    for file in ancestry.files:
         _privatize_file(file, seen)
 
 

--- a/betty/extension/trees/assets/public/localized/people.json.j2
+++ b/betty/extension/trees/assets/public/localized/people.json.j2
@@ -1,5 +1,5 @@
 {% set ns = namespace(people={}) %}
-{% for person in app.ancestry.people.values() %}
+{% for person in app.ancestry.people %}
     {% set person_label %}
         {% with embedded=True %}
             {% include 'label/person.html.j2' %}

--- a/betty/generate.py
+++ b/betty/generate.py
@@ -53,32 +53,26 @@ async def _generate(app: App) -> None:
             await app.renderer.render_tree(www_directory_path)
 
             locale_label = Locale.parse(locale, '-').get_display_name()
-            await _generate_entity_type(www_directory_path, app.ancestry.files.values(
-            ), 'file', app, locale, app.jinja2_environment)
+            await _generate_entity_type(www_directory_path, app.ancestry.files, 'file', app, locale, app.jinja2_environment)
             logger.info('Generated pages for %d files in %s.' %
                         (len(app.ancestry.files), locale_label))
-            await _generate_entity_type(www_directory_path, app.ancestry.people.values(
-            ), 'person', app, locale, app.jinja2_environment)
+            await _generate_entity_type(www_directory_path, app.ancestry.people, 'person', app, locale, app.jinja2_environment)
             logger.info('Generated pages for %d people in %s.' %
                         (len(app.ancestry.people), locale_label))
-            await _generate_entity_type(www_directory_path, app.ancestry.places.values(
-            ), 'place', app, locale, app.jinja2_environment)
+            await _generate_entity_type(www_directory_path, app.ancestry.places, 'place', app, locale, app.jinja2_environment)
             logger.info('Generated pages for %d places in %s.' %
                         (len(app.ancestry.places), locale_label))
-            await _generate_entity_type(www_directory_path, app.ancestry.events.values(
-            ), 'event', app, locale, app.jinja2_environment)
+            await _generate_entity_type(www_directory_path, app.ancestry.events, 'event', app, locale, app.jinja2_environment)
             logger.info('Generated pages for %d events in %s.' %
                         (len(app.ancestry.events), locale_label))
-            await _generate_entity_type(www_directory_path, app.ancestry.citations.values(
-            ), 'citation', app, locale, app.jinja2_environment)
+            await _generate_entity_type(www_directory_path, app.ancestry.citations, 'citation', app, locale, app.jinja2_environment)
             logger.info('Generated pages for %d citations in %s.' %
                         (len(app.ancestry.citations), locale_label))
-            await _generate_entity_type(www_directory_path, app.ancestry.sources.values(
-            ), 'source', app, locale, app.jinja2_environment)
+            await _generate_entity_type(www_directory_path, app.ancestry.sources, 'source', app, locale, app.jinja2_environment)
             logger.info('Generated pages for %d sources in %s.' %
                         (len(app.ancestry.sources), locale_label))
-            _generate_entity_type_list_json(www_directory_path, app.ancestry.notes.values(), 'note', app)
-            for note in app.ancestry.notes.values():
+            _generate_entity_type_list_json(www_directory_path, app.ancestry.notes, 'note', app)
+            for note in app.ancestry.notes:
                 _generate_entity_json(www_directory_path, note, 'note', app, locale)
             logger.info('Generated pages for %d notes in %s.' % (len(app.ancestry.notes), locale_label))
             _generate_openapi(www_directory_path, app)

--- a/betty/search.py
+++ b/betty/search.py
@@ -10,9 +10,9 @@ class Index:
 
     def build(self) -> Iterable[Dict]:
         return filter(None, [
-            *[self._build_person(person) for person in self._app.ancestry.people.values()],
-            *[self._build_place(place) for place in self._app.ancestry.places.values()],
-            *[self._build_file(file) for file in self._app.ancestry.files.values()],
+            *[self._build_person(person) for person in self._app.ancestry.people],
+            *[self._build_place(place) for place in self._app.ancestry.places],
+            *[self._build_file(file) for file in self._app.ancestry.files],
         ])
 
     def _render_resource(self, resource: Resource):

--- a/betty/tests/extension/anonymizer/test__init__.py
+++ b/betty/tests/extension/anonymizer/test__init__.py
@@ -59,7 +59,7 @@ class AnonymizeTest(TestCase):
         person = Person('P0')
         person.private = False
         ancestry = Ancestry()
-        ancestry.people[person.id] = person
+        ancestry.people.add(person)
         anonymize(ancestry)
         m_anonymize_person.assert_not_called()
 
@@ -68,7 +68,7 @@ class AnonymizeTest(TestCase):
         person = Person('P0')
         person.private = True
         ancestry = Ancestry()
-        ancestry.people[person.id] = person
+        ancestry.people.add(person)
         anonymize(ancestry)
         m_anonymize_person.assert_called_once_with(person)
 
@@ -77,7 +77,7 @@ class AnonymizeTest(TestCase):
         event = IdentifiableEvent('E0', Birth())
         event.private = False
         ancestry = Ancestry()
-        ancestry.events[event.id] = event
+        ancestry.events.add(event)
         anonymize(ancestry)
         m_anonymize_event.assert_not_called()
 
@@ -86,7 +86,7 @@ class AnonymizeTest(TestCase):
         event = IdentifiableEvent('E0', Birth())
         event.private = True
         ancestry = Ancestry()
-        ancestry.events[event.id] = event
+        ancestry.events.add(event)
         anonymize(ancestry)
         m_anonymize_event.assert_called_once_with(event)
 
@@ -95,7 +95,7 @@ class AnonymizeTest(TestCase):
         file = File('F0', __file__)
         file.private = False
         ancestry = Ancestry()
-        ancestry.files[file.id] = file
+        ancestry.files.add(file)
         anonymize(ancestry)
         m_anonymize_file.assert_not_called()
 
@@ -104,7 +104,7 @@ class AnonymizeTest(TestCase):
         file = File('F0', __file__)
         file.private = True
         ancestry = Ancestry()
-        ancestry.files[file.id] = file
+        ancestry.files.add(file)
         anonymize(ancestry)
         m_anonymize_file.assert_called_once_with(file)
 
@@ -113,7 +113,7 @@ class AnonymizeTest(TestCase):
         source = IdentifiableSource('S0', 'The Source')
         source.private = False
         ancestry = Ancestry()
-        ancestry.sources[source.id] = source
+        ancestry.sources.add(source)
         anonymize(ancestry)
         m_anonymize_source.assert_not_called()
 
@@ -122,7 +122,7 @@ class AnonymizeTest(TestCase):
         source = IdentifiableSource('S0', 'The Source')
         source.private = True
         ancestry = Ancestry()
-        ancestry.sources[source.id] = source
+        ancestry.sources.add(source)
         anonymize(ancestry)
         m_anonymize_source.assert_called_once_with(source, ANY)
 
@@ -132,7 +132,7 @@ class AnonymizeTest(TestCase):
         citation = IdentifiableCitation('C0', source)
         citation.private = False
         ancestry = Ancestry()
-        ancestry.citations[citation.id] = citation
+        ancestry.citations.add(citation)
         anonymize(ancestry)
         m_anonymize_citation.assert_not_called()
 
@@ -142,7 +142,7 @@ class AnonymizeTest(TestCase):
         citation = IdentifiableCitation('C0', source)
         citation.private = True
         ancestry = Ancestry()
-        ancestry.citations[citation.id] = citation
+        ancestry.citations.add(citation)
         anonymize(ancestry)
         m_anonymize_citation.assert_called_once_with(citation, ANY)
 
@@ -325,6 +325,6 @@ class AnonymizerTest(TestCase):
                 output_directory_path, 'https://example.com')
             configuration.extensions.add(ExtensionConfiguration(Anonymizer))
             async with App(configuration) as app:
-                app.ancestry.people[person.id] = person
+                app.ancestry.people.add(person)
                 await load(app)
         self.assertEquals(0, len(person.names))

--- a/betty/tests/extension/cleaner/test__init__.py
+++ b/betty/tests/extension/cleaner/test__init__.py
@@ -19,9 +19,9 @@ class CleanerTest(TestCase):
                 output_directory_path, 'https://example.com')
             configuration.extensions.add(ExtensionConfiguration(Cleaner))
             async with App(configuration) as app:
-                app.ancestry.events[event.id] = event
+                app.ancestry.events.add(event)
                 await load(app)
-                self.assertEquals({}, app.ancestry.events)
+                self.assertEquals([], list(app.ancestry.events))
 
 
 class CleanTest(TestCase):
@@ -30,34 +30,28 @@ class CleanTest(TestCase):
 
         onymous_event = IdentifiableEvent('E0', Birth())
         Presence(Person('P0'), Subject(), onymous_event)
-        ancestry.events[onymous_event.id] = onymous_event
+        ancestry.events.add(onymous_event)
 
         anonymous_event = IdentifiableEvent('E1', Birth())
-        ancestry.events[anonymous_event.id] = anonymous_event
+        ancestry.events.add(anonymous_event)
 
         onymous_place = Place('P0', [PlaceName('Amsterdam')])
         onymous_place.events.append(onymous_event)
-        ancestry.places[onymous_place.id] = onymous_place
+        ancestry.places.add(onymous_place)
 
         anonymous_place = Place('P1', [PlaceName('Almelo')])
-        ancestry.places[anonymous_place.id] = anonymous_place
+        ancestry.places.add(anonymous_place)
 
         onmyous_place_because_encloses_onmyous_places = Place(
             'P3', [PlaceName('Netherlands')])
         Enclosure(onymous_place, onmyous_place_because_encloses_onmyous_places)
         Enclosure(anonymous_place, onmyous_place_because_encloses_onmyous_places)
-        ancestry.places[
-            onmyous_place_because_encloses_onmyous_places.id] = onmyous_place_because_encloses_onmyous_places
+        ancestry.places.add(onmyous_place_because_encloses_onmyous_places)
 
         clean(ancestry)
 
-        self.assertDictEqual({
-            onymous_event.id: onymous_event,
-        }, ancestry.events)
-        self.assertDictEqual({
-            onymous_place.id: onymous_place,
-            onmyous_place_because_encloses_onmyous_places.id: onmyous_place_because_encloses_onmyous_places,
-        }, ancestry.places)
+        self.assertEquals([onymous_event], list(ancestry.events))
+        self.assertEquals([onymous_place, onmyous_place_because_encloses_onmyous_places], list(ancestry.places))
 
         self.assertNotIn(
             anonymous_place, onmyous_place_because_encloses_onmyous_places.encloses)
@@ -67,7 +61,7 @@ class CleanTest(TestCase):
 
         person = Person('P0')
         person.private = False
-        ancestry.people[person.id] = person
+        ancestry.people.add(person)
 
         clean(ancestry)
 
@@ -78,16 +72,16 @@ class CleanTest(TestCase):
 
         person = Person('P0')
         person.private = True
-        ancestry.people[person.id] = person
+        ancestry.people.add(person)
         child = Person('P1')
         child.private = True
-        ancestry.people[child.id] = child
+        ancestry.people.add(child)
         grandchild = Person('P2')
         grandchild.private = True
-        ancestry.people[grandchild.id] = grandchild
+        ancestry.people.add(grandchild)
         great_grandchild = Person('P3')
         great_grandchild.private = True
-        ancestry.people[great_grandchild.id] = great_grandchild
+        ancestry.people.add(great_grandchild)
 
         clean(ancestry)
 
@@ -98,16 +92,16 @@ class CleanTest(TestCase):
 
         person = Person('P0')
         person.private = False
-        ancestry.people[person.id] = person
+        ancestry.people.add(person)
         child = Person('P1')
         child.private = True
-        ancestry.people[child.id] = child
+        ancestry.people.add(child)
         grandchild = Person('P2')
         grandchild.private = True
-        ancestry.people[grandchild.id] = grandchild
+        ancestry.people.add(grandchild)
         great_grandchild = Person('P3')
         great_grandchild.private = False
-        ancestry.people[great_grandchild.id] = great_grandchild
+        ancestry.people.add(great_grandchild)
 
         clean(ancestry)
 
@@ -117,22 +111,22 @@ class CleanTest(TestCase):
         ancestry = Ancestry()
 
         source = IdentifiableSource('S1', 'The Source')
-        ancestry.sources[source.id] = source
+        ancestry.sources.add(source)
 
         citation = IdentifiableCitation('C1', source)
-        ancestry.citations[citation.id] = citation
+        ancestry.citations.add(citation)
 
         file = File('F1', __file__)
-        ancestry.files[file.id] = file
+        ancestry.files.add(file)
 
         place = Place('P0', [PlaceName('The Place')])
-        ancestry.places[place.id] = place
+        ancestry.places.add(place)
 
         event = IdentifiableEvent('E0', Birth())
         event.citations.append(citation)
         event.files.append(file)
         event.place = place
-        ancestry.events[event.id] = event
+        ancestry.events.add(event)
 
         clean(ancestry)
 
@@ -149,16 +143,16 @@ class CleanTest(TestCase):
         ancestry = Ancestry()
 
         source = IdentifiableSource('S1', 'The Source')
-        ancestry.sources[source.id] = source
+        ancestry.sources.add(source)
 
         citation = IdentifiableCitation('C1', source)
-        ancestry.citations[citation.id] = citation
+        ancestry.citations.add(citation)
 
         file = File('F1', __file__)
-        ancestry.files[file.id] = file
+        ancestry.files.add(file)
 
         place = Place('P0', [PlaceName('The Place')])
-        ancestry.places[place.id] = place
+        ancestry.places.add(place)
 
         person = Person('P0')
 
@@ -166,7 +160,7 @@ class CleanTest(TestCase):
         event.citations.append(citation)
         event.files.append(file)
         event.place = place
-        ancestry.events[event.id] = event
+        ancestry.events.add(event)
 
         Presence(person, Subject(), event)
 
@@ -184,7 +178,7 @@ class CleanTest(TestCase):
         ancestry = Ancestry()
 
         file = File('F0', __file__)
-        ancestry.files[file.id] = file
+        ancestry.files.add(file)
 
         clean(ancestry)
 
@@ -194,11 +188,11 @@ class CleanTest(TestCase):
         ancestry = Ancestry()
 
         person = Person('P0')
-        ancestry.people[person.id] = person
+        ancestry.people.add(person)
 
         file = File('F0', __file__)
         file.resources.append(person)
-        ancestry.files[file.id] = file
+        ancestry.files.add(file)
 
         clean(ancestry)
 
@@ -212,11 +206,11 @@ class CleanTest(TestCase):
         source = Source()
 
         citation = IdentifiableCitation('C1', source)
-        ancestry.citations[citation.id] = citation
+        ancestry.citations.add(citation)
 
         file = File('F0', __file__)
         file.citations.append(citation)
-        ancestry.files[file.id] = file
+        ancestry.files.add(file)
 
         clean(ancestry)
 
@@ -228,7 +222,7 @@ class CleanTest(TestCase):
         ancestry = Ancestry()
 
         source = IdentifiableSource('S0', 'The source')
-        ancestry.sources[source.id] = source
+        ancestry.sources.add(source)
 
         clean(ancestry)
 
@@ -238,11 +232,11 @@ class CleanTest(TestCase):
         ancestry = Ancestry()
 
         source = IdentifiableSource('S0', 'The Source')
-        ancestry.sources[source.id] = source
+        ancestry.sources.add(source)
 
         citation = IdentifiableCitation('C0', source)
         citation.facts.append(PersonName('Jane'))
-        ancestry.citations[citation.id] = citation
+        ancestry.citations.add(citation)
 
         clean(ancestry)
 
@@ -254,11 +248,11 @@ class CleanTest(TestCase):
         ancestry = Ancestry()
 
         source = IdentifiableSource('S0', 'The Source')
-        ancestry.sources[source.id] = source
+        ancestry.sources.add(source)
 
         contained_by = IdentifiableSource('S1', 'The Source')
         contained_by.contains.append(source)
-        ancestry.sources[contained_by.id] = contained_by
+        ancestry.sources.add(contained_by)
 
         clean(ancestry)
 
@@ -270,11 +264,11 @@ class CleanTest(TestCase):
         ancestry = Ancestry()
 
         source = IdentifiableSource('S0', 'The Source')
-        ancestry.sources[source.id] = source
+        ancestry.sources.add(source)
 
         contains = IdentifiableSource('S1', 'The Source')
         contains.contained_by = source
-        ancestry.sources[contains.id] = contains
+        ancestry.sources.add(contains)
 
         clean(ancestry)
 
@@ -286,11 +280,11 @@ class CleanTest(TestCase):
         ancestry = Ancestry()
 
         file = File('F0', __file__)
-        ancestry.files[file.id] = file
+        ancestry.files.add(file)
 
         source = IdentifiableSource('S0', 'The Source')
         source.files.append(file)
-        ancestry.sources[source.id] = source
+        ancestry.sources.add(source)
 
         clean(ancestry)
 
@@ -302,10 +296,10 @@ class CleanTest(TestCase):
         ancestry = Ancestry()
 
         source = IdentifiableSource('S0', 'The source')
-        ancestry.sources[source.id] = source
+        ancestry.sources.add(source)
 
         citation = IdentifiableCitation('C0', source)
-        ancestry.citations[citation.id] = citation
+        ancestry.citations.add(citation)
 
         clean(ancestry)
 
@@ -316,15 +310,15 @@ class CleanTest(TestCase):
         ancestry = Ancestry()
 
         source = IdentifiableSource('S0', 'The Source')
-        ancestry.sources[source.id] = source
+        ancestry.sources.add(source)
 
         citation = IdentifiableCitation('C0', source)
         citation.facts.append(PersonName('Jane'))
-        ancestry.citations[citation.id] = citation
+        ancestry.citations.add(citation)
 
         fact = Person('P0')
         fact.citations.append(citation)
-        ancestry.people[fact.id] = fact
+        ancestry.people.add(fact)
 
         clean(ancestry)
 
@@ -336,14 +330,14 @@ class CleanTest(TestCase):
         ancestry = Ancestry()
 
         source = IdentifiableSource('S0', 'The Source')
-        ancestry.sources[source.id] = source
+        ancestry.sources.add(source)
 
         file = File('F0', __file__)
-        ancestry.files[file.id] = file
+        ancestry.files.add(file)
 
         citation = IdentifiableCitation('C0', source)
         citation.files.append(file)
-        ancestry.citations[citation.id] = citation
+        ancestry.citations.add(citation)
 
         clean(ancestry)
 

--- a/betty/tests/extension/deriver/test__init__.py
+++ b/betty/tests/extension/deriver/test__init__.py
@@ -71,7 +71,7 @@ class DeriverTest(TestCase):
                 output_directory_path, 'https://example.com')
             configuration.extensions.add(ExtensionConfiguration(Deriver))
             async with App(configuration) as app:
-                app.ancestry.people[person.id] = person
+                app.ancestry.people.add(person)
                 await load(app)
 
         self.assertEquals(3, len(person.presences))

--- a/betty/tests/extension/nginx/test_integration.py
+++ b/betty/tests/extension/nginx/test_integration.py
@@ -195,7 +195,7 @@ class NginxTest(TestCase):
             ))
             app = App(configuration)
             file_id = 'FILE1'
-            app.ancestry.files[file_id] = File(file_id, __file__)
+            app.ancestry.files.add(File(file_id, __file__))
             async with self.NginxTestServer(app) as server:
                 response = requests.get(f'{server.public_url}/file/{file_id}.py', headers={
                     'Accept': 'application/json',

--- a/betty/tests/extension/privatizer/test__init__.py
+++ b/betty/tests/extension/privatizer/test__init__.py
@@ -101,9 +101,9 @@ class PrivatizerTest(TestCase):
                 output_directory_path, 'https://example.com')
             configuration.extensions.add(ExtensionConfiguration(Privatizer))
             async with App(configuration) as app:
-                app.ancestry.people[person.id] = person
-                app.ancestry.sources[source.id] = source
-                app.ancestry.citations[citation.id] = citation
+                app.ancestry.people.add(person)
+                app.ancestry.sources.add(source)
+                app.ancestry.citations.add(citation)
                 await load(app)
 
             self.assertTrue(person.private)
@@ -127,7 +127,7 @@ class PrivatizerTest(TestCase):
         Presence(person, Subject(), event_as_subject)
         Presence(person, Attendee(), event_as_attendee)
         ancestry = Ancestry()
-        ancestry.people[person.id] = person
+        ancestry.people.add(person)
         privatize(ancestry)
         self.assertEqual(False, person.private)
         self.assertIsNone(citation.private)
@@ -155,7 +155,7 @@ class PrivatizerTest(TestCase):
         Presence(person, Subject(), event_as_subject)
         Presence(person, Attendee(), event_as_attendee)
         ancestry = Ancestry()
-        ancestry.people[person.id] = person
+        ancestry.people.add(person)
         privatize(ancestry)
         self.assertTrue(person.private)
         self.assertTrue(citation.private)
@@ -173,7 +173,7 @@ class PrivatizerTest(TestCase):
         if event is not None:
             Presence(person, Subject(), event)
         ancestry = Ancestry()
-        ancestry.people[person.id] = person
+        ancestry.people.add(person)
         privatize(ancestry)
         self.assertEquals(expected, person.private)
 
@@ -186,7 +186,7 @@ class PrivatizerTest(TestCase):
             Presence(child, Subject(), event)
         person.children.append(child)
         ancestry = Ancestry()
-        ancestry.people[person.id] = person
+        ancestry.people.add(person)
         privatize(ancestry)
         self.assertEquals(expected, person.private)
 
@@ -201,7 +201,7 @@ class PrivatizerTest(TestCase):
             Presence(grandchild, Subject(), event)
         child.children.append(grandchild)
         ancestry = Ancestry()
-        ancestry.people[person.id] = person
+        ancestry.people.add(person)
         privatize(ancestry)
         self.assertEquals(expected, person.private)
 
@@ -218,7 +218,7 @@ class PrivatizerTest(TestCase):
             Presence(great_grandchild, Subject(), event)
         grandchild.children.append(great_grandchild)
         ancestry = Ancestry()
-        ancestry.people[person.id] = person
+        ancestry.people.add(person)
         privatize(ancestry)
         self.assertEquals(expected, person.private)
 
@@ -231,7 +231,7 @@ class PrivatizerTest(TestCase):
             Presence(parent, Subject(), event)
         person.parents.append(parent)
         ancestry = Ancestry()
-        ancestry.people[person.id] = person
+        ancestry.people.add(person)
         privatize(ancestry)
         self.assertEquals(expected, person.private)
 
@@ -246,7 +246,7 @@ class PrivatizerTest(TestCase):
             Presence(grandparent, Subject(), event)
         parent.parents.append(grandparent)
         ancestry = Ancestry()
-        ancestry.people[person.id] = person
+        ancestry.people.add(person)
         privatize(ancestry)
         self.assertEquals(expected, person.private)
 
@@ -263,7 +263,7 @@ class PrivatizerTest(TestCase):
             Presence(great_grandparent, Subject(), event)
         grandparent.parents.append(great_grandparent)
         ancestry = Ancestry()
-        ancestry.people[person.id] = person
+        ancestry.people.add(person)
         privatize(ancestry)
         self.assertEquals(expected, person.private)
 
@@ -282,7 +282,7 @@ class PrivatizerTest(TestCase):
         person = Person('P0')
         Presence(person, Subject(), event)
         ancestry = Ancestry()
-        ancestry.events[event.id] = event
+        ancestry.events.add(event)
         privatize(ancestry)
         self.assertEqual(False, event.private)
         self.assertIsNone(event_file.private)
@@ -307,7 +307,7 @@ class PrivatizerTest(TestCase):
         person = Person('P0')
         Presence(person, Subject(), event)
         ancestry = Ancestry()
-        ancestry.events[event.id] = event
+        ancestry.events.add(event)
         privatize(ancestry)
         self.assertTrue(event.private)
         self.assertTrue(event_file.private)
@@ -323,7 +323,7 @@ class PrivatizerTest(TestCase):
         source.private = False
         source.files.append(file)
         ancestry = Ancestry()
-        ancestry.sources[source.id] = source
+        ancestry.sources.add(source)
         privatize(ancestry)
         self.assertEqual(False, source.private)
         self.assertIsNone(file.private)
@@ -334,7 +334,7 @@ class PrivatizerTest(TestCase):
         source.private = True
         source.files.append(file)
         ancestry = Ancestry()
-        ancestry.sources[source.id] = source
+        ancestry.sources.add(source)
         privatize(ancestry)
         self.assertTrue(source.private)
         self.assertTrue(file.private)
@@ -348,7 +348,7 @@ class PrivatizerTest(TestCase):
         citation.private = False
         citation.files.append(citation_file)
         ancestry = Ancestry()
-        ancestry.citations[citation.id] = citation
+        ancestry.citations.add(citation)
         privatize(ancestry)
         self.assertEqual(False, citation.private)
         self.assertIsNone(source.private)
@@ -364,7 +364,7 @@ class PrivatizerTest(TestCase):
         citation.private = True
         citation.files.append(citation_file)
         ancestry = Ancestry()
-        ancestry.citations[citation.id] = citation
+        ancestry.citations.add(citation)
         privatize(ancestry)
         self.assertTrue(citation.private)
         self.assertTrue(source.private)
@@ -378,7 +378,7 @@ class PrivatizerTest(TestCase):
         file.private = False
         file.citations.append(citation)
         ancestry = Ancestry()
-        ancestry.files[file.id] = file
+        ancestry.files.add(file)
         privatize(ancestry)
         self.assertEqual(False, file.private)
         self.assertIsNone(citation.private)
@@ -390,7 +390,7 @@ class PrivatizerTest(TestCase):
         file.private = True
         file.citations.append(citation)
         ancestry = Ancestry()
-        ancestry.files[file.id] = file
+        ancestry.files.add(file)
         privatize(ancestry)
         self.assertTrue(True, file.private)
         self.assertTrue(citation.private)

--- a/betty/tests/extension/wikipedia/test__init__.py
+++ b/betty/tests/extension/wikipedia/test__init__.py
@@ -353,7 +353,7 @@ class PopulatorTest(TestCase):
                     output_directory_path, 'https://example.com')
                 configuration.cache_directory_path = cache_directory_path
                 async with App(configuration) as app:
-                    app.ancestry.citations[resource.id] = resource
+                    app.ancestry.citations.add(resource)
                     sut = _Populator(app, m_retriever)
                     await sut.populate()
 
@@ -367,7 +367,7 @@ class PopulatorTest(TestCase):
                     output_directory_path, 'https://example.com')
                 configuration.cache_directory_path = cache_directory_path
                 async with App(configuration) as app:
-                    app.ancestry.sources[resource.id] = resource
+                    app.ancestry.sources.add(resource)
                     sut = _Populator(app, m_retriever)
                     await sut.populate()
         self.assertSetEqual(set(), resource.links)
@@ -384,7 +384,7 @@ class PopulatorTest(TestCase):
                     output_directory_path, 'https://example.com')
                 configuration.cache_directory_path = cache_directory_path
                 async with App(configuration) as app:
-                    app.ancestry.sources[resource.id] = resource
+                    app.ancestry.sources.add(resource)
                     sut = _Populator(app, m_retriever)
                     await sut.populate()
         self.assertSetEqual({link}, resource.links)
@@ -408,7 +408,7 @@ class PopulatorTest(TestCase):
                     output_directory_path, 'https://example.com')
                 configuration.cache_directory_path = cache_directory_path
                 async with App(configuration) as app:
-                    app.ancestry.sources[resource.id] = resource
+                    app.ancestry.sources.add(resource)
                     sut = _Populator(app, m_retriever)
                     await sut.populate()
         m_retriever.get_entry.assert_called_once_with(entry_language, entry_name)
@@ -455,7 +455,7 @@ class PopulatorTest(TestCase):
                     LocaleConfiguration('nl-NL', 'nl'),
                 ])
                 async with App(configuration) as app:
-                    app.ancestry.sources[resource.id] = resource
+                    app.ancestry.sources.add(resource)
                     sut = _Populator(app, m_retriever)
                     await sut.populate()
 
@@ -550,7 +550,7 @@ class WikipediaTest(TestCase):
                 configuration.cache_directory_path = Path(cache_directory_path)
                 configuration.extensions.add(ExtensionConfiguration(Wikipedia))
                 async with App(configuration) as app:
-                    app.ancestry.sources[resource.id] = resource
+                    app.ancestry.sources.add(resource)
                     await load(app)
 
         self.assertEqual(1, len(resource.links))

--- a/betty/tests/test_generate.py
+++ b/betty/tests/test_generate.py
@@ -63,7 +63,7 @@ class RenderTest(GenerateTestCase):
         # @todo This fails somewhere in file.html.j2, very likely because of jinja2._filter_file()
         with NamedTemporaryFile() as f:
             file = File('FILE1', Path(f.name))
-            self.app.ancestry.files[file.id] = file
+            self.app.ancestry.files.add(file)
             await generate(self.app)
             self.assert_betty_html('/file/%s/index.html' % file.id)
             self.assert_betty_json('/file/%s/index.json' % file.id, 'file')
@@ -77,7 +77,7 @@ class RenderTest(GenerateTestCase):
     @sync
     async def test_place(self):
         place = Place('PLACE1', [PlaceName('one')])
-        self.app.ancestry.places[place.id] = place
+        self.app.ancestry.places.add(place)
         await generate(self.app)
         self.assert_betty_html('/place/%s/index.html' % place.id)
         self.assert_betty_json('/place/%s/index.json' % place.id, 'place')
@@ -91,7 +91,7 @@ class RenderTest(GenerateTestCase):
     @sync
     async def test_person(self):
         person = Person('PERSON1')
-        self.app.ancestry.people[person.id] = person
+        self.app.ancestry.people.add(person)
         await generate(self.app)
         self.assert_betty_html('/person/%s/index.html' % person.id)
         self.assert_betty_json('/person/%s/index.json' % person.id, 'person')
@@ -105,7 +105,7 @@ class RenderTest(GenerateTestCase):
     @sync
     async def test_event(self):
         event = IdentifiableEvent('EVENT1', Birth())
-        self.app.ancestry.events[event.id] = event
+        self.app.ancestry.events.add(event)
         await generate(self.app)
         self.assert_betty_html('/event/%s/index.html' % event.id)
         self.assert_betty_json('/event/%s/index.json' % event.id, 'event')
@@ -113,7 +113,7 @@ class RenderTest(GenerateTestCase):
     @sync
     async def test_citation(self):
         citation = IdentifiableCitation('CITATION1', Source('A Little Birdie'))
-        self.app.ancestry.citations[citation.id] = citation
+        self.app.ancestry.citations.add(citation)
         await generate(self.app)
         self.assert_betty_html('/citation/%s/index.html' % citation.id)
         self.assert_betty_json('/citation/%s/index.json' %
@@ -128,7 +128,7 @@ class RenderTest(GenerateTestCase):
     @sync
     async def test_source(self):
         source = IdentifiableSource('SOURCE1', 'A Little Birdie')
-        self.app.ancestry.sources[source.id] = source
+        self.app.ancestry.sources.add(source)
         await generate(self.app)
         self.assert_betty_html('/source/%s/index.html' % source.id)
         self.assert_betty_json('/source/%s/index.json' % source.id, 'source')
@@ -164,7 +164,7 @@ class MultilingualTest(GenerateTestCase):
     @sync
     async def test_entity(self):
         person = Person('PERSON1')
-        self.app.ancestry.people[person.id] = person
+        self.app.ancestry.people.add(person)
         await generate(self.app)
         with open(self.assert_betty_html('/nl/person/%s/index.html' % person.id)) as f:
             translation_link = '<a href="/en/person/%s/index.html" hreflang="en" lang="en" rel="alternate">English</a>' % person.id

--- a/betty/tests/test_search.py
+++ b/betty/tests/test_search.py
@@ -38,7 +38,7 @@ class IndexTest(TestCase):
                 LocaleConfiguration('nl-NL', 'nl'),
             ])
             async with App(configuration) as app:
-                app.ancestry.people[person_id] = person
+                app.ancestry.people.add(person)
                 indexed = [item for item in Index(app).build()]
 
         self.assertEquals([], indexed)
@@ -59,7 +59,7 @@ class IndexTest(TestCase):
                 LocaleConfiguration('nl-NL', 'nl'),
             ])
             async with App(configuration) as app:
-                app.ancestry.people[person_id] = person
+                app.ancestry.people.add(person)
                 indexed = [item for item in Index(app).build()]
 
         self.assertEquals([], indexed)
@@ -83,7 +83,7 @@ class IndexTest(TestCase):
                 LocaleConfiguration('nl-NL', 'nl'),
             ])
             async with App(configuration).with_locale(locale) as app:
-                app.ancestry.people[person_id] = person
+                app.ancestry.people.add(person)
                 indexed = [item for item in Index(app).build()]
 
         self.assertEquals('jane', indexed[0]['text'])
@@ -108,7 +108,7 @@ class IndexTest(TestCase):
                 LocaleConfiguration('nl-NL', 'nl'),
             ])
             async with App(configuration).with_locale(locale) as app:
-                app.ancestry.people[person_id] = person
+                app.ancestry.people.add(person)
                 indexed = [item for item in Index(app).build()]
 
         self.assertEquals('doughnut', indexed[0]['text'])
@@ -134,7 +134,7 @@ class IndexTest(TestCase):
                 LocaleConfiguration('nl-NL', 'nl'),
             ])
             async with App(configuration).with_locale(locale) as app:
-                app.ancestry.people[person_id] = person
+                app.ancestry.people.add(person)
                 indexed = [item for item in Index(app).build()]
 
         self.assertEquals('jane doughnut', indexed[0]['text'])
@@ -157,7 +157,7 @@ class IndexTest(TestCase):
                 LocaleConfiguration('nl-NL', 'nl'),
             ])
             async with App(configuration).with_locale(locale) as app:
-                app.ancestry.places[place_id] = place
+                app.ancestry.places.add(place)
                 indexed = [item for item in Index(app).build()]
 
         self.assertEquals('netherlands nederland', indexed[0]['text'])
@@ -176,7 +176,7 @@ class IndexTest(TestCase):
                 LocaleConfiguration('nl-NL', 'nl'),
             ])
             async with App(configuration) as app:
-                app.ancestry.files[file_id] = file
+                app.ancestry.files.add(file)
                 indexed = [item for item in Index(app).build()]
 
         self.assertEquals([], indexed)
@@ -199,7 +199,7 @@ class IndexTest(TestCase):
                 LocaleConfiguration('nl-NL', 'nl'),
             ])
             async with App(configuration).with_locale(locale) as app:
-                app.ancestry.files[file_id] = file
+                app.ancestry.files.add(file)
                 indexed = [item for item in Index(app).build()]
 
         self.assertEquals('"file" is dutch for "traffic jam"', indexed[0]['text'])


### PR DESCRIPTION
Simplify how ancestries expose resources and make this more consistent, so identifiable and non-identifiable resources are supported simultaneously.

This fixes https://github.com/bartfeenstra/betty/issues/687