### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,6 @@ jobs:
             os: ubuntu-latest
             python: '3.7'
             node: '15'
-          - name: 'Python 3.6'
-            os: ubuntu-latest
-            python: '3.6'
-            node: '15'
           - name: 'Node.js 16'
             os: ubuntu-latest
             python: '3.9'

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ secure**.
 ## Installation
 
 ### Requirements
-- **Python 3.6+**
+- **Python 3.7+**
 - Node.js 10+ (optional)
 - Linux, Mac OS, or Windows
 

--- a/betty/app.py
+++ b/betty/app.py
@@ -2,6 +2,8 @@ import gettext
 from collections import defaultdict
 from concurrent.futures._base import Executor
 from concurrent.futures.thread import ThreadPoolExecutor
+from contextlib import AsyncExitStack
+
 try:
     from graphlib import TopologicalSorter
 except ImportError:
@@ -18,10 +20,6 @@ from betty.extension import _build_extension_type_graph, ConfigurableExtension, 
 from betty.lock import Locks
 from betty.render import Renderer, SequentialRenderer
 
-try:
-    from contextlib import AsyncExitStack
-except ImportError:
-    from async_exit_stack import AsyncExitStack
 from copy import copy
 from typing import Type, Dict, Sequence, List
 

--- a/betty/tests/__init__.py
+++ b/betty/tests/__init__.py
@@ -1,22 +1,16 @@
 import functools
 import logging
-from contextlib import suppress
+import unittest
+from contextlib import suppress, asynccontextmanager
 from pathlib import Path
-
-from betty import fs
-
-try:
-    from contextlib import asynccontextmanager
-except ImportError:
-    from async_generator import asynccontextmanager
 from tempfile import TemporaryDirectory
 from typing import Optional, Dict, Callable, Tuple
-import unittest
 
 from jinja2 import Environment, Template
 
-from betty.config import Configuration
+from betty import fs
 from betty.app import App
+from betty.config import Configuration
 
 
 def patch_cache(f):
@@ -29,7 +23,7 @@ def patch_cache(f):
             f(*args, **kwargs)
         finally:
             fs.CACHE_DIRECTORY_PATH = original_cache_directory_path
-            # Pythons 3.6 and 3.7 do not allow the temporary directory to have been removed already.
+            # Python 3.7 does not allow the temporary directory to have been removed already.
             with suppress(FileNotFoundError):
                 cache_directory.cleanup()
 

--- a/betty/tests/extension/nginx/test_integration.py
+++ b/betty/tests/extension/nginx/test_integration.py
@@ -1,13 +1,9 @@
 import json
 import sys
 import unittest
+from contextlib import asynccontextmanager
 from pathlib import Path
 from tempfile import TemporaryDirectory
-
-try:
-    from contextlib import asynccontextmanager
-except ImportError:
-    from async_generator import asynccontextmanager
 
 import html5lib
 import jsonschema
@@ -16,12 +12,12 @@ from requests import Response
 
 from betty import generate
 from betty.ancestry import File
-from betty.config import from_file, Configuration, ExtensionConfiguration
+from betty.app import App
 from betty.asyncio import sync
+from betty.config import from_file, Configuration, ExtensionConfiguration
 from betty.extension.nginx import Nginx, NginxConfiguration
 from betty.extension.nginx.serve import DockerizedNginxServer
 from betty.serve import Server
-from betty.app import App
 from betty.tests import TestCase
 
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ SETUP = {
     'url': 'https://github.com/bartfeenstra/betty',
     'classifiers': [
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -38,11 +37,9 @@ SETUP = {
         'Natural Language :: English',
         'Natural Language :: Ukrainian',
     ],
-    'python_requires': '~= 3.6',
+    'python_requires': '~= 3.7',
     'install_requires': [
         'aiohttp ~= 3.7',
-        'async-exit-stack ~= 1.0; python_version <= "3.6"',
-        'async_generator ~= 1.10; python_version <= "3.6"',
         'babel ~= 2.9',
         'click ~= 8.0.1',
         'docker ~= 5.0.0',

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,11 @@
 [tox]
-envlist = py36, py37, py38, py39
+envlist = py37, py38, py39
 skip_missing_interpreters = true
 
 [testenv]
 install_command = {toxinidir}/bin/build-dev {opts} {packages}
 commands = {toxinidir}/bin/test
 usedevelop = True
-
-[testenv:py36]
-basepython = python3.6
 
 [testenv:py37]
 basepython = python3.7


### PR DESCRIPTION
Drop support for Python 3.6, which will be EOL on 2021-12-23.