### PR TITLE
No longer keep multiple copies of App around

### DIFF
--- a/betty/demo.py
+++ b/betty/demo.py
@@ -31,7 +31,7 @@ class DemoServer(Server):
         ])
         self._app = App(configuration)
         self._server = None
-        await self._app.enter()
+        await self._app.activate()
         await load.load(self._app)
         await generate.generate(self._app)
         self._server = serve.AppServer(self._app)
@@ -41,6 +41,6 @@ class DemoServer(Server):
         if self._server is not None:
             await self._server.stop()
         if self._app is not None:
-            await self._app.exit()
+            await self._app.deactivate()
         if self._output_directory is not None:
             self._output_directory.__aexit__(None, None, None)

--- a/betty/generate.py
+++ b/betty/generate.py
@@ -44,6 +44,7 @@ async def generate(app: App) -> None:
             os.chmod(directory_path / subdirectory_name, 0o755)
         for file_name in file_names:
             os.chmod(directory_path / file_name, 0o644)
+    await app.wait()
 
 
 async def _generate(app: App) -> None:
@@ -52,7 +53,7 @@ async def _generate(app: App) -> None:
     await app.renderer.render_tree(app.configuration.www_directory_path)
     for locale_configuration in app.configuration.locales:
         locale = locale_configuration.locale
-        async with app.with_locale(locale) as app:
+        async with app.with_locale(locale):
             if app.configuration.multilingual:
                 www_directory_path = app.configuration.www_directory_path / locale_configuration.alias
             else:

--- a/betty/gui.py
+++ b/betty/gui.py
@@ -682,11 +682,11 @@ class ProjectWindow(BettyMainWindow):
 
     @sync
     async def init(self):
-        await self._app.enter()
+        await self._app.activate()
 
     @sync
     async def close(self):
-        await self._app.exit()
+        await self._app.deactivate()
 
     def _initialize_menu(self) -> None:
         super()._initialize_menu()

--- a/betty/load.py
+++ b/betty/load.py
@@ -20,3 +20,4 @@ class PostLoader:
 async def load(app: App) -> None:
     await app.dispatcher.dispatch(Loader, 'load')()
     await app.dispatcher.dispatch(PostLoader, 'post_load')()
+    await app.wait()

--- a/betty/tests/__init__.py
+++ b/betty/tests/__init__.py
@@ -78,7 +78,5 @@ class TemplateTestCase(TestCase):
                 update_configuration(configuration)
             async with App(configuration) as app:
                 rendered = template_factory(app.jinja2_environment, template).render(**data)
-                # We want to keep the app around, but we must make sure all dispatched tasks are done, so we shut down
-                # the executor. Crude, but effective.
-                app.executor.shutdown()
+                await app.wait()
                 yield rendered, app

--- a/betty/tests/extension/anonymizer/test__init__.py
+++ b/betty/tests/extension/anonymizer/test__init__.py
@@ -8,6 +8,7 @@ from betty.config import Configuration, ExtensionConfiguration
 from betty.extension.anonymizer import Anonymizer, anonymize, anonymize_person, anonymize_event, anonymize_file, \
     anonymize_citation, anonymize_source, AnonymousSource, AnonymousCitation
 from betty.load import load
+from betty.locale import Translations
 from betty.model import Entity
 from betty.model.ancestry import Ancestry, Person, File, Source, Citation, PersonName, Presence, Event, Birth, Subject, \
     HasCitations
@@ -15,6 +16,13 @@ from betty.tests import TestCase
 
 
 class AnonymousSourceTest(TestCase):
+    def setUp(self) -> None:
+        self._translations = Translations(gettext.NullTranslations())
+        self._translations.install()
+
+    def tearDown(self) -> None:
+        self._translations.uninstall()
+
     def test_name(self):
         self.assertIsInstance(AnonymousSource().name, str)
 
@@ -34,6 +42,13 @@ class AnonymousSourceTest(TestCase):
 
 
 class AnonymousCitationTest(TestCase):
+    def setUp(self) -> None:
+        self._translations = Translations(gettext.NullTranslations())
+        self._translations.install()
+
+    def tearDown(self) -> None:
+        self._translations.uninstall()
+
     def test_location(self):
         source = Mock(Source)
         self.assertIsInstance(AnonymousCitation(source).location, str)
@@ -55,7 +70,11 @@ class AnonymousCitationTest(TestCase):
 
 class AnonymizeTest(TestCase):
     def setUp(self) -> None:
-        gettext.NullTranslations().install()
+        self._translations = Translations(gettext.NullTranslations())
+        self._translations.install()
+
+    def tearDown(self) -> None:
+        self._translations.uninstall()
 
     @patch('betty.extension.anonymizer.anonymize_person')
     def test_with_public_person_should_not_anonymize(self, m_anonymize_person) -> None:
@@ -243,7 +262,11 @@ class AnonymizeFileTest(TestCase):
 
 class AnonymizeSourceTest(TestCase):
     def setUp(self) -> None:
-        gettext.NullTranslations().install()
+        self._translations = Translations(gettext.NullTranslations())
+        self._translations.install()
+
+    def tearDown(self) -> None:
+        self._translations.uninstall()
 
     def test_should_remove_citations(self) -> None:
         source = Source('S0', 'The Source')
@@ -283,7 +306,11 @@ class AnonymizeSourceTest(TestCase):
 
 class AnonymizeCitationTest(TestCase):
     def setUp(self) -> None:
-        gettext.NullTranslations().install()
+        self._translations = Translations(gettext.NullTranslations())
+        self._translations.install()
+
+    def tearDown(self) -> None:
+        self._translations.uninstall()
 
     def test_should_remove_facts(self) -> None:
         source = Source('The Source')

--- a/betty/tests/test_generate.py
+++ b/betty/tests/test_generate.py
@@ -19,156 +19,195 @@ from betty.tests import TestCase
 class GenerateTestCase(TestCase):
     def setUp(self):
         self._output_directory = TemporaryDirectory()
-        self.app = None
 
     def tearDown(self):
         self._output_directory.cleanup()
 
-    def assert_betty_html(self, url_path: str) -> Path:
-        file_path = self.app.configuration.www_directory_path / Path(url_path.lstrip('/'))
+    def assert_betty_html(self, app: App, url_path: str) -> Path:
+        file_path = app.configuration.www_directory_path / Path(url_path.lstrip('/'))
         self.assertTrue(file_path.exists(), '%s does not exist' % file_path)
         with open(file_path) as f:
             parser = html5lib.HTMLParser(strict=True)
             parser.parse(f)
         return file_path
 
-    def assert_betty_json(self, url_path: str, schema_definition: str) -> str:
-        file_path = self.app.configuration.www_directory_path / Path(url_path.lstrip('/'))
+    def assert_betty_json(self, app: App, url_path: str, schema_definition: str) -> Path:
+        file_path = app.configuration.www_directory_path / Path(url_path.lstrip('/'))
         self.assertTrue(file_path.exists(), '%s does not exist' % file_path)
         with open(file_path) as f:
-            json.validate(stdjson.load(f), schema_definition, self.app)
+            json.validate(stdjson.load(f), schema_definition, app)
         return file_path
 
 
-class RenderTest(GenerateTestCase):
-    def setUp(self):
-        GenerateTestCase.setUp(self)
-        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
-        self.app = App(configuration)
-
+class GenerateTest(GenerateTestCase):
     @sync
     async def test_front_page(self):
-        await generate(self.app)
-        self.assert_betty_html('/index.html')
+        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
+        app = App(configuration)
+        async with app:
+            await generate(app)
+        self.assert_betty_html(app, '/index.html')
 
     @sync
     async def test_files(self):
-        await generate(self.app)
-        self.assert_betty_html('/file/index.html')
-        self.assert_betty_json('/file/index.json', 'fileCollection')
+        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
+        app = App(configuration)
+        async with app:
+            await generate(app)
+        self.assert_betty_html(app, '/file/index.html')
+        self.assert_betty_json(app, '/file/index.json', 'fileCollection')
 
     @sync
     async def test_file(self):
-        # @todo This fails somewhere in file.html.j2, very likely because of jinja2._filter_file()
-        with NamedTemporaryFile() as f:
-            file = File('FILE1', Path(f.name))
-            self.app.ancestry.entities.append(file)
-            await generate(self.app)
-            self.assert_betty_html('/file/%s/index.html' % file.id)
-            self.assert_betty_json('/file/%s/index.json' % file.id, 'file')
+        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
+        app = App(configuration)
+        async with app:
+            with NamedTemporaryFile() as f:
+                file = File('FILE1', Path(f.name))
+                app.ancestry.entities.append(file)
+                await generate(app)
+            self.assert_betty_html(app, '/file/%s/index.html' % file.id)
+            self.assert_betty_json(app, '/file/%s/index.json' % file.id, 'file')
 
     @sync
     async def test_places(self):
-        await generate(self.app)
-        self.assert_betty_html('/place/index.html')
-        self.assert_betty_json('/place/index.json', 'placeCollection')
+        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
+        app = App(configuration)
+        async with app:
+            await generate(app)
+        self.assert_betty_html(app, '/place/index.html')
+        self.assert_betty_json(app, '/place/index.json', 'placeCollection')
 
     @sync
     async def test_place(self):
-        place = Place('PLACE1', [PlaceName('one')])
-        self.app.ancestry.entities.append(place)
-        await generate(self.app)
-        self.assert_betty_html('/place/%s/index.html' % place.id)
-        self.assert_betty_json('/place/%s/index.json' % place.id, 'place')
+        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
+        app = App(configuration)
+        async with app:
+            place = Place('PLACE1', [PlaceName('one')])
+            app.ancestry.entities.append(place)
+            await generate(app)
+        self.assert_betty_html(app, '/place/%s/index.html' % place.id)
+        self.assert_betty_json(app, '/place/%s/index.json' % place.id, 'place')
 
     @sync
     async def test_people(self):
-        await generate(self.app)
-        self.assert_betty_html('/person/index.html')
-        self.assert_betty_json('/person/index.json', 'personCollection')
+        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
+        app = App(configuration)
+        async with app:
+            await generate(app)
+        self.assert_betty_html(app, '/person/index.html')
+        self.assert_betty_json(app, '/person/index.json', 'personCollection')
 
     @sync
     async def test_person(self):
-        person = Person('PERSON1')
-        self.app.ancestry.entities.append(person)
-        await generate(self.app)
-        self.assert_betty_html('/person/%s/index.html' % person.id)
-        self.assert_betty_json('/person/%s/index.json' % person.id, 'person')
+        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
+        app = App(configuration)
+        async with app:
+            person = Person('PERSON1')
+            app.ancestry.entities.append(person)
+            await generate(app)
+        self.assert_betty_html(app, '/person/%s/index.html' % person.id)
+        self.assert_betty_json(app, '/person/%s/index.json' % person.id, 'person')
 
     @sync
     async def test_events(self):
-        await generate(self.app)
-        self.assert_betty_html('/event/index.html')
-        self.assert_betty_json('/event/index.json', 'eventCollection')
+        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
+        app = App(configuration)
+        async with app:
+            await generate(app)
+        self.assert_betty_html(app, '/event/index.html')
+        self.assert_betty_json(app, '/event/index.json', 'eventCollection')
 
     @sync
     async def test_event(self):
-        event = Event('EVENT1', Birth())
-        self.app.ancestry.entities.append(event)
-        await generate(self.app)
-        self.assert_betty_html('/event/%s/index.html' % event.id)
-        self.assert_betty_json('/event/%s/index.json' % event.id, 'event')
+        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
+        app = App(configuration)
+        async with app:
+            event = Event('EVENT1', Birth())
+            app.ancestry.entities.append(event)
+            await generate(app)
+        self.assert_betty_html(app, '/event/%s/index.html' % event.id)
+        self.assert_betty_json(app, '/event/%s/index.json' % event.id, 'event')
 
     @sync
     async def test_citation(self):
+        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
+        app = App(configuration)
         citation = Citation('CITATION1', Source('A Little Birdie'))
-        self.app.ancestry.entities.append(citation)
-        await generate(self.app)
-        self.assert_betty_html('/citation/%s/index.html' % citation.id)
-        self.assert_betty_json('/citation/%s/index.json' %
+        app.ancestry.entities.append(citation)
+        async with app:
+            await generate(app)
+        self.assert_betty_html(app, '/citation/%s/index.html' % citation.id)
+        self.assert_betty_json(app, '/citation/%s/index.json' %
                                citation.id, 'citation')
 
     @sync
     async def test_sources(self):
-        await generate(self.app)
-        self.assert_betty_html('/source/index.html')
-        self.assert_betty_json('/source/index.json', 'sourceCollection')
+        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
+        app = App(configuration)
+        async with app:
+            await generate(app)
+        self.assert_betty_html(app, '/source/index.html')
+        self.assert_betty_json(app, '/source/index.json', 'sourceCollection')
 
     @sync
     async def test_source(self):
+        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
+        app = App(configuration)
         source = Source('SOURCE1', 'A Little Birdie')
-        self.app.ancestry.entities.append(source)
-        await generate(self.app)
-        self.assert_betty_html('/source/%s/index.html' % source.id)
-        self.assert_betty_json('/source/%s/index.json' % source.id, 'source')
+        app.ancestry.entities.append(source)
+        async with app:
+            await generate(app)
+        self.assert_betty_html(app, '/source/%s/index.html' % source.id)
+        self.assert_betty_json(app, '/source/%s/index.json' % source.id, 'source')
 
 
 class MultilingualTest(GenerateTestCase):
-    def setUp(self):
-        GenerateTestCase.setUp(self)
+    @sync
+    async def test_root_redirect(self):
         configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
         configuration.locales.replace([
             LocaleConfiguration('nl'),
             LocaleConfiguration('en'),
         ])
-        self.app = App(configuration)
-
-    @sync
-    async def test_root_redirect(self):
-        await generate(self.app)
-        with open(self.assert_betty_html('/index.html')) as f:
+        async with App(configuration) as app:
+            await generate(app)
+        with open(self.assert_betty_html(app, '/index.html')) as f:
             meta_redirect = '<meta http-equiv="refresh" content="0; url=/nl/index.html">'
             self.assertIn(meta_redirect, f.read())
 
     @sync
     async def test_public_localized_resource(self):
-        await generate(self.app)
-        with open(self.assert_betty_html('/nl/index.html')) as f:
+        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
+        configuration.locales.replace([
+            LocaleConfiguration('nl'),
+            LocaleConfiguration('en'),
+        ])
+        async with App(configuration) as app:
+            await generate(app)
+        with open(self.assert_betty_html(app, '/nl/index.html')) as f:
             translation_link = '<a href="/en/index.html" hreflang="en" lang="en" rel="alternate">English</a>'
             self.assertIn(translation_link, f.read())
-        with open(self.assert_betty_html('/en/index.html')) as f:
+        with open(self.assert_betty_html(app, '/en/index.html')) as f:
             translation_link = '<a href="/nl/index.html" hreflang="nl" lang="nl" rel="alternate">Nederlands</a>'
             self.assertIn(translation_link, f.read())
 
     @sync
     async def test_entity(self):
+        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
+        configuration.locales.replace([
+            LocaleConfiguration('nl'),
+            LocaleConfiguration('en'),
+        ])
+        app = App(configuration)
         person = Person('PERSON1')
-        self.app.ancestry.entities.append(person)
-        await generate(self.app)
-        with open(self.assert_betty_html('/nl/person/%s/index.html' % person.id)) as f:
+        app.ancestry.entities.append(person)
+        async with app:
+            await generate(app)
+        with open(self.assert_betty_html(app, '/nl/person/%s/index.html' % person.id)) as f:
             translation_link = '<a href="/en/person/%s/index.html" hreflang="en" lang="en" rel="alternate">English</a>' % person.id
             self.assertIn(translation_link, f.read())
-        with open(self.assert_betty_html('/en/person/%s/index.html' % person.id)) as f:
+        with open(self.assert_betty_html(app, '/en/person/%s/index.html' % person.id)) as f:
             translation_link = '<a href="/nl/person/%s/index.html" hreflang="nl" lang="nl" rel="alternate">Nederlands</a>' % person.id
             self.assertIn(translation_link, f.read())
 
@@ -186,25 +225,22 @@ class ResourceOverrideTest(GenerateTestCase):
                 configuration = Configuration(
                     output_directory_path, 'https://ancestry.example.com')
                 configuration.assets_directory_path = assets_directory_path
-                app = App(configuration)
-                await generate(app)
-                with open(configuration.www_directory_path / 'index.html') as f:
-                    self.assertIn('Betty was here', f.read())
+                async with App(configuration) as app:
+                    await generate(app)
+            with open(configuration.www_directory_path / 'index.html') as f:
+                self.assertIn('Betty was here', f.read())
 
 
 @unittest.skipIf(sys.platform == 'win32', 'lxml cannot be installed directly onto vanilla Windows.')
-class SitemapRenderTest(GenerateTestCase):
-    def setUp(self):
-        GenerateTestCase.setUp(self)
-        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
-        self.app = App(configuration)
-
+class SitemapGenerateTest(GenerateTestCase):
     @sync
     async def test_validate(self):
-        await generate(self.app)
+        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
+        async with App(configuration) as app:
+            await generate(app)
         with open(Path(__file__).parent / 'test_generate_assets' / 'sitemap.xsd') as f:
             schema_doc = etree.parse(f)
         schema = etree.XMLSchema(schema_doc)
-        with open(self.app.configuration.www_directory_path / 'sitemap.xml') as f:
+        with open(app.configuration.www_directory_path / 'sitemap.xml') as f:
             sitemap_doc = etree.parse(f)
         schema.validate(sitemap_doc)


### PR DESCRIPTION
No longer keep multiple copies of `App` around by removing the app stack and making App.with_*() context managers. The reason is that with copies we run into confusing reactive behavior (different instances with the same reactors) which is all by the book, but makes it harder to keep things sensible. Multiple `App` copies also makes pickling impossible under some circumstances.