### PR TITLE
Refactor resources into entities

### DIFF
--- a/betty/app.py
+++ b/betty/app.py
@@ -23,7 +23,7 @@ from betty.render import Renderer, SequentialRenderer
 from copy import copy
 from typing import Type, Dict, Sequence, List
 
-from betty.ancestry import Ancestry
+from betty.model.ancestry import Ancestry
 from betty.config import Configuration
 from betty.fs import FileSystem
 from betty.locale import open_translations, Translations, negotiate_locale

--- a/betty/assets/public/localized/index.html.j2
+++ b/betty/assets/public/localized/index.html.j2
@@ -9,7 +9,7 @@
     {% if 'betty.extension.demo.Demo' in extensions %}
         <p>
             {% set liberta_lankester_label -%}
-                {%- with person = app.ancestry.people['betty-demo-liberta-lankester'] -%}
+                {%- with person = app.ancestry.entities['Person']['betty-demo-liberta-lankester'] -%}
                     {% include 'label/person.html.j2' %}
                 {%- endwith -%}
             {%- endset %}

--- a/betty/assets/public/static/schema.json
+++ b/betty/assets/public/static/schema.json
@@ -170,7 +170,7 @@
         "notes": {
           "$ref": "#/definitions/notes"
         },
-        "resources": {
+        "entities": {
           "type": "array",
           "items": {
             "type": "string",
@@ -185,7 +185,7 @@
         "$schema",
         "id",
         "notes",
-        "resources"
+        "entities"
       ],
       "patternProperties": {
         "^@": {
@@ -512,6 +512,9 @@
         "id": {
           "type": "string"
         },
+        "links": {
+          "$ref": "#/definitions/links"
+        },
         "text": {
           "type": "string"
         }
@@ -519,6 +522,7 @@
       "required": [
         "$schema",
         "id",
+        "links",
         "text"
       ],
       "patternProperties": {
@@ -538,7 +542,7 @@
     },
     "id": {
       "type": "string",
-      "description": "A unique resource ID."
+      "description": "A unique ID."
     },
     "locale": {
       "type": "string",

--- a/betty/assets/public/static/sitemap.xml.j2
+++ b/betty/assets/public/static/sitemap.xml.j2
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
     {% for locale_configuration in app.configuration.locales %}
-        {% for resource in app.ancestry.resources | select('identifiable') %}
+        {% for entity in app.ancestry.entities | reject('generated_entity_id') %}
             <url>
-                <loc>{{ resource | url(absolute=true, locale=locale_configuration.locale) }}</loc>
+                <loc>{{ entity | url(absolute=true, locale=locale_configuration.locale) }}</loc>
             </url>
         {% endfor %}
     {% endfor %}

--- a/betty/assets/templates/base.html.j2
+++ b/betty/assets/templates/base.html.j2
@@ -23,7 +23,7 @@
             {% endif %}
         {% endfor %}
         <link rel="canonical" href="{{ page_resource | url(absolute=true) }}"/>
-        {% if page_resource is defined and page_resource is resource and resource is identifiable %}
+        {% if page_resource is defined and page_resource is entity and resource is not generated_entity_id %}
             <link rel="alternate" href="{{ page_resource | url(media_type='application/json') }}" type="application/json"/>
             <script type="application/ld+json">
               {{ page_resource | tojson }}
@@ -48,8 +48,8 @@
 </head>
 {% if page_resource is has_files %}
     {% set page_image = page_resource.associated_files | selectattr('media_type.type', 'eq', 'image') | first %}
-{% elif app.configuration.theme.background_image_id and app.configuration.theme.background_image_id in app.ancestry.files %}
-    {% set page_image = app.ancestry.files[app.configuration.theme.background_image_id] %}
+{% elif app.configuration.theme.background_image_id and app.configuration.theme.background_image_id in app.ancestry.entities['File'] %}
+    {% set page_image = app.ancestry.entities['File'][app.configuration.theme.background_image_id] %}
 {% endif %}
 <body>
 <script>
@@ -67,7 +67,7 @@
                 <span class="overlay-control overlay-close" title="{% trans %}Exit the search{% endtrans %}">{% trans %}Exit the search{% endtrans %}</span>
             </div>
             <form>
-                {% set search_keywords_example_person_name = app.ancestry.people | map(attribute='name') | first | default(none) %}
+                {% set search_keywords_example_person_name = app.ancestry.entities['Person'] | map(attribute='name') | first | default(none) %}
                 {% if search_keywords_example_person_name %}
                     {% set search_keywords_example -%}
                         {% trans example = person_macros.name_label(search_keywords_example_person_name, embedded=True) | striptags -%}
@@ -93,16 +93,16 @@
             <h2 class="nav-primary-action">{% trans %}Menu{% endtrans %}</h2>
             <div class="nav-primary-expanded">
                 <ul class="nav-secondary">
-                    {% if app.ancestry.people | length > 0 %}
+                    {% if app.ancestry.entities['Person'] | length > 0 %}
                         <li><a href="{{ '/person/index.html' | url }}">{% trans %}People{% endtrans %}</a></li>
                     {% endif %}
-                    {% if app.ancestry.events | length > 0 %}
+                    {% if app.ancestry.entities['Event'] | length > 0 %}
                         <li><a href="{{ '/event/index.html' | url }}">{% trans %}Timeline{% endtrans %}</a></li>
                     {% endif %}
-                    {% if app.ancestry.places | length > 0 %}
+                    {% if app.ancestry.entities['Place'] | length > 0 %}
                         <li><a href="{{ '/place/index.html' | url }}">{% trans %}Places{% endtrans %}</a></li>
                     {% endif %}
-                    {% if app.ancestry.sources | length > 0 %}
+                    {% if app.ancestry.entities['Source'] | length > 0 %}
                         <li><a href="{{ '/source/index.html' | url }}">{% trans %}Sources{% endtrans %}</a></li>
                     {% endif %}
                 </ul>

--- a/betty/assets/templates/label/citation.html.j2
+++ b/betty/assets/templates/label/citation.html.j2
@@ -1,5 +1,5 @@
 {# Citation formatting is inspired by the MLA style guide(https://style.mla.org/) #}
-{% set citation = citation | default(resource) %}
+{% set citation = citation | default(entity) %}
 {% set citation_context = citation_context | default(None) %}
 <span>
     {% if citation.source -%}
@@ -12,7 +12,7 @@
         {%- endif -%}
     {% endif %}
     {%- if citation.location -%}
-            <span class="citation-location">{% if citation_context == citation %}{{ citation.location }}{% else %}{% if citation is identifiable %}<a href="{{ citation | url }}">{% endif %}{{ citation.location }}{% if citation is identifiable %}</a>{% endif %}{% endif %}</span>
+            <span class="citation-location">{% if citation_context == citation %}{{ citation.location }}{% else %}{% if citation is not generated_entity_id %}<a href="{{ citation | url }}">{% endif %}{{ citation.location }}{% if citation is not generated_entity_id %}</a>{% endif %}{% endif %}</span>
     {%- endif -%}
     {%- if citation.date -%}
         <span class="citation-date">{% trans date = citation.date | format_date %}Accessed {{ date }}{% endtrans %}</span>

--- a/betty/assets/templates/label/entity.html.j2
+++ b/betty/assets/templates/label/entity.html.j2
@@ -1,0 +1,1 @@
+{% include 'label/' ~ entity.entity_type() | entity_type_name | camel_case_to_kebab_case ~ '.html.j2' %}

--- a/betty/assets/templates/label/event.html.j2
+++ b/betty/assets/templates/label/event.html.j2
@@ -1,11 +1,11 @@
-{%- set event = event | default(resource) -%}
+{%- set event = event | default(entity) -%}
 {%- set embedded = embedded | default(False) -%}
 {%- set person_context = person_context | default(None) -%}
 {%- macro person_label(person) -%}
     {% include 'label/person.html.j2' %}
 {%- endmacro -%}
 {%- set formatted_event = event.type.label -%}
-{%- if event is identifiable and not embedded -%}
+{%- if event is not generated_entity_id and not embedded -%}
     {% set formatted_event = '<a href="' + event | url + '">' + formatted_event + '</a>' %}
 {%- endif -%}
 {%- if event.description is not none -%}

--- a/betty/assets/templates/label/file.html.j2
+++ b/betty/assets/templates/label/file.html.j2
@@ -1,4 +1,4 @@
-{% set file = file | default(resource) %}
+{% set file = file | default(entity) %}
 {% set embedded = embedded | default(False) %}
 {% if not embedded -%}
     <a href="{{ file | url }}">

--- a/betty/assets/templates/label/person.html.j2
+++ b/betty/assets/templates/label/person.html.j2
@@ -1,5 +1,5 @@
 {% import 'macro/person.html.j2' as person_macros %}
-{% set person = person | default(resource) %}
+{% set person = person | default(entity) %}
 {% set embedded = embedded | default(False) %}
 {% set person_context = person_context | default(False) %}
 {% if not embedded and person_context != person -%}

--- a/betty/assets/templates/label/place.html.j2
+++ b/betty/assets/templates/label/place.html.j2
@@ -1,4 +1,4 @@
-{% set place = place | default(resource) %}
+{% set place = place | default(entity) %}
 {% set embedded = embedded | default(False) %}
 <address>
     {%- set names = place.names | select_dateds(date_context | default(none)) | list -%}

--- a/betty/assets/templates/label/resource.html.j2
+++ b/betty/assets/templates/label/resource.html.j2
@@ -1,1 +1,0 @@
-{% include 'label/' ~ resource.resource_type_name() ~ '.html.j2' %}

--- a/betty/assets/templates/label/source.html.j2
+++ b/betty/assets/templates/label/source.html.j2
@@ -1,9 +1,9 @@
-{% set source = source | default(resource) %}
+{% set source = source | default(entity) %}
 {% set embedded = embedded | default(False) %}
-{% if not embedded and source is identifiable -%}
+{% if not embedded and source is not generated_entity_id -%}
     <a href="{{ source | url }}">
 {%- endif -%}
 {{ source.name }}
-{%- if not embedded and source is identifiable -%}
+{%- if not embedded and source is not generated_entity_id -%}
     </a>
 {%- endif %}

--- a/betty/assets/templates/meta/entity.html.j2
+++ b/betty/assets/templates/meta/entity.html.j2
@@ -1,0 +1,1 @@
+{% include 'meta/' ~ entity.entity_type() | entity_type_name | camel_case_to_kebab_case ~ '.html.j2' %}

--- a/betty/assets/templates/meta/event.html.j2
+++ b/betty/assets/templates/meta/event.html.j2
@@ -1,4 +1,4 @@
-{% set event = event | default(resource) %}
+{% set event = event | default(entity) %}
 <div class="meta">
     {% include 'event-dimensions.html.j2' %}
 </div>

--- a/betty/assets/templates/meta/person.html.j2
+++ b/betty/assets/templates/meta/person.html.j2
@@ -2,7 +2,7 @@
 {%- macro _embedded_person_name_label(name) -%}
     {{ person_macros.name_label(name, embedded=True) }}
 {%- endmacro -%}
-{%- set person = person | default(resource) -%}
+{%- set person = person | default(entity) -%}
 {%- if not embedded is defined -%}
     {%- set embedded = False -%}
 {%- endif -%}

--- a/betty/assets/templates/meta/resource.html.j2
+++ b/betty/assets/templates/meta/resource.html.j2
@@ -1,1 +1,0 @@
-{% include 'meta/' ~ resource.resource_type_name() ~ '.html.j2' %}

--- a/betty/assets/templates/meta/source.html.j2
+++ b/betty/assets/templates/meta/source.html.j2
@@ -1,4 +1,4 @@
-{% set source = source | default(resource) %}
+{% set source = source | default(entity) %}
 <div class="meta">
 {% if source.contained_by %}
     {% with source=source.contained_by %}

--- a/betty/assets/templates/page/citation.html.j2
+++ b/betty/assets/templates/page/citation.html.j2
@@ -16,7 +16,7 @@
             {% include 'list-file.html.j2' %}
         </section>
     {% endif %}
-    {% set facts = citation.facts | select('resource') | list %}
+    {% set facts = citation.facts | reject('generated_entity_id') | list %}
     {% if facts | length > 0 %}
         <section id="facts">
             <h2>
@@ -28,9 +28,9 @@
             <ul class="entities">
                 {% for fact in facts %}
                     <li class="{{ loop.cycle('odd', 'even') }}">
-                        {% with resource=fact, citation_context=citation %}
-                            {% include 'label/resource.html.j2' %}
-                            {% include 'meta/resource.html.j2' %}
+                        {% with entity=fact, citation_context=citation %}
+                            {% include 'label/entity.html.j2' %}
+                            {% include 'meta/entity.html.j2' %}
                         {% endwith %}
                     </li>
                 {% endfor %}

--- a/betty/assets/templates/page/file.html.j2
+++ b/betty/assets/templates/page/file.html.j2
@@ -21,8 +21,8 @@
             {% endfor %}
         </section>
     {% endif %}
-    {% set resources = file.resources | select('resource') | list %}
-    {% if resources | length > 0 %}
+    {% set entities = file.entities | reject('generated_entity_id') | list %}
+    {% if entities | length > 0 %}
         <section id="appearances">
             <h2>
                 {% trans %}Appearances{% endtrans %}
@@ -31,10 +31,10 @@
                 {% endwith %}
             </h2>
             <ul class="entities">
-                {% for resource in resources %}
+                {% for entity in entities %}
                     <li class="{{ loop.cycle('odd', 'even') }}">
-                        {% include 'label/resource.html.j2' %}
-                        {% include 'meta/resource.html.j2' %}
+                        {% include 'label/entity.html.j2' %}
+                        {% include 'meta/entity.html.j2' %}
                     </li>
                 {% endfor %}
             </ul>

--- a/betty/assets/templates/page/place.html.j2
+++ b/betty/assets/templates/page/place.html.j2
@@ -3,7 +3,7 @@
 {% block page_content %}
     {% include 'meta/place.html.j2' %}
 
-    {% set places = place | walk('encloses') | select('place_resource') | list %}
+    {% set places = place | walk('encloses') | select('place_entity') | list %}
     {% if place.coordinates %}
         {% set places = places + [place] %}
     {% endif %}
@@ -35,7 +35,7 @@
         </section>
     {% endif %}
 
-    {% set events = place.events | list + place | walk('encloses') | select('place_resource') | map(attribute="events") | flatten | rejectattr('date', 'none') | selectattr('date.comparable') | list %}
+    {% set events = place.events | list + place | walk('encloses') | select('place_entity') | map(attribute='events') | flatten | rejectattr('date', 'none') | selectattr('date.comparable') | list %}
     {% if events | length > 0 %}
         <section id="timeline">
             <h2>

--- a/betty/assets/templates/page/source.html.j2
+++ b/betty/assets/templates/page/source.html.j2
@@ -10,15 +10,15 @@
         <h2>{% trans %}Media{% endtrans %}</h2>
         {% include 'list-file.html.j2' %}
     {% endif %}
-    {% set facts = sources | map(attribute='citations') | flatten | map(attribute='facts') | flatten | select('resource') | unique | list %}
+    {% set facts = sources | map(attribute='citations') | flatten | map(attribute='facts') | flatten | reject('generated_entity_id') | unique | list %}
     {% if facts | length > 0 %}
         <h2>{% trans %}Facts{% endtrans %}</h2>
         <ul class="entities">
             {% for fact in facts %}
                 <li class="{{ loop.cycle('odd', 'even') }}">
-                    {% with resource=fact, source_context=source %}
-                        {% include 'label/resource.html.j2' %}
-                        {% include 'meta/resource.html.j2' %}
+                    {% with entity=fact, source_context=source %}
+                        {% include 'label/entity.html.j2' %}
+                        {% include 'meta/entity.html.j2' %}
                 {% endwith %}
                 </li>
             {% endfor %}

--- a/betty/extension/cleaner/__init__.py
+++ b/betty/extension/cleaner/__init__.py
@@ -5,7 +5,7 @@ except ImportError:
     from graphlib_backport import TopologicalSorter
 from typing import Set, Type, Dict
 
-from betty.ancestry import Ancestry, Place, File, Person, Event, Source, Citation
+from betty.model.ancestry import Ancestry, Place, File, Person, Event, Source, Citation
 from betty.gui import GuiBuilder
 from betty.load import PostLoader
 from betty.extension import Extension
@@ -22,7 +22,7 @@ def clean(ancestry: Ancestry) -> None:
 
 
 def _clean_events(ancestry: Ancestry) -> None:
-    for event in ancestry.events:
+    for event in ancestry.entities[Event]:
         _clean_event(ancestry, event)
 
 
@@ -34,11 +34,11 @@ def _clean_event(ancestry: Ancestry, event: Event) -> None:
     del event.place
     del event.citations
     del event.files
-    ancestry.events.remove(event)
+    del ancestry.entities[Event][event]
 
 
 def _clean_places(ancestry: Ancestry) -> None:
-    places = list(ancestry.places)
+    places = ancestry.entities[Place]
 
     def _extend_place_graph(graph: Dict, enclosing_place: Place) -> None:
         enclosures = enclosing_place.encloses
@@ -67,11 +67,11 @@ def _clean_place(ancestry: Ancestry, place: Place) -> None:
         return
 
     del place.enclosed_by
-    ancestry.places.remove(place)
+    del ancestry.entities[Place][place]
 
 
 def _clean_people(ancestry: Ancestry) -> None:
-    for person in list(ancestry.people):
+    for person in ancestry.entities[Person]:
         _clean_person(ancestry, person)
 
 
@@ -82,26 +82,26 @@ def _clean_person(ancestry: Ancestry, person: Person) -> None:
     if len(person.children) > 0:
         return
 
-    ancestry.people.remove(person)
+    del ancestry.entities[Person][person]
 
 
 def _clean_files(ancestry: Ancestry) -> None:
-    for file in list(ancestry.files):
+    for file in ancestry.entities[File]:
         _clean_file(ancestry, file)
 
 
 def _clean_file(ancestry: Ancestry, file: File) -> None:
-    if len(file.resources) > 0:
+    if len(file.entities) > 0:
         return
 
     if len(file.citations) > 0:
         return
 
-    ancestry.files.remove(file)
+    del ancestry.entities[File][file]
 
 
 def _clean_sources(ancestry: Ancestry) -> None:
-    for source in list(ancestry.sources):
+    for source in ancestry.entities[Source]:
         _clean_source(ancestry, source)
 
 
@@ -118,11 +118,11 @@ def _clean_source(ancestry: Ancestry, source: Source) -> None:
     if len(source.files) > 0:
         return
 
-    ancestry.sources.remove(source)
+    del ancestry.entities[Source][source]
 
 
 def _clean_citations(ancestry: Ancestry) -> None:
-    for citation in list(ancestry.citations):
+    for citation in ancestry.entities[Citation]:
         _clean_citation(ancestry, citation)
 
 
@@ -134,7 +134,7 @@ def _clean_citation(ancestry: Ancestry, citation: Citation) -> None:
         return
 
     del citation.source
-    ancestry.citations.remove(citation)
+    del ancestry.entities[Citation][citation]
 
 
 class Cleaner(Extension, PostLoader, GuiBuilder):

--- a/betty/extension/demo/__init__.py
+++ b/betty/extension/demo/__init__.py
@@ -2,8 +2,8 @@ from typing import Set, Type
 
 from geopy import Point
 
-from betty.ancestry import Place, PlaceName, Person, Presence, Subject, Birth, IdentifiableEvent, \
-    PersonName, IdentifiableSource, IdentifiableCitation, Link, Death, Marriage
+from betty.model.ancestry import Place, PlaceName, Person, Presence, Subject, Birth, PersonName, Link, Death, Marriage, \
+    Source, Citation, Event
 from betty.extension import Extension
 from betty.extension.redoc import ReDoc
 from betty.extension.wikipedia import Wikipedia
@@ -20,132 +20,132 @@ class Demo(Extension, Loader):
         amsterdam = Place('betty-demo-amsterdam', [PlaceName('Amsterdam')])
         amsterdam.coordinates = Point(52.366667, 4.9)
         amsterdam.links.add(Link('https://nl.wikipedia.org/wiki/Amsterdam'))
-        self._app.ancestry.places.add(amsterdam)
+        self._app.ancestry.entities.append(amsterdam)
 
         ilpendam = Place('betty-demo-ilpendam', [PlaceName('Ilpendam')])
         ilpendam.coordinates = Point(52.465556, 4.951111)
         ilpendam.links.add(Link('https://nl.wikipedia.org/wiki/Ilpendam'))
-        self._app.ancestry.places.add(ilpendam)
+        self._app.ancestry.entities.append(ilpendam)
 
-        personal_accounts = IdentifiableSource('betty-demo-personal-accounts', 'Personal accounts')
-        self._app.ancestry.sources.add(personal_accounts)
+        personal_accounts = Source('betty-demo-personal-accounts', 'Personal accounts')
+        self._app.ancestry.entities.append(personal_accounts)
 
-        cite_first_person_account = IdentifiableCitation('betty-demo-first-person-account', personal_accounts)
-        self._app.ancestry.citations.add(cite_first_person_account)
+        cite_first_person_account = Citation('betty-demo-first-person-account', personal_accounts)
+        self._app.ancestry.entities.append(cite_first_person_account)
 
-        bevolkingsregister_amsterdam = IdentifiableSource('betty-demo-bevolkingsregister-amsterdam', 'Bevolkingsregister Amsterdam')
+        bevolkingsregister_amsterdam = Source('betty-demo-bevolkingsregister-amsterdam', 'Bevolkingsregister Amsterdam')
         bevolkingsregister_amsterdam.author = 'Gemeente Amsterdam'
         bevolkingsregister_amsterdam.publisher = 'Gemeente Amsterdam'
-        self._app.ancestry.sources.add(bevolkingsregister_amsterdam)
+        self._app.ancestry.entities.append(bevolkingsregister_amsterdam)
 
         david_marinus_lankester = Person('betty-demo-david-marinus-lankester')
-        david_marinus_lankester.names.append(PersonName('David Marinus', 'Lankester'))
-        self._app.ancestry.people.add(david_marinus_lankester)
+        PersonName(david_marinus_lankester, 'David Marinus', 'Lankester')
+        self._app.ancestry.entities.append(david_marinus_lankester)
 
         geertruida_van_ling = Person('betty-demo-geertruida-van-ling')
-        geertruida_van_ling.names.append(PersonName('Geertruida', 'Van Ling'))
-        self._app.ancestry.people.add(geertruida_van_ling)
+        PersonName(geertruida_van_ling, 'Geertruida', 'Van Ling')
+        self._app.ancestry.entities.append(geertruida_van_ling)
 
-        marriage_of_dirk_jacobus_lankester_and_jannigje_palsen = IdentifiableEvent('betty-demo-marriage-of-dirk-jacobus-lankester-and-jannigje-palsen', Marriage(), Date(1922, 7, 4))
+        marriage_of_dirk_jacobus_lankester_and_jannigje_palsen = Event('betty-demo-marriage-of-dirk-jacobus-lankester-and-jannigje-palsen', Marriage(), Date(1922, 7, 4))
         marriage_of_dirk_jacobus_lankester_and_jannigje_palsen.place = ilpendam
-        self._app.ancestry.events.add(marriage_of_dirk_jacobus_lankester_and_jannigje_palsen)
+        self._app.ancestry.entities.append(marriage_of_dirk_jacobus_lankester_and_jannigje_palsen)
 
-        birth_of_dirk_jacobus_lankester = IdentifiableEvent('betty-demo-birth-of-dirk-jacobus-lankester', Birth(), Date(1897, 8, 25))
+        birth_of_dirk_jacobus_lankester = Event('betty-demo-birth-of-dirk-jacobus-lankester', Birth(), Date(1897, 8, 25))
         birth_of_dirk_jacobus_lankester.place = amsterdam
-        self._app.ancestry.events.add(birth_of_dirk_jacobus_lankester)
+        self._app.ancestry.entities.append(birth_of_dirk_jacobus_lankester)
 
-        death_of_dirk_jacobus_lankester = IdentifiableEvent('betty-demo-death-of-dirk-jacobus-lankester', Death(), Date(1986, 8, 18))
+        death_of_dirk_jacobus_lankester = Event('betty-demo-death-of-dirk-jacobus-lankester', Death(), Date(1986, 8, 18))
         death_of_dirk_jacobus_lankester.place = amsterdam
-        self._app.ancestry.events.add(death_of_dirk_jacobus_lankester)
+        self._app.ancestry.entities.append(death_of_dirk_jacobus_lankester)
 
         dirk_jacobus_lankester = Person('betty-demo-dirk-jacobus-lankester')
-        dirk_jacobus_lankester.names.append(PersonName('Dirk Jacobus', 'Lankester'))
+        PersonName(dirk_jacobus_lankester, 'Dirk Jacobus', 'Lankester')
         Presence(dirk_jacobus_lankester, Subject(), birth_of_dirk_jacobus_lankester)
         Presence(dirk_jacobus_lankester, Subject(), death_of_dirk_jacobus_lankester)
         Presence(dirk_jacobus_lankester, Subject(), marriage_of_dirk_jacobus_lankester_and_jannigje_palsen)
         dirk_jacobus_lankester.parents.append(david_marinus_lankester, geertruida_van_ling)
-        self._app.ancestry.people.add(dirk_jacobus_lankester)
+        self._app.ancestry.entities.append(dirk_jacobus_lankester)
 
-        birth_of_marinus_david_lankester = IdentifiableEvent('betty-demo-birth-of-marinus-david', Birth(), DateRange(Date(1874, 1, 15), Date(1874, 3, 21), start_is_boundary=True, end_is_boundary=True))
+        birth_of_marinus_david_lankester = Event('betty-demo-birth-of-marinus-david', Birth(), DateRange(Date(1874, 1, 15), Date(1874, 3, 21), start_is_boundary=True, end_is_boundary=True))
         birth_of_marinus_david_lankester.place = amsterdam
-        self._app.ancestry.events.add(birth_of_marinus_david_lankester)
+        self._app.ancestry.entities.append(birth_of_marinus_david_lankester)
 
-        death_of_marinus_david_lankester = IdentifiableEvent('betty-demo-death-of-marinus-david', Death(), Date(1971))
+        death_of_marinus_david_lankester = Event('betty-demo-death-of-marinus-david', Death(), Date(1971))
         death_of_marinus_david_lankester.place = amsterdam
-        self._app.ancestry.events.add(death_of_marinus_david_lankester)
+        self._app.ancestry.entities.append(death_of_marinus_david_lankester)
 
         marinus_david_lankester = Person('betty-demo-marinus-david-lankester')
-        marinus_david_lankester.names.append(PersonName('Marinus David', 'Lankester'))
+        PersonName(marinus_david_lankester, 'Marinus David', 'Lankester')
         Presence(marinus_david_lankester, Subject(), birth_of_marinus_david_lankester)
         Presence(marinus_david_lankester, Subject(), death_of_marinus_david_lankester)
         marinus_david_lankester.parents.append(david_marinus_lankester, geertruida_van_ling)
-        self._app.ancestry.people.add(marinus_david_lankester)
+        self._app.ancestry.entities.append(marinus_david_lankester)
 
-        birth_of_jacoba_gesina_lankester = IdentifiableEvent('betty-demo-birth-of-jacoba-gesina', Birth(), Date(1900, 3, 14))
+        birth_of_jacoba_gesina_lankester = Event('betty-demo-birth-of-jacoba-gesina', Birth(), Date(1900, 3, 14))
         birth_of_jacoba_gesina_lankester.place = amsterdam
-        self._app.ancestry.events.add(birth_of_jacoba_gesina_lankester)
+        self._app.ancestry.entities.append(birth_of_jacoba_gesina_lankester)
 
         jacoba_gesina_lankester = Person('betty-demo-jacoba-gesina-lankester')
-        jacoba_gesina_lankester.names.append(PersonName('Jacoba Gesina', 'Lankester'))
+        PersonName(jacoba_gesina_lankester, 'Jacoba Gesina', 'Lankester')
         Presence(jacoba_gesina_lankester, Subject(), birth_of_jacoba_gesina_lankester)
         jacoba_gesina_lankester.parents.append(david_marinus_lankester, geertruida_van_ling)
-        self._app.ancestry.people.add(jacoba_gesina_lankester)
+        self._app.ancestry.entities.append(jacoba_gesina_lankester)
 
         jannigje_palsen = Person('betty-demo-jannigje-palsen')
-        jannigje_palsen.names.append(PersonName('Jannigje', 'Palsen'))
+        PersonName(jannigje_palsen, 'Jannigje', 'Palsen')
         Presence(jannigje_palsen, Subject(), marriage_of_dirk_jacobus_lankester_and_jannigje_palsen)
-        self._app.ancestry.people.add(jannigje_palsen)
+        self._app.ancestry.entities.append(jannigje_palsen)
 
-        marriage_of_johan_de_boer_and_liberta_lankester = IdentifiableEvent('betty-demo-marriage-of-johan-de-boer-and-liberta-lankester', Marriage(), Date(1953, 6, 19))
+        marriage_of_johan_de_boer_and_liberta_lankester = Event('betty-demo-marriage-of-johan-de-boer-and-liberta-lankester', Marriage(), Date(1953, 6, 19))
         marriage_of_johan_de_boer_and_liberta_lankester.place = amsterdam
-        self._app.ancestry.events.add(marriage_of_johan_de_boer_and_liberta_lankester)
+        self._app.ancestry.entities.append(marriage_of_johan_de_boer_and_liberta_lankester)
 
-        cite_birth_of_liberta_lankester_from_bevolkingsregister_amsterdam = IdentifiableCitation('betty-demo-birth-of-liberta-lankester-from-bevolkingsregister-amsterdam', bevolkingsregister_amsterdam)
+        cite_birth_of_liberta_lankester_from_bevolkingsregister_amsterdam = Citation('betty-demo-birth-of-liberta-lankester-from-bevolkingsregister-amsterdam', bevolkingsregister_amsterdam)
         cite_birth_of_liberta_lankester_from_bevolkingsregister_amsterdam.location = 'Amsterdam'
-        self._app.ancestry.citations.add(cite_birth_of_liberta_lankester_from_bevolkingsregister_amsterdam)
+        self._app.ancestry.entities.append(cite_birth_of_liberta_lankester_from_bevolkingsregister_amsterdam)
 
-        birth_of_liberta_lankester = IdentifiableEvent('betty-demo-birth-of-liberta-lankester', Birth(), Date(1929, 12, 22))
+        birth_of_liberta_lankester = Event('betty-demo-birth-of-liberta-lankester', Birth(), Date(1929, 12, 22))
         birth_of_liberta_lankester.place = amsterdam
         birth_of_liberta_lankester.citations.append(cite_birth_of_liberta_lankester_from_bevolkingsregister_amsterdam)
-        self._app.ancestry.events.add(birth_of_liberta_lankester)
+        self._app.ancestry.entities.append(birth_of_liberta_lankester)
 
-        death_of_liberta_lankester = IdentifiableEvent('betty-demo-death-of-liberta-lankester', Death(), Date(2015, 1, 17))
+        death_of_liberta_lankester = Event('betty-demo-death-of-liberta-lankester', Death(), Date(2015, 1, 17))
         death_of_liberta_lankester.place = amsterdam
         death_of_liberta_lankester.citations.append(cite_first_person_account)
-        self._app.ancestry.events.add(death_of_liberta_lankester)
+        self._app.ancestry.entities.append(death_of_liberta_lankester)
 
         liberta_lankester = Person('betty-demo-liberta-lankester')
-        liberta_lankester.names.append(PersonName('Liberta', 'Lankester'))
-        liberta_lankester.names.append(PersonName('Betty'))
+        PersonName(liberta_lankester, 'Liberta', 'Lankester')
+        PersonName(liberta_lankester, 'Betty')
         Presence(liberta_lankester, Subject(), birth_of_liberta_lankester)
         Presence(liberta_lankester, Subject(), death_of_liberta_lankester)
         Presence(liberta_lankester, Subject(), marriage_of_johan_de_boer_and_liberta_lankester)
         liberta_lankester.parents.append(dirk_jacobus_lankester, jannigje_palsen)
-        self._app.ancestry.people.add(liberta_lankester)
+        self._app.ancestry.entities.append(liberta_lankester)
 
-        birth_of_johan_de_boer = IdentifiableEvent('betty-demo-birth-of-johan-de-boer', Birth(), Date(1930, 6, 20))
+        birth_of_johan_de_boer = Event('betty-demo-birth-of-johan-de-boer', Birth(), Date(1930, 6, 20))
         birth_of_johan_de_boer.place = amsterdam
-        self._app.ancestry.events.add(birth_of_johan_de_boer)
+        self._app.ancestry.entities.append(birth_of_johan_de_boer)
 
-        death_of_johan_de_boer = IdentifiableEvent('betty-demo-death-of-johan-de-boer', Death(), Date(1999, 3, 10))
+        death_of_johan_de_boer = Event('betty-demo-death-of-johan-de-boer', Death(), Date(1999, 3, 10))
         death_of_johan_de_boer.place = amsterdam
         death_of_johan_de_boer.citations.append(cite_first_person_account)
-        self._app.ancestry.events.add(death_of_johan_de_boer)
+        self._app.ancestry.entities.append(death_of_johan_de_boer)
 
         johan_de_boer = Person('betty-demo-johan-de-boer')
-        johan_de_boer.names.append(PersonName('Johan', 'De Boer'))
-        johan_de_boer.names.append(PersonName('Hans'))
+        PersonName(johan_de_boer, 'Johan', 'De Boer')
+        PersonName(johan_de_boer, 'Hans')
         Presence(johan_de_boer, Subject(), birth_of_johan_de_boer)
         Presence(johan_de_boer, Subject(), death_of_johan_de_boer)
         Presence(johan_de_boer, Subject(), marriage_of_johan_de_boer_and_liberta_lankester)
-        self._app.ancestry.people.add(johan_de_boer)
+        self._app.ancestry.entities.append(johan_de_boer)
 
         parent_of_bart_feenstra_child_of_liberta_lankester = Person('betty-demo-parent-of-bart-feenstra-child-of-liberta-lankester')
-        parent_of_bart_feenstra_child_of_liberta_lankester.names.append(PersonName('Bart\'s parent'))
+        PersonName(parent_of_bart_feenstra_child_of_liberta_lankester, 'Bart\'s parent')
         parent_of_bart_feenstra_child_of_liberta_lankester.parents.append(johan_de_boer, liberta_lankester)
-        self._app.ancestry.people.add(parent_of_bart_feenstra_child_of_liberta_lankester)
+        self._app.ancestry.entities.append(parent_of_bart_feenstra_child_of_liberta_lankester)
 
         bart_feenstra = Person('betty-demo-bart-feenstra')
-        bart_feenstra.names.append(PersonName('Bart', 'Feenstra'))
+        PersonName(bart_feenstra, 'Bart', 'Feenstra')
         bart_feenstra.parents.append(parent_of_bart_feenstra_child_of_liberta_lankester)
-        self._app.ancestry.people.add(bart_feenstra)
+        self._app.ancestry.entities.append(bart_feenstra)

--- a/betty/extension/deriver/__init__.py
+++ b/betty/extension/deriver/__init__.py
@@ -1,17 +1,18 @@
 import logging
-from typing import List, Tuple, Set, Type, Iterable
+from typing import List, Tuple, Set, Type, Iterable, Optional
 
-from betty.ancestry import Person, Presence, Event, Subject, EventType, EVENT_TYPE_TYPES, DerivableEventType, \
+from betty.model.ancestry import Person, Presence, Event, Subject, EventType, EVENT_TYPE_TYPES, DerivableEventType, \
     CreatableDerivableEventType, Ancestry
 from betty.gui import GuiBuilder
-from betty.locale import DateRange, Date
+from betty.locale import DateRange, Date, Datey
 from betty.load import PostLoader
 from betty.extension import Extension
 from betty.extension.privatizer import Privatizer
 
 
 class DerivedEvent(Event):
-    pass  # pragma: no cover
+    def __init__(self, event_type: EventType, date: Optional[Datey] = None):
+        super().__init__(None, event_type, date)
 
 
 class DerivedDate(Date):
@@ -31,7 +32,7 @@ class Deriver(Extension, PostLoader, GuiBuilder):
             if isinstance(event_type, DerivableEventType):
                 created_derivations = 0
                 updated_derivations = 0
-                for person in ancestry.people:
+                for person in ancestry.entities[Person]:
                     created, updated = derive(person, event_type_type)
                     created_derivations += created
                     updated_derivations += updated

--- a/betty/extension/nginx/assets/nginx.conf.j2
+++ b/betty/extension/nginx/assets/nginx.conf.j2
@@ -22,9 +22,9 @@ server {
     gzip_vary on;
     gzip_types text/css application/javascript application/json application/xml;
 
-    {% if app.ancestry.files | length > 0 %}
+    {% if app.ancestry.entities['File'] | length > 0 %}
         # Redirect Betty <0.3 file paths to Betty 0.3 file paths.
-        {% for file in app.ancestry.files %}
+        {% for file in app.ancestry.entities['File'] %}
             location /file/{{ file.id }}{{ file.path.suffix }} {
                 return 301 /file/{{ file.id }}/file/{{ file.path.name }};
             }

--- a/betty/extension/privatizer/__init__.py
+++ b/betty/extension/privatizer/__init__.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime
 from typing import Optional, List
 
-from betty.ancestry import Ancestry, Person, Event, Citation, Source, HasPrivacy, Subject, File, HasFiles, HasCitations
+from betty.model.ancestry import Ancestry, Person, Event, Citation, Source, HasPrivacy, Subject, File, HasFiles, HasCitations
 from betty.functools import walk
 from betty.gui import GuiBuilder
 from betty.locale import DateRange, Date
@@ -27,7 +27,7 @@ def privatize(ancestry: Ancestry, lifetime_threshold: int = 125) -> None:
     seen = []
 
     privatized = 0
-    for person in ancestry.people:
+    for person in ancestry.entities[Person]:
         private = person.private
         _privatize_person(person, seen, lifetime_threshold)
         if private is None and person.private is True:
@@ -35,16 +35,16 @@ def privatize(ancestry: Ancestry, lifetime_threshold: int = 125) -> None:
     logger = logging.getLogger()
     logger.info('Privatized %d people because they are likely still alive.' % privatized)
 
-    for citation in ancestry.citations:
+    for citation in ancestry.entities[Citation]:
         _privatize_citation(citation, seen)
 
-    for source in ancestry.sources:
+    for source in ancestry.entities[Source]:
         _privatize_source(source, seen)
 
-    for event in ancestry.events:
+    for event in ancestry.entities[Event]:
         _privatize_event(event, seen)
 
-    for file in ancestry.files:
+    for file in ancestry.entities[File]:
         _privatize_file(file, seen)
 
 

--- a/betty/extension/trees/assets/public/localized/people.json.j2
+++ b/betty/extension/trees/assets/public/localized/people.json.j2
@@ -1,5 +1,5 @@
 {% set ns = namespace(people={}) %}
-{% for person in app.ancestry.people %}
+{% for person in app.ancestry.entities['Person'] %}
     {% set person_label %}
         {% with embedded=True %}
             {% include 'label/person.html.j2' %}

--- a/betty/extension/wikipedia/__init__.py
+++ b/betty/extension/wikipedia/__init__.py
@@ -14,7 +14,7 @@ import aiohttp
 from babel import parse_locale
 from jinja2 import pass_context
 
-from betty.ancestry import Link, HasLinks, Resource
+from betty.model.ancestry import Link, HasLinks, Entity
 from betty.app import App
 from betty.asyncio import sync
 from betty.extension import Extension
@@ -143,14 +143,14 @@ class _Populator:
 
     async def populate(self) -> None:
         locales = set(map(lambda x: x.alias, self._app.configuration.locales))
-        await asyncio.gather(*[self._populate_resource(resource, locales) for resource in self._app.ancestry.resources])
+        await asyncio.gather(*[self._populate_entity(entity, locales) for entity in self._app.ancestry.entities])
 
-    async def _populate_resource(self, resource: Resource, locales: Set[str]) -> None:
-        if not isinstance(resource, HasLinks):
+    async def _populate_entity(self, entity: Entity, locales: Set[str]) -> None:
+        if not isinstance(entity, HasLinks):
             return
 
         entry_links = set()
-        for link in resource.links:
+        for link in entity.links:
             try:
                 entry_language, entry_name = _parse_url(link.url)
                 entry_links.add((entry_language, entry_name))
@@ -181,7 +181,7 @@ class _Populator:
                     continue
                 added_link = Link(added_entry.url)
                 await self.populate_link(added_link, added_entry_language, added_entry)
-                resource.links.add(added_link)
+                entity.links.add(added_link)
                 entry_links.add((added_entry_language, added_entry_name))
 
     async def populate_link(self, link: Link, entry_language: str, entry: Optional[Entry] = None) -> None:

--- a/betty/functools.py
+++ b/betty/functools.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable
+from typing import Any, Iterable, Sized
 
 
 def walk(item: Any, attribute_name: str) -> Iterable[Any]:
@@ -17,3 +17,11 @@ def walk(item: Any, attribute_name: str) -> Iterable[Any]:
     for child in child:
         yield child
         yield from walk(child, attribute_name)
+
+
+def slice_to_range(ranged_slice: slice, iterable: Sized) -> Iterable[int]:
+    return range(
+        0 if ranged_slice.start is None else ranged_slice.start,
+        len(iterable) if ranged_slice.stop is None else ranged_slice.stop,
+        1 if ranged_slice.step is None else ranged_slice.step,
+    )

--- a/betty/generate.py
+++ b/betty/generate.py
@@ -10,6 +10,7 @@ from babel import Locale
 from jinja2 import Environment, TemplateNotFound
 
 from betty.json import JSONEncoder
+from betty.model.ancestry import File, Person, Place, Event, Citation, Source, Note
 from betty.openapi import build_specification
 from betty.app import App
 
@@ -53,28 +54,28 @@ async def _generate(app: App) -> None:
             await app.renderer.render_tree(www_directory_path)
 
             locale_label = Locale.parse(locale, '-').get_display_name()
-            await _generate_entity_type(www_directory_path, app.ancestry.files, 'file', app, locale, app.jinja2_environment)
+            await _generate_entity_type(www_directory_path, app.ancestry.entities[File], 'file', app, locale, app.jinja2_environment)
             logger.info('Generated pages for %d files in %s.' %
-                        (len(app.ancestry.files), locale_label))
-            await _generate_entity_type(www_directory_path, app.ancestry.people, 'person', app, locale, app.jinja2_environment)
+                        (len(app.ancestry.entities[File]), locale_label))
+            await _generate_entity_type(www_directory_path, app.ancestry.entities[Person], 'person', app, locale, app.jinja2_environment)
             logger.info('Generated pages for %d people in %s.' %
-                        (len(app.ancestry.people), locale_label))
-            await _generate_entity_type(www_directory_path, app.ancestry.places, 'place', app, locale, app.jinja2_environment)
+                        (len(app.ancestry.entities[Person]), locale_label))
+            await _generate_entity_type(www_directory_path, app.ancestry.entities[Place], 'place', app, locale, app.jinja2_environment)
             logger.info('Generated pages for %d places in %s.' %
-                        (len(app.ancestry.places), locale_label))
-            await _generate_entity_type(www_directory_path, app.ancestry.events, 'event', app, locale, app.jinja2_environment)
+                        (len(app.ancestry.entities[Place]), locale_label))
+            await _generate_entity_type(www_directory_path, app.ancestry.entities[Event], 'event', app, locale, app.jinja2_environment)
             logger.info('Generated pages for %d events in %s.' %
-                        (len(app.ancestry.events), locale_label))
-            await _generate_entity_type(www_directory_path, app.ancestry.citations, 'citation', app, locale, app.jinja2_environment)
+                        (len(app.ancestry.entities[Event]), locale_label))
+            await _generate_entity_type(www_directory_path, app.ancestry.entities[Citation], 'citation', app, locale, app.jinja2_environment)
             logger.info('Generated pages for %d citations in %s.' %
-                        (len(app.ancestry.citations), locale_label))
-            await _generate_entity_type(www_directory_path, app.ancestry.sources, 'source', app, locale, app.jinja2_environment)
+                        (len(app.ancestry.entities[Citation]), locale_label))
+            await _generate_entity_type(www_directory_path, app.ancestry.entities[Source], 'source', app, locale, app.jinja2_environment)
             logger.info('Generated pages for %d sources in %s.' %
-                        (len(app.ancestry.sources), locale_label))
-            _generate_entity_type_list_json(www_directory_path, app.ancestry.notes, 'note', app)
-            for note in app.ancestry.notes:
+                        (len(app.ancestry.entities[Source]), locale_label))
+            _generate_entity_type_list_json(www_directory_path, app.ancestry.entities[Note], 'note', app)
+            for note in app.ancestry.entities[Note]:
                 _generate_entity_json(www_directory_path, note, 'note', app, locale)
-            logger.info('Generated pages for %d notes in %s.' % (len(app.ancestry.notes), locale_label))
+            logger.info('Generated pages for %d notes in %s.' % (len(app.ancestry.entities[Note]), locale_label))
             _generate_openapi(www_directory_path, app)
             logger.info('Generated OpenAPI documentation in %s.', locale_label)
 

--- a/betty/model/__init__.py
+++ b/betty/model/__init__.py
@@ -1,0 +1,373 @@
+from collections import defaultdict
+from typing import TypeVar, Generic, Callable, List, Optional, Iterable, Any, Type, Union
+
+from betty.functools import slice_to_range
+
+
+class GeneratedEntityId(str):
+    """
+    Generate a unique entity ID for internal use.
+
+    Entities must have IDs for identification. However, not all entities can be provided with an ID that exists in the
+    original data set (such as a third-party family tree loaded into Betty), so IDs can be generated.
+    Because of this, these generated IDs SHOULD NOT be used outside of Betty, such as when serializing entities to JSON.
+    """
+
+    _last_id = 0
+
+    def __new__(cls):
+        cls._last_id += 1
+        entity_id = f'betty-generated-entity-id:{cls._last_id}'
+        return super().__new__(cls, entity_id)
+
+
+class Entity:
+    def __init__(self, entity_id: Optional[str] = None):
+        super().__init__()
+        self._id = GeneratedEntityId() if entity_id is None else entity_id
+
+    @classmethod
+    def entity_type(cls) -> Type['EntityT']:
+        for ancestor_cls in cls.__mro__:
+            if Entity in ancestor_cls.__bases__:
+                return ancestor_cls
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+
+EntityTypeT = TypeVar('EntityTypeT', bound=Type[Entity])
+EntityT = TypeVar('EntityT', bound=Entity)
+
+
+def get_entity_type_name(entity_type: Type[Entity]) -> str:
+    if entity_type.__module__.startswith('betty.'):
+        return entity_type.__name__
+    return f'{entity_type.__module__}.{entity_type.__name__}'
+
+
+class EntityCollection(Generic[EntityT]):
+    def __init__(self, entity_type: Type[Entity] = Entity):
+        self._entities = []
+        self._entity_type = entity_type
+
+    @property
+    def list(self) -> List[EntityT]:
+        return list(self._entities)
+
+    def prepend(self, *entities: EntityT) -> None:
+        for entity in reversed(entities):
+            assert isinstance(entity, self._entity_type), f'{entity} is not a {self._entity_type}.'
+            if entity in self._entities:
+                continue
+            self._prepend_one(entity)
+
+    def _prepend_one(self, entity: EntityT) -> None:
+        self._entities.insert(0, entity)
+
+    def append(self, *entities: EntityT) -> None:
+        for entity in entities:
+            assert isinstance(entity, self._entity_type), f'{entity} is not a {self._entity_type}.'
+            if entity in self._entities:
+                continue
+            self._append_one(entity)
+
+    def _append_one(self, entity: EntityT) -> None:
+        self._entities.append(entity)
+
+    def remove(self, *entities: EntityT) -> None:
+        for entity in entities:
+            if entity not in self._entities:
+                continue
+            self._remove_one(entity)
+
+    def _remove_one(self, entity: EntityT) -> None:
+        self._entities.remove(entity)
+
+    def replace(self, *entities: EntityT) -> None:
+        self._entities = []
+        self.append(*entities)
+
+    def clear(self) -> None:
+        self._entities = []
+
+    def __iter__(self) -> Iterable[EntityT]:
+        return self._entities.__iter__()
+
+    def __len__(self) -> int:
+        return len(self._entities)
+
+    def __getitem__(self, entity_id_or_index: Union[str, int]) -> Union[EntityT, List[EntityT]]:
+        if isinstance(entity_id_or_index, int):
+            return self._entities[entity_id_or_index]
+
+        if isinstance(entity_id_or_index, slice):
+            return [
+                self._entities[index]
+                for index
+                in slice_to_range(entity_id_or_index, self._entities)
+            ]
+
+        for entity in self._entities:
+            if entity_id_or_index == entity.id:
+                return entity
+        raise KeyError(f'Unknown {self._entity_type} entity with ID "{entity_id_or_index}".')
+
+    def __delitem__(self, entity_or_entity_id_or_index: Union[EntityT, str, int]) -> None:
+        if isinstance(entity_or_entity_id_or_index, self._entity_type):
+            self.remove(entity_or_entity_id_or_index)
+            return
+
+        if isinstance(entity_or_entity_id_or_index, int):
+            del self._entities[entity_or_entity_id_or_index]
+            return
+
+        for index, entity in enumerate(self._entities):
+            if entity_or_entity_id_or_index == entity.id:
+                del self._entities[index]
+                return
+        raise KeyError(f'Unknown {self._entity_type} entity with ID "{entity_or_entity_id_or_index}".')
+
+    def __contains__(self, entity_or_id: Union[EntityT, str]) -> bool:
+        if isinstance(entity_or_id, Entity):
+            return entity_or_id in self._entities
+        if isinstance(entity_or_id, str):
+            for entity in self._entities:
+                if entity.id == entity_or_id:
+                    return True
+        return False
+
+
+class EventDispatchingEntityCollection(EntityCollection):
+    def __init__(self, on_add: Callable[[EntityT], None], on_remove: Callable[[EntityT], None], entity_type: Type[Entity] = Entity):
+        super().__init__(entity_type)
+        self._on_add = on_add
+        self._on_remove = on_remove
+
+    def _prepend_one(self, entity: EntityT) -> None:
+        super()._prepend_one(entity)
+        self._on_add(entity)
+
+    def _append_one(self, entity: EntityT) -> None:
+        super()._append_one(entity)
+        self._on_add(entity)
+
+    def _remove_one(self, entity: EntityT) -> None:
+        super()._remove_one(entity)
+        self._on_remove(entity)
+
+    def replace(self, *entities: EntityT) -> None:
+        self.remove(*list(self._entities))
+        self.append(*entities)
+
+    def clear(self) -> None:
+        self.replace()
+
+    def __delitem__(self, entity_id: str) -> None:
+        removed_entity = self[entity_id]
+        super().__delitem__(entity_id)
+        self._on_remove(removed_entity)
+
+
+class GroupedEntityCollection:
+    def __init__(self, entity_collection_factory: Callable[[], EntityCollection] = EntityCollection):
+        self._collections = defaultdict(entity_collection_factory)
+
+    def __getitem__(self, entity_type_or_entity_type_name_or_index: Union[EntityTypeT, str, int]) -> EntityCollection[EntityTypeT]:
+        if isinstance(entity_type_or_entity_type_name_or_index, str):
+            return self._collections[entity_type_or_entity_type_name_or_index]
+
+        if isinstance(entity_type_or_entity_type_name_or_index, int):
+            for collection in self._collections.values():
+                collection_length = len(collection)
+                if collection_length > entity_type_or_entity_type_name_or_index:
+                    return collection[entity_type_or_entity_type_name_or_index]
+                entity_type_or_entity_type_name_or_index -= collection_length
+            raise IndexError
+
+        return self._collections[get_entity_type_name(entity_type_or_entity_type_name_or_index)]
+
+    def __iter__(self) -> Iterable[EntityT]:
+        for collection in self._collections.values():
+            for entity in collection:
+                yield entity
+
+    def __len__(self) -> int:
+        return sum(map(len, self._collections.values()))
+
+    def __contains__(self, value: Any) -> bool:
+        for collection in self._collections.values():
+            if value in collection:
+                return True
+        return False
+
+    def prepend(self, *entities: EntityT) -> None:
+        for entity in entities:
+            self[get_entity_type_name(entity.entity_type())].prepend(entity)
+
+    def append(self, *entities: EntityT) -> None:
+        for entity in entities:
+            self[get_entity_type_name(entity.entity_type())].append(entity)
+
+    def remove(self, *entities: EntityT) -> None:
+        for entity in entities:
+            self[get_entity_type_name(entity.entity_type())].remove(entity)
+
+
+class _ToMany:
+    def __init__(self, self_attr_name: str, associated_name: str):
+        self._self_attr_name = self_attr_name
+        self._associated_name = associated_name
+
+    def __call__(self, cls: EntityTypeT) -> EntityTypeT:
+        _decorated_self_attr_name = '_%s' % self._self_attr_name
+        try:
+            original_init = cls.__init__
+        except AttributeError:
+            original_init = None
+
+        def _init(decorated_self: Entity, *args, **kwargs):
+            assert isinstance(decorated_self, Entity), f'{decorated_self} is not an {Entity}.'
+
+            collection = EventDispatchingEntityCollection(
+                self._create_on_add(decorated_self),
+                self._create_on_remove(decorated_self),
+            )
+            setattr(decorated_self, _decorated_self_attr_name, collection)
+            if original_init is not None:
+                original_init(decorated_self, *args, **kwargs)
+        cls.__init__ = _init
+        setattr(cls, self._self_attr_name, property(
+            lambda decorated_self: getattr(decorated_self, _decorated_self_attr_name),
+            lambda decorated_self, values: getattr(decorated_self, _decorated_self_attr_name).replace(*values),
+            lambda decorated_self: getattr(decorated_self, _decorated_self_attr_name).clear(),
+        ))
+        return cls
+
+    def _create_on_add(self, decorated_self: EntityT) -> Callable[[EntityT], None]:
+        raise NotImplementedError
+
+    def _create_on_remove(self, decorated_self: EntityT) -> Callable[[EntityT], None]:
+        raise NotImplementedError
+
+
+class _ToManyHandler(Generic[EntityT]):
+    def __init__(self, associated_attr_name: str, decorated_self: EntityT):
+        self._associated_attr_name = associated_attr_name
+        self._decorated_self = decorated_self
+
+
+class _ManyToManyOnAdd(_ToManyHandler):
+    def __call__(self, associated: Entity) -> None:
+        getattr(associated, self._associated_attr_name).append(self._decorated_self)
+
+
+class _ManyToManyOnRemove(_ToManyHandler):
+    def __call__(self, associated: Entity) -> None:
+        getattr(associated, self._associated_attr_name).remove(self._decorated_self)
+
+
+class _ManyToMany(_ToMany):
+    def _create_on_add(self, decorated_self: EntityT) -> Callable[[EntityT], None]:
+        return _ManyToManyOnAdd(self._associated_name, decorated_self)
+
+    def _create_on_remove(self, decorated_self: EntityT) -> Callable[[EntityT], None]:
+        return _ManyToManyOnRemove(self._associated_name, decorated_self)
+
+
+# Alias the class so its original name follows the PEP code style, but the alias follows the decorator code style.
+many_to_many = _ManyToMany
+
+
+def many_to_one_to_many(left_associated_attr_name: str, left_self_attr_name: str, right_self_attr_name: str, right_associated_attr_name: str):
+    def decorator(cls: EntityTypeT) -> EntityTypeT:
+        cls = many_to_one(
+            left_self_attr_name,
+            left_associated_attr_name,
+            lambda decorated_self: delattr(decorated_self, right_self_attr_name),
+        )(cls)
+        cls = many_to_one(
+            right_self_attr_name,
+            right_associated_attr_name,
+            lambda decorated_self: delattr(decorated_self, left_self_attr_name),
+        )(cls)
+        return cls
+    return decorator
+
+
+class _OneToManyOnAdd(_ToManyHandler):
+    def __call__(self, associated) -> None:
+        setattr(associated, self._associated_attr_name, self._decorated_self)
+
+
+class _OneToManyOnRemove(_ToManyHandler):
+    def __call__(self, associated) -> None:
+        setattr(associated, self._associated_attr_name, None)
+
+
+class _OneToMany(_ToMany):
+    def _create_on_add(self, decorated_self: EntityT) -> Callable[[EntityT], None]:
+        return _OneToManyOnAdd(self._associated_name, decorated_self)
+
+    def _create_on_remove(self, decorated_self: EntityT) -> Callable[[EntityT], None]:
+        return _OneToManyOnRemove(self._associated_name, decorated_self)
+
+
+# Alias the class so its original name follows the PEP code style, but the alias follows the decorator code style.
+one_to_many = _OneToMany
+
+
+class _ManyToOneGetter:
+    def __init__(self, decorated_self_attr_name: str):
+        self._decorated_self_attr_name = decorated_self_attr_name
+
+    def __call__(self, decorated_self: EntityT) -> Any:
+        return getattr(decorated_self, self._decorated_self_attr_name)
+
+
+class _ManyToOneSetter(Generic[EntityT]):
+    def __init__(self, decorated_self_attr_name: str, associated_name: str, _on_remove: Optional[Callable[[EntityT], None]] = None):
+        self._decorated_self_attr_name = decorated_self_attr_name
+        self._associated_name = associated_name
+        self._on_remove = _on_remove
+
+    def __call__(self, decorated_self: EntityT, value) -> None:
+        previous_value = getattr(decorated_self, self._decorated_self_attr_name)
+        if previous_value == value:
+            return
+        setattr(decorated_self, self._decorated_self_attr_name, value)
+        if previous_value is not None:
+            getattr(previous_value, self._associated_name).remove(decorated_self)
+            if value is None and self._on_remove is not None:
+                self._on_remove(decorated_self)
+        if value is not None:
+            getattr(value, self._associated_name).append(decorated_self)
+
+
+class _ManyToOneDeleter(_ManyToOneSetter):
+    def __call__(self, decorated_self: EntityT, *_) -> None:
+        super().__call__(decorated_self, None)
+
+
+def many_to_one(self_attr_name: str, associated_attr_name: str, _on_remove: Optional[Callable[[Entity], None]] = None) -> Callable[[EntityTypeT], EntityTypeT]:
+    def decorator(cls: EntityTypeT) -> EntityTypeT:
+        _decorated_self_attr_name = '_%s' % self_attr_name
+        try:
+            original_init = cls.__init__
+        except AttributeError:
+            original_init = None
+
+        def _init(decorated_self: EntityT, *args, **kwargs):
+            setattr(decorated_self, _decorated_self_attr_name, None)
+            if original_init is not None:
+                original_init(decorated_self, *args, **kwargs)
+        cls.__init__ = _init
+
+        setattr(cls, self_attr_name, property(
+            _ManyToOneGetter(_decorated_self_attr_name),
+            _ManyToOneSetter(_decorated_self_attr_name, associated_attr_name, _on_remove),
+            _ManyToOneDeleter(_decorated_self_attr_name, associated_attr_name, _on_remove),
+        ))
+        return cls
+    return decorator

--- a/betty/search.py
+++ b/betty/search.py
@@ -1,7 +1,9 @@
 from typing import Dict, Iterable, Optional
 
-from betty.ancestry import Person, Place, File, Resource
+from betty.model import get_entity_type_name
+from betty.model.ancestry import Person, Place, File, Entity
 from betty.app import App
+from betty.string import camel_case_to_kebab_case, camel_case_to_snake_case
 
 
 class Index:
@@ -10,14 +12,17 @@ class Index:
 
     def build(self) -> Iterable[Dict]:
         return filter(None, [
-            *[self._build_person(person) for person in self._app.ancestry.people],
-            *[self._build_place(place) for place in self._app.ancestry.places],
-            *[self._build_file(file) for file in self._app.ancestry.files],
+            *[self._build_person(person) for person in self._app.ancestry.entities[Person]],
+            *[self._build_place(place) for place in self._app.ancestry.entities[Place]],
+            *[self._build_file(file) for file in self._app.ancestry.entities[File]],
         ])
 
-    def _render_resource(self, resource: Resource):
-        return self._app.jinja2_environment.get_template('search/result-%s.html.j2' % resource.resource_type_name()).render({
-            resource.resource_type_name(): resource,
+    def _render_entity(self, entity: Entity):
+        entity_type_name = get_entity_type_name(entity.entity_type())
+        return self._app.jinja2_environment.get_template(
+            f'search/result-{camel_case_to_kebab_case(entity_type_name)}.html.j2'
+        ).render({
+            camel_case_to_snake_case(entity_type_name): entity,
         })
 
     def _build_person(self, person: Person) -> Optional[Dict]:
@@ -32,18 +37,18 @@ class Index:
         if names:
             return {
                 'text': ' '.join(names),
-                'result': self._render_resource(person),
+                'result': self._render_entity(person),
             }
 
     def _build_place(self, place: Place) -> Optional[Dict]:
         return {
             'text': ' '.join(map(lambda x: x.name.lower(), place.names)),
-            'result': self._render_resource(place),
+            'result': self._render_entity(place),
         }
 
     def _build_file(self, file: File) -> Optional[Dict]:
         if file.description is not None:
             return {
                 'text': file.description.lower(),
-                'result': self._render_resource(file),
+                'result': self._render_entity(file),
             }

--- a/betty/string.py
+++ b/betty/string.py
@@ -1,0 +1,15 @@
+import re
+
+_CAMEL_CASE_PATTERN = re.compile(r'(?<!^)(?=[A-Z])')
+
+
+def camel_case_to_snake_case(string: str) -> str:
+    return _CAMEL_CASE_PATTERN.sub('_', string).lower()
+
+
+def camel_case_to_kebab_case(string: str) -> str:
+    return _CAMEL_CASE_PATTERN.sub('-', string).lower()
+
+
+def upper_camel_case_to_lower_camel_case(string: str) -> str:
+    return string[0].lower() + string[1:]

--- a/betty/tests/assets/templates/label/test_event_html_j2.py
+++ b/betty/tests/assets/templates/label/test_event_html_j2.py
@@ -1,5 +1,5 @@
-from betty.ancestry import Person, Event, IdentifiableEvent, Presence, Subject, Witness, Birth, Marriage
 from betty.asyncio import sync
+from betty.model.ancestry import Person, Event, Presence, Subject, Witness, Birth, Marriage
 from betty.tests import TemplateTestCase
 
 
@@ -8,7 +8,7 @@ class Test(TemplateTestCase):
 
     @sync
     async def test_minimal(self):
-        event = Event(Birth())
+        event = Event(None, Birth())
         expected = 'Birth'
         async with self._render(data={
             'event': event,
@@ -17,7 +17,7 @@ class Test(TemplateTestCase):
 
     @sync
     async def test_with_identifiable(self):
-        event = IdentifiableEvent('E0', Birth())
+        event = Event('E0', Birth())
         expected = '<a href="/event/E0/index.html">Birth</a>'
         async with self._render(data={
             'event': event,
@@ -26,7 +26,7 @@ class Test(TemplateTestCase):
 
     @sync
     async def test_embedded_with_identifiable(self):
-        event = IdentifiableEvent('E0', Birth())
+        event = Event('E0', Birth())
         Presence(Person('P0'), Subject(), event)
         expected = 'Birth of <span class="nn" title="This person\'s name is unknown.">n.n.</span>'
         async with self._render(data={
@@ -37,7 +37,7 @@ class Test(TemplateTestCase):
 
     @sync
     async def test_with_description(self):
-        event = Event(Birth())
+        event = Event(None, Birth())
         event.description = 'Something happened!'
         expected = 'Birth (Something happened!)'
         async with self._render(data={
@@ -47,7 +47,7 @@ class Test(TemplateTestCase):
 
     @sync
     async def test_with_witnesses(self):
-        event = Event(Birth())
+        event = Event(None, Birth())
         Presence(Person('P0'), Witness(), event)
         expected = 'Birth'
         async with self._render(data={
@@ -57,7 +57,7 @@ class Test(TemplateTestCase):
 
     @sync
     async def test_with_person_context_as_witness(self):
-        event = Event(Birth())
+        event = Event(None, Birth())
         person = Person('P0')
         Presence(person, Witness(), event)
         expected = 'Birth (Witness)'
@@ -69,7 +69,7 @@ class Test(TemplateTestCase):
 
     @sync
     async def test_with_person_context_as_subject(self):
-        event = Event(Birth())
+        event = Event(None, Birth())
         person = Person('P0')
         Presence(person, Subject(), event)
         expected = 'Birth'
@@ -81,7 +81,7 @@ class Test(TemplateTestCase):
 
     @sync
     async def test_with_person_context_and_other_as_subject(self):
-        event = Event(Marriage())
+        event = Event(None, Marriage())
         person = Person('P0')
         other_person = Person('P1')
         Presence(person, Subject(), event)
@@ -95,7 +95,7 @@ class Test(TemplateTestCase):
 
     @sync
     async def test_with_subjects(self):
-        event = Event(Birth())
+        event = Event(None, Birth())
         Presence(Person('P0'), Subject(), event)
         Presence(Person('P1'), Subject(), event)
         expected = 'Birth of <a href="/person/P0/index.html"><span class="nn" title="This person\'s name is unknown.">n.n.</span></a>, <a href="/person/P1/index.html"><span class="nn" title="This person\'s name is unknown.">n.n.</span></a>'
@@ -106,7 +106,7 @@ class Test(TemplateTestCase):
 
     @sync
     async def test_without_subjects(self):
-        event = Event(Birth())
+        event = Event(None, Birth())
         expected = 'Birth'
         async with self._render(data={
             'event': event,
@@ -114,10 +114,10 @@ class Test(TemplateTestCase):
             self.assertEqual(expected, actual)
 
     @sync
-    async def test_with_resource(self):
-        event = Event(Birth())
+    async def test_with_entity(self):
+        event = Event(None, Birth())
         expected = 'Birth'
         async with self._render(data={
-            'resource': event,
+            'entity': event,
         }) as (actual, _):
             self.assertEqual(expected, actual)

--- a/betty/tests/assets/templates/label/test_person_html_j2.py
+++ b/betty/tests/assets/templates/label/test_person_html_j2.py
@@ -1,4 +1,4 @@
-from betty.ancestry import Person, PersonName
+from betty.model.ancestry import Person, PersonName
 from betty.asyncio import sync
 from betty.tests import TemplateTestCase
 
@@ -9,7 +9,7 @@ class Test(TemplateTestCase):
     @sync
     async def test_with_name(self):
         person = Person('P0')
-        person.names.append(PersonName('Jane', 'Dough'))
+        PersonName(person, 'Jane', 'Dough')
         expected = '<a href="/person/P0/index.html"><span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Jane</span> <span property="foaf:familyName">Dough</span></span></a>'
         async with self._render(data={
             'person': person,
@@ -56,11 +56,11 @@ class Test(TemplateTestCase):
             self.assertEqual(expected, actual)
 
     @sync
-    async def test_with_resource(self):
+    async def test_with_entity(self):
         person = Person('P0')
-        person.names.append(PersonName('Jane', 'Dough'))
+        PersonName(person, 'Jane', 'Dough')
         expected = '<a href="/person/P0/index.html"><span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Jane</span> <span property="foaf:familyName">Dough</span></span></a>'
         async with self._render(data={
-            'resource': person,
+            'entity': person,
         }) as (actual, _):
             self.assertEqual(expected, actual)

--- a/betty/tests/assets/templates/label/test_place_html_j2.py
+++ b/betty/tests/assets/templates/label/test_place_html_j2.py
@@ -1,6 +1,6 @@
 from parameterized import parameterized
 
-from betty.ancestry import Place, PlaceName
+from betty.model.ancestry import Place, PlaceName
 from betty.asyncio import sync
 from betty.locale import DateRange, Date
 from betty.tests import TemplateTestCase

--- a/betty/tests/assets/templates/macro/test_person_html_j2.py
+++ b/betty/tests/assets/templates/macro/test_person_html_j2.py
@@ -1,4 +1,4 @@
-from betty.ancestry import PersonName, Citation, Source
+from betty.model.ancestry import PersonName, Citation, Source, Person
 from betty.asyncio import sync
 from betty.tests import TemplateTestCase
 
@@ -8,7 +8,8 @@ class TestNameLabel(TemplateTestCase):
 
     @sync
     async def test_with_full_name(self):
-        name = PersonName('Jane', 'Dough')
+        person = Person(None)
+        name = PersonName(person, 'Jane', 'Dough')
         expected = '<span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Jane</span> <span property="foaf:familyName">Dough</span></span>'
         async with self._render(data={
             'name': name,
@@ -17,7 +18,8 @@ class TestNameLabel(TemplateTestCase):
 
     @sync
     async def test_with_individual_name(self):
-        name = PersonName('Jane')
+        person = Person(None)
+        name = PersonName(person, 'Jane')
         expected = '<span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Jane</span></span>'
         async with self._render(data={
             'name': name,
@@ -26,7 +28,8 @@ class TestNameLabel(TemplateTestCase):
 
     @sync
     async def test_with_affiliation_name(self):
-        name = PersonName(None, 'Dough')
+        person = Person(None)
+        name = PersonName(person, None, 'Dough')
         expected = '<span class="person-label" typeof="foaf:Person">… <span property="foaf:familyName">Dough</span></span>'
         async with self._render(data={
             'name': name,
@@ -35,9 +38,10 @@ class TestNameLabel(TemplateTestCase):
 
     @sync
     async def test_embedded(self):
-        name = PersonName('Jane', 'Dough')
-        source = Source()
-        citation = Citation(source)
+        person = Person(None)
+        name = PersonName(person, 'Jane', 'Dough')
+        source = Source(None)
+        citation = Citation(None, source)
         name.citations.append(citation)
         expected = '<span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Jane</span> <span property="foaf:familyName">Dough</span></span>'
         async with self._render(data={
@@ -48,9 +52,10 @@ class TestNameLabel(TemplateTestCase):
 
     @sync
     async def test_with_citation(self):
-        name = PersonName('Jane')
-        source = Source()
-        citation = Citation(source)
+        person = Person(None)
+        name = PersonName(person, 'Jane')
+        source = Source(None)
+        citation = Citation(None, source)
         name.citations.append(citation)
         expected = '<span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Jane</span></span><a href="#reference-1" class="citation">[1]</a>'
         async with self._render(data={

--- a/betty/tests/assets/templates/meta/test_person_html_j2.py
+++ b/betty/tests/assets/templates/meta/test_person_html_j2.py
@@ -1,4 +1,4 @@
-from betty.ancestry import Person, Presence, Event, PersonName, Source, Citation, Birth, Subject, Death
+from betty.model.ancestry import Person, Presence, Event, PersonName, Source, Citation, Birth, Subject, Death
 from betty.asyncio import sync
 from betty.locale import Date
 from betty.tests import TemplateTestCase
@@ -29,10 +29,9 @@ class Test(TemplateTestCase):
     @sync
     async def test_with_one_alternative_name(self):
         person = Person('P0')
-        person.names.append(PersonName('Jane', 'Dough'))
-        name = PersonName('Janet', 'Doughnut')
-        name.citations.append(Citation(Source('The Source')))
-        person.names.append(name)
+        PersonName(person, 'Jane', 'Dough')
+        name = PersonName(person, 'Janet', 'Doughnut')
+        name.citations.append(Citation(None, Source(None, 'The Source')))
         expected = '<div class="meta person-meta"><span class="aka">Also known as <span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Janet</span> <span property="foaf:familyName">Doughnut</span></span><a href="#reference-1" class="citation">[1]</a></span></div>'
         async with self._render(data={
             'person': person,
@@ -42,9 +41,9 @@ class Test(TemplateTestCase):
     @sync
     async def test_with_multiple_alternative_names(self):
         person = Person('P0')
-        person.names.append(PersonName('Jane', 'Dough'))
-        person.names.append(PersonName('Janet', 'Doughnut'))
-        person.names.append(PersonName('Janetar', 'Of Doughnuton'))
+        PersonName(person, 'Jane', 'Dough')
+        PersonName(person, 'Janet', 'Doughnut')
+        PersonName(person, 'Janetar', 'Of Doughnuton')
         expected = '<div class="meta person-meta"><span class="aka">Also known as <span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Janet</span> <span property="foaf:familyName">Doughnut</span></span>, <span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Janetar</span> <span property="foaf:familyName">Of Doughnuton</span></span></span></div>'
         async with self._render(data={
             'person': person,
@@ -54,7 +53,7 @@ class Test(TemplateTestCase):
     @sync
     async def test_with_start(self):
         person = Person('P0')
-        Presence(person, Subject(), Event(Birth(), Date(1970)))
+        Presence(person, Subject(), Event(None, Birth(), Date(1970)))
         expected = '<div class="meta person-meta"><dl><div><dt>Birth</dt><dd>1970</dd></div></dl></div>'
         async with self._render(data={
             'person': person,
@@ -64,7 +63,7 @@ class Test(TemplateTestCase):
     @sync
     async def test_with_end(self):
         person = Person('P0')
-        Presence(person, Subject(), Event(Death(), Date(1970)))
+        Presence(person, Subject(), Event(None, Death(), Date(1970)))
         expected = '<div class="meta person-meta"><dl><div><dt>Death</dt><dd>1970</dd></div></dl></div>'
         async with self._render(data={
             'person': person,
@@ -74,11 +73,10 @@ class Test(TemplateTestCase):
     @sync
     async def test_embedded(self):
         person = Person('P0')
-        Presence(person, Subject(), Event(Birth(), Date(1970)))
-        person.names.append(PersonName('Jane', 'Dough'))
-        name = PersonName('Janet', 'Doughnut')
-        name.citations.append(Citation(Source('The Source')))
-        person.names.append(name)
+        Presence(person, Subject(), Event(None, Birth(), Date(1970)))
+        PersonName(person, 'Jane', 'Dough')
+        name = PersonName(person, 'Janet', 'Doughnut')
+        name.citations.append(Citation(None, Source(None, 'The Source')))
         expected = '<div class="meta person-meta"><span class="aka">Also known as <span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Janet</span> <span property="foaf:familyName">Doughnut</span></span></span><dl><div><dt>Birth</dt><dd>1970</dd></div></dl></div>'
         async with self._render(data={
             'person': person,

--- a/betty/tests/assets/templates/meta/test_place_html_j2.py
+++ b/betty/tests/assets/templates/meta/test_place_html_j2.py
@@ -1,4 +1,4 @@
-from betty.ancestry import PlaceName, Place, Enclosure
+from betty.model.ancestry import PlaceName, Place, Enclosure
 from betty.asyncio import sync
 from betty.tests import TemplateTestCase
 

--- a/betty/tests/assets/templates/page/test_person_html_j2.py
+++ b/betty/tests/assets/templates/page/test_person_html_j2.py
@@ -1,4 +1,4 @@
-from betty.ancestry import Person, PersonName
+from betty.model.ancestry import Person, PersonName
 from betty.asyncio import sync
 from betty.tests import TemplateTestCase
 
@@ -13,12 +13,12 @@ class TestDescendantNames(TemplateTestCase):
         child_one = Person('P1C1')
         child_one.parents.append(person)
         child_one.parents.append(partner_one)
-        child_one.names.append(PersonName(None, 'FamilyOneAssociationName'))
+        PersonName(child_one, None, 'FamilyOneAssociationName')
         partner_two = Person('P2')
         child_two = Person('P2C2')
         child_two.parents.append(person)
         child_two.parents.append(partner_two)
-        child_two.names.append(PersonName(None, 'FamilyTwoAssociationName'))
+        PersonName(child_two, None, 'FamilyTwoAssociationName')
         async with self._render(data={
             'page_resource': person,
             'entity_type_name': 'person',

--- a/betty/tests/assets/templates/test_event_dimensions_html_j2.py
+++ b/betty/tests/assets/templates/test_event_dimensions_html_j2.py
@@ -1,4 +1,4 @@
-from betty.ancestry import Event, Place, PlaceName, Citation, Source, Birth
+from betty.model.ancestry import Event, Place, PlaceName, Citation, Source, Birth
 from betty.asyncio import sync
 from betty.locale import Date
 from betty.tests import TemplateTestCase
@@ -9,7 +9,7 @@ class Test(TemplateTestCase):
 
     @sync
     async def test_without_meta(self):
-        event = Event(Birth())
+        event = Event(None, Birth())
         expected = ''
         async with self._render(data={
             'event': event,
@@ -18,7 +18,7 @@ class Test(TemplateTestCase):
 
     @sync
     async def test_with_date(self):
-        event = Event(Birth())
+        event = Event(None, Birth())
         event.date = Date(1970)
         expected = '1970'
         async with self._render(data={
@@ -28,7 +28,7 @@ class Test(TemplateTestCase):
 
     @sync
     async def test_with_place(self):
-        event = Event(Birth())
+        event = Event(None, Birth())
         event.place = Place('P0', [PlaceName('The Place')])
         expected = 'in <address><a href="/place/P0/index.html"><span>The Place</span></a></address>'
         async with self._render(data={
@@ -38,7 +38,7 @@ class Test(TemplateTestCase):
 
     @sync
     async def test_with_place_is_place_context(self):
-        event = Event(Birth())
+        event = Event(None, Birth())
         place = Place('P0', [PlaceName('The Place')])
         event.place = place
         expected = ''
@@ -50,7 +50,7 @@ class Test(TemplateTestCase):
 
     @sync
     async def test_with_date_and_place(self):
-        event = Event(Birth())
+        event = Event(None, Birth())
         event.date = Date(1970)
         event.place = Place('P0', [PlaceName('The Place')])
         expected = '1970 in <address><a href="/place/P0/index.html"><span>The Place</span></a></address>'
@@ -61,8 +61,8 @@ class Test(TemplateTestCase):
 
     @sync
     async def test_with_citation(self):
-        event = Event(Birth())
-        event.citations.append(Citation(Source('The Source')))
+        event = Event(None, Birth())
+        event.citations.append(Citation(None, Source(None, 'The Source')))
         expected = '<a href="#reference-1" class="citation">[1]</a>'
         async with self._render(data={
             'event': event,
@@ -71,10 +71,10 @@ class Test(TemplateTestCase):
 
     @sync
     async def test_embedded(self):
-        event = Event(Birth())
+        event = Event(None, Birth())
         event.date = Date(1970)
         event.place = Place('P0', [PlaceName('The Place')])
-        event.citations.append(Citation(Source('The Source')))
+        event.citations.append(Citation(None, Source(None, 'The Source')))
         expected = '1970 in <address><span>The Place</span></address>'
         async with self._render(data={
             'event': event,

--- a/betty/tests/extension/demo/test__init__.py
+++ b/betty/tests/extension/demo/test__init__.py
@@ -5,6 +5,7 @@ from betty.asyncio import sync
 from betty.config import Configuration, ExtensionConfiguration
 from betty.extension.demo import Demo
 from betty.load import load
+from betty.model.ancestry import Person, Place, Event, Source, Citation
 from betty.tests import TestCase
 
 
@@ -16,8 +17,8 @@ class DemoTest(TestCase):
             configuration.extensions.add(ExtensionConfiguration(Demo))
             async with App(configuration) as app:
                 await load(app)
-            self.assertNotEqual(0, len(app.ancestry.people))
-            self.assertNotEqual(0, len(app.ancestry.places))
-            self.assertNotEqual(0, len(app.ancestry.events))
-            self.assertNotEqual(0, len(app.ancestry.sources))
-            self.assertNotEqual(0, len(app.ancestry.citations))
+            self.assertNotEqual(0, len(app.ancestry.entities[Person]))
+            self.assertNotEqual(0, len(app.ancestry.entities[Place]))
+            self.assertNotEqual(0, len(app.ancestry.entities[Event]))
+            self.assertNotEqual(0, len(app.ancestry.entities[Source]))
+            self.assertNotEqual(0, len(app.ancestry.entities[Citation]))

--- a/betty/tests/extension/deriver/test__init__.py
+++ b/betty/tests/extension/deriver/test__init__.py
@@ -2,7 +2,7 @@ from tempfile import TemporaryDirectory
 from typing import Optional, Set, Type
 from parameterized import parameterized
 
-from betty.ancestry import Person, Presence, Subject, EventType, CreatableDerivableEventType, \
+from betty.model.ancestry import Person, Presence, Subject, EventType, CreatableDerivableEventType, \
     DerivableEventType, Event, Residence
 from betty.config import Configuration, ExtensionConfiguration
 from betty.asyncio import sync
@@ -63,7 +63,7 @@ class DeriverTest(TestCase):
     @sync
     async def test_post_parse(self):
         person = Person('P0')
-        reference_presence = Presence(person, Subject(), Event(Residence()))
+        reference_presence = Presence(person, Subject(), Event(None, Residence()))
         reference_presence.event.date = Date(1970, 1, 1)
 
         with TemporaryDirectory() as output_directory_path:
@@ -71,7 +71,7 @@ class DeriverTest(TestCase):
                 output_directory_path, 'https://example.com')
             configuration.extensions.add(ExtensionConfiguration(Deriver))
             async with App(configuration) as app:
-                app.ancestry.people.add(person)
+                app.ancestry.entities.append(person)
                 await load(app)
 
         self.assertEquals(3, len(person.presences))
@@ -109,7 +109,7 @@ class DeriveTest(TestCase):
     @sync
     async def test_derive_create_derivable_events_without_reference_events(self, event_type_type: Type[DerivableEventType]):
         person = Person('P0')
-        derivable_event = Event(Ignored())
+        derivable_event = Event(None, Ignored())
         Presence(person, Subject(), derivable_event)
 
         created, updated = derive(person, event_type_type)
@@ -130,8 +130,8 @@ class DeriveTest(TestCase):
     @sync
     async def test_derive_update_derivable_event_without_reference_events(self, event_type_type: Type[DerivableEventType]):
         person = Person('P0')
-        Presence(person, Subject(), Event(Ignored()))
-        derivable_event = Event(event_type_type())
+        Presence(person, Subject(), Event(None, Ignored()))
+        derivable_event = Event(None, event_type_type())
         Presence(person, Subject(), derivable_event)
 
         created, updated = derive(person, event_type_type)
@@ -192,9 +192,9 @@ class DeriveTest(TestCase):
     async def test_derive_update_comes_before_derivable_event(self, expected_datey: Optional[Datey], before_datey: Optional[Datey], derivable_datey: Optional[Datey]):
         expected_updates = 0 if expected_datey == derivable_datey else 1
         person = Person('P0')
-        Presence(person, Subject(), Event(Ignored(), Date(0, 0, 0)))
-        Presence(person, Subject(), Event(ComesBeforeReference(), before_datey))
-        derivable_event = Event(ComesBeforeDerivable(), derivable_datey)
+        Presence(person, Subject(), Event(None, Ignored(), Date(0, 0, 0)))
+        Presence(person, Subject(), Event(None, ComesBeforeReference(), before_datey))
+        derivable_event = Event(None, ComesBeforeDerivable(), derivable_datey)
         Presence(person, Subject(), derivable_event)
 
         created, updated = derive(person, ComesBeforeDerivable)
@@ -216,8 +216,8 @@ class DeriveTest(TestCase):
     async def test_derive_create_comes_before_derivable_event(self, expected_datey: Optional[Datey], before_datey: Optional[Datey]):
         expected_creations = 0 if expected_datey is None else 1
         person = Person('P0')
-        Presence(person, Subject(), Event(Ignored(), Date(0, 0, 0)))
-        Presence(person, Subject(), Event(ComesBeforeReference(), before_datey))
+        Presence(person, Subject(), Event(None, Ignored(), Date(0, 0, 0)))
+        Presence(person, Subject(), Event(None, ComesBeforeReference(), before_datey))
 
         created, updated = derive(person, ComesBeforeCreatableDerivable)
 
@@ -282,9 +282,9 @@ class DeriveTest(TestCase):
     async def test_derive_update_comes_after_derivable_event(self, expected_datey: Optional[Datey], after_datey: Optional[Datey], derivable_datey: Optional[Datey]):
         expected_updates = 0 if expected_datey == derivable_datey else 1
         person = Person('P0')
-        Presence(person, Subject(), Event(Ignored(), Date(0, 0, 0)))
-        Presence(person, Subject(), Event(ComesAfterReference(), after_datey))
-        derivable_event = Event(ComesAfterDerivable(), derivable_datey)
+        Presence(person, Subject(), Event(None, Ignored(), Date(0, 0, 0)))
+        Presence(person, Subject(), Event(None, ComesAfterReference(), after_datey))
+        derivable_event = Event(None, ComesAfterDerivable(), derivable_datey)
         Presence(person, Subject(), derivable_event)
 
         created, updated = derive(person, ComesAfterDerivable)
@@ -307,8 +307,8 @@ class DeriveTest(TestCase):
     async def test_derive_create_comes_after_derivable_event(self, expected_datey: Optional[Datey], after_datey: Optional[Datey]):
         expected_creations = 0 if expected_datey is None else 1
         person = Person('P0')
-        Presence(person, Subject(), Event(Ignored(), Date(0, 0, 0)))
-        Presence(person, Subject(), Event(ComesAfterReference(), after_datey))
+        Presence(person, Subject(), Event(None, Ignored(), Date(0, 0, 0)))
+        Presence(person, Subject(), Event(None, ComesAfterReference(), after_datey))
 
         created, updated = derive(person, ComesAfterCreatableDerivable)
 

--- a/betty/tests/extension/nginx/test_integration.py
+++ b/betty/tests/extension/nginx/test_integration.py
@@ -11,7 +11,7 @@ import requests
 from requests import Response
 
 from betty import generate
-from betty.ancestry import File
+from betty.model.ancestry import File
 from betty.app import App
 from betty.asyncio import sync
 from betty.config import from_file, Configuration, ExtensionConfiguration
@@ -191,7 +191,7 @@ class NginxTest(TestCase):
             ))
             app = App(configuration)
             file_id = 'FILE1'
-            app.ancestry.files.add(File(file_id, __file__))
+            app.ancestry.entities.append(File(file_id, __file__))
             async with self.NginxTestServer(app) as server:
                 response = requests.get(f'{server.public_url}/file/{file_id}.py', headers={
                     'Accept': 'application/json',

--- a/betty/tests/extension/privatizer/test__init__.py
+++ b/betty/tests/extension/privatizer/test__init__.py
@@ -4,14 +4,14 @@ from typing import Optional
 
 from parameterized import parameterized
 
-from betty.ancestry import Person, Presence, Event, Source, IdentifiableSource, File, \
-    IdentifiableCitation, Subject, Attendee, Birth, Marriage, Death, Ancestry, IdentifiableEvent, Citation
-from betty.config import Configuration, ExtensionConfiguration
-from betty.asyncio import sync
-from betty.locale import Date, DateRange
-from betty.load import load
-from betty.extension.privatizer import Privatizer, privatize
 from betty.app import App
+from betty.asyncio import sync
+from betty.config import Configuration, ExtensionConfiguration
+from betty.extension.privatizer import Privatizer, privatize
+from betty.load import load
+from betty.locale import Date, DateRange
+from betty.model.ancestry import Person, Presence, Event, Source, File, Subject, Attendee, Birth, Marriage, Death, \
+    Ancestry, Citation
 from betty.tests import TestCase
 
 
@@ -34,48 +34,48 @@ def _expand_person(generation: int):
         # Deaths and other end-of-life events are special, but only for the person whose privacy is being checked:
         # - If they're present without dates, the person isn't private.
         # - If they're present and their dates or date ranges' end dates are in the past, the person isn't private.
-        (generation != 0, None, Event(Death(), date=Date(datetime.now().year, datetime.now().month, datetime.now().day))),
-        (generation != 0, None, Event(Death(), date=date_under_lifetime_threshold)),
-        (True, None, Event(Death(), date=date_range_start_under_lifetime_threshold)),
-        (generation != 0, None, Event(Death(), date=date_range_end_under_lifetime_threshold)),
-        (False, None, Event(Death(), date=date_over_lifetime_threshold)),
-        (True, None, Event(Death(), date=date_range_start_over_lifetime_threshold)),
-        (False, None, Event(Death(), date=date_range_end_over_lifetime_threshold)),
-        (True, True, Event(Death())),
-        (False, False, Event(Death())),
-        (generation != 0, None, Event(Death())),
+        (generation != 0, None, Event(None, Death(), date=Date(datetime.now().year, datetime.now().month, datetime.now().day))),
+        (generation != 0, None, Event(None, Death(), date=date_under_lifetime_threshold)),
+        (True, None, Event(None, Death(), date=date_range_start_under_lifetime_threshold)),
+        (generation != 0, None, Event(None, Death(), date=date_range_end_under_lifetime_threshold)),
+        (False, None, Event(None, Death(), date=date_over_lifetime_threshold)),
+        (True, None, Event(None, Death(), date=date_range_start_over_lifetime_threshold)),
+        (False, None, Event(None, Death(), date=date_range_end_over_lifetime_threshold)),
+        (True, True, Event(None, Death())),
+        (False, False, Event(None, Death())),
+        (generation != 0, None, Event(None, Death())),
 
         # Regular events without dates do not affect privacy.
-        (True, None, Event(Birth())),
-        (True, True, Event(Birth())),
-        (False, False, Event(Birth())),
+        (True, None, Event(None, Birth())),
+        (True, True, Event(None, Birth())),
+        (False, False, Event(None, Birth())),
 
         # Regular events with incomplete dates do not affect privacy.
-        (True, None, Event(Birth(), date=Date())),
-        (True, True, Event(Birth(), date=Date())),
-        (False, False, Event(Birth(), date=Date())),
+        (True, None, Event(None, Birth(), date=Date())),
+        (True, True, Event(None, Birth(), date=Date())),
+        (False, False, Event(None, Birth(), date=Date())),
 
         # Regular events under the lifetime threshold do not affect privacy.
-        (True, None, Event(Birth(), date=date_under_lifetime_threshold)),
-        (True, True, Event(Birth(), date=date_under_lifetime_threshold)),
-        (False, False, Event(Birth(), date=date_under_lifetime_threshold)),
-        (True, None, Event(Birth(), date=date_range_start_under_lifetime_threshold)),
-        (True, True, Event(Birth(), date=date_range_start_under_lifetime_threshold)),
-        (False, False, Event(Birth(), date=date_range_start_under_lifetime_threshold)),
-        (True, None, Event(Birth(), date=date_range_end_under_lifetime_threshold)),
-        (True, True, Event(Birth(), date=date_range_end_under_lifetime_threshold)),
-        (False, False, Event(Birth(), date=date_range_end_under_lifetime_threshold)),
+        (True, None, Event(None, Birth(), date=date_under_lifetime_threshold)),
+        (True, True, Event(None, Birth(), date=date_under_lifetime_threshold)),
+        (False, False, Event(None, Birth(), date=date_under_lifetime_threshold)),
+        (True, None, Event(None, Birth(), date=date_range_start_under_lifetime_threshold)),
+        (True, True, Event(None, Birth(), date=date_range_start_under_lifetime_threshold)),
+        (False, False, Event(None, Birth(), date=date_range_start_under_lifetime_threshold)),
+        (True, None, Event(None, Birth(), date=date_range_end_under_lifetime_threshold)),
+        (True, True, Event(None, Birth(), date=date_range_end_under_lifetime_threshold)),
+        (False, False, Event(None, Birth(), date=date_range_end_under_lifetime_threshold)),
 
         # Regular events over the lifetime threshold affect privacy.
-        (False, None, Event(Birth(), date=date_over_lifetime_threshold)),
-        (True, True, Event(Birth(), date=date_over_lifetime_threshold)),
-        (False, False, Event(Birth(), date=date_over_lifetime_threshold)),
-        (True, None, Event(Birth(), date=date_range_start_over_lifetime_threshold)),
-        (True, True, Event(Birth(), date=date_range_start_over_lifetime_threshold)),
-        (False, False, Event(Birth(), date=date_range_start_over_lifetime_threshold)),
-        (False, None, Event(Birth(), date=date_range_end_over_lifetime_threshold)),
-        (True, True, Event(Birth(), date=date_range_end_over_lifetime_threshold)),
-        (False, False, Event(Birth(), date=date_range_end_over_lifetime_threshold)),
+        (False, None, Event(None, Birth(), date=date_over_lifetime_threshold)),
+        (True, True, Event(None, Birth(), date=date_over_lifetime_threshold)),
+        (False, False, Event(None, Birth(), date=date_over_lifetime_threshold)),
+        (True, None, Event(None, Birth(), date=date_range_start_over_lifetime_threshold)),
+        (True, True, Event(None, Birth(), date=date_range_start_over_lifetime_threshold)),
+        (False, False, Event(None, Birth(), date=date_range_start_over_lifetime_threshold)),
+        (False, None, Event(None, Birth(), date=date_range_end_over_lifetime_threshold)),
+        (True, True, Event(None, Birth(), date=date_range_end_over_lifetime_threshold)),
+        (False, False, Event(None, Birth(), date=date_range_end_over_lifetime_threshold)),
     ])
 
 
@@ -83,16 +83,16 @@ class PrivatizerTest(TestCase):
     @sync
     async def test_post_load(self):
         person = Person('P0')
-        Presence(person, Subject(), Event(Birth()))
+        Presence(person, Subject(), Event(None, Birth()))
 
         source_file = File('F0', __file__)
-        source = IdentifiableSource('S0', 'The Source')
+        source = Source('S0', 'The Source')
         source.private = True
         source.files.append(source_file)
 
         citation_file = File('F0', __file__)
         citation_source = Source('The Source')
-        citation = IdentifiableCitation('C0', citation_source)
+        citation = Citation('C0', citation_source)
         citation.private = True
         citation.files.append(citation_file)
 
@@ -101,9 +101,9 @@ class PrivatizerTest(TestCase):
                 output_directory_path, 'https://example.com')
             configuration.extensions.add(ExtensionConfiguration(Privatizer))
             async with App(configuration) as app:
-                app.ancestry.people.add(person)
-                app.ancestry.sources.add(source)
-                app.ancestry.citations.add(citation)
+                app.ancestry.entities.append(person)
+                app.ancestry.entities.append(source)
+                app.ancestry.entities.append(citation)
                 await load(app)
 
             self.assertTrue(person.private)
@@ -115,10 +115,10 @@ class PrivatizerTest(TestCase):
         source = Source('The Source')
         source.files.append(source_file)
         citation_file = File('F1', __file__)
-        citation = IdentifiableCitation('C0', source)
+        citation = Citation('C0', source)
         citation.files.append(citation_file)
-        event_as_subject = Event(Birth())
-        event_as_attendee = Event(Marriage())
+        event_as_subject = Event(None, Birth())
+        event_as_attendee = Event(None, Marriage())
         person_file = File('F2', __file__)
         person = Person('P0')
         person.private = False
@@ -127,7 +127,7 @@ class PrivatizerTest(TestCase):
         Presence(person, Subject(), event_as_subject)
         Presence(person, Attendee(), event_as_attendee)
         ancestry = Ancestry()
-        ancestry.people.add(person)
+        ancestry.entities.append(person)
         privatize(ancestry)
         self.assertEqual(False, person.private)
         self.assertIsNone(citation.private)
@@ -143,10 +143,10 @@ class PrivatizerTest(TestCase):
         source = Source('The Source')
         source.files.append(source_file)
         citation_file = File('F1', __file__)
-        citation = IdentifiableCitation('C0', source)
+        citation = Citation('C0', source)
         citation.files.append(citation_file)
-        event_as_subject = Event(Birth())
-        event_as_attendee = Event(Marriage())
+        event_as_subject = Event(None, Birth())
+        event_as_attendee = Event(None, Marriage())
         person_file = File('F2', __file__)
         person = Person('P0')
         person.private = True
@@ -155,7 +155,7 @@ class PrivatizerTest(TestCase):
         Presence(person, Subject(), event_as_subject)
         Presence(person, Attendee(), event_as_attendee)
         ancestry = Ancestry()
-        ancestry.people.add(person)
+        ancestry.entities.append(person)
         privatize(ancestry)
         self.assertTrue(person.private)
         self.assertTrue(citation.private)
@@ -173,7 +173,7 @@ class PrivatizerTest(TestCase):
         if event is not None:
             Presence(person, Subject(), event)
         ancestry = Ancestry()
-        ancestry.people.add(person)
+        ancestry.entities.append(person)
         privatize(ancestry)
         self.assertEquals(expected, person.private)
 
@@ -186,7 +186,7 @@ class PrivatizerTest(TestCase):
             Presence(child, Subject(), event)
         person.children.append(child)
         ancestry = Ancestry()
-        ancestry.people.add(person)
+        ancestry.entities.append(person)
         privatize(ancestry)
         self.assertEquals(expected, person.private)
 
@@ -201,7 +201,7 @@ class PrivatizerTest(TestCase):
             Presence(grandchild, Subject(), event)
         child.children.append(grandchild)
         ancestry = Ancestry()
-        ancestry.people.add(person)
+        ancestry.entities.append(person)
         privatize(ancestry)
         self.assertEquals(expected, person.private)
 
@@ -218,7 +218,7 @@ class PrivatizerTest(TestCase):
             Presence(great_grandchild, Subject(), event)
         grandchild.children.append(great_grandchild)
         ancestry = Ancestry()
-        ancestry.people.add(person)
+        ancestry.entities.append(person)
         privatize(ancestry)
         self.assertEquals(expected, person.private)
 
@@ -231,7 +231,7 @@ class PrivatizerTest(TestCase):
             Presence(parent, Subject(), event)
         person.parents.append(parent)
         ancestry = Ancestry()
-        ancestry.people.add(person)
+        ancestry.entities.append(person)
         privatize(ancestry)
         self.assertEquals(expected, person.private)
 
@@ -246,7 +246,7 @@ class PrivatizerTest(TestCase):
             Presence(grandparent, Subject(), event)
         parent.parents.append(grandparent)
         ancestry = Ancestry()
-        ancestry.people.add(person)
+        ancestry.entities.append(person)
         privatize(ancestry)
         self.assertEquals(expected, person.private)
 
@@ -263,7 +263,7 @@ class PrivatizerTest(TestCase):
             Presence(great_grandparent, Subject(), event)
         grandparent.parents.append(great_grandparent)
         ancestry = Ancestry()
-        ancestry.people.add(person)
+        ancestry.entities.append(person)
         privatize(ancestry)
         self.assertEquals(expected, person.private)
 
@@ -272,17 +272,17 @@ class PrivatizerTest(TestCase):
         source = Source('The Source')
         source.files.append(source_file)
         citation_file = File('F1', __file__)
-        citation = IdentifiableCitation('C0', source)
+        citation = Citation('C0', source)
         citation.files.append(citation_file)
         event_file = File('F1', __file__)
-        event = IdentifiableEvent('E1', Birth())
+        event = Event('E1', Birth())
         event.private = False
         event.citations.append(citation)
         event.files.append(event_file)
         person = Person('P0')
         Presence(person, Subject(), event)
         ancestry = Ancestry()
-        ancestry.events.add(event)
+        ancestry.entities.append(event)
         privatize(ancestry)
         self.assertEqual(False, event.private)
         self.assertIsNone(event_file.private)
@@ -297,17 +297,17 @@ class PrivatizerTest(TestCase):
         source = Source('The Source')
         source.files.append(source_file)
         citation_file = File('F1', __file__)
-        citation = IdentifiableCitation('C0', source)
+        citation = Citation('C0', source)
         citation.files.append(citation_file)
         event_file = File('F1', __file__)
-        event = IdentifiableEvent('E1', Birth())
+        event = Event('E1', Birth())
         event.private = True
         event.citations.append(citation)
         event.files.append(event_file)
         person = Person('P0')
         Presence(person, Subject(), event)
         ancestry = Ancestry()
-        ancestry.events.add(event)
+        ancestry.entities.append(event)
         privatize(ancestry)
         self.assertTrue(event.private)
         self.assertTrue(event_file.private)
@@ -319,22 +319,22 @@ class PrivatizerTest(TestCase):
 
     def test_privatize_source_should_not_privatize_if_public(self):
         file = File('F0', __file__)
-        source = IdentifiableSource('S0', 'The Source')
+        source = Source('S0', 'The Source')
         source.private = False
         source.files.append(file)
         ancestry = Ancestry()
-        ancestry.sources.add(source)
+        ancestry.entities.append(source)
         privatize(ancestry)
         self.assertEqual(False, source.private)
         self.assertIsNone(file.private)
 
     def test_privatize_source_should_privatize_if_private(self):
         file = File('F0', __file__)
-        source = IdentifiableSource('S0', 'The Source')
+        source = Source('S0', 'The Source')
         source.private = True
         source.files.append(file)
         ancestry = Ancestry()
-        ancestry.sources.add(source)
+        ancestry.entities.append(source)
         privatize(ancestry)
         self.assertTrue(source.private)
         self.assertTrue(file.private)
@@ -344,11 +344,11 @@ class PrivatizerTest(TestCase):
         source = Source('The Source')
         source.files.append(source_file)
         citation_file = File('F1', __file__)
-        citation = IdentifiableCitation('C0', source)
+        citation = Citation('C0', source)
         citation.private = False
         citation.files.append(citation_file)
         ancestry = Ancestry()
-        ancestry.citations.add(citation)
+        ancestry.entities.append(citation)
         privatize(ancestry)
         self.assertEqual(False, citation.private)
         self.assertIsNone(source.private)
@@ -360,11 +360,11 @@ class PrivatizerTest(TestCase):
         source = Source('The Source')
         source.files.append(source_file)
         citation_file = File('F1', __file__)
-        citation = IdentifiableCitation('C0', source)
+        citation = Citation('C0', source)
         citation.private = True
         citation.files.append(citation_file)
         ancestry = Ancestry()
-        ancestry.citations.add(citation)
+        ancestry.entities.append(citation)
         privatize(ancestry)
         self.assertTrue(citation.private)
         self.assertTrue(source.private)
@@ -372,25 +372,25 @@ class PrivatizerTest(TestCase):
         self.assertTrue(source_file.private)
 
     def test_privatize_file_should_not_privatize_if_public(self):
-        source = Source('The Source')
-        citation = Citation(source)
+        source = Source(None, 'The Source')
+        citation = Citation(None, source)
         file = File('F0', __file__)
         file.private = False
         file.citations.append(citation)
         ancestry = Ancestry()
-        ancestry.files.add(file)
+        ancestry.entities.append(file)
         privatize(ancestry)
         self.assertEqual(False, file.private)
         self.assertIsNone(citation.private)
 
     def test_privatize_file_should_privatize_if_private(self):
-        source = Source('The Source')
-        citation = Citation(source)
+        source = Source(None, 'The Source')
+        citation = Citation(None, source)
         file = File('F0', __file__)
         file.private = True
         file.citations.append(citation)
         ancestry = Ancestry()
-        ancestry.files.add(file)
+        ancestry.entities.append(file)
         privatize(ancestry)
         self.assertTrue(True, file.private)
         self.assertTrue(citation.private)

--- a/betty/tests/model/test_ancestry.py
+++ b/betty/tests/model/test_ancestry.py
@@ -7,107 +7,16 @@ from unittest.mock import Mock
 from geopy import Point
 from parameterized import parameterized
 
-from betty.ancestry import EventHandlingSetList, Person, Event, Place, File, Note, Presence, PlaceName, PersonName, \
-    IdentifiableEvent, Subject, Birth, Enclosure, Identifiable, Described, Dated, HasPrivacy, HasMediaType, Link, \
-    HasLinks, HasNotes, HasFiles, Source, Citation, HasCitations, IdentifiableCitation, IdentifiableSource, \
-    PresenceRole, Attendee, Beneficiary, Witness, EventType, UnknownEventType, LifeEventType, PreBirthEventType, \
-    PostDeathEventType, Baptism, Adoption, Death, Funeral, FinalDispositionEventType, Cremation, Burial, Will, \
-    Engagement, Marriage, MarriageAnnouncement, Divorce, DivorceAnnouncement, Residence, Immigration, Emigration, \
-    Correspondence, Occupation, Retirement, Confirmation, Missing, EVENT_TYPE_TYPES, RESOURCE_TYPES, Resource
 from betty.locale import Date, Translations
 from betty.media_type import MediaType
+from betty.model import Entity
+from betty.model.ancestry import Person, Event, Place, File, Note, Presence, PlaceName, PersonName, Subject, Birth, \
+    Enclosure, Described, Dated, HasPrivacy, HasMediaType, Link, HasLinks, HasNotes, HasFiles, Source, Citation, \
+    HasCitations, PresenceRole, Attendee, Beneficiary, Witness, EventType, UnknownEventType, LifeEventType, \
+    PreBirthEventType, PostDeathEventType, Baptism, Adoption, Death, Funeral, FinalDispositionEventType, Cremation, \
+    Burial, Will, Engagement, Marriage, MarriageAnnouncement, Divorce, DivorceAnnouncement, Residence, Immigration, \
+    Emigration, Correspondence, Occupation, Retirement, Confirmation, Missing, EVENT_TYPE_TYPES, ENTITY_TYPES
 from betty.tests import TestCase
-
-
-class EventHandlingSetListTest(TestCase):
-    def test_prepend(self) -> None:
-        added = []
-        removal_handler = Mock()
-        sut = EventHandlingSetList(lambda value: added.append(value), removal_handler)
-        sut.prepend(3)
-        sut.prepend(2)
-        sut.prepend(1)
-        # Prepend an already prepended value again, and assert that it was ignored.
-        sut.prepend(1)
-        self.assertSequenceEqual([1, 2, 3], sut)
-        self.assertSequenceEqual([3, 2, 1], added)
-        removal_handler.assert_not_called()
-
-    def test_append(self) -> None:
-        added = []
-        removal_handler = Mock()
-        sut = EventHandlingSetList(lambda value: added.append(value), removal_handler)
-        sut.append(3)
-        sut.append(2)
-        sut.append(1)
-        # Append an already appended value again, and assert that it was ignored.
-        sut.append(1)
-        self.assertSequenceEqual([3, 2, 1], sut)
-        self.assertSequenceEqual([3, 2, 1], added)
-        removal_handler.assert_not_called()
-
-    def test_remove(self) -> None:
-        added = []
-        removed = []
-        sut = EventHandlingSetList(lambda value: added.append(value), lambda value: removed.append(value))
-        sut.append(1, 2, 3, 4)
-        sut.remove(4, 2)
-        self.assertSequenceEqual([1, 3], sut)
-        self.assertSequenceEqual([1, 2, 3, 4], added)
-        self.assertSequenceEqual([4, 2], removed)
-
-    def test_replace(self) -> None:
-        added = []
-        removed = []
-        sut = EventHandlingSetList(lambda value: added.append(value), lambda value: removed.append(value))
-        sut.append(1, 2, 3)
-        sut.replace(4, 5, 6)
-        self.assertSequenceEqual([4, 5, 6], sut)
-        self.assertSequenceEqual([1, 2, 3, 4, 5, 6], added)
-        self.assertSequenceEqual([1, 2, 3], removed)
-
-    def test_clear(self) -> None:
-        added = []
-        removed = []
-        sut = EventHandlingSetList(lambda value: added.append(value), lambda value: removed.append(value))
-        sut.append(1, 2, 3)
-        sut.clear()
-        self.assertSequenceEqual([], sut)
-        self.assertSequenceEqual([1, 2, 3], added)
-        self.assertSequenceEqual([1, 2, 3], removed)
-
-    def test_list(self) -> None:
-        sut = EventHandlingSetList(lambda _: None, lambda _: None)
-        sut.append(1, 2, 3)
-        self.assertEqual([1, 2, 3], sut.list)
-
-    def test_len(self) -> None:
-        sut = EventHandlingSetList(lambda _: None, lambda _: None)
-        sut.append(1, 2, 3)
-        self.assertEqual(3, len(sut))
-
-    def test_iter(self) -> None:
-        sut = EventHandlingSetList(lambda _: None, lambda _: None)
-        sut.append(1, 2, 3)
-        # list() gets all items through __iter__ and stores them in the same order.
-        self.assertSequenceEqual([1, 2, 3], list(sut))
-
-    def test_getitem(self) -> None:
-        sut = EventHandlingSetList(lambda _: None, lambda _: None)
-        sut.append(1, 2, 3)
-        self.assertEqual(1, sut[0])
-        self.assertEqual(2, sut[1])
-        self.assertEqual(3, sut[2])
-        with self.assertRaises(IndexError):
-            sut[3]
-
-    def test_set_like_functionality(self) -> None:
-        sut = EventHandlingSetList(lambda _: None, lambda _: None)
-        # Ensure duplicates are skipped.
-        sut.append(1, 2, 3, 1, 2, 3, 1, 2, 3)
-        # Ensure skipped duplicates do not affect further new values.
-        sut.append(1, 2, 3, 4, 5, 6, 7, 8, 9)
-        self.assertSequenceEqual([1, 2, 3, 4, 5, 6, 7, 8, 9], sut)
 
 
 class HasPrivacyTest(TestCase):
@@ -138,13 +47,6 @@ class HasNotesTest(TestCase):
     def test_notes(self) -> None:
         sut = HasNotes()
         self.assertEquals([], sut.notes)
-
-
-class IdentifiableTest(TestCase):
-    def test_id(self) -> None:
-        identifiable_id = '000000001'
-        sut = Identifiable(identifiable_id)
-        self.assertEquals(identifiable_id, sut.id)
 
 
 class DescribedTest(TestCase):
@@ -198,10 +100,6 @@ class HasLinksTest(TestCase):
 
 
 class FileTest(TestCase):
-    def test_resource_type_name(self) -> None:
-        self.assertIsInstance(File.resource_type_name(), str)
-        self.assertNotEqual('', File.resource_type_name())
-
     def test_id(self) -> None:
         file_id = 'BETTY01'
         file_path = Path('~')
@@ -257,14 +155,17 @@ class FileTest(TestCase):
         sut.notes = notes
         self.assertCountEqual(notes, sut.notes)
 
-    def test_resources(self) -> None:
+    def test_entities(self) -> None:
         file_id = 'BETTY01'
         file_path = Path('~')
         sut = File(file_id, file_path)
-        self.assertCountEqual([], sut.resources)
-        resources = [Mock(HasFiles), Mock(HasFiles)]
-        sut.resources = resources
-        self.assertCountEqual(resources, sut.resources)
+        self.assertCountEqual([], sut.entities)
+
+        class _HasFiles(Entity, HasFiles):
+            pass
+        entities = [_HasFiles(), _HasFiles()]
+        sut.entities = entities
+        self.assertCountEqual(entities, sut.entities)
 
     def test_citations(self) -> None:
         file_id = 'BETTY01'
@@ -275,7 +176,9 @@ class FileTest(TestCase):
 
 class HasFilesTest(TestCase):
     def test_files(self) -> None:
-        sut = HasFiles()
+        class _HasFiles(Entity, HasFiles):
+            pass
+        sut = _HasFiles()
         self.assertCountEqual([], sut.files)
         files = [Mock(File), Mock(File)]
         sut.files = files
@@ -283,124 +186,116 @@ class HasFilesTest(TestCase):
 
 
 class SourceTest(TestCase):
-    def test_resource_type_name(self) -> None:
-        self.assertIsInstance(Source.resource_type_name(), str)
-        self.assertNotEqual('', Source.resource_type_name())
+    def test_id(self) -> None:
+        source_id = 'S1'
+        sut = Source(source_id)
+        self.assertEquals(source_id, sut.id)
 
     def test_name(self) -> None:
         name = 'The Source'
-        sut = Source(name)
+        sut = Source(None, name)
         self.assertEquals(name, sut.name)
 
     def test_contained_by(self) -> None:
-        contained_by_source = Source()
-        sut = Source()
+        contained_by_source = Source(None)
+        sut = Source(None)
         self.assertIsNone(sut.contained_by)
         sut.contained_by = contained_by_source
         self.assertEquals(contained_by_source, sut.contained_by)
 
     def test_contains(self) -> None:
-        contains_source = Source()
-        sut = Source()
+        contains_source = Source(None)
+        sut = Source(None)
         self.assertCountEqual([], sut.contains)
         sut.contains = [contains_source]
         self.assertCountEqual([contains_source], sut.contains)
 
     def test_citations(self) -> None:
-        sut = Source()
+        sut = Source(None)
         self.assertCountEqual([], sut.citations)
 
     def test_author(self) -> None:
-        sut = Source()
+        sut = Source(None)
         self.assertIsNone(sut.author)
         author = 'Me'
         sut.author = author
         self.assertEquals(author, sut.author)
 
     def test_publisher(self) -> None:
-        sut = Source()
+        sut = Source(None)
         self.assertIsNone(sut.publisher)
         publisher = 'Me'
         sut.publisher = publisher
         self.assertEquals(publisher, sut.publisher)
 
     def test_date(self) -> None:
-        sut = Source()
+        sut = Source(None)
         self.assertIsNone(sut.date)
 
     def test_files(self) -> None:
-        sut = Source()
+        sut = Source(None)
         self.assertCountEqual([], sut.files)
 
     def test_links(self) -> None:
-        sut = Source()
+        sut = Source(None)
         self.assertCountEqual([], sut.links)
 
     def test_private(self) -> None:
-        sut = Source()
+        sut = Source(None)
         self.assertIsNone(sut.private)
         private = True
         sut.private = private
         self.assertEquals(private, sut.private)
 
 
-class IdentifiableSourceTest(TestCase):
-    def test_id(self) -> None:
-        source_id = 'C1'
-        sut = IdentifiableSource(source_id)
-        self.assertEquals(source_id, sut.id)
-
-
 class CitationTest(TestCase):
-    def test_resource_type_name(self) -> None:
-        self.assertIsInstance(Citation.resource_type_name(), str)
-        self.assertNotEqual('', Citation.resource_type_name())
+    def test_id(self) -> None:
+        citation_id = 'C1'
+        sut = Citation(citation_id, Mock(Source))
+        self.assertEquals(citation_id, sut.id)
 
     def test_facts(self) -> None:
-        fact = Mock(HasCitations)
-        sut = Citation(Mock(Source))
+        class _HasCitations(Entity, HasCitations):
+            pass
+        fact = _HasCitations()
+        sut = Citation(None, Mock(Source))
         self.assertCountEqual([], sut.facts)
         sut.facts = [fact]
         self.assertCountEqual([fact], sut.facts)
 
     def test_source(self) -> None:
         source = Mock(Source)
-        sut = Citation(source)
+        sut = Citation(None, source)
         self.assertEquals(source, sut.source)
 
     def test_location(self) -> None:
-        sut = Citation(Mock(Source))
+        sut = Citation(None, Mock(Source))
         self.assertIsNone(sut.location)
         location = 'Somewhere'
         sut.location = location
         self.assertEquals(location, sut.location)
 
     def test_date(self) -> None:
-        sut = Citation(Mock(Source))
+        sut = Citation(None, Mock(Source))
         self.assertIsNone(sut.date)
 
     def test_files(self) -> None:
-        sut = Citation(Mock(Source))
+        sut = Citation(None, Mock(Source))
         self.assertCountEqual([], sut.files)
 
     def test_private(self) -> None:
-        sut = Citation(Mock(Source))
+        sut = Citation(None, Mock(Source))
         self.assertIsNone(sut.private)
         private = True
         sut.private = private
         self.assertEquals(private, sut.private)
 
 
-class IdentifiableCitationTest(TestCase):
-    def test_id(self) -> None:
-        citation_id = 'C1'
-        sut = IdentifiableCitation(citation_id, Mock(Source))
-        self.assertEquals(citation_id, sut.id)
-
-
 class HasCitationsTest(TestCase):
     def test_citations(self) -> None:
-        sut = HasCitations()
+        class _HasCitations(Entity, HasCitations):
+            pass
+        sut = _HasCitations()
         self.assertCountEqual([], sut.citations)
         citation = Mock(Citation)
         sut.citations = [citation]
@@ -474,13 +369,9 @@ class EnclosureTest(TestCase):
 
 
 class PlaceTest(TestCase):
-    def test_resource_type_name(self) -> None:
-        self.assertIsInstance(Citation.resource_type_name(), str)
-        self.assertNotEqual('', Citation.resource_type_name())
-
     def test_events(self) -> None:
         sut = Place('P1', [PlaceName('The Place')])
-        event = IdentifiableEvent('1', Birth())
+        event = Event('1', Birth())
         sut.events.append(event)
         self.assertIn(event, sut.events)
         self.assertEquals(sut, event.place)
@@ -932,13 +823,14 @@ class EventTypeTypesTest(TestCase):
 
 
 class EventTest(TestCase):
-    def test_resource_type_name(self) -> None:
-        self.assertIsInstance(Event.resource_type_name(), str)
-        self.assertNotEqual('', Event.resource_type_name())
+    def test_id(self) -> None:
+        event_id = 'E1'
+        sut = Event(event_id, Mock(EventType))
+        self.assertEquals(event_id, sut.id)
 
     def test_place(self) -> None:
         place = Place('1', [PlaceName('one')])
-        sut = Event(Mock(EventType))
+        sut = Event(None, Mock(EventType))
         sut.place = place
         self.assertEquals(place, sut.place)
         self.assertIn(sut, place.events)
@@ -948,7 +840,7 @@ class EventTest(TestCase):
 
     def test_presences(self) -> None:
         person = Person('P1')
-        sut = Event(Mock(EventType))
+        sut = Event(None, Mock(EventType))
         presence = Presence(person, Subject(), sut)
         sut.presences.append(presence)
         self.assertCountEqual([presence], sut.presences)
@@ -958,31 +850,31 @@ class EventTest(TestCase):
         self.assertIsNone(presence.event)
 
     def test_date(self) -> None:
-        sut = Event(Mock(EventType))
+        sut = Event(None, Mock(EventType))
         self.assertIsNone(sut.date)
         date = Mock(Date)
         sut.date = date
         self.assertEquals(date, sut.date)
 
     def test_files(self) -> None:
-        sut = Event(Mock(EventType))
+        sut = Event(None, Mock(EventType))
         self.assertCountEqual([], sut.files)
 
     def test_citations(self) -> None:
-        sut = Event(Mock(EventType))
+        sut = Event(None, Mock(EventType))
         self.assertCountEqual([], sut.citations)
 
     def test_description(self) -> None:
-        sut = Event(Mock(EventType))
+        sut = Event(None, Mock(EventType))
         self.assertIsNone(sut.description)
 
     def test_private(self) -> None:
-        sut = Event(Mock(EventType))
+        sut = Event(None, Mock(EventType))
         self.assertIsNone(sut.private)
 
     def test_type(self) -> None:
         event_type = Mock(EventType)
-        sut = Event(event_type)
+        sut = Event(None, event_type)
         self.assertEquals(event_type, sut.type)
 
     def test_associated_files(self) -> None:
@@ -990,7 +882,7 @@ class EventTest(TestCase):
         file2 = Mock(File)
         file3 = Mock(File)
         file4 = Mock(File)
-        sut = Event(Mock(EventType))
+        sut = Event(None, Mock(EventType))
         sut.files = [file1, file2, file1]
         citation = Mock(Citation)
         citation.associated_files = [file3, file4, file2]
@@ -998,18 +890,10 @@ class EventTest(TestCase):
         self.assertEquals([file1, file2, file3, file4], list(sut.associated_files))
 
 
-class IdentifiableEventTest(TestCase):
-    def test_id(self) -> None:
-        event_id = 'E1'
-        sut = IdentifiableEvent(event_id, Mock(EventType))
-        self.assertEquals(event_id, sut.id)
-
-
 class PersonNameTest(TestCase):
     def test_person(self) -> None:
-        sut = PersonName('Janet', 'Not a Girl')
         person = Person('1')
-        sut.person = person
+        sut = PersonName(person, 'Janet', 'Not a Girl')
         self.assertEquals(person, sut.person)
         self.assertCountEqual([sut], person.names)
         sut.person = None
@@ -1017,50 +901,50 @@ class PersonNameTest(TestCase):
         self.assertCountEqual([], person.names)
 
     def test_locale(self) -> None:
-        sut = PersonName('Janet', 'Not a Girl')
+        person = Person('1')
+        sut = PersonName(person, 'Janet', 'Not a Girl')
         self.assertIsNone(sut.locale)
 
     def test_citations(self) -> None:
-        sut = PersonName('Janet', 'Not a Girl')
+        person = Person('1')
+        sut = PersonName(person, 'Janet', 'Not a Girl')
         self.assertCountEqual([], sut.citations)
 
     def test_individual(self) -> None:
+        person = Person('1')
         individual = 'Janet'
-        sut = PersonName(individual, 'Not a Girl')
+        sut = PersonName(person, individual, 'Not a Girl')
         self.assertEquals(individual, sut.individual)
 
     def test_affiliation(self) -> None:
+        person = Person('1')
         affiliation = 'Not a Girl'
-        sut = PersonName('Janet', affiliation)
+        sut = PersonName(person, 'Janet', affiliation)
         self.assertEquals(affiliation, sut.affiliation)
 
     @parameterized.expand([
-        (True, PersonName('Janet', 'Not a Girl'), PersonName('Janet', 'Not a Girl')),
-        (True, PersonName('Janet'), PersonName('Janet')),
-        (True, PersonName(None, 'Not a Girl'), PersonName(None, 'Not a Girl')),
-        (False, PersonName('Janet'), PersonName(None, 'Not a Girl')),
-        (False, PersonName('Janet', 'Not a Girl'), None),
-        (False, PersonName('Janet', 'Not a Girl'), True),
-        (False, PersonName('Janet', 'Not a Girl'), 9),
-        (False, PersonName('Janet', 'Not a Girl'), object()),
+        (True, PersonName(Person('1'), 'Janet', 'Not a Girl'), PersonName(Person('1'), 'Janet', 'Not a Girl')),
+        (True, PersonName(Person('1'), 'Janet'), PersonName(Person('1'), 'Janet')),
+        (True, PersonName(Person('1'), None, 'Not a Girl'), PersonName(Person('1'), None, 'Not a Girl')),
+        (False, PersonName(Person('1'), 'Janet'), PersonName(Person('1'), None, 'Not a Girl')),
+        (False, PersonName(Person('1'), 'Janet', 'Not a Girl'), None),
+        (False, PersonName(Person('1'), 'Janet', 'Not a Girl'), True),
+        (False, PersonName(Person('1'), 'Janet', 'Not a Girl'), 9),
+        (False, PersonName(Person('1'), 'Janet', 'Not a Girl'), object()),
     ])
     def test_eq(self, expected: bool, left: PersonName, right: Any) -> None:
         self.assertEquals(expected, left == right)
 
     @parameterized.expand([
-        (False, PersonName('Janet', 'Not a Girl'), PersonName('Janet', 'Not a Girl')),
-        (True, PersonName('Janet', 'Not a Girl'), PersonName('Not a Girl', 'Janet')),
-        (True, PersonName('Janet', 'Not a Girl'), None),
+        (False, PersonName(Person('1'), 'Janet', 'Not a Girl'), PersonName(Person('1'), 'Janet', 'Not a Girl')),
+        (True, PersonName(Person('1'), 'Janet', 'Not a Girl'), PersonName(Person('1'), 'Not a Girl', 'Janet')),
+        (True, PersonName(Person('1'), 'Janet', 'Not a Girl'), None),
     ])
     def test_gt(self, expected: bool, left: PersonName, right: Any) -> None:
         self.assertEquals(expected, left > right)
 
 
 class PersonTest(TestCase):
-    def test_resource_type_name(self) -> None:
-        self.assertIsInstance(Person.resource_type_name(), str)
-        self.assertNotEqual('', Person.resource_type_name())
-
     def test_parents(self) -> None:
         sut = Person('1')
         parent = Person('2')
@@ -1082,7 +966,7 @@ class PersonTest(TestCase):
         self.assertCountEqual([], child.parents)
 
     def test_presences(self) -> None:
-        event = Event(Birth())
+        event = Event(None, Birth())
         sut = Person('1')
         presence = Presence(sut, Subject(), event)
         sut.presences.append(presence)
@@ -1094,8 +978,7 @@ class PersonTest(TestCase):
 
     def test_names(self) -> None:
         sut = Person('1')
-        name = PersonName('Janet', 'Not a Girl')
-        sut.names.append(name)
+        name = PersonName(sut, 'Janet', 'Not a Girl')
         self.assertCountEqual([name], sut.names)
         self.assertEquals(sut, name.person)
         sut.names.remove(name)
@@ -1108,25 +991,24 @@ class PersonTest(TestCase):
         self.assertEquals(person_id, sut.id)
 
     def test_files(self) -> None:
-        sut = Source()
+        sut = Source(None)
         self.assertCountEqual([], sut.files)
 
     def test_citations(self) -> None:
-        sut = Source()
+        sut = Source(None)
         self.assertCountEqual([], sut.citations)
 
     def test_links(self) -> None:
-        sut = Source()
+        sut = Source(None)
         self.assertCountEqual([], sut.links)
 
     def test_private(self) -> None:
-        sut = Event(Mock(EventType))
+        sut = Event(None, Mock(EventType))
         self.assertIsNone(sut.private)
 
     def test_name_with_names(self) -> None:
         sut = Person('P1')
-        name = PersonName()
-        sut.names = [name, PersonName()]
+        name = PersonName(sut)
         self.assertEquals(name, sut.name)
 
     def test_name_without_names(self) -> None:
@@ -1134,19 +1016,18 @@ class PersonTest(TestCase):
 
     def test_alternative_names(self) -> None:
         sut = Person('P1')
-        name = PersonName('Janet', 'Not a Girl')
-        alternative_name = PersonName('Janet', 'Still not a Girl')
-        sut.names = [name, alternative_name]
+        PersonName(sut, 'Janet', 'Not a Girl')
+        alternative_name = PersonName(sut, 'Janet', 'Still not a Girl')
         self.assertEquals([alternative_name], sut.alternative_names)
 
     def test_start(self) -> None:
-        start = Event(Birth())
+        start = Event(None, Birth())
         sut = Person('P1')
         Presence(sut, Subject(), start)
         self.assertEquals(start, sut.start)
 
     def test_end(self) -> None:
-        end = Event(Burial())
+        end = Event(None, Burial())
         sut = Person('P1')
         Presence(sut, Subject(), end)
         self.assertEquals(end, sut.end)
@@ -1180,16 +1061,15 @@ class PersonTest(TestCase):
         sut.files = [file1, file2, file1]
         citation = Mock(Citation)
         citation.associated_files = [file3, file4, file2]
-        name = PersonName()
+        name = PersonName(sut)
         name.citations = [citation]
-        sut.names = [name]
         event = Mock(Event)
         event.associated_files = [file5, file6, file4]
         Presence(sut, Subject(), event)
         self.assertEquals([file1, file2, file3, file4, file5, file6], list(sut.associated_files))
 
 
-class ResourceTypesTest(TestCase):
+class EntityTypesTest(TestCase):
     def test(self) -> None:
-        for resource_type in RESOURCE_TYPES:
-            self.assertTrue(issubclass(resource_type, Resource))
+        for entity_type in ENTITY_TYPES:
+            self.assertTrue(issubclass(entity_type, Entity))

--- a/betty/tests/model/test_init.py
+++ b/betty/tests/model/test_init.py
@@ -1,0 +1,494 @@
+import pickle
+from typing import Optional
+from unittest.mock import Mock
+
+from betty.model import EntityCollection, Entity, many_to_one, one_to_many, EventDispatchingEntityCollection, \
+    many_to_many, many_to_one_to_many, GroupedEntityCollection
+from betty.tests import TestCase
+
+
+class EntityTest(TestCase):
+    def test_id(self) -> None:
+        entity_id = '000000001'
+        sut = Entity(entity_id)
+        self.assertEqual(entity_id, sut.id)
+
+
+class EntityCollectionTest(TestCase):
+    def test_pickle(self) -> None:
+        sut = EntityCollection()
+        pickle.dumps(sut)
+
+    def test_prepend(self) -> None:
+        sut = EntityCollection()
+        entity1 = Entity('1')
+        entity2 = Entity('2')
+        entity3 = Entity('3')
+        sut.prepend(entity3)
+        sut.prepend(entity2)
+        sut.prepend(entity1)
+        # Prepend an already prepended value again, and assert that it was ignored.
+        sut.prepend(entity1)
+        self.assertIs(entity1, sut['1'])
+        self.assertIs(entity2, sut['2'])
+        self.assertIs(entity3, sut['3'])
+
+    def test_append(self) -> None:
+        sut = EntityCollection()
+        entity1 = Entity()
+        entity2 = Entity()
+        entity3 = Entity()
+        sut.append(entity3)
+        sut.append(entity2)
+        sut.append(entity1)
+        # Append an already appended value again, and assert that it was ignored.
+        sut.append(entity1)
+        self.assertSequenceEqual([entity3, entity2, entity1], sut)
+
+    def test_remove(self) -> None:
+        sut = EntityCollection()
+        entity1 = Entity()
+        entity2 = Entity()
+        entity3 = Entity()
+        entity4 = Entity()
+        sut.append(entity1, entity2, entity3, entity4)
+        sut.remove(entity4, entity2)
+        self.assertSequenceEqual([entity1, entity3], sut)
+
+    def test_replace(self) -> None:
+        sut = EntityCollection()
+        entity1 = Entity()
+        entity2 = Entity()
+        entity3 = Entity()
+        entity4 = Entity()
+        entity5 = Entity()
+        entity6 = Entity()
+        sut.append(entity1, entity2, entity3)
+        sut.replace(entity4, entity5, entity6)
+        self.assertSequenceEqual([entity4, entity5, entity6], sut)
+
+    def test_clear(self) -> None:
+        sut = EntityCollection()
+        entity1 = Entity()
+        entity2 = Entity()
+        entity3 = Entity()
+        sut.append(entity1, entity2, entity3)
+        sut.clear()
+        self.assertSequenceEqual([], sut)
+
+    def test_list(self) -> None:
+        sut = EntityCollection()
+        entity1 = Entity()
+        entity2 = Entity()
+        entity3 = Entity()
+        sut.append(entity1, entity2, entity3)
+        self.assertIs(entity1, sut[0])
+        self.assertIs(entity2, sut[1])
+        self.assertIs(entity3, sut[2])
+
+    def test_len(self) -> None:
+        sut = EntityCollection()
+        entity1 = Entity()
+        entity2 = Entity()
+        entity3 = Entity()
+        sut.append(entity1, entity2, entity3)
+        self.assertEqual(3, len(sut))
+
+    def test_iter(self) -> None:
+        sut = EntityCollection()
+        entity1 = Entity()
+        entity2 = Entity()
+        entity3 = Entity()
+        sut.append(entity1, entity2, entity3)
+        self.assertSequenceEqual([entity1, entity2, entity3], list(sut))
+
+    def test_getitem(self) -> None:
+        sut = EntityCollection()
+        entity1 = Entity('1')
+        entity2 = Entity('2')
+        entity3 = Entity('3')
+        sut.append(entity1, entity2, entity3)
+        self.assertIs(entity1, sut[0])
+        self.assertIs(entity1, sut['1'])
+        self.assertIs(entity2, sut[1])
+        self.assertIs(entity2, sut['2'])
+        self.assertIs(entity3, sut[2])
+        self.assertIs(entity3, sut['3'])
+        self.assertSequenceEqual([entity1, entity2, entity3], sut[0:3])
+        with self.assertRaises(KeyError):
+            sut['4']
+
+    def test_delitem(self) -> None:
+        sut = EntityCollection()
+        entity1 = Entity('1')
+        entity2 = Entity('2')
+        entity3 = Entity('3')
+        sut.append(entity1, entity2, entity3)
+
+        del sut['2']
+
+        self.assertSequenceEqual([entity1, entity3], sut)
+        with self.assertRaises(KeyError):
+            sut['2']
+
+    def test_contains(self) -> None:
+        sut = EntityCollection()
+        entity1 = Entity()
+        entity2 = Entity()
+        sut.append(entity1)
+
+        self.assertIn(entity1, sut)
+        self.assertNotIn(entity2, sut)
+
+    def test_set_like_functionality(self) -> None:
+        sut = EntityCollection()
+        entity1 = Entity()
+        entity2 = Entity()
+        entity3 = Entity()
+        entity4 = Entity()
+        entity5 = Entity()
+        entity6 = Entity()
+        entity7 = Entity()
+        entity8 = Entity()
+        entity9 = Entity()
+        # Ensure duplicates are skipped.
+        sut.append(entity1, entity2, entity3, entity1, entity2, entity3, entity1, entity2, entity3)
+        # Ensure skipped duplicates do not affect further new values.
+        sut.append(entity1, entity2, entity3, entity4, entity5, entity6, entity7, entity8, entity9)
+        self.assertSequenceEqual([entity1, entity2, entity3, entity4, entity5, entity6, entity7, entity8, entity9], sut)
+
+
+class EventDispatchingEntityCollectionTest(TestCase):
+    class _PickleableCallable:
+        def __call__(self, *args, **kwargs):
+            pass
+
+    class _SelfReferentialHandler:
+        def __init__(self, handled_self):
+            self._handled_self = handled_self
+
+    class _SelfReferentialOnAdd(_SelfReferentialHandler):
+        def __call__(self, other_self):
+            other_self.other_selfs.append(self._handled_self)
+
+    class _SelfReferentialOnRemove(_SelfReferentialHandler):
+        def __call__(self, other_self):
+            other_self.other_selfs.remove(self._handled_self)
+
+    class _SelfReferentialEntity(Entity):
+        def __init__(self):
+            super().__init__()
+            self.other_selfs = EventDispatchingEntityCollection(
+                EventDispatchingEntityCollectionTest._SelfReferentialOnAdd(self),
+                EventDispatchingEntityCollectionTest._SelfReferentialOnRemove(self),
+            )
+
+    def test_pickle(self) -> None:
+        sut = EventDispatchingEntityCollection(
+            EventDispatchingEntityCollectionTest._PickleableCallable(),
+            EventDispatchingEntityCollectionTest._PickleableCallable(),
+        )
+        pickle.dumps(sut)
+
+    def test_pickle_with_recursion(self) -> None:
+        entity1 = self._SelfReferentialEntity()
+        entity2 = self._SelfReferentialEntity()
+        entity1.other_selfs.append(entity2)
+        self.assertIn(entity2, entity1.other_selfs)
+        self.assertIn(entity1, entity2.other_selfs)
+        pickle.dumps(entity1)
+        pickle.dumps(entity2)
+
+    def test_prepend(self) -> None:
+        added = []
+        on_remove = Mock()
+        sut = EventDispatchingEntityCollection(lambda value: added.append(value), on_remove)
+        entity1 = Entity('1')
+        entity2 = Entity('2')
+        entity3 = Entity('3')
+        sut.prepend(entity3)
+        sut.prepend(entity2)
+        sut.prepend(entity1)
+        # Prepend an already prepended value again, and assert that it was ignored.
+        sut.prepend(entity1)
+        self.assertIs(entity1, sut['1'])
+        self.assertIs(entity2, sut['2'])
+        self.assertIs(entity3, sut['3'])
+        self.assertIs(entity3, added[0])
+        self.assertIs(entity2, added[1])
+        self.assertIs(entity1, added[2])
+        on_remove.assert_not_called()
+
+    def test_append(self) -> None:
+        added = []
+        on_remove = Mock()
+        sut = EventDispatchingEntityCollection(lambda value: added.append(value), on_remove)
+        entity1 = Entity()
+        entity2 = Entity()
+        entity3 = Entity()
+        sut.append(entity3)
+        sut.append(entity2)
+        sut.append(entity1)
+        # Append an already appended value again, and assert that it was ignored.
+        sut.append(entity1)
+        self.assertSequenceEqual([entity3, entity2, entity1], sut)
+        self.assertSequenceEqual([entity3, entity2, entity1], added)
+        on_remove.assert_not_called()
+
+    def test_remove(self) -> None:
+        added = []
+        removed = []
+        sut = EventDispatchingEntityCollection(lambda value: added.append(value), lambda value: removed.append(value))
+        entity1 = Entity()
+        entity2 = Entity()
+        entity3 = Entity()
+        entity4 = Entity()
+        sut.append(entity1, entity2, entity3, entity4)
+        sut.remove(entity4, entity2)
+        self.assertSequenceEqual([entity1, entity3], sut)
+        self.assertSequenceEqual([entity1, entity2, entity3, entity4], added)
+        self.assertSequenceEqual([entity4, entity2], removed)
+
+    def test_replace(self) -> None:
+        added = []
+        removed = []
+        sut = EventDispatchingEntityCollection(lambda value: added.append(value), lambda value: removed.append(value))
+        entity1 = Entity()
+        entity2 = Entity()
+        entity3 = Entity()
+        entity4 = Entity()
+        entity5 = Entity()
+        entity6 = Entity()
+        sut.append(entity1, entity2, entity3)
+        sut.replace(entity4, entity5, entity6)
+        self.assertSequenceEqual([entity4, entity5, entity6], sut)
+        self.assertSequenceEqual([entity1, entity2, entity3, entity4, entity5, entity6], added)
+        self.assertSequenceEqual([entity1, entity2, entity3], removed)
+
+    def test_clear(self) -> None:
+        added = []
+        removed = []
+        sut = EventDispatchingEntityCollection(lambda value: added.append(value), lambda value: removed.append(value))
+        entity1 = Entity()
+        entity2 = Entity()
+        entity3 = Entity()
+        sut.append(entity1, entity2, entity3)
+        sut.clear()
+        self.assertSequenceEqual([], sut)
+        self.assertIs(entity1, added[0])
+        self.assertIs(entity2, added[1])
+        self.assertIs(entity3, added[2])
+        self.assertIs(entity1, removed[0])
+        self.assertIs(entity2, removed[1])
+        self.assertIs(entity3, removed[2])
+
+    def test_list(self) -> None:
+        sut = EventDispatchingEntityCollection(lambda _: None, lambda _: None)
+        entity1 = Entity()
+        entity2 = Entity()
+        entity3 = Entity()
+        sut.append(entity1, entity2, entity3)
+        self.assertIs(entity1, sut[0])
+        self.assertIs(entity2, sut[1])
+        self.assertIs(entity3, sut[2])
+
+    def test_delitem(self) -> None:
+        added = []
+        removed = []
+        sut = EventDispatchingEntityCollection(lambda value: added.append(value), lambda value: removed.append(value))
+        entity1 = Entity('1')
+        entity2 = Entity('2')
+        entity3 = Entity('3')
+        sut.append(entity1, entity2, entity3)
+
+        del sut['2']
+
+        self.assertSequenceEqual([entity1, entity3], sut)
+        with self.assertRaises(KeyError):
+            sut['2']
+        self.assertSequenceEqual([entity2], removed)
+
+
+class GroupedEntityCollectionTest(TestCase):
+    class _One(Entity):
+        pass
+
+    class _Other(Entity):
+        pass
+
+    def test_prepend(self) -> None:
+        sut = GroupedEntityCollection()
+        entity_one = self._One()
+        entity_other1 = self._Other()
+        entity_other2 = self._Other()
+        entity_other3 = self._Other()
+        sut.prepend(entity_one, entity_other1, entity_other2, entity_other3)
+        self.assertSequenceEqual([entity_other3, entity_other2, entity_other1], sut[self._Other])
+
+    def test_append(self) -> None:
+        sut = GroupedEntityCollection()
+        entity_one = self._One()
+        entity_other1 = self._Other()
+        entity_other2 = self._Other()
+        entity_other3 = self._Other()
+        sut.append(entity_one, entity_other1, entity_other2, entity_other3)
+        self.assertSequenceEqual([entity_other1, entity_other2, entity_other3], sut[self._Other])
+
+    def test_remove(self) -> None:
+        sut = GroupedEntityCollection()
+        entity_one = self._One()
+        entity_other = self._Other()
+        sut[self._One].append(entity_one)
+        sut[self._Other].append(entity_other)
+        sut.remove(entity_one)
+        self.assertSequenceEqual([entity_other], list(sut))
+        sut.remove(entity_other)
+        self.assertSequenceEqual([], list(sut))
+
+    def test_getitem(self) -> None:
+        sut = GroupedEntityCollection()
+        entity_one = self._One()
+        entity_other = self._Other()
+        sut[self._One].append(entity_one)
+        sut[self._Other].append(entity_other)
+        self.assertIs(entity_one, sut[0])
+        self.assertIs(entity_other, sut[1])
+
+    def test_iter(self) -> None:
+        sut = GroupedEntityCollection()
+        entity_one = self._One()
+        entity_other = self._Other()
+        sut[self._One].append(entity_one)
+        sut[self._Other].append(entity_other)
+        self.assertSequenceEqual([entity_one, entity_other], list(sut))
+
+    def test_len(self) -> None:
+        sut = GroupedEntityCollection()
+        entity_one = self._One()
+        entity_other = self._Other()
+        sut[self._One].append(entity_one)
+        sut[self._Other].append(entity_other)
+        self.assertEqual(2, len(sut))
+
+    def test_contain(self) -> None:
+        sut = GroupedEntityCollection()
+        entity_one = self._One()
+        entity_other1 = self._Other()
+        entity_other2 = self._Other()
+        sut[self._One].append(entity_one)
+        sut[self._Other].append(entity_other1)
+        self.assertIn(entity_one, sut)
+        self.assertIn(entity_other1, sut)
+        self.assertNotIn(entity_other2, sut)
+
+
+class ManyToManyTest(TestCase):
+    @many_to_many('other_many', 'many')
+    class _Many(Entity):
+        other_many: EntityCollection['ManyToManyTest._OtherMany']
+
+    @many_to_many('many', 'other_many')
+    class _OtherMany(Entity):
+        many: EntityCollection['ManyToManyTest._Many']
+
+    def test(self) -> None:
+        entity_many = self._Many()
+        entity_other_many = self._OtherMany()
+
+        entity_many.other_many.append(entity_other_many)
+        self.assertSequenceEqual([entity_other_many], entity_many.other_many)
+        self.assertSequenceEqual([entity_many], entity_other_many.many)
+
+        entity_many.other_many.remove(entity_other_many)
+        self.assertSequenceEqual([], entity_many.other_many)
+        self.assertSequenceEqual([], entity_other_many.many)
+
+    def test_pickle(self) -> None:
+        entity = self._Many()
+        pickle.dumps(entity)
+
+
+class ManyToOneToManyTest(TestCase):
+    @many_to_one_to_many('one', 'left_many', 'right_many', 'one')
+    class _One(Entity):
+        left_many: Optional['ManyToOneToManyTest._Many']
+        right_many: Optional['ManyToOneToManyTest._Many']
+
+    @one_to_many('one', 'many')
+    class _Many(Entity):
+        one: EntityCollection['ManyToOneToManyTest._One']
+
+    def test(self) -> None:
+        entity_one = self._One()
+        entity_left_many = self._Many()
+        entity_right_many = self._Many()
+
+        entity_one.left_many = entity_left_many
+        self.assertIs(entity_left_many, entity_one.left_many)
+        self.assertSequenceEqual([entity_one], entity_left_many.one)
+
+        entity_one.right_many = entity_right_many
+        self.assertIs(entity_right_many, entity_one.right_many)
+        self.assertSequenceEqual([entity_one], entity_right_many.one)
+
+        del entity_one.left_many
+        self.assertIsNone(entity_one.left_many)
+        self.assertSequenceEqual([], entity_left_many.one)
+        self.assertIsNone(entity_one.right_many)
+        self.assertSequenceEqual([], entity_right_many.one)
+
+    def test_pickle(self) -> None:
+        entity = self._One()
+        pickle.dumps(entity)
+
+
+class OneToManyTest(TestCase):
+    @one_to_many('many', 'one')
+    class _One(Entity):
+        many: EntityCollection['OneToManyTest._Many']
+
+    @many_to_one('one', 'many')
+    class _Many(Entity):
+        one: Optional['OneToManyTest._One']
+
+    def test(self) -> None:
+        entity_one = self._One()
+        entity_many = self._Many()
+
+        entity_one.many.append(entity_many)
+        self.assertSequenceEqual([entity_many], entity_one.many)
+        self.assertIs(entity_one, entity_many.one)
+
+        entity_one.many.remove(entity_many)
+        self.assertSequenceEqual([], entity_one.many)
+        self.assertIsNone(entity_many.one)
+
+    def test_pickle(self) -> None:
+        entity = self._One()
+        pickle.dumps(entity)
+
+
+class ManyToOneTest(TestCase):
+    @many_to_one('one', 'many')
+    class _Many(Entity):
+        one: Optional['ManyToOneTest._One']
+
+    @one_to_many('many', 'one')
+    class _One(Entity):
+        many: EntityCollection['ManyToOneTest._Many']
+
+    def test(self) -> None:
+        entity_many = self._Many()
+        entity_one = self._One()
+
+        entity_many.one = entity_one
+        self.assertIs(entity_one, entity_many.one)
+        self.assertSequenceEqual([entity_many], entity_one.many)
+
+        del entity_many.one
+        self.assertIsNone(entity_many.one)
+        self.assertSequenceEqual([], entity_one.many)
+
+    def test_pickle(self) -> None:
+        entity = self._Many()
+        pickle.dumps(entity)

--- a/betty/tests/test_app.py
+++ b/betty/tests/test_app.py
@@ -8,7 +8,7 @@ from typing import List, Type, Set, Dict
 from voluptuous import Schema, Required, Invalid
 
 from betty import extension
-from betty.ancestry import Ancestry
+from betty.model.ancestry import Ancestry
 from betty.config import Configuration, ConfigurationError, ExtensionConfiguration
 from betty.asyncio import sync
 from betty.app import App

--- a/betty/tests/test_functools.py
+++ b/betty/tests/test_functools.py
@@ -1,8 +1,8 @@
-from typing import Any
+from typing import Any, List
 
 from parameterized import parameterized
 
-from betty.functools import walk
+from betty.functools import walk, slice_to_range
 from betty.tests import TestCase
 
 
@@ -56,3 +56,17 @@ class WalkTest(TestCase):
         actual = walk(item, 'child')
         expected = [child, grandchild]
         self.assertEquals(expected, list(actual))
+
+
+class SliceToRangeTest(TestCase):
+    @parameterized.expand([
+        ([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], slice(0, 16, 1)),
+        ([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], slice(0, None, 1)),
+        ([0], slice(None, 1, 1)),
+        ([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], slice(None, None, 1)),
+        ([9, 10, 11, 12, 13, 14, 15], slice(9, None, 1)),
+        ([0, 3, 6, 9, 12, 15], slice(None, None, 3)),
+    ])
+    def test(self, expected_range_items: List[int], ranged_slice: slice) -> None:
+        iterable = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        self.assertEqual(expected_range_items, list(slice_to_range(ranged_slice, iterable)))

--- a/betty/tests/test_generate.py
+++ b/betty/tests/test_generate.py
@@ -8,8 +8,7 @@ import html5lib
 from lxml import etree
 
 from betty import json
-from betty.ancestry import Person, Place, Source, PlaceName, File, IdentifiableEvent, IdentifiableCitation, \
-    IdentifiableSource, Birth
+from betty.model.ancestry import Person, Place, Source, PlaceName, File, Birth, Event, Citation
 from betty.config import Configuration, LocaleConfiguration
 from betty.asyncio import sync
 from betty.generate import generate
@@ -63,7 +62,7 @@ class RenderTest(GenerateTestCase):
         # @todo This fails somewhere in file.html.j2, very likely because of jinja2._filter_file()
         with NamedTemporaryFile() as f:
             file = File('FILE1', Path(f.name))
-            self.app.ancestry.files.add(file)
+            self.app.ancestry.entities.append(file)
             await generate(self.app)
             self.assert_betty_html('/file/%s/index.html' % file.id)
             self.assert_betty_json('/file/%s/index.json' % file.id, 'file')
@@ -77,7 +76,7 @@ class RenderTest(GenerateTestCase):
     @sync
     async def test_place(self):
         place = Place('PLACE1', [PlaceName('one')])
-        self.app.ancestry.places.add(place)
+        self.app.ancestry.entities.append(place)
         await generate(self.app)
         self.assert_betty_html('/place/%s/index.html' % place.id)
         self.assert_betty_json('/place/%s/index.json' % place.id, 'place')
@@ -91,7 +90,7 @@ class RenderTest(GenerateTestCase):
     @sync
     async def test_person(self):
         person = Person('PERSON1')
-        self.app.ancestry.people.add(person)
+        self.app.ancestry.entities.append(person)
         await generate(self.app)
         self.assert_betty_html('/person/%s/index.html' % person.id)
         self.assert_betty_json('/person/%s/index.json' % person.id, 'person')
@@ -104,16 +103,16 @@ class RenderTest(GenerateTestCase):
 
     @sync
     async def test_event(self):
-        event = IdentifiableEvent('EVENT1', Birth())
-        self.app.ancestry.events.add(event)
+        event = Event('EVENT1', Birth())
+        self.app.ancestry.entities.append(event)
         await generate(self.app)
         self.assert_betty_html('/event/%s/index.html' % event.id)
         self.assert_betty_json('/event/%s/index.json' % event.id, 'event')
 
     @sync
     async def test_citation(self):
-        citation = IdentifiableCitation('CITATION1', Source('A Little Birdie'))
-        self.app.ancestry.citations.add(citation)
+        citation = Citation('CITATION1', Source('A Little Birdie'))
+        self.app.ancestry.entities.append(citation)
         await generate(self.app)
         self.assert_betty_html('/citation/%s/index.html' % citation.id)
         self.assert_betty_json('/citation/%s/index.json' %
@@ -127,8 +126,8 @@ class RenderTest(GenerateTestCase):
 
     @sync
     async def test_source(self):
-        source = IdentifiableSource('SOURCE1', 'A Little Birdie')
-        self.app.ancestry.sources.add(source)
+        source = Source('SOURCE1', 'A Little Birdie')
+        self.app.ancestry.entities.append(source)
         await generate(self.app)
         self.assert_betty_html('/source/%s/index.html' % source.id)
         self.assert_betty_json('/source/%s/index.json' % source.id, 'source')
@@ -164,7 +163,7 @@ class MultilingualTest(GenerateTestCase):
     @sync
     async def test_entity(self):
         person = Person('PERSON1')
-        self.app.ancestry.people.add(person)
+        self.app.ancestry.entities.append(person)
         await generate(self.app)
         with open(self.assert_betty_html('/nl/person/%s/index.html' % person.id)) as f:
             translation_link = '<a href="/en/person/%s/index.html" hreflang="en" lang="en" rel="alternate">English</a>' % person.id

--- a/betty/tests/test_jinja2.py
+++ b/betty/tests/test_jinja2.py
@@ -6,7 +6,8 @@ from unittest.mock import Mock
 
 from parameterized import parameterized
 
-from betty.ancestry import File, PlaceName, Subject, Attendee, Witness, Dated, Resource, Person, Place, Citation
+from betty.model import get_entity_type_name
+from betty.model.ancestry import File, PlaceName, Subject, Attendee, Witness, Dated, Entity, Person, Place, Citation
 from betty.config import Configuration, LocaleConfiguration, ExtensionConfiguration
 from betty.asyncio import sync
 from betty.jinja2 import Jinja2Renderer, _Citer, Jinja2Provider
@@ -14,6 +15,7 @@ from betty.locale import Date, Datey, DateRange, Localized
 from betty.media_type import MediaType
 from betty.extension import Extension
 from betty.app import App
+from betty.string import camel_case_to_snake_case
 from betty.tests import TemplateTestCase
 
 
@@ -498,8 +500,8 @@ class TestResourceTest(TemplateTestCase):
         ('false', Person, object()),
     ])
     @sync
-    async def test(self, expected, resource_type: Type[Resource], data) -> None:
-        template = f'{{% if data is {resource_type.resource_type_name()}_resource %}}true{{% else %}}false{{% endif %}}'
+    async def test(self, expected, entity_type: Type[Entity], data) -> None:
+        template = f'{{% if data is {camel_case_to_snake_case(get_entity_type_name(entity_type))}_entity %}}true{{% else %}}false{{% endif %}}'
         async with self._render(template_string=template, data={
             'data': data,
         }) as (actual, _):

--- a/betty/tests/test_search.py
+++ b/betty/tests/test_search.py
@@ -2,7 +2,7 @@ from tempfile import TemporaryDirectory
 
 from parameterized import parameterized
 
-from betty.ancestry import Person, Place, PlaceName, PersonName, File
+from betty.model.ancestry import Person, Place, PlaceName, PersonName, File
 from betty.config import Configuration, LocaleConfiguration
 from betty.asyncio import sync
 from betty.search import Index
@@ -38,7 +38,7 @@ class IndexTest(TestCase):
                 LocaleConfiguration('nl-NL', 'nl'),
             ])
             async with App(configuration) as app:
-                app.ancestry.people.add(person)
+                app.ancestry.entities.append(person)
                 indexed = [item for item in Index(app).build()]
 
         self.assertEquals([], indexed)
@@ -48,7 +48,7 @@ class IndexTest(TestCase):
         person_id = 'P1'
         individual_name = 'Jane'
         person = Person(person_id)
-        person.names.append(PersonName(individual_name))
+        PersonName(person, individual_name)
         person.private = True
 
         with TemporaryDirectory() as output_directory_path:
@@ -59,7 +59,7 @@ class IndexTest(TestCase):
                 LocaleConfiguration('nl-NL', 'nl'),
             ])
             async with App(configuration) as app:
-                app.ancestry.people.add(person)
+                app.ancestry.entities.append(person)
                 indexed = [item for item in Index(app).build()]
 
         self.assertEquals([], indexed)
@@ -73,7 +73,7 @@ class IndexTest(TestCase):
         person_id = 'P1'
         individual_name = 'Jane'
         person = Person(person_id)
-        person.names.append(PersonName(individual_name))
+        PersonName(person, individual_name)
 
         with TemporaryDirectory() as output_directory_path:
             configuration = Configuration(
@@ -83,7 +83,7 @@ class IndexTest(TestCase):
                 LocaleConfiguration('nl-NL', 'nl'),
             ])
             async with App(configuration).with_locale(locale) as app:
-                app.ancestry.people.add(person)
+                app.ancestry.entities.append(person)
                 indexed = [item for item in Index(app).build()]
 
         self.assertEquals('jane', indexed[0]['text'])
@@ -98,7 +98,7 @@ class IndexTest(TestCase):
         person_id = 'P1'
         affiliation_name = 'Doughnut'
         person = Person(person_id)
-        person.names.append(PersonName(None, affiliation_name))
+        PersonName(person, None, affiliation_name)
 
         with TemporaryDirectory() as output_directory_path:
             configuration = Configuration(
@@ -108,7 +108,7 @@ class IndexTest(TestCase):
                 LocaleConfiguration('nl-NL', 'nl'),
             ])
             async with App(configuration).with_locale(locale) as app:
-                app.ancestry.people.add(person)
+                app.ancestry.entities.append(person)
                 indexed = [item for item in Index(app).build()]
 
         self.assertEquals('doughnut', indexed[0]['text'])
@@ -124,7 +124,7 @@ class IndexTest(TestCase):
         individual_name = 'Jane'
         affiliation_name = 'Doughnut'
         person = Person(person_id)
-        person.names.append(PersonName(individual_name, affiliation_name))
+        PersonName(person, individual_name, affiliation_name)
 
         with TemporaryDirectory() as output_directory_path:
             configuration = Configuration(
@@ -134,7 +134,7 @@ class IndexTest(TestCase):
                 LocaleConfiguration('nl-NL', 'nl'),
             ])
             async with App(configuration).with_locale(locale) as app:
-                app.ancestry.people.add(person)
+                app.ancestry.entities.append(person)
                 indexed = [item for item in Index(app).build()]
 
         self.assertEquals('jane doughnut', indexed[0]['text'])
@@ -157,7 +157,7 @@ class IndexTest(TestCase):
                 LocaleConfiguration('nl-NL', 'nl'),
             ])
             async with App(configuration).with_locale(locale) as app:
-                app.ancestry.places.add(place)
+                app.ancestry.entities.append(place)
                 indexed = [item for item in Index(app).build()]
 
         self.assertEquals('netherlands nederland', indexed[0]['text'])
@@ -176,7 +176,7 @@ class IndexTest(TestCase):
                 LocaleConfiguration('nl-NL', 'nl'),
             ])
             async with App(configuration) as app:
-                app.ancestry.files.add(file)
+                app.ancestry.entities.append(file)
                 indexed = [item for item in Index(app).build()]
 
         self.assertEquals([], indexed)
@@ -199,7 +199,7 @@ class IndexTest(TestCase):
                 LocaleConfiguration('nl-NL', 'nl'),
             ])
             async with App(configuration).with_locale(locale) as app:
-                app.ancestry.files.add(file)
+                app.ancestry.entities.append(file)
                 indexed = [item for item in Index(app).build()]
 
         self.assertEquals('"file" is dutch for "traffic jam"', indexed[0]['text'])

--- a/betty/tests/test_string.py
+++ b/betty/tests/test_string.py
@@ -1,0 +1,35 @@
+from unittest import TestCase
+
+from parameterized import parameterized
+
+from betty.string import camel_case_to_snake_case, camel_case_to_kebab_case, upper_camel_case_to_lower_camel_case
+
+
+class CamelCaseToSnakeCaseTest(TestCase):
+    @parameterized.expand([
+        ('snake_case', 'snakeCase'),
+        ('snake_case', 'SnakeCase'),
+        ('snake__case', 'Snake_Case'),
+    ])
+    def test(self, expected: str, string: str) -> None:
+        self.assertEquals(expected, camel_case_to_snake_case(string))
+
+
+class CamelCaseToKebabCaseTest(TestCase):
+    @parameterized.expand([
+        ('snake-case', 'snakeCase'),
+        ('snake-case', 'SnakeCase'),
+        ('snake--case', 'Snake-Case'),
+    ])
+    def test(self, expected: str, string: str) -> None:
+        self.assertEquals(expected, camel_case_to_kebab_case(string))
+
+
+class UpperCamelCaseToLowerCamelCase(TestCase):
+    @parameterized.expand([
+        ('snakeCase', 'snakeCase'),
+        ('snakeCase', 'SnakeCase'),
+        ('123SnakeCase', '123SnakeCase'),
+    ])
+    def test(self, expected: str, string: str) -> None:
+        self.assertEquals(expected, upper_camel_case_to_lower_camel_case(string))

--- a/betty/tests/test_url.py
+++ b/betty/tests/test_url.py
@@ -2,11 +2,11 @@ from typing import Any
 
 from parameterized import parameterized
 
-from betty.ancestry import Person, Place, File, Source, Identifiable, PlaceName, IdentifiableEvent, \
-    IdentifiableSource, IdentifiableCitation, Death
+from betty.model import Entity
+from betty.model.ancestry import Person, Place, File, Source, Death, PlaceName, Event, Citation
 from betty.config import Configuration, LocaleConfiguration
 from betty.tests import TestCase
-from betty.url import LocalizedPathUrlGenerator, IdentifiableResourceUrlGenerator, AppUrlGenerator
+from betty.url import LocalizedPathUrlGenerator, _EntityUrlGenerator, AppUrlGenerator
 
 
 class LocalizedPathUrlGeneratorTest(TestCase):
@@ -66,18 +66,18 @@ class LocalizedPathUrlGeneratorTest(TestCase):
             '/en/index.html', sut.generate('/index.html', 'text/html', locale='en'))
 
 
-class IdentifiableResourceUrlGeneratorTest(TestCase):
+class EntityUrlGeneratorTest(TestCase):
+    class UrlyEntity(Entity):
+        pass
+
     def test_generate(self):
         configuration = Configuration('/tmp', 'https://example.com')
-        sut = IdentifiableResourceUrlGenerator(
-            configuration, Identifiable, 'prefix/%s/index.%s')
-        self.assertEquals('/prefix/I1/index.html',
-                          sut.generate(Identifiable('I1'), 'text/html'))
+        sut = _EntityUrlGenerator(configuration, self.UrlyEntity, 'prefix/%s/index.%s')
+        self.assertEquals('/prefix/I1/index.html', sut.generate(self.UrlyEntity('I1'), 'text/html'))
 
     def test_generate_with_invalid_value(self):
         configuration = Configuration('/tmp', 'https://example.com')
-        sut = IdentifiableResourceUrlGenerator(
-            configuration, Identifiable, 'prefix/%s/index.html')
+        sut = _EntityUrlGenerator(configuration, self.UrlyEntity, 'prefix/%s/index.html')
         with self.assertRaises(ValueError):
             sut.generate(9, 'text/html')
 
@@ -86,11 +86,11 @@ class AppUrlGeneratorTest(TestCase):
     @parameterized.expand([
         ('/index.html', '/index.html'),
         ('/person/P1/index.html', Person('P1')),
-        ('/event/E1/index.html', IdentifiableEvent('E1', Death())),
+        ('/event/E1/index.html', Event('E1', Death())),
         ('/place/P1/index.html', Place('P1', [PlaceName('Place 1')])),
         ('/file/F1/index.html', File('F1', '/tmp')),
-        ('/source/S1/index.html', IdentifiableSource('S1', 'Source 1')),
-        ('/citation/C1/index.html', IdentifiableCitation('C1', Source('Source 1'))),
+        ('/source/S1/index.html', Source('S1', 'Source 1')),
+        ('/citation/C1/index.html', Citation('C1', Source('Source 1'))),
     ])
     def test_generate(self, expected: str, resource: Any):
         configuration = Configuration('/tmp', 'https://example.com')

--- a/betty/url.py
+++ b/betty/url.py
@@ -1,8 +1,8 @@
 from contextlib import suppress
-from typing import Any, Type, Optional
+from typing import Any, Optional, Type
 
-from betty.ancestry import Person, File, Place, Identifiable, PersonName, IdentifiableSource, IdentifiableEvent, \
-    IdentifiableCitation, Note
+from betty.model import Entity
+from betty.model.ancestry import PersonName, Event, Place, File, Source, Citation, Note, Person
 from betty.config import Configuration
 from betty.media_type import EXTENSIONS
 
@@ -33,17 +33,17 @@ class StaticPathUrlGenerator(StaticUrlGenerator):
         return _generate_from_path(self._configuration, resource, localize=False, **kwargs)
 
 
-class IdentifiableResourceUrlGenerator(LocalizedUrlGenerator):
-    def __init__(self, configuration: Configuration, identifiable_type: Type[Identifiable], pattern: str):
+class _EntityUrlGenerator(LocalizedUrlGenerator):
+    def __init__(self, configuration: Configuration, entity_type: Type[Entity], pattern: str):
         self._configuration = configuration
-        self._type = identifiable_type
+        self._entity_type = entity_type
         self._pattern = pattern
 
-    def generate(self, resource: Identifiable, media_type, **kwargs) -> str:
-        if not isinstance(resource, self._type):
-            raise ValueError('%s is not a %s' % (type(resource), self._type))
+    def generate(self, entity: Entity, media_type, **kwargs) -> str:
+        if not isinstance(entity, self._entity_type):
+            raise ValueError('%s is not a %s' % (type(entity), self._entity_type))
         kwargs['localize'] = True
-        return _generate_from_path(self._configuration, self._pattern % (resource.id, EXTENSIONS[media_type]), **kwargs)
+        return _generate_from_path(self._configuration, self._pattern % (entity.id, EXTENSIONS[media_type]), **kwargs)
 
 
 class PersonNameUrlGenerator(LocalizedUrlGenerator):
@@ -58,21 +58,16 @@ class PersonNameUrlGenerator(LocalizedUrlGenerator):
 
 class AppUrlGenerator(LocalizedUrlGenerator):
     def __init__(self, configuration: Configuration):
-        person_url_generator = IdentifiableResourceUrlGenerator(configuration, Person, 'person/%s/index.%s')
+        person_url_generator = _EntityUrlGenerator(configuration, Person, 'person/%s/index.%s')
         self._generators = [
             person_url_generator,
             PersonNameUrlGenerator(person_url_generator),
-            IdentifiableResourceUrlGenerator(
-                configuration, IdentifiableEvent, 'event/%s/index.%s'),
-            IdentifiableResourceUrlGenerator(
-                configuration, Place, 'place/%s/index.%s'),
-            IdentifiableResourceUrlGenerator(
-                configuration, File, 'file/%s/index.%s'),
-            IdentifiableResourceUrlGenerator(
-                configuration, IdentifiableSource, 'source/%s/index.%s'),
-            IdentifiableResourceUrlGenerator(
-                configuration, IdentifiableCitation, 'citation/%s/index.%s'),
-            IdentifiableResourceUrlGenerator(configuration, Note, 'note/%s/index.%s'),
+            _EntityUrlGenerator(configuration, Event, 'event/%s/index.%s'),
+            _EntityUrlGenerator(configuration, Place, 'place/%s/index.%s'),
+            _EntityUrlGenerator(configuration, File, 'file/%s/index.%s'),
+            _EntityUrlGenerator(configuration, Source, 'source/%s/index.%s'),
+            _EntityUrlGenerator(configuration, Citation, 'citation/%s/index.%s'),
+            _EntityUrlGenerator(configuration, Note, 'note/%s/index.%s'),
             LocalizedPathUrlGenerator(configuration),
         ]
 


### PR DESCRIPTION
Refactor resources into entities by requiring IDs, and require associations to be between entities. Make the associations API simpler and more consistent, and introduce error checking.

## Changes
- `betty.ancestry.Resource` is now `betty.model.Entity`.
- `betty.ancestry.Resource.resource_type_name()` is now `betty.model.Entity.entity_type()`, which returns `Type[Entity]`.
- Use `betty.model.get_entity_type_name()` to get an entity's internal string name, and use the new `betty.string` module to convert it to the required naming convention.
- Any classes using associations must now extend `betty.model.Entity`.
- `betty.extension.anonymizer.anonymize()` now takes a required `AnonymousSource` and `AnonymousCitation`.
- Introduced new Jinja2 filters and tests. Removed old ones.
- `betty.ancestry.ManyAssociation` is now `betty.model.EntityCollection[typing.Type[Entity]]`.

## Additional benefits
- Introduce test coverage for the entity associations
- Make entity associations pickleable (and therefore entities themselves pickleable)
- Corrected and improved type hints.