### PR TITLE
Clean up the code by enabling postponed evaluation of annotations

### DIFF
--- a/betty/app.py
+++ b/betty/app.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import gettext
 from collections import defaultdict
 from concurrent.futures._base import Executor
@@ -116,7 +117,7 @@ class App:
 
             await self._extension_exit_stack.aclose()
 
-    async def __aenter__(self) -> 'App':
+    async def __aenter__(self) -> App:
         return await self.enter()
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
@@ -258,7 +259,7 @@ class App:
             self._http_client = aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit_per_host=5))
         return self._http_client
 
-    def with_locale(self, locale: str) -> 'App':
+    def with_locale(self, locale: str) -> App:
         locale = negotiate_locale(locale, [locale_configuration.locale for locale_configuration in self.configuration.locales])
         if locale is None:
             raise ValueError('Locale "%s" is not enabled.' % locale)
@@ -274,7 +275,7 @@ class App:
 
         return app
 
-    def with_debug(self, debug: bool) -> 'App':
+    def with_debug(self, debug: bool) -> App:
         app = copy(self)
         app._debug = debug
 

--- a/betty/extension/__init__.py
+++ b/betty/extension/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import asyncio
 from collections import defaultdict
 
@@ -24,7 +25,7 @@ class Extension:
     Extensions that take configuration must implement betty.extension.ConfigurableExtension.
     """
 
-    def __init__(self, app: 'betty.app.App'):
+    def __init__(self, app: betty.app.App):
         self._app = app
 
     async def __aenter__(self):
@@ -38,15 +39,15 @@ class Extension:
         return '%s.%s' % (cls.__module__, cls.__name__)
 
     @classmethod
-    def depends_on(cls) -> Set[Type['Extension']]:
+    def depends_on(cls) -> Set[Type[Extension]]:
         return set()
 
     @classmethod
-    def comes_after(cls) -> Set[Type['Extension']]:
+    def comes_after(cls) -> Set[Type[Extension]]:
         return set()
 
     @classmethod
-    def comes_before(cls) -> Set[Type['Extension']]:
+    def comes_before(cls) -> Set[Type[Extension]]:
         return set()
 
     @property
@@ -77,7 +78,7 @@ class Configuration:
 
 
 class ConfigurableExtension(Extension):
-    def __init__(self, app: 'betty.app.App', configuration: Configuration):
+    def __init__(self, app: betty.app.App, configuration: Configuration):
         super().__init__(app)
         self._configuration = configuration
 

--- a/betty/extension/deriver/__init__.py
+++ b/betty/extension/deriver/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import logging
 from typing import List, Tuple, Set, Type, Iterable, Optional
 
@@ -17,7 +18,7 @@ class DerivedEvent(Event):
 
 class DerivedDate(Date):
     @classmethod
-    def derive(cls, date: Date) -> 'DerivedDate':
+    def derive(cls, date: Date) -> DerivedDate:
         return cls(date.year, date.month, date.day, fuzzy=date.fuzzy)
 
 

--- a/betty/locale.py
+++ b/betty/locale.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import calendar
 import contextlib
 import datetime
@@ -57,7 +58,7 @@ class Date:
     def parts(self) -> Tuple[Optional[int], Optional[int], Optional[int]]:
         return self.year, self.month, self.day
 
-    def to_range(self) -> 'DateRange':
+    def to_range(self) -> DateRange:
         if not self.comparable:
             raise ValueError('Cannot convert non-comparable date %s to a date range.' % self)
         if self.month is None:

--- a/betty/model/__init__.py
+++ b/betty/model/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import copy
 import operator
 from collections import defaultdict
@@ -34,7 +35,7 @@ class Entity:
         self._id = GeneratedEntityId() if entity_id is None else entity_id
 
     @classmethod
-    def entity_type(cls) -> Type['EntityT']:
+    def entity_type(cls) -> Type[EntityT]:
         for ancestor_cls in cls.__mro__:
             if Entity in ancestor_cls.__bases__:
                 return ancestor_cls
@@ -103,7 +104,7 @@ class EntityCollection(Generic[EntityT]):
     def __len__(self) -> int:
         raise NotImplementedError
 
-    def __getitem__(self, key: Union[EntityT, int, slice]) -> Union[EntityT, 'EntityCollection[EntityT]']:
+    def __getitem__(self, key: Union[EntityT, int, slice]) -> Union[EntityT, EntityCollection[EntityT]]:
         raise TypeError(f'Cannot get entities by {type(key)}.')
 
     def __delitem__(self, key: Union[EntityT, int, slice]) -> None:
@@ -112,7 +113,7 @@ class EntityCollection(Generic[EntityT]):
     def __contains__(self, entity: EntityT) -> bool:
         raise NotImplementedError
 
-    def __add__(self, other) -> 'EntityCollection':
+    def __add__(self, other) -> EntityCollection:
         raise NotImplementedError
 
 
@@ -129,7 +130,7 @@ class SingleTypeEntityCollection(EntityCollection[EntityT]):
             self._copy_entities(copied)
         return copied
 
-    def _copy_entities(self, copied: 'SingleTypeEntityCollection'):
+    def _copy_entities(self, copied: SingleTypeEntityCollection):
         for entity in self:
             copied.append(entity)
 
@@ -281,7 +282,7 @@ class _AssociateCollection(SingleTypeEntityCollection[EntityT], Generic[EntityT,
     def _on_remove(self, associate: EntityT) -> None:
         raise NotImplementedError
 
-    def copy_for_owner(self, owner: EntityU) -> '_AssociateCollection':
+    def copy_for_owner(self, owner: EntityU) -> _AssociateCollection:
         # We cannot check for identity or equality, because owner is a copy of self._owner, and may have undergone
         # .additional changes
         assert owner.__class__ is self._owner.__class__, f'{owner.__class__} must be identical to the existing owner, which is a {self._owner.__class__}.'
@@ -542,7 +543,7 @@ class FlattenedEntity(Entity):
         super().__init__(entity_id)
         self._entity = entity
 
-    def entity_type(self) -> Type['EntityT']:
+    def entity_type(self) -> Type[EntityT]:
         return self._entity.entity_type()
 
     def unflatten(self) -> Entity:

--- a/betty/model/ancestry.py
+++ b/betty/model/ancestry.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from functools import total_ordering
 from pathlib import Path
 from typing import Optional, List, Set, Sequence, Type
@@ -27,7 +28,7 @@ class Dated:
 
 @many_to_one('entity', 'notes')
 class Note(Entity):
-    entity: 'HasNotes'
+    entity: HasNotes
 
     def __init__(self, note_id: str, text: str):
         Entity.__init__(self, note_id)
@@ -82,13 +83,13 @@ class HasLinks:
 
 @many_to_many('citations', 'facts')
 class HasCitations:
-    citations: EntityCollection['Citation']
+    citations: EntityCollection[Citation]
 
 
 @many_to_many('entities', 'files')
 @many_to_many('notes', 'entity')
 class File(Entity, Described, HasPrivacy, HasMediaType, HasNotes, HasCitations):
-    entities: EntityCollection['HasFiles']
+    entities: EntityCollection[HasFiles]
 
     def __init__(self, file_id: Optional[str], path: PathLike, media_type: Optional[MediaType] = None):
         Entity.__init__(self, file_id)
@@ -119,9 +120,9 @@ class HasFiles:
 @one_to_many('citations', 'source')
 class Source(Entity, Dated, HasFiles, HasLinks, HasPrivacy):
     name: Optional[str]
-    contained_by: 'Source'
-    contains: EntityCollection['Source']
-    citations: EntityCollection['Citation']
+    contained_by: Source
+    contains: EntityCollection[Source]
+    citations: EntityCollection[Citation]
     author: Optional[str]
     publisher: Optional[str]
 
@@ -139,7 +140,7 @@ class Source(Entity, Dated, HasFiles, HasLinks, HasPrivacy):
 @many_to_many('facts', 'citations')
 @many_to_one('source', 'citations')
 class Citation(Entity, Dated, HasFiles, HasPrivacy):
-    facts: EntityCollection['HasCitations']
+    facts: EntityCollection[HasCitations]
     source: Source
     location: Optional[str]
 
@@ -177,10 +178,10 @@ class PlaceName(Localized, Dated):
 
 @many_to_one_to_many('enclosed_by', 'encloses', 'enclosed_by', 'encloses')
 class Enclosure(Entity, Dated, HasCitations):
-    encloses: 'Place'
-    enclosed_by: 'Place'
+    encloses: Place
+    enclosed_by: Place
 
-    def __init__(self, encloses: 'Place', enclosed_by: 'Place'):
+    def __init__(self, encloses: Place, enclosed_by: Place):
         Entity.__init__(self)
         Dated.__init__(self)
         HasCitations.__init__(self)
@@ -266,11 +267,11 @@ class Attendee(PresenceRole):
 
 @many_to_one_to_many('presences', 'person', 'event', 'presences')
 class Presence(Entity):
-    person: Optional['Person']
-    event: Optional['Event']
+    person: Optional[Person]
+    event: Optional[Event]
     role: PresenceRole
 
-    def __init__(self, person: 'Person', role: PresenceRole, event: 'Event'):
+    def __init__(self, person: Person, role: PresenceRole, event: Event):
         Entity.__init__(self)
         self.person = person
         self.role = role
@@ -287,11 +288,11 @@ class EventType:
         raise NotImplementedError
 
     @classmethod
-    def comes_before(cls) -> Set[Type['EventType']]:
+    def comes_before(cls) -> Set[Type[EventType]]:
         return set()
 
     @classmethod
-    def comes_after(cls) -> Set[Type['EventType']]:
+    def comes_after(cls) -> Set[Type[EventType]]:
         return set()
 
 
@@ -315,23 +316,23 @@ class CreatableDerivableEventType(DerivableEventType):
 
 class PreBirthEventType(EventType):
     @classmethod
-    def comes_before(cls) -> Set[Type['EventType']]:
+    def comes_before(cls) -> Set[Type[EventType]]:
         return {Birth}
 
 
 class LifeEventType(EventType):
     @classmethod
-    def comes_after(cls) -> Set[Type['EventType']]:
+    def comes_after(cls) -> Set[Type[EventType]]:
         return {Birth}
 
     @classmethod
-    def comes_before(cls) -> Set[Type['EventType']]:
+    def comes_before(cls) -> Set[Type[EventType]]:
         return {Death}
 
 
 class PostDeathEventType(EventType):
     @classmethod
-    def comes_after(cls) -> Set[Type['EventType']]:
+    def comes_after(cls) -> Set[Type[EventType]]:
         return {Death}
 
 
@@ -652,9 +653,9 @@ class Event(Entity, Dated, HasFiles, HasCitations, Described, HasPrivacy):
 @total_ordering
 @many_to_one('person', 'names')
 class PersonName(Entity, Localized, HasCitations):
-    person: 'Person'
+    person: Person
 
-    def __init__(self, person: 'Person', individual: Optional[str] = None, affiliation: Optional[str] = None):
+    def __init__(self, person: Person, individual: Optional[str] = None, affiliation: Optional[str] = None):
         Entity.__init__(self)
         Localized.__init__(self)
         HasCitations.__init__(self)
@@ -693,8 +694,8 @@ class PersonName(Entity, Localized, HasCitations):
 @one_to_many('presences', 'person')
 @one_to_many('names', 'person')
 class Person(Entity, HasFiles, HasCitations, HasLinks, HasPrivacy):
-    parents: EntityCollection['Person']
-    children: EntityCollection['Person']
+    parents: EntityCollection[Person]
+    children: EntityCollection[Person]
     presences: EntityCollection[Presence]
     names: EntityCollection[PersonName]
 

--- a/betty/serve.py
+++ b/betty/serve.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import contextlib
 import logging
 import threading
@@ -48,7 +49,7 @@ class Server:
     def public_url(self) -> str:
         raise NotImplementedError
 
-    async def __aenter__(self) -> 'Server':
+    async def __aenter__(self) -> Server:
         await self.start()
         return self
 


### PR DESCRIPTION
Clean up the code by enabling postponed evaluation of annotations, allowing type hints to be unquoted at all times.