### PR TITLE
Improve locale handling

### DIFF
--- a/betty/demo.py
+++ b/betty/demo.py
@@ -32,15 +32,17 @@ class DemoServer(Server):
         self._app = App(configuration)
         self._server = None
         await self._app.activate()
-        await load.load(self._app)
-        await generate.generate(self._app)
-        self._server = serve.AppServer(self._app)
-        await self._server.start()
+        try:
+            await load.load(self._app)
+            await generate.generate(self._app)
+            self._server = serve.AppServer(self._app)
+            await self._server.start()
+        except BaseException:
+            await self._app.deactivate()
+            raise
 
     async def stop(self) -> None:
-        if self._server is not None:
-            await self._server.stop()
-        if self._app is not None:
-            await self._app.deactivate()
+        await self._server.stop()
+        await self._app.deactivate()
         if self._output_directory is not None:
             self._output_directory.__aexit__(None, None, None)

--- a/betty/tests/__init__.py
+++ b/betty/tests/__init__.py
@@ -45,7 +45,7 @@ class TemplateTestCase(TestCase):
     template_file = None
 
     def __init__(self, *args, **kwargs):
-        TestCase.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         if self.template_string is not None and self.template_file is not None:
             class_name = self.__class__.__name__
             raise RuntimeError(f'{class_name} must define either `{class_name}.template_string` or `{class_name}.template_file`, but not both.')

--- a/betty/tests/assets/locale/test_translations.py
+++ b/betty/tests/assets/locale/test_translations.py
@@ -1,4 +1,4 @@
-import gettext
+from gettext import NullTranslations
 from os import listdir
 from pathlib import Path
 
@@ -11,4 +11,4 @@ class TranslationsTest(TestCase):
         assets_directory_path = Path(__file__).parents[3] / 'assets'
         for locale_path_name in listdir(assets_directory_path / 'locale'):
             locale = locale_path_name.replace('_', '-')
-            self.assertIsInstance(open_translations(locale, assets_directory_path), gettext.NullTranslations)
+            self.assertIsInstance(open_translations(locale, assets_directory_path), NullTranslations)

--- a/betty/tests/extension/anonymizer/test__init__.py
+++ b/betty/tests/extension/anonymizer/test__init__.py
@@ -1,4 +1,4 @@
-import gettext
+from gettext import NullTranslations
 from tempfile import TemporaryDirectory
 from unittest.mock import patch, ANY, Mock
 
@@ -17,7 +17,7 @@ from betty.tests import TestCase
 
 class AnonymousSourceTest(TestCase):
     def setUp(self) -> None:
-        self._translations = Translations(gettext.NullTranslations())
+        self._translations = Translations(NullTranslations())
         self._translations.install()
 
     def tearDown(self) -> None:
@@ -43,7 +43,7 @@ class AnonymousSourceTest(TestCase):
 
 class AnonymousCitationTest(TestCase):
     def setUp(self) -> None:
-        self._translations = Translations(gettext.NullTranslations())
+        self._translations = Translations(NullTranslations())
         self._translations.install()
 
     def tearDown(self) -> None:
@@ -70,7 +70,7 @@ class AnonymousCitationTest(TestCase):
 
 class AnonymizeTest(TestCase):
     def setUp(self) -> None:
-        self._translations = Translations(gettext.NullTranslations())
+        self._translations = Translations(NullTranslations())
         self._translations.install()
 
     def tearDown(self) -> None:
@@ -262,7 +262,7 @@ class AnonymizeFileTest(TestCase):
 
 class AnonymizeSourceTest(TestCase):
     def setUp(self) -> None:
-        self._translations = Translations(gettext.NullTranslations())
+        self._translations = Translations(NullTranslations())
         self._translations.install()
 
     def tearDown(self) -> None:
@@ -306,7 +306,7 @@ class AnonymizeSourceTest(TestCase):
 
 class AnonymizeCitationTest(TestCase):
     def setUp(self) -> None:
-        self._translations = Translations(gettext.NullTranslations())
+        self._translations = Translations(NullTranslations())
         self._translations.install()
 
     def tearDown(self) -> None:

--- a/betty/tests/test_jinja2.py
+++ b/betty/tests/test_jinja2.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import List, Dict, Optional, Iterable, Type
-from unittest import TestCase
 from unittest.mock import Mock
 
 from parameterized import parameterized
@@ -16,7 +15,7 @@ from betty.media_type import MediaType
 from betty.extension import Extension
 from betty.app import App
 from betty.string import camel_case_to_snake_case
-from betty.tests import TemplateTestCase
+from betty.tests import TemplateTestCase, TestCase
 
 
 class Jinja2ProviderTest(TestCase):

--- a/betty/tests/test_readme.py
+++ b/betty/tests/test_readme.py
@@ -1,9 +1,9 @@
 import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from unittest import TestCase
 
 from betty import os, subprocess
+from betty.tests import TestCase
 
 
 class ReadmeTest(TestCase):

--- a/betty/tests/test_string.py
+++ b/betty/tests/test_string.py
@@ -1,8 +1,7 @@
-from unittest import TestCase
-
 from parameterized import parameterized
 
 from betty.string import camel_case_to_snake_case, camel_case_to_kebab_case, upper_camel_case_to_lower_camel_case
+from betty.tests import TestCase
 
 
 class CamelCaseToSnakeCaseTest(TestCase):


### PR DESCRIPTION
Improve the locale module and gettext usage:
- no longer import the `gettext` module (which conflicts with the `gettext()` built-in)
- make Translations error handling stricter and raise custom exceptions
- add test coverage for the Translations API
- fix bugs where translations would not be installed or reverted due to
  exceptions raised when entering certain context managers