### PR TITLE
Allow betty.asyncio.sync() to be called multiple times in the same stack

### DIFF
--- a/betty/asyncio.py
+++ b/betty/asyncio.py
@@ -2,9 +2,11 @@ import asyncio
 import inspect
 from contextlib import suppress
 from functools import wraps
+from threading import Thread
+from typing import Any
 
 
-def _wrap_sync(f):
+def _sync_function(f):
     @wraps(f)
     def _synced(*args, **kwargs):
         return sync(f(*args, **kwargs))
@@ -14,19 +16,38 @@ def _wrap_sync(f):
 def sync(f):
     if inspect.iscoroutine(f):
         try:
-            loop = asyncio.get_event_loop()
+            asyncio.get_running_loop()
         except RuntimeError:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
-        return loop.run_until_complete(f)
+            return loop.run_until_complete(f)
+        synced = _SyncedAwaitable(f)
+        synced.start()
+        synced.join()
+        return synced.return_value
 
     if inspect.iscoroutinefunction(f):
-        return _wrap_sync(f)
+        return _sync_function(f)
 
     if callable(f):
         with suppress(AttributeError):
             if inspect.iscoroutinefunction(getattr(f, '__call__')):
-                return _wrap_sync(f)
+                return _sync_function(f)
         return f
 
     raise ValueError('Can only synchronize coroutine callables (`async def`) or coroutines (values returned by `async def`), or pass through synchronous callables, but "%s" was given.' % f)
+
+
+class _SyncedAwaitable(Thread):
+    def __init__(self, awaitable):
+        super().__init__()
+        self._awaitable = awaitable
+        self._return_value = None
+
+    @property
+    def return_value(self) -> Any:
+        return self._return_value
+
+    @sync
+    async def run(self) -> None:
+        self._return_value = await self._awaitable

--- a/betty/tests/test_asyncio.py
+++ b/betty/tests/test_asyncio.py
@@ -67,6 +67,22 @@ class SyncTest(TestCase):
         actual = sync(_Sync())()
         self.assertEqual(expected, actual)
 
+    def test_call_nested_sync_and_async(self) -> None:
+        expected = 'Hello, oh asynchronous, world!'
+
+        @sync
+        async def _async_one():
+            return _sync()
+
+        def _sync():
+            return _async_two()
+
+        @sync
+        async def _async_two():
+            return expected
+
+        self.assertEqual(expected, _async_one())
+
     def test_unsychronizable(self) -> None:
         with self.assertRaises(ValueError):
             sync(True)


### PR DESCRIPTION
Allow betty.asyncio.sync() to be called multiple times in the same stack by awaiting coroutines in a separate thread if an event loop is already running.