### PR TITLE
Let App initialize its own Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ To build a site from your GEDCOM files:
 ### The Python API
 
 ```python
-from betty.app import App, Configuration
+from betty.app import App
 from betty.asyncio import sync
 from betty.generate import generate
 from betty.load import load
@@ -201,8 +201,7 @@ from betty.load import load
 
 @sync
 async def generate():
-    configuration = Configuration('/var/www/betty', 'https://betty.example.com')
-    async with App(configuration) as app:
+    async with App() as app:
         await load(app)
         await generate(app)
 

--- a/betty/app/extension.py
+++ b/betty/app/extension.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
-from typing import Generic, TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING, Iterable
 
 from betty.requirement import Requirer, AllRequirements
 
@@ -13,7 +13,6 @@ try:
 except ImportError:
     from importlib_metadata import entry_points
 
-from betty.config import Configurable, ConfigurationT
 from pathlib import Path
 from typing import Type, Set, Optional, Any, List, Dict, Sequence, TypeVar
 
@@ -48,8 +47,6 @@ class Dependencies(AllRequirements):
 class Extension(Environment, Requirer):
     """
     Integrate optional functionality with the Betty app.
-
-    Extensions that take configuration must implement betty.app.ConfigurableExtension.
     """
 
     def __init__(self, app: App, *args, **kwargs):
@@ -83,15 +80,6 @@ class Extension(Environment, Requirer):
     @classmethod
     def assets_directory_path(cls) -> Optional[Path]:
         return None
-
-
-class ConfigurableExtension(Configurable, Extension, Generic[ConfigurationT]):
-    def __init__(self, app: App, configuration: ConfigurationT):
-        super().__init__(configuration, app)
-
-    @classmethod
-    def default_configuration(cls) -> ConfigurationT:
-        raise NotImplementedError
 
 
 ExtensionT = TypeVar('ExtensionT', bound=Extension)

--- a/betty/assets/public/static/search-configuration.json.j2
+++ b/betty/assets/public/static/search-configuration.json.j2
@@ -1,6 +1,6 @@
 {% set ns = namespace(search_shortcuts=[]) %}
 {% for locale_configuration in app.configuration.locales %}
-    {% enter app.with_locale(locale_configuration.locale) %}
+    {% enter app.activate_locale(locale_configuration.locale) %}
         {% do ns.search_shortcuts.append(pgettext('enter-search-shortcut', 's')) %}
     {% exit %}
 {% endfor %}

--- a/betty/assets/public/static/sitemap.xml.j2
+++ b/betty/assets/public/static/sitemap.xml.j2
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
     {% for locale_configuration in app.configuration.locales %}
-        {% enter app.with_locale(locale_configuration.locale) %}
+        {% enter app.activate_locale(locale_configuration.locale) %}
             {% for entity in app.ancestry.entities | reject('generated_entity_id') %}
                 <url>
                     <loc>{{ entity | url(absolute=true) }}</loc>

--- a/betty/assets/templates/base.html.j2
+++ b/betty/assets/templates/base.html.j2
@@ -117,7 +117,7 @@
                         {% do ns.available_locales.append((available_locale_configuration.locale, available_locale_data.get_display_name())) %}
                     {% endfor %}
                     {% for available_locale, available_locale_name in ns.available_locales | sort(attribute='1') %}
-                        {% enter app.with_locale(available_locale) %}
+                        {% enter app.activate_locale(available_locale) %}
                             <li><a href="{{ page_resource | url }}" hreflang="{{ available_locale }}" lang="{{ available_locale }}" rel="alternate">{{ available_locale_name }}</a></li>
                         {% exit %}
                     {% endfor %}

--- a/betty/cli.py
+++ b/betty/cli.py
@@ -16,7 +16,7 @@ from betty.error import UserFacingError
 from betty.asyncio import sync
 from betty.gui import BettyApplication, ProjectWindow, _WelcomeWindow
 from betty.logging import CliHandler
-from betty.app import App, Configuration
+from betty.app import App
 
 
 class CommandProvider:
@@ -84,13 +84,14 @@ async def _init_ctx(ctx: Context, _: Optional[Option] = None, configuration_file
     else:
         try_configuration_file_paths = [configuration_file_path]
 
+    app = App()
+
     for try_configuration_file_path in try_configuration_file_paths:
         with suppress(FileNotFoundError):
-            with open(try_configuration_file_path) as f:
-                logger.info('Loading the configuration from %s.' % try_configuration_file_path)
-                configuration = from_file(f, Configuration)
-            app = App(configuration)
             async with app:
+                with open(try_configuration_file_path) as f:
+                    logger.info('Loading the configuration from %s.' % try_configuration_file_path)
+                    from_file(f, app.configuration)
                 ctx.obj['commands']['generate'] = _generate
                 ctx.obj['commands']['serve'] = _serve
                 for extension in app.extensions.flatten():

--- a/betty/concurrent.py
+++ b/betty/concurrent.py
@@ -14,7 +14,7 @@ class ExceptionRaisingAwaitableExecutor(Executor):
     def map(self, *args, **kwargs):
         return self._executor.map(*args, **kwargs)
 
-    async def wait(self) -> None:
+    def wait(self) -> None:
         wait(self._futures)
 
     def shutdown(self, *args, **kwargs):

--- a/betty/fs.py
+++ b/betty/fs.py
@@ -5,7 +5,7 @@ from contextlib import suppress
 from os.path import getmtime
 from pathlib import Path
 from shutil import copy2
-from typing import AsyncIterable, Optional, Tuple, AsyncContextManager
+from typing import AsyncIterable, Optional, Tuple, AsyncContextManager, Sequence
 
 import aiofiles
 
@@ -54,9 +54,18 @@ class FileSystem:
     def __init__(self, *paths: Tuple[PathLike, Optional[str]]):
         self._paths = deque([(Path(fs_path), fs_encoding) for fs_path, fs_encoding in paths])
 
+    def __len__(self) -> int:
+        return len(self._paths)
+
     @property
-    def paths(self) -> deque:
-        return self._paths
+    def paths(self) -> Sequence[Tuple[Path, str]]:
+        return list(self._paths)
+
+    def prepend(self, path: PathLike, fs_encoding: Optional[str] = None) -> None:
+        self._paths.appendleft((Path(path), fs_encoding))
+
+    def clear(self) -> None:
+        self._paths.clear()
 
     def open(self, *file_paths: PathLike) -> AsyncContextManager[object]:
         return self._Open(self, file_paths)

--- a/betty/generate.py
+++ b/betty/generate.py
@@ -44,7 +44,7 @@ async def generate(app: App) -> None:
             os.chmod(directory_path / subdirectory_name, 0o755)
         for file_name in file_names:
             os.chmod(directory_path / file_name, 0o644)
-    await app.wait()
+    app.wait()
 
 
 async def _generate(app: App) -> None:
@@ -53,7 +53,7 @@ async def _generate(app: App) -> None:
     await app.renderer.render_tree(app.configuration.www_directory_path)
     for locale_configuration in app.configuration.locales:
         locale = locale_configuration.locale
-        async with app.with_locale(locale):
+        with app.activate_locale(locale):
             if app.configuration.multilingual:
                 www_directory_path = app.configuration.www_directory_path / locale_configuration.alias
             else:

--- a/betty/gramps/__init__.py
+++ b/betty/gramps/__init__.py
@@ -2,8 +2,8 @@ from typing import Optional, Type
 
 from PyQt6.QtWidgets import QWidget
 
-from betty.app import ConfigurableExtension
-from betty.config import Configuration
+from betty.app import Extension
+from betty.config import Configuration, Configurable
 from betty.gramps.config import GrampsConfiguration
 from betty.gramps.gui import _GrampsGuiWidget
 from betty.gramps.loader import load_file
@@ -11,14 +11,10 @@ from betty.gui import GuiBuilder
 from betty.load import Loader
 
 
-class Gramps(ConfigurableExtension, Loader, GuiBuilder):
+class Gramps(Extension, Configurable, Loader, GuiBuilder):
     @classmethod
     def configuration_type(cls) -> Type[Configuration]:
         return GrampsConfiguration
-
-    @classmethod
-    def default_configuration(cls) -> Configuration:
-        return GrampsConfiguration()
 
     async def load(self) -> None:
         for family_tree in self._configuration.family_trees:

--- a/betty/gui.py
+++ b/betty/gui.py
@@ -681,10 +681,10 @@ class _ProjectExtensionConfigurationPane(QWidget):
 
 class ProjectWindow(BettyMainWindow):
     def __init__(self, configuration_file_path: str, *args, **kwargs):
+        self._app = App()
         with open(configuration_file_path) as f:
-            self._configuration = from_file(f, Configuration)
-        self._configuration.react.react_weakref(self._save_configuration)
-        self._app = App(self._configuration)
+            from_file(f, self._app.configuration)
+        self._app.configuration.react.react_weakref(self._save_configuration)
         self._configuration_file_path = configuration_file_path
 
         super().__init__(*args, **kwargs)
@@ -723,7 +723,7 @@ class ProjectWindow(BettyMainWindow):
 
     def _save_configuration(self) -> None:
         with open(self._configuration_file_path, 'w') as f:
-            to_file(f, self._configuration)
+            to_file(f, self._app.configuration)
 
     @reactive(on_trigger_call=True)
     def _set_window_title(self) -> None:
@@ -764,12 +764,12 @@ class ProjectWindow(BettyMainWindow):
         self.project_menu.serve_action.triggered.connect(lambda _: self._serve())
         self.project_menu.addAction(self.project_menu.serve_action)
 
-    @catch_exceptions
+    # @catch_exceptions
     def _save_project_as(self) -> None:
         configuration_file_path, _ = QFileDialog.getSaveFileName(self, 'Save your project to...', '', _CONFIGURATION_FILE_FILTER)
         os.makedirs(path.dirname(configuration_file_path))
         with open(configuration_file_path, mode='w') as f:
-            to_file(f, self._configuration)
+            to_file(f, self._app.configuration)
 
     @catch_exceptions
     def _generate(self) -> None:

--- a/betty/json.py
+++ b/betty/json.py
@@ -86,7 +86,7 @@ class JSONEncoder(stdjson.JSONEncoder):
             for locale_configuration in self._app.configuration.locales:
                 if locale_configuration.locale == self._app.locale:
                     continue
-                async with self._app.with_locale(locale_configuration.locale):
+                with self._app.activate_locale(locale_configuration.locale):
                     translation = Link(self._generate_url(entity))
                 translation.relationship = 'alternate'
                 translation.locale = locale_configuration.locale

--- a/betty/load.py
+++ b/betty/load.py
@@ -20,4 +20,4 @@ class PostLoader:
 async def load(app: App) -> None:
     await app.dispatcher.dispatch(Loader)()
     await app.dispatcher.dispatch(PostLoader)()
-    await app.wait()
+    app.wait()

--- a/betty/pytests/extension/gramps/test_gui.py
+++ b/betty/pytests/extension/gramps/test_gui.py
@@ -4,7 +4,7 @@ from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QFileDialog
 from reactives import ReactiveList
 
-from betty.app import App, Configuration, AppExtensionConfiguration
+from betty.app import App, AppExtensionConfiguration
 from betty.asyncio import sync
 from betty.gramps import Gramps, GrampsConfiguration
 from betty.gramps.config import FamilyTreeConfiguration
@@ -13,9 +13,8 @@ from betty.gramps.gui import _AddFamilyTreeWindow
 
 @sync
 async def test_add_family_tree_set_path(assert_not_window, assert_window, tmpdir, qtbot) -> None:
-    configuration = Configuration(tmpdir, 'https://example.com')
-    configuration.extensions.add(AppExtensionConfiguration(Gramps))
-    async with App(configuration) as app:
+    async with App() as app:
+        app.configuration.extensions.add(AppExtensionConfiguration(Gramps))
         sut = app.extensions[Gramps]
         widget = sut.gui_build()
         qtbot.addWidget(widget)
@@ -37,9 +36,8 @@ async def test_add_family_tree_set_path(assert_not_window, assert_window, tmpdir
 
 @sync
 async def test_add_family_tree_find_path(assert_window, mocker, tmpdir, qtbot) -> None:
-    configuration = Configuration(tmpdir, 'https://example.com')
-    configuration.extensions.add(AppExtensionConfiguration(Gramps))
-    async with App(configuration) as app:
+    async with App() as app:
+        app.configuration.extensions.add(AppExtensionConfiguration(Gramps))
         sut = app.extensions[Gramps]
         widget = sut.gui_build()
         qtbot.addWidget(widget)
@@ -60,16 +58,15 @@ async def test_add_family_tree_find_path(assert_window, mocker, tmpdir, qtbot) -
 
 @sync
 async def test_remove_family_tree(tmpdir, qtbot) -> None:
-    configuration = Configuration(tmpdir, 'https://example.com')
-    configuration.extensions.add(AppExtensionConfiguration(
-        Gramps,
-        extension_configuration=GrampsConfiguration(
-            family_trees=ReactiveList([
-                FamilyTreeConfiguration('/tmp/family-tree.gpkg'),
-            ])
-        ),
-    ))
-    async with App(configuration) as app:
+    async with App() as app:
+        app.configuration.extensions.add(AppExtensionConfiguration(
+            Gramps,
+            extension_configuration=GrampsConfiguration(
+                family_trees=ReactiveList([
+                    FamilyTreeConfiguration('/tmp/family-tree.gpkg'),
+                ])
+            ),
+        ))
         sut = app.extensions[Gramps]
         widget = sut.gui_build()
         qtbot.addWidget(widget)

--- a/betty/pytests/test_gui.py
+++ b/betty/pytests/test_gui.py
@@ -8,7 +8,7 @@ from PyQt6.QtWidgets import QFileDialog
 from babel import Locale
 
 from betty import fs
-from betty.app import App, Configuration, LocaleConfiguration
+from betty.app import App, LocaleConfiguration
 from betty.asyncio import sync
 from betty.config import ConfigurationError
 from betty.gui import BettyMainWindow, _WelcomeWindow, ProjectWindow, _AboutBettyWindow, ExceptionError, \
@@ -219,8 +219,8 @@ def test_project_window_localization_configuration_add_locale(qtbot, assert_not_
     qtbot.mouseClick(add_locale_window._save_and_close, Qt.MouseButton.LeftButton)
     assert_not_window(_AddLocaleWindow)
 
-    assert locale in sut._configuration.locales
-    assert sut._configuration.locales[locale].alias == alias
+    assert locale in sut._app.configuration.locales
+    assert sut._app.configuration.locales[locale].alias == alias
 
 
 def test_project_window_localization_configuration_remove_locale(qtbot, minimal_dumped_app_configuration, tmpdir) -> None:
@@ -244,7 +244,7 @@ def test_project_window_localization_configuration_remove_locale(qtbot, minimal_
 
     qtbot.mouseClick(sut._localization_configuration_pane._locales_configuration_widget._remove_buttons[locale], Qt.MouseButton.LeftButton)
 
-    assert locale not in sut._configuration.locales
+    assert locale not in sut._app.configuration.locales
 
 
 def test_project_window_localization_configuration_default_locale(qtbot, minimal_dumped_app_configuration, tmpdir) -> None:
@@ -270,7 +270,7 @@ def test_project_window_localization_configuration_default_locale(qtbot, minimal
     # @todo directly.
     sut._localization_configuration_pane._locales_configuration_widget._default_buttons[locale].click()
 
-    assert sut._configuration.locales.default == LocaleConfiguration(locale)
+    assert sut._app.configuration.locales.default == LocaleConfiguration(locale)
 
 
 def test_project_window_save_project_as_should_create_duplicate_configuration_file(mocker, navigate, qtbot, tmpdir) -> None:
@@ -315,9 +315,8 @@ def test_project_window_save_project_as_should_create_duplicate_configuration_fi
 
 
 @sync
-async def test_generate_window_close_button_should_close_window(assert_not_window, navigate, qtbot, tmpdir) -> None:
-    configuration = Configuration(tmpdir, 'https://example.com')
-    async with App(configuration) as app:
+async def test_generate_window_close_button_should_close_window(assert_not_window, navigate, qtbot) -> None:
+    async with App() as app:
         sut = _GenerateWindow(app)
         qtbot.addWidget(sut)
 
@@ -329,10 +328,9 @@ async def test_generate_window_close_button_should_close_window(assert_not_windo
 
 
 @sync
-async def test_generate_window_serve_button_should_open_serve_window(assert_window, mocker, navigate, qtbot, tmpdir) -> None:
+async def test_generate_window_serve_button_should_open_serve_window(assert_window, mocker, navigate, qtbot) -> None:
     mocker.patch('webbrowser.open_new_tab')
-    configuration = Configuration(tmpdir, 'https://example.com')
-    async with App(configuration) as app:
+    async with App() as app:
         sut = _GenerateWindow(app)
         qtbot.addWidget(sut)
 

--- a/betty/tests/__init__.py
+++ b/betty/tests/__init__.py
@@ -68,12 +68,11 @@ class TemplateTestCase(TestCase):
             raise RuntimeError(f'You must define one of `template_string`, `template_file`, `{class_name}.template_string`, or `{class_name}.template_file`.')
         if data is None:
             data = {}
-        with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(output_directory_path, 'https://example.com')
-            configuration.debug = True
-            if update_configuration is not None:
-                update_configuration(configuration)
-            async with App(configuration) as app:
-                rendered = template_factory(app.jinja2_environment, template).render(**data)
-                await app.wait()
-                yield rendered, app
+        app = App()
+        app.configuration.debug = True
+        if update_configuration is not None:
+            update_configuration(app.configuration)
+        async with app:
+            rendered = template_factory(app.jinja2_environment, template).render(**data)
+            app.wait()
+            yield rendered, app

--- a/betty/tests/anonymizer/test__init__.py
+++ b/betty/tests/anonymizer/test__init__.py
@@ -1,8 +1,7 @@
 from gettext import NullTranslations
-from tempfile import TemporaryDirectory
 from unittest.mock import patch, ANY, Mock
 
-from betty.app import App, Configuration, AppExtensionConfiguration
+from betty.app import App, AppExtensionConfiguration
 from betty.asyncio import sync
 from betty.anonymizer import anonymize, anonymize_person, anonymize_event, anonymize_file, anonymize_citation, \
     anonymize_source, AnonymousSource, AnonymousCitation, Anonymizer
@@ -349,11 +348,8 @@ class AnonymizerTest(TestCase):
         person = Person('P0')
         person.private = True
         PersonName(person, 'Jane', 'Dough')
-        with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(
-                output_directory_path, 'https://example.com')
-            configuration.extensions.add(AppExtensionConfiguration(Anonymizer))
-            async with App(configuration) as app:
-                app.ancestry.entities.append(person)
-                await load(app)
+        async with App() as app:
+            app.configuration.extensions.add(AppExtensionConfiguration(Anonymizer))
+            app.ancestry.entities.append(person)
+            await load(app)
         self.assertEquals(0, len(person.names))

--- a/betty/tests/app/test___init__.py
+++ b/betty/tests/app/test___init__.py
@@ -1,39 +1,16 @@
-from contextlib import contextmanager
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Dict, Any, Type, List, Set
+from typing import Any, Type, List, Set
 
 from parameterized import parameterized
 from reactives.tests import assert_reactor_called, assert_in_scope, assert_scope_empty
 
-from betty import app
 from betty.app import Configuration, LocaleConfiguration, LocalesConfiguration, AppExtensionConfiguration, Extension, \
-    AppExtensionsConfiguration, ConfigurationError, ConfigurableExtension, App, CyclicDependencyError
+    AppExtensionsConfiguration, ConfigurationError, App, CyclicDependencyError
 from betty.asyncio import sync
-from betty.config import Configuration as GenericConfiguration
+from betty.config import Configuration as GenericConfiguration, ConfigurationT, Configurable
 from betty.model.ancestry import Ancestry
 from betty.tests import TestCase
-
-
-@contextmanager
-def _build_minimal_app_dumped_configuration() -> Dict:
-    output_directory = TemporaryDirectory()
-    try:
-        yield {
-            'output': output_directory.name,
-            'base_url': 'https://example.com',
-        }
-    finally:
-        output_directory.cleanup()
-
-
-@contextmanager
-def _build_minimal_app_configuration() -> Configuration:
-    output_directory = TemporaryDirectory()
-    try:
-        yield Configuration(output_directory.name, 'https://example.com')
-    finally:
-        output_directory.cleanup()
 
 
 class LocaleConfigurationTest(TestCase):
@@ -171,25 +148,55 @@ class LocalesConfigurationTest(TestCase):
         self.assertEquals(locale_configuration_b, sut.default)
 
 
+class _DummyExtension(Extension):
+    @classmethod
+    def label(cls) -> str:
+        return 'Dummy'
+
+
+class _DummyConfiguration(Configuration):
+    pass
+
+
+class _DummyConfigurableExtension(Extension, Configurable):
+    @classmethod
+    def label(cls) -> str:
+        return 'Configurable dummy'
+
+    @classmethod
+    def configuration_type(cls) -> Type[ConfigurationT]:
+        return _DummyConfiguration
+
+
 class AppExtensionConfigurationTest(TestCase):
-    def test_extension_type(self):
-        extension_type = Extension
+    def test_extension_type(self) -> None:
+        extension_type = _DummyExtension
         sut = AppExtensionConfiguration(extension_type)
         self.assertEquals(extension_type, sut.extension_type)
 
-    def test_enabled(self):
+    def test_enabled(self) -> None:
         enabled = True
-        sut = AppExtensionConfiguration(Extension, enabled)
+        sut = AppExtensionConfiguration(_DummyExtension, enabled)
         self.assertEquals(enabled, sut.enabled)
         with assert_reactor_called(sut):
             sut.enabled = False
 
-    def test_configuration(self):
+    def test_configuration(self) -> None:
         extension_type_configuration = GenericConfiguration()
         sut = AppExtensionConfiguration(Extension, True, extension_type_configuration)
         self.assertEquals(extension_type_configuration, sut.extension_configuration)
         with assert_reactor_called(sut):
             extension_type_configuration.react.trigger()
+
+    @parameterized.expand([
+        (True, AppExtensionConfiguration(_DummyExtension, True), AppExtensionConfiguration(_DummyExtension, True)),
+        (True, AppExtensionConfiguration(_DummyExtension, True, None), AppExtensionConfiguration(_DummyExtension, True, None)),
+        (False, AppExtensionConfiguration(_DummyExtension, True, GenericConfiguration()), AppExtensionConfiguration(_DummyExtension, True, GenericConfiguration())),
+        (False, AppExtensionConfiguration(_DummyExtension, True), AppExtensionConfiguration(_DummyExtension, False)),
+        (False, AppExtensionConfiguration(_DummyExtension, True), AppExtensionConfiguration(_DummyConfigurableExtension, True)),
+    ])
+    def test_eq(self, expected: bool, one: AppExtensionConfiguration, other: AppExtensionConfiguration) -> None:
+        self.assertEqual(expected, one == other)
 
 
 class AppExtensionsConfigurationTest(TestCase):
@@ -258,113 +265,106 @@ class AppExtensionsConfigurationTest(TestCase):
 
 
 class ConfigurationTest(TestCase):
-    def test_output_directory_path(self):
-        output_directory_path = Path('~')
-        sut = Configuration(output_directory_path, 'https://example.com')
-        self.assertEquals(output_directory_path, sut.output_directory_path)
-
-    def test_www_directory_path_with_absolute_path(self):
-        output_directory_path = Path('~')
-        sut = Configuration(output_directory_path, 'https://example.com')
-        expected = output_directory_path / 'www'
-        self.assertEquals(expected, sut.www_directory_path)
-
     def test_assets_directory_path_without_path(self):
-        sut = Configuration('~', 'https://example.com')
+        sut = Configuration()
         self.assertIsNone(sut.assets_directory_path)
 
     def test_assets_directory_path_with_path(self):
-        sut = Configuration('~', 'https://example.com')
+        sut = Configuration()
         assets_directory_path = '/tmp/betty-assets'
         sut.assets_directory_path = assets_directory_path
         self.assertEquals(assets_directory_path,
                           sut.assets_directory_path)
 
     def test_base_url(self):
-        sut = Configuration('/tmp/betty', 'https://example.com')
+        sut = Configuration()
         base_url = 'https://example.com'
         sut.base_url = base_url
         self.assertEquals(base_url, sut.base_url)
 
     def test_base_url_without_scheme_should_error(self):
-        sut = Configuration('/tmp/betty', 'https://example.com')
+        sut = Configuration()
         with self.assertRaises(ConfigurationError):
             sut.base_url = '/'
 
     def test_base_url_without_path_should_error(self):
-        sut = Configuration('/tmp/betty', 'https://example.com')
+        sut = Configuration()
         with self.assertRaises(ConfigurationError):
             sut.base_url = 'file://'
 
     def test_root_path(self):
-        sut = Configuration('~', 'https://example.com')
+        sut = Configuration()
         configured_root_path = '/betty/'
         expected_root_path = 'betty'
         sut.root_path = configured_root_path
         self.assertEquals(expected_root_path, sut.root_path)
 
     def test_clean_urls(self):
-        sut = Configuration('~', 'https://example.com')
+        sut = Configuration()
         clean_urls = True
         sut.clean_urls = clean_urls
         self.assertEquals(clean_urls, sut.clean_urls)
 
     def test_content_negotiation(self):
-        sut = Configuration('~', 'https://example.com')
+        sut = Configuration()
         content_negotiation = True
         sut.content_negotiation = content_negotiation
         self.assertEquals(content_negotiation, sut.content_negotiation)
 
     def test_clean_urls_implied_by_content_negotiation(self):
-        sut = Configuration('~', 'https://example.com')
+        sut = Configuration()
         sut.content_negotiation = True
         self.assertTrue(sut.clean_urls)
 
     def test_author_without_author(self):
-        sut = Configuration('~', 'https://example.com')
+        sut = Configuration()
         self.assertIsNone(sut.author)
 
     def test_author_with_author(self):
-        sut = Configuration('~', 'https://example.com')
+        sut = Configuration()
         author = 'Bart'
         sut.author = author
         self.assertEquals(author, sut.author)
 
     def test_load_should_load_minimal(self) -> None:
-        with _build_minimal_app_dumped_configuration() as dumped_configuration:
-            configuration = Configuration.load(dumped_configuration)
-            self.assertEquals(Path(dumped_configuration['output']).expanduser().resolve(), configuration.output_directory_path)
-            self.assertEquals(dumped_configuration['base_url'], configuration.base_url)
-            self.assertEquals('Betty', configuration.title)
-            self.assertIsNone(configuration.author)
-            self.assertFalse(configuration.debug)
-            self.assertEquals('', configuration.root_path)
-            self.assertFalse(configuration.clean_urls)
-            self.assertFalse(configuration.content_negotiation)
+        dumped_configuration = Configuration().dump()
+        configuration = Configuration()
+        configuration.load(dumped_configuration)
+        self.assertEquals(Path(dumped_configuration['output']).expanduser().resolve(), configuration.output_directory_path)
+        self.assertEquals(dumped_configuration['base_url'], configuration.base_url)
+        self.assertEquals('Betty', configuration.title)
+        self.assertIsNone(configuration.author)
+        self.assertFalse(configuration.debug)
+        self.assertEquals('', configuration.root_path)
+        self.assertFalse(configuration.clean_urls)
+        self.assertFalse(configuration.content_negotiation)
 
     def test_load_should_load_title(self) -> None:
         title = 'My first Betty site'
-        with _build_minimal_app_dumped_configuration() as dumped_configuration:
-            dumped_configuration['title'] = title
-            configuration = Configuration.load(dumped_configuration)
-            self.assertEquals(title, configuration.title)
+        dumped_configuration = Configuration().dump()
+        dumped_configuration['title'] = title
+        configuration = Configuration()
+        configuration.load(dumped_configuration)
+        self.assertEquals(title, configuration.title)
 
     def test_load_should_load_author(self) -> None:
         author = 'Bart'
-        with _build_minimal_app_dumped_configuration() as dumped_configuration:
-            dumped_configuration['author'] = author
-            configuration = Configuration.load(dumped_configuration)
-            self.assertEquals(author, configuration.author)
+        dumped_configuration = Configuration().dump()
+        dumped_configuration['author'] = author
+        configuration = Configuration()
+        configuration.load(dumped_configuration)
+        self.assertEquals(author, configuration.author)
 
     def test_load_should_load_locale_locale(self) -> None:
         locale = 'nl-NL'
         locale_config = {
             'locale': locale,
         }
-        with _build_minimal_app_dumped_configuration() as dumped_configuration:
-            dumped_configuration['locales'] = [locale_config]
-            configuration = Configuration.load(dumped_configuration)
-            self.assertEquals(LocalesConfiguration([LocaleConfiguration(locale)]), configuration.locales)
+        dumped_configuration = Configuration().dump()
+        dumped_configuration['locales'] = [locale_config]
+        configuration = Configuration()
+        configuration.load(dumped_configuration)
+        self.assertEquals(LocalesConfiguration([LocaleConfiguration(locale)]), configuration.locales)
 
     def test_load_should_load_locale_alias(self) -> None:
         locale = 'nl-NL'
@@ -373,248 +373,262 @@ class ConfigurationTest(TestCase):
             'locale': locale,
             'alias': alias,
         }
-        with _build_minimal_app_dumped_configuration() as dumped_configuration:
-            dumped_configuration['locales'] = [locale_config]
-            configuration = Configuration.load(dumped_configuration)
-            self.assertEquals(LocalesConfiguration([LocaleConfiguration(locale, alias)]), configuration.locales)
+        dumped_configuration = Configuration().dump()
+        dumped_configuration['locales'] = [locale_config]
+        configuration = Configuration()
+        configuration.load(dumped_configuration)
+        self.assertEquals(LocalesConfiguration([LocaleConfiguration(locale, alias)]), configuration.locales)
 
     def test_load_should_root_path(self) -> None:
         configured_root_path = '/betty/'
         expected_root_path = 'betty'
-        with _build_minimal_app_dumped_configuration() as dumped_configuration:
-            dumped_configuration['root_path'] = configured_root_path
-            configuration = Configuration.load(dumped_configuration)
-            self.assertEquals(expected_root_path, configuration.root_path)
+        dumped_configuration = Configuration().dump()
+        dumped_configuration['root_path'] = configured_root_path
+        configuration = Configuration()
+        configuration.load(dumped_configuration)
+        self.assertEquals(expected_root_path, configuration.root_path)
 
     def test_load_should_clean_urls(self) -> None:
         clean_urls = True
-        with _build_minimal_app_dumped_configuration() as dumped_configuration:
-            dumped_configuration['clean_urls'] = clean_urls
-            configuration = Configuration.load(dumped_configuration)
-            self.assertEquals(clean_urls, configuration.clean_urls)
+        dumped_configuration = Configuration().dump()
+        dumped_configuration['clean_urls'] = clean_urls
+        configuration = Configuration()
+        configuration.load(dumped_configuration)
+        self.assertEquals(clean_urls, configuration.clean_urls)
 
     def test_load_should_content_negotiation(self) -> None:
         content_negotiation = True
-        with _build_minimal_app_dumped_configuration() as dumped_configuration:
-            dumped_configuration['content_negotiation'] = content_negotiation
-            configuration = Configuration.load(dumped_configuration)
-            self.assertEquals(content_negotiation, configuration.content_negotiation)
+        dumped_configuration = Configuration().dump()
+        dumped_configuration['content_negotiation'] = content_negotiation
+        configuration = Configuration()
+        configuration.load(dumped_configuration)
+        self.assertEquals(content_negotiation, configuration.content_negotiation)
 
     @parameterized.expand([
         (True,),
         (False,),
     ])
     def test_load_should_load_debug(self, debug: bool) -> None:
-        with _build_minimal_app_dumped_configuration() as dumped_configuration:
-            dumped_configuration['debug'] = debug
-            configuration = Configuration.load(dumped_configuration)
-            self.assertEquals(debug, configuration.debug)
+        dumped_configuration = Configuration().dump()
+        dumped_configuration['debug'] = debug
+        configuration = Configuration()
+        configuration.load(dumped_configuration)
+        self.assertEquals(debug, configuration.debug)
 
     def test_load_should_load_assets_directory_path(self) -> None:
         with TemporaryDirectory() as assets_directory_path:
-            with _build_minimal_app_dumped_configuration() as dumped_configuration:
-                dumped_configuration['assets'] = assets_directory_path
-                configuration = Configuration.load(dumped_configuration)
-                self.assertEquals(Path(assets_directory_path).expanduser().resolve(), configuration.assets_directory_path)
+            dumped_configuration = Configuration().dump()
+            dumped_configuration['assets'] = assets_directory_path
+            configuration = Configuration()
+            configuration.load(dumped_configuration)
+            self.assertEquals(Path(assets_directory_path).expanduser().resolve(), configuration.assets_directory_path)
 
     def test_load_should_load_one_extension_with_configuration(self) -> None:
-        with _build_minimal_app_dumped_configuration() as dumped_configuration:
-            extension_configuration = {
-                'check': 1337,
-            }
-            dumped_configuration['extensions'] = {
-                DummyConfigurableExtension.name(): {
-                    'configuration': extension_configuration,
-                },
-            }
-            configuration = Configuration.load(dumped_configuration)
-            expected = AppExtensionsConfiguration([
-                AppExtensionConfiguration(DummyConfigurableExtension, True, DummyConfigurableExtensionConfiguration(
-                    check=1337,
-                    default='I will always be there for you.',
-                )),
-            ])
-            self.assertEquals(expected, configuration.extensions)
+        dumped_configuration = Configuration().dump()
+        extension_configuration = {
+            'check': 1337,
+        }
+        dumped_configuration['extensions'] = {
+            DummyConfigurableExtension.name(): {
+                'configuration': extension_configuration,
+            },
+        }
+        configuration = Configuration()
+        configuration.load(dumped_configuration)
+        expected = AppExtensionsConfiguration([
+            AppExtensionConfiguration(DummyConfigurableExtension, True, DummyConfigurableExtensionConfiguration(
+                check=1337,
+                default='I will always be there for you.',
+            )),
+        ])
+        self.assertEquals(expected, configuration.extensions)
 
     def test_load_should_load_one_extension_without_configuration(self) -> None:
-        with _build_minimal_app_dumped_configuration() as dumped_configuration:
-            dumped_configuration['extensions'] = {
-                DummyNonConfigurableExtension.name(): {},
-            }
-            configuration = Configuration.load(dumped_configuration)
-            expected = AppExtensionsConfiguration([
-                AppExtensionConfiguration(DummyNonConfigurableExtension, True),
-            ])
-            self.assertEquals(expected, configuration.extensions)
+        dumped_configuration = Configuration().dump()
+        dumped_configuration['extensions'] = {
+            DummyNonConfigurableExtension.name(): {},
+        }
+        configuration = Configuration()
+        configuration.load(dumped_configuration)
+        expected = AppExtensionsConfiguration([
+            AppExtensionConfiguration(DummyNonConfigurableExtension, True),
+        ])
+        self.assertEquals(expected, configuration.extensions)
 
     def test_load_extension_with_invalid_configuration_should_raise_error(self):
-        with _build_minimal_app_dumped_configuration() as dumped_configuration:
-            dumped_configuration['extensions'] = {
-                DummyConfigurableExtension.name(): 1337,
-            }
-            with self.assertRaises(ConfigurationError):
-                Configuration.load(dumped_configuration)
+        dumped_configuration = Configuration().dump()
+        dumped_configuration['extensions'] = {
+            DummyConfigurableExtension.name(): 1337,
+        }
+        with self.assertRaises(ConfigurationError):
+            configuration = Configuration()
+            configuration.load(dumped_configuration)
 
     def test_load_unknown_extension_type_name_should_error(self):
-        with _build_minimal_app_dumped_configuration() as dumped_configuration:
-            dumped_configuration['extensions'] = {
-                'non.existent.type': None,
-            }
-            with self.assertRaises(ConfigurationError):
-                Configuration.load(dumped_configuration)
+        dumped_configuration = Configuration().dump()
+        dumped_configuration['extensions'] = {
+            'non.existent.type': None,
+        }
+        with self.assertRaises(ConfigurationError):
+            configuration = Configuration()
+            configuration.load(dumped_configuration)
 
     def test_load_not_an_extension_type_name_should_error(self):
-        with _build_minimal_app_dumped_configuration() as dumped_configuration:
-            dumped_configuration['extensions'] = {
-                '%s.%s' % (self.__class__.__module__, self.__class__.__name__): None,
-            }
-            with self.assertRaises(ConfigurationError):
-                Configuration.load(dumped_configuration)
+        dumped_configuration = Configuration().dump()
+        dumped_configuration['extensions'] = {
+            '%s.%s' % (self.__class__.__module__, self.__class__.__name__): None,
+        }
+        with self.assertRaises(ConfigurationError):
+            configuration = Configuration()
+            configuration.load(dumped_configuration)
 
     def test_load_should_load_theme_background_id(self) -> None:
         background_image_id = 'my-favorite-picture'
-        with _build_minimal_app_dumped_configuration() as dumped_configuration:
-            dumped_configuration['theme'] = {
-                'background_image_id': background_image_id
-            }
-            configuration = Configuration.load(dumped_configuration)
-            self.assertEquals(background_image_id, configuration.theme.background_image_id)
+        dumped_configuration = Configuration().dump()
+        dumped_configuration['theme'] = {
+            'background_image_id': background_image_id
+        }
+        configuration = Configuration()
+        configuration.load(dumped_configuration)
+        self.assertEquals(background_image_id, configuration.theme.background_image_id)
 
     def test_load_should_error_if_invalid_config(self) -> None:
         dumped_configuration = {}
         with self.assertRaises(ConfigurationError):
-            Configuration.load(dumped_configuration)
+            configuration = Configuration()
+            configuration.load(dumped_configuration)
 
     def test_dump_should_dump_minimal(self) -> None:
-        with _build_minimal_app_configuration() as configuration:
-            dumped_configuration = Configuration.dump(configuration)
-            self.assertEquals(dumped_configuration['output'], str(configuration.output_directory_path))
-            self.assertEquals(dumped_configuration['base_url'], configuration.base_url)
-            self.assertEquals('Betty', configuration.title)
-            self.assertIsNone(configuration.author)
-            self.assertEquals(False, configuration.debug)
-            self.assertEquals('', configuration.root_path)
-            self.assertFalse(configuration.clean_urls)
-            self.assertFalse(configuration.content_negotiation)
+        configuration = Configuration()
+        dumped_configuration = Configuration.dump(configuration)
+        self.assertEquals(dumped_configuration['output'], str(configuration.output_directory_path))
+        self.assertEquals(dumped_configuration['base_url'], configuration.base_url)
+        self.assertEquals('Betty', configuration.title)
+        self.assertIsNone(configuration.author)
+        self.assertEquals(False, configuration.debug)
+        self.assertEquals('', configuration.root_path)
+        self.assertFalse(configuration.clean_urls)
+        self.assertFalse(configuration.content_negotiation)
 
     def test_dump_should_dump_title(self) -> None:
         title = 'My first Betty site'
-        with _build_minimal_app_configuration() as configuration:
-            configuration.title = title
-            dumped_configuration = Configuration.dump(configuration)
-            self.assertEquals(title, dumped_configuration['title'])
+        configuration = Configuration()
+        configuration.title = title
+        dumped_configuration = Configuration.dump(configuration)
+        self.assertEquals(title, dumped_configuration['title'])
 
     def test_dump_should_dump_author(self) -> None:
         author = 'Bart'
-        with _build_minimal_app_configuration() as configuration:
-            configuration.author = author
-            dumped_configuration = Configuration.dump(configuration)
-            self.assertEquals(author, dumped_configuration['author'])
+        configuration = Configuration()
+        configuration.author = author
+        dumped_configuration = Configuration.dump(configuration)
+        self.assertEquals(author, dumped_configuration['author'])
 
     def test_dump_should_dump_locale_locale(self) -> None:
         locale = 'nl-NL'
         locale_configuration = LocaleConfiguration(locale)
-        with _build_minimal_app_configuration() as configuration:
-            configuration.locales.replace([locale_configuration])
-            dumped_configuration = Configuration.dump(configuration)
-            self.assertListEqual([
-                {
-                    'locale': locale,
-                },
-            ], dumped_configuration['locales'])
+        configuration = Configuration()
+        configuration.locales.replace([locale_configuration])
+        dumped_configuration = Configuration.dump(configuration)
+        self.assertListEqual([
+            {
+                'locale': locale,
+            },
+        ], dumped_configuration['locales'])
 
     def test_dump_should_dump_locale_alias(self) -> None:
         locale = 'nl-NL'
         alias = 'nl'
         locale_configuration = LocaleConfiguration(locale, alias)
-        with _build_minimal_app_configuration() as configuration:
-            configuration.locales.replace([locale_configuration])
-            dumped_configuration = Configuration.dump(configuration)
-            self.assertListEqual([
-                {
-                    'locale': locale,
-                    'alias': alias,
-                },
-            ], dumped_configuration['locales'])
+        configuration = Configuration()
+        configuration.locales.replace([locale_configuration])
+        dumped_configuration = Configuration.dump(configuration)
+        self.assertListEqual([
+            {
+                'locale': locale,
+                'alias': alias,
+            },
+        ], dumped_configuration['locales'])
 
     def test_dump_should_dump_root_path(self) -> None:
         root_path = 'betty'
-        with _build_minimal_app_configuration() as configuration:
-            configuration.root_path = root_path
-            dumped_configuration = Configuration.dump(configuration)
-            self.assertEquals(root_path, dumped_configuration['root_path'])
+        configuration = Configuration()
+        configuration.root_path = root_path
+        dumped_configuration = Configuration.dump(configuration)
+        self.assertEquals(root_path, dumped_configuration['root_path'])
 
     def test_dump_should_dump_clean_urls(self) -> None:
         clean_urls = True
-        with _build_minimal_app_configuration() as configuration:
-            configuration.clean_urls = clean_urls
-            dumped_configuration = Configuration.dump(configuration)
-            self.assertEquals(clean_urls, dumped_configuration['clean_urls'])
+        configuration = Configuration()
+        configuration.clean_urls = clean_urls
+        dumped_configuration = Configuration.dump(configuration)
+        self.assertEquals(clean_urls, dumped_configuration['clean_urls'])
 
     def test_dump_should_dump_content_negotiation(self) -> None:
         content_negotiation = True
-        with _build_minimal_app_configuration() as configuration:
-            configuration.content_negotiation = content_negotiation
-            dumped_configuration = Configuration.dump(configuration)
-            self.assertEquals(content_negotiation, dumped_configuration['content_negotiation'])
+        configuration = Configuration()
+        configuration.content_negotiation = content_negotiation
+        dumped_configuration = Configuration.dump(configuration)
+        self.assertEquals(content_negotiation, dumped_configuration['content_negotiation'])
 
     @parameterized.expand([
         (True,),
         (False,),
     ])
     def test_dump_should_dump_debug(self, debug: bool) -> None:
-        with _build_minimal_app_configuration() as configuration:
-            configuration.debug = debug
-            dumped_configuration = Configuration.dump(configuration)
-            self.assertEquals(debug, dumped_configuration['debug'])
+        configuration = Configuration()
+        configuration.debug = debug
+        dumped_configuration = Configuration.dump(configuration)
+        self.assertEquals(debug, dumped_configuration['debug'])
 
     def test_dump_should_dump_assets_directory_path(self) -> None:
         with TemporaryDirectory() as assets_directory_path:
-            with _build_minimal_app_configuration() as configuration:
-                configuration.assets_directory_path = assets_directory_path
-                dumped_configuration = Configuration.dump(configuration)
-                self.assertEquals(assets_directory_path, dumped_configuration['assets'])
+            configuration = Configuration()
+            configuration.assets_directory_path = assets_directory_path
+            dumped_configuration = Configuration.dump(configuration)
+            self.assertEquals(assets_directory_path, dumped_configuration['assets'])
 
     def test_dump_should_dump_one_extension_with_configuration(self) -> None:
-        with _build_minimal_app_configuration() as configuration:
-            configuration.extensions.add(AppExtensionConfiguration(DummyConfigurableExtension, True, DummyConfigurableExtensionConfiguration(
-                check=1337,
-                default='I will always be there for you.',
-            )))
-            dumped_configuration = Configuration.dump(configuration)
-            expected = {
-                DummyConfigurableExtension.name(): {
-                    'enabled': True,
-                    'configuration': {
-                        'check': 1337,
-                        'default': 'I will always be there for you.',
-                    },
+        configuration = Configuration()
+        configuration.extensions.add(AppExtensionConfiguration(DummyConfigurableExtension, True, DummyConfigurableExtensionConfiguration(
+            check=1337,
+            default='I will always be there for you.',
+        )))
+        dumped_configuration = Configuration.dump(configuration)
+        expected = {
+            DummyConfigurableExtension.name(): {
+                'enabled': True,
+                'configuration': {
+                    'check': 1337,
+                    'default': 'I will always be there for you.',
                 },
-            }
-            self.assertEquals(expected, dumped_configuration['extensions'])
+            },
+        }
+        self.assertEquals(expected, dumped_configuration['extensions'])
 
     def test_dump_should_dump_one_extension_without_configuration(self) -> None:
-        with _build_minimal_app_configuration() as configuration:
-            configuration.extensions.add(AppExtensionConfiguration(DummyNonConfigurableExtension))
-            dumped_configuration = Configuration.dump(configuration)
-            expected = {
-                DummyNonConfigurableExtension.name(): {
-                    'enabled': True,
-                },
-            }
-            self.assertEquals(expected, dumped_configuration['extensions'])
+        configuration = Configuration()
+        configuration.extensions.add(AppExtensionConfiguration(DummyNonConfigurableExtension))
+        dumped_configuration = Configuration.dump(configuration)
+        expected = {
+            DummyNonConfigurableExtension.name(): {
+                'enabled': True,
+            },
+        }
+        self.assertEquals(expected, dumped_configuration['extensions'])
 
     def test_dump_should_error_if_invalid_config(self) -> None:
         dumped_configuration = {}
         with self.assertRaises(ConfigurationError):
-            Configuration.load(dumped_configuration)
+            configuration = Configuration()
+            configuration.load(dumped_configuration)
 
     def test_dump_should_dump_theme_background_id(self) -> None:
         background_image_id = 'my-favorite-picture'
-        with _build_minimal_app_configuration() as configuration:
-            configuration.theme.background_image_id = background_image_id
-            dumped_configuration = Configuration.dump(configuration)
-            self.assertEquals(background_image_id, dumped_configuration['theme']['background_image_id'])
+        configuration = Configuration()
+        configuration.theme.background_image_id = background_image_id
+        dumped_configuration = Configuration.dump(configuration)
+        self.assertEquals(background_image_id, dumped_configuration['theme']['background_image_id'])
 
 
 class DummyNonConfigurableExtension(Extension):
@@ -622,25 +636,28 @@ class DummyNonConfigurableExtension(Extension):
 
 
 class DummyConfigurableExtensionConfiguration(GenericConfiguration):
-    def __init__(self, check, default):
+    def __init__(self, check, default='I will always be there for you.'):
         super().__init__()
         self.check = check
         self.default = default
 
+    @classmethod
+    def default(cls) -> GenericConfiguration:
+        return cls(False)
+
     def __eq__(self, other):
         return self.check == other.check and self.default == other.default
 
-    @classmethod
-    def load(cls, dumped_configuration: Any) -> Configuration:
+    def load(self, dumped_configuration: Any) -> None:
         if not isinstance(dumped_configuration, dict):
             raise ConfigurationError
 
         if 'check' not in dumped_configuration:
             raise ConfigurationError
+        self.check = dumped_configuration['check']
 
-        default = dumped_configuration['default'] if 'default' in dumped_configuration else 'I will always be there for you.'
-
-        return cls(dumped_configuration['check'], default)
+        if 'default' in dumped_configuration:
+            self.default = dumped_configuration['default']
 
     def dump(self) -> Any:
         return {
@@ -649,14 +666,10 @@ class DummyConfigurableExtensionConfiguration(GenericConfiguration):
         }
 
 
-class DummyConfigurableExtension(ConfigurableExtension):
+class DummyConfigurableExtension(Extension, Configurable):
     @classmethod
-    def configuration_type(cls) -> Type[Configuration]:
+    def configuration_type(cls) -> Type[GenericConfiguration]:
         return DummyConfigurableExtensionConfiguration
-
-    @classmethod
-    def default_configuration(cls) -> DummyConfigurableExtensionConfiguration:
-        return DummyConfigurableExtensionConfiguration(None, None)
 
 
 class Tracker:
@@ -679,12 +692,15 @@ class ConfigurableExtensionConfiguration(GenericConfiguration):
         self.check = check
 
     @classmethod
-    def load(cls, dumped_configuration: Any) -> Configuration:
+    def default(cls) -> Configuration:
+        return cls(False)
+
+    def load(self, dumped_configuration: Any) -> None:
         if not isinstance(dumped_configuration, dict):
             raise ConfigurationError
         if 'check' not in dumped_configuration:
             raise ConfigurationError
-        return cls(dumped_configuration['check'])
+        self.check = dumped_configuration['check']
 
     def dump(self) -> Any:
         return {
@@ -692,11 +708,7 @@ class ConfigurableExtensionConfiguration(GenericConfiguration):
         }
 
 
-class ConfigurableExtension(app.ConfigurableExtension):
-    @classmethod
-    def default_configuration(cls) -> Configuration:
-        return ConfigurableExtensionConfiguration(None)
-
+class ConfigurableExtension(Extension, Configurable):
     @classmethod
     def configuration_type(cls) -> Type[Configuration]:
         return ConfigurableExtensionConfiguration
@@ -752,39 +764,29 @@ class AppTest(TestCase):
 
     @sync
     async def test_ancestry(self) -> None:
-        configuration = Configuration(**self._MINIMAL_CONFIGURATION_ARGS)
-        async with App(configuration) as sut:
+        async with App() as sut:
             self.assertIsInstance(sut.ancestry, Ancestry)
 
     @sync
-    async def test_configuration(self) -> None:
-        configuration = Configuration(**self._MINIMAL_CONFIGURATION_ARGS)
-        async with App(configuration) as sut:
-            self.assertEquals(configuration, sut.configuration)
-
-    @sync
     async def test_extensions_with_one_extension(self) -> None:
-        configuration = Configuration(**self._MINIMAL_CONFIGURATION_ARGS)
-        configuration.extensions.add(AppExtensionConfiguration(NonConfigurableExtension))
-        async with App(configuration) as sut:
+        async with App() as sut:
+            sut.configuration.extensions.add(AppExtensionConfiguration(NonConfigurableExtension))
             self.assertIsInstance(sut.extensions[NonConfigurableExtension], NonConfigurableExtension)
 
     @sync
     async def test_extensions_with_one_configurable_extension(self) -> None:
-        configuration = Configuration(**self._MINIMAL_CONFIGURATION_ARGS)
         check = 1337
-        configuration.extensions.add(AppExtensionConfiguration(ConfigurableExtension, True, ConfigurableExtensionConfiguration(
-            check=check,
-        )))
-        async with App(configuration) as sut:
+        async with App() as sut:
+            sut.configuration.extensions.add(AppExtensionConfiguration(ConfigurableExtension, True, ConfigurableExtensionConfiguration(
+                check=check,
+            )))
             self.assertIsInstance(sut.extensions[ConfigurableExtension], ConfigurableExtension)
             self.assertEquals(check, sut.extensions[ConfigurableExtension]._configuration.check)
 
     @sync
     async def test_extensions_with_one_extension_with_single_chained_dependency(self) -> None:
-        configuration = Configuration(**self._MINIMAL_CONFIGURATION_ARGS)
-        configuration.extensions.add(AppExtensionConfiguration(DependsOnNonConfigurableExtensionExtensionExtension))
-        async with App(configuration) as sut:
+        async with App() as sut:
+            sut.configuration.extensions.add(AppExtensionConfiguration(DependsOnNonConfigurableExtensionExtensionExtension))
             carrier = []
             await sut.dispatcher.dispatch(Tracker)(carrier)
             self.assertEquals(3, len(carrier))
@@ -796,10 +798,9 @@ class AppTest(TestCase):
 
     @sync
     async def test_extensions_with_multiple_extensions_with_duplicate_dependencies(self) -> None:
-        configuration = Configuration(**self._MINIMAL_CONFIGURATION_ARGS)
-        configuration.extensions.add(AppExtensionConfiguration(DependsOnNonConfigurableExtensionExtension))
-        configuration.extensions.add(AppExtensionConfiguration(AlsoDependsOnNonConfigurableExtensionExtension))
-        async with App(configuration) as sut:
+        async with App() as sut:
+            sut.configuration.extensions.add(AppExtensionConfiguration(DependsOnNonConfigurableExtensionExtension))
+            sut.configuration.extensions.add(AppExtensionConfiguration(AlsoDependsOnNonConfigurableExtensionExtension))
             carrier = []
             await sut.dispatcher.dispatch(Tracker)(carrier)
             self.assertEquals(3, len(carrier))
@@ -811,18 +812,16 @@ class AppTest(TestCase):
 
     @sync
     async def test_extensions_with_multiple_extensions_with_cyclic_dependencies(self) -> None:
-        configuration = Configuration(**self._MINIMAL_CONFIGURATION_ARGS)
-        configuration.extensions.add(AppExtensionConfiguration(CyclicDependencyOneExtension))
         with self.assertRaises(CyclicDependencyError):
-            async with App(configuration) as sut:
+            async with App() as sut:
+                sut.configuration.extensions.add(AppExtensionConfiguration(CyclicDependencyOneExtension))
                 sut.extensions
 
     @sync
     async def test_extensions_with_comes_before_with_other_extension(self) -> None:
-        configuration = Configuration(**self._MINIMAL_CONFIGURATION_ARGS)
-        configuration.extensions.add(AppExtensionConfiguration(NonConfigurableExtension))
-        configuration.extensions.add(AppExtensionConfiguration(ComesBeforeNonConfigurableExtensionExtension))
-        async with App(configuration) as sut:
+        async with App() as sut:
+            sut.configuration.extensions.add(AppExtensionConfiguration(NonConfigurableExtension))
+            sut.configuration.extensions.add(AppExtensionConfiguration(ComesBeforeNonConfigurableExtensionExtension))
             carrier = []
             await sut.dispatcher.dispatch(Tracker)(carrier)
             self.assertEquals(2, len(carrier))
@@ -832,9 +831,8 @@ class AppTest(TestCase):
 
     @sync
     async def test_extensions_with_comes_before_without_other_extension(self) -> None:
-        configuration = Configuration(**self._MINIMAL_CONFIGURATION_ARGS)
-        configuration.extensions.add(AppExtensionConfiguration(ComesBeforeNonConfigurableExtensionExtension))
-        async with App(configuration) as sut:
+        async with App() as sut:
+            sut.configuration.extensions.add(AppExtensionConfiguration(ComesBeforeNonConfigurableExtensionExtension))
             carrier = []
             await sut.dispatcher.dispatch(Tracker)(carrier)
             self.assertEquals(1, len(carrier))
@@ -843,10 +841,9 @@ class AppTest(TestCase):
 
     @sync
     async def test_extensions_with_comes_after_with_other_extension(self) -> None:
-        configuration = Configuration(**self._MINIMAL_CONFIGURATION_ARGS)
-        configuration.extensions.add(AppExtensionConfiguration(ComesAfterNonConfigurableExtensionExtension))
-        configuration.extensions.add(AppExtensionConfiguration(NonConfigurableExtension))
-        async with App(configuration) as sut:
+        async with App() as sut:
+            sut.configuration.extensions.add(AppExtensionConfiguration(ComesAfterNonConfigurableExtensionExtension))
+            sut.configuration.extensions.add(AppExtensionConfiguration(NonConfigurableExtension))
             carrier = []
             await sut.dispatcher.dispatch(Tracker)(carrier)
             self.assertEquals(2, len(carrier))
@@ -856,9 +853,8 @@ class AppTest(TestCase):
 
     @sync
     async def test_extensions_with_comes_after_without_other_extension(self) -> None:
-        configuration = Configuration(**self._MINIMAL_CONFIGURATION_ARGS)
-        configuration.extensions.add(AppExtensionConfiguration(ComesAfterNonConfigurableExtensionExtension))
-        async with App(configuration) as sut:
+        async with App() as sut:
+            sut.configuration.extensions.add(AppExtensionConfiguration(ComesAfterNonConfigurableExtensionExtension))
             carrier = []
             await sut.dispatcher.dispatch(Tracker)(carrier)
             self.assertEquals(1, len(carrier))
@@ -867,34 +863,30 @@ class AppTest(TestCase):
 
     @sync
     async def test_extensions_addition_to_configuration(self) -> None:
-        configuration = Configuration(**self._MINIMAL_CONFIGURATION_ARGS)
-        async with App(configuration) as sut:
+        async with App() as sut:
             # Get the extensions before making configuration changes to warm the cache.
             sut.extensions
-            configuration.extensions.add(AppExtensionConfiguration(NonConfigurableExtension))
+            sut.configuration.extensions.add(AppExtensionConfiguration(NonConfigurableExtension))
             self.assertIsInstance(sut.extensions[NonConfigurableExtension], NonConfigurableExtension)
 
     @sync
     async def test_extensions_removal_from_configuration(self) -> None:
-        configuration = Configuration(**self._MINIMAL_CONFIGURATION_ARGS)
-        configuration.extensions.add(AppExtensionConfiguration(NonConfigurableExtension))
-        async with App(configuration) as sut:
+        async with App() as sut:
+            sut.configuration.extensions.add(AppExtensionConfiguration(NonConfigurableExtension))
             # Get the extensions before making configuration changes to warm the cache.
             sut.extensions
-            del configuration.extensions[NonConfigurableExtension]
+            del sut.configuration.extensions[NonConfigurableExtension]
             self.assertNotIn(NonConfigurableExtension, sut.extensions)
 
     @sync
     async def test_assets_without_assets_directory_path(self) -> None:
-        configuration = Configuration(**self._MINIMAL_CONFIGURATION_ARGS)
-        async with App(configuration) as sut:
-            self.assertEquals(1, len(sut.assets.paths))
+        async with App() as sut:
+            self.assertEquals(1, len(sut.assets))
 
     @sync
     async def test_assets_with_assets_directory_path(self) -> None:
-        assets_directory_path = Path('/tmp/betty')
-        configuration = Configuration(**self._MINIMAL_CONFIGURATION_ARGS)
-        configuration.assets_directory_path = assets_directory_path
-        async with App(configuration) as sut:
-            self.assertEquals(2, len(sut.assets.paths))
-            self.assertEquals((assets_directory_path, None), sut.assets.paths[0])
+        with TemporaryDirectory() as assets_directory_path:
+            async with App() as sut:
+                sut.configuration.assets_directory_path = assets_directory_path
+                self.assertEquals(2, len(sut.assets))
+                self.assertEquals((Path(assets_directory_path), None), sut.assets.paths[0])

--- a/betty/tests/app/test_extension.py
+++ b/betty/tests/app/test_extension.py
@@ -1,7 +1,6 @@
-from tempfile import TemporaryDirectory
 from typing import Set, Type, Any
 
-from betty.app import App, Configuration
+from betty.app import App
 from betty.app.extension import Extension, ListExtensions, ExtensionDispatcher, build_extension_type_graph, \
     discover_extension_types
 from betty.asyncio import sync
@@ -34,17 +33,15 @@ class ExtensionDispatcherTest(TestCase):
 
     @sync
     async def test(self) -> None:
-        with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(output_directory_path, 'https://example.com')
-            async with App(configuration) as app:
-                extensions = ListExtensions([
-                    [self._MultiplyingExtension(app, 1), self._MultiplyingExtension(app, 3)],
-                    [self._MultiplyingExtension(app, 2), self._MultiplyingExtension(app, 4)]
-                ])
-                sut = ExtensionDispatcher(extensions)
-                actual_returned_somethings = await sut.dispatch(self._Multiplier)(3)
-                expected_returned_somethings = [3, 9, 6, 12]
-                self.assertEqual(expected_returned_somethings, actual_returned_somethings)
+        async with App() as app:
+            extensions = ListExtensions([
+                [self._MultiplyingExtension(app, 1), self._MultiplyingExtension(app, 3)],
+                [self._MultiplyingExtension(app, 2), self._MultiplyingExtension(app, 4)]
+            ])
+            sut = ExtensionDispatcher(extensions)
+            actual_returned_somethings = await sut.dispatch(self._Multiplier)(3)
+            expected_returned_somethings = [3, 9, 6, 12]
+            self.assertEqual(expected_returned_somethings, actual_returned_somethings)
 
 
 class BuildExtensionTypeGraphTest(TestCase):

--- a/betty/tests/cleaner/test__init__.py
+++ b/betty/tests/cleaner/test__init__.py
@@ -1,6 +1,4 @@
-from tempfile import TemporaryDirectory
-
-from betty.app import App, Configuration, AppExtensionConfiguration
+from betty.app import App, AppExtensionConfiguration
 from betty.asyncio import sync
 from betty.cleaner import clean, Cleaner
 from betty.load import load
@@ -14,14 +12,11 @@ class CleanerTest(TestCase):
     @sync
     async def test_post_parse(self) -> None:
         event = Event('E0', Birth())
-        with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(
-                output_directory_path, 'https://example.com')
-            configuration.extensions.add(AppExtensionConfiguration(Cleaner))
-            async with App(configuration) as app:
-                app.ancestry.entities.append(event)
-                await load(app)
-                self.assertEquals([], list(app.ancestry.entities[Event]))
+        async with App() as app:
+            app.configuration.extensions.add(AppExtensionConfiguration(Cleaner))
+            app.ancestry.entities.append(event)
+            await load(app)
+            self.assertEquals([], list(app.ancestry.entities[Event]))
 
 
 class CleanTest(TestCase):

--- a/betty/tests/demo/test__init__.py
+++ b/betty/tests/demo/test__init__.py
@@ -1,6 +1,4 @@
-from tempfile import TemporaryDirectory
-
-from betty.app import App, Configuration, AppExtensionConfiguration
+from betty.app import App, AppExtensionConfiguration
 from betty.asyncio import sync
 from betty.demo import Demo
 from betty.load import load
@@ -11,13 +9,11 @@ from betty.tests import TestCase
 class DemoTest(TestCase):
     @sync
     async def test_load(self):
-        with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(output_directory_path, 'https://example.com')
-            configuration.extensions.add(AppExtensionConfiguration(Demo))
-            async with App(configuration) as app:
-                await load(app)
-            self.assertNotEqual(0, len(app.ancestry.entities[Person]))
-            self.assertNotEqual(0, len(app.ancestry.entities[Place]))
-            self.assertNotEqual(0, len(app.ancestry.entities[Event]))
-            self.assertNotEqual(0, len(app.ancestry.entities[Source]))
-            self.assertNotEqual(0, len(app.ancestry.entities[Citation]))
+        async with App() as app:
+            app.configuration.extensions.add(AppExtensionConfiguration(Demo))
+            await load(app)
+        self.assertNotEqual(0, len(app.ancestry.entities[Person]))
+        self.assertNotEqual(0, len(app.ancestry.entities[Place]))
+        self.assertNotEqual(0, len(app.ancestry.entities[Event]))
+        self.assertNotEqual(0, len(app.ancestry.entities[Source]))
+        self.assertNotEqual(0, len(app.ancestry.entities[Citation]))

--- a/betty/tests/gramps/test___init__.py
+++ b/betty/tests/gramps/test___init__.py
@@ -3,7 +3,7 @@ from tempfile import TemporaryDirectory
 
 from reactives import ReactiveList
 
-from betty.app import App, Configuration, AppExtensionConfiguration
+from betty.app import App, AppExtensionConfiguration
 from betty.asyncio import sync
 from betty.gramps import Gramps, GrampsConfiguration
 from betty.gramps.config import FamilyTreeConfiguration
@@ -128,29 +128,27 @@ class GrampsTest(TestCase):
             with open(gramps_family_tree_two_path, mode='w') as f:
                 f.write(family_tree_two_xml)
 
-            with TemporaryDirectory() as output_directory_path:
-                configuration = Configuration(output_directory_path, 'https://example.com')
-                configuration.extensions.add(AppExtensionConfiguration(Gramps, True, GrampsConfiguration(
+            async with App() as app:
+                app.configuration.extensions.add(AppExtensionConfiguration(Gramps, True, GrampsConfiguration(
                     family_trees=ReactiveList([
                         FamilyTreeConfiguration(gramps_family_tree_one_path),
                         FamilyTreeConfiguration(gramps_family_tree_two_path),
                     ])
                 )))
-                async with App(configuration) as app:
-                    await load(app)
-                self.assertIn('O0001', app.ancestry.entities[File])
-                self.assertIn('O0002', app.ancestry.entities[File])
-                self.assertIn('I0001', app.ancestry.entities[Person])
-                self.assertIn('I0002', app.ancestry.entities[Person])
-                self.assertIn('P0001', app.ancestry.entities[Place])
-                self.assertIn('P0002', app.ancestry.entities[Place])
-                self.assertIn('E0001', app.ancestry.entities[Event])
-                self.assertIn('E0002', app.ancestry.entities[Event])
-                self.assertIn('S0001', app.ancestry.entities[Source])
-                self.assertIn('S0002', app.ancestry.entities[Source])
-                self.assertIn('R0001', app.ancestry.entities[Source])
-                self.assertIn('R0002', app.ancestry.entities[Source])
-                self.assertIn('C0001', app.ancestry.entities[Citation])
-                self.assertIn('C0002', app.ancestry.entities[Citation])
-                self.assertIn('N0001', app.ancestry.entities[Note])
-                self.assertIn('N0002', app.ancestry.entities[Note])
+                await load(app)
+            self.assertIn('O0001', app.ancestry.entities[File])
+            self.assertIn('O0002', app.ancestry.entities[File])
+            self.assertIn('I0001', app.ancestry.entities[Person])
+            self.assertIn('I0002', app.ancestry.entities[Person])
+            self.assertIn('P0001', app.ancestry.entities[Place])
+            self.assertIn('P0002', app.ancestry.entities[Place])
+            self.assertIn('E0001', app.ancestry.entities[Event])
+            self.assertIn('E0002', app.ancestry.entities[Event])
+            self.assertIn('S0001', app.ancestry.entities[Source])
+            self.assertIn('S0002', app.ancestry.entities[Source])
+            self.assertIn('R0001', app.ancestry.entities[Source])
+            self.assertIn('R0002', app.ancestry.entities[Source])
+            self.assertIn('C0001', app.ancestry.entities[Citation])
+            self.assertIn('C0002', app.ancestry.entities[Citation])
+            self.assertIn('N0001', app.ancestry.entities[Note])
+            self.assertIn('N0002', app.ancestry.entities[Note])

--- a/betty/tests/gramps/test_loader.py
+++ b/betty/tests/gramps/test_loader.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from parameterized import parameterized
 
-from betty.app import App, Configuration
+from betty.app import App
 from betty.asyncio import sync
 from betty.gramps.loader import load_xml, load_gpkg, load_gramps
 from betty.locale import Date
@@ -17,21 +17,17 @@ from betty.tests import TestCase
 class LoadGrampsTest(TestCase):
     @sync
     async def test_load_gramps(self):
-        with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(output_directory_path, 'https://example.com')
-            async with App(configuration) as app:
-                gramps_file_path = Path(__file__).parent / 'assets' / 'minimal.gramps'
-                load_gramps(app.ancestry, gramps_file_path)
+        async with App() as app:
+            gramps_file_path = Path(__file__).parent / 'assets' / 'minimal.gramps'
+            load_gramps(app.ancestry, gramps_file_path)
 
 
 class LoadGpkgTest(TestCase):
     @sync
     async def test_load_gpkg(self):
-        with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(output_directory_path, 'https://example.com')
-            async with App(configuration) as app:
-                gramps_file_path = Path(__file__).parent / 'assets' / 'minimal.gpkg'
-                load_gpkg(app.ancestry, gramps_file_path)
+        async with App() as app:
+            gramps_file_path = Path(__file__).parent / 'assets' / 'minimal.gpkg'
+            load_gpkg(app.ancestry, gramps_file_path)
 
 
 class LoadXmlTest(TestCase):
@@ -40,22 +36,18 @@ class LoadXmlTest(TestCase):
     async def setUpClass(cls) -> None:
         TestCase.setUpClass()
         # @todo Convert each test method to use self._load(), so we can remove this shared XML file.
-        with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(output_directory_path, 'https://example.com')
-            async with App(configuration) as app:
-                cls.ancestry = app.ancestry
-                xml_file_path = Path(__file__).parent / 'assets' / 'data.xml'
-                with open(xml_file_path) as f:
-                    load_xml(app.ancestry, f.read(), rootname(xml_file_path))
+        async with App() as app:
+            cls.ancestry = app.ancestry
+            xml_file_path = Path(__file__).parent / 'assets' / 'data.xml'
+            with open(xml_file_path) as f:
+                load_xml(app.ancestry, f.read(), rootname(xml_file_path))
 
     @sync
     async def load(self, xml: str) -> Ancestry:
-        with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(output_directory_path, 'https://example.com')
-            async with App(configuration) as app:
-                with TemporaryDirectory() as tree_directory_path:
-                    load_xml(app.ancestry, xml.strip(), Path(tree_directory_path))
-                    return app.ancestry
+        async with App() as app:
+            with TemporaryDirectory() as tree_directory_path:
+                load_xml(app.ancestry, xml.strip(), Path(tree_directory_path))
+                return app.ancestry
 
     def _load_partial(self, xml: str) -> Ancestry:
         return self.load("""
@@ -74,20 +66,16 @@ class LoadXmlTest(TestCase):
 
     @sync
     async def test_load_xml_with_string(self):
-        with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(output_directory_path, 'https://example.com')
-            async with App(configuration) as app:
-                gramps_file_path = Path(__file__).parent / 'assets' / 'minimal.xml'
-                with open(gramps_file_path) as f:
-                    load_xml(app.ancestry, f.read(), rootname(gramps_file_path))
+        async with App() as app:
+            gramps_file_path = Path(__file__).parent / 'assets' / 'minimal.xml'
+            with open(gramps_file_path) as f:
+                load_xml(app.ancestry, f.read(), rootname(gramps_file_path))
 
     @sync
     async def test_load_xml_with_file_path(self):
-        with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(output_directory_path, 'https://example.com')
-            async with App(configuration) as app:
-                gramps_file_path = Path(__file__).parent / 'assets' / 'minimal.xml'
-                load_xml(app.ancestry, gramps_file_path, rootname(gramps_file_path))
+        async with App() as app:
+            gramps_file_path = Path(__file__).parent / 'assets' / 'minimal.xml'
+            load_xml(app.ancestry, gramps_file_path, rootname(gramps_file_path))
 
     def test_place_should_include_name(self):
         place = self.ancestry.entities[Place]['P0000']

--- a/betty/tests/http_api_doc/test__init__.py
+++ b/betty/tests/http_api_doc/test__init__.py
@@ -1,10 +1,7 @@
-from pathlib import Path
-from tempfile import TemporaryDirectory
-
 from betty.asyncio import sync
 from betty.http_api_doc import HttpApiDoc
 from betty.generate import generate
-from betty.app import App, Configuration, AppExtensionConfiguration
+from betty.app import App, AppExtensionConfiguration
 from betty.tests import patch_cache, TestCase
 
 
@@ -12,11 +9,8 @@ class HttpApiDocTest(TestCase):
     @patch_cache
     @sync
     async def test(self):
-        with TemporaryDirectory() as output_directory_path_str:
-            output_directory_path = Path(output_directory_path_str)
-            configuration = Configuration(output_directory_path, 'https://ancestry.example.com')
-            configuration.extensions.add(AppExtensionConfiguration(HttpApiDoc))
-            async with App(configuration) as app:
-                await generate(app)
-            self.assertTrue((output_directory_path / 'www' / 'api' / 'index.html').is_file())
-            self.assertTrue((output_directory_path / 'www' / 'http-api-doc.js').is_file())
+        async with App() as app:
+            app.configuration.extensions.add(AppExtensionConfiguration(HttpApiDoc))
+            await generate(app)
+            self.assertTrue((app.configuration.output_directory_path / 'www' / 'api' / 'index.html').is_file())
+            self.assertTrue((app.configuration.output_directory_path / 'www' / 'http-api-doc.js').is_file())

--- a/betty/tests/maps/test__init__.py
+++ b/betty/tests/maps/test__init__.py
@@ -1,9 +1,7 @@
-from tempfile import TemporaryDirectory
-
 from betty.asyncio import sync
 from betty.generate import generate
 from betty.maps import Maps
-from betty.app import App, Configuration, AppExtensionConfiguration
+from betty.app import App, AppExtensionConfiguration
 from betty.tests import patch_cache, TestCase
 
 
@@ -11,15 +9,13 @@ class MapsTest(TestCase):
     @patch_cache
     @sync
     async def test_post_generate_event(self):
-        with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(output_directory_path, 'https://ancestry.example.com')
-            configuration.debug = True
-            configuration.extensions.add(AppExtensionConfiguration(Maps))
-            async with App(configuration) as app:
-                await generate(app)
-            with open(configuration.www_directory_path / 'maps.js', encoding='utf-8') as f:
+        async with App() as app:
+            app.configuration.debug = True
+            app.configuration.extensions.add(AppExtensionConfiguration(Maps))
+            await generate(app)
+            with open(app.configuration.www_directory_path / 'maps.js', encoding='utf-8') as f:
                 betty_js = f.read()
             self.assertIn('maps.js', betty_js)
-            with open(configuration.www_directory_path / 'maps.css', encoding='utf-8') as f:
+            with open(app.configuration.www_directory_path / 'maps.css', encoding='utf-8') as f:
                 betty_css = f.read()
             self.assertIn('.map', betty_css)

--- a/betty/tests/npm/test___init__.py
+++ b/betty/tests/npm/test___init__.py
@@ -1,10 +1,9 @@
 from subprocess import CalledProcessError
-from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 from parameterized import parameterized
 
-from betty.app import Configuration, App
+from betty.app import App
 from betty.asyncio import sync
 from betty.npm import _NpmRequirement
 from betty.tests import TestCase
@@ -13,10 +12,8 @@ from betty.tests import TestCase
 class NpmRequirementTest(TestCase):
     @sync
     async def test_check_met(self) -> None:
-        with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(output_directory_path, 'https://example.com')
-            async with App(configuration):
-                sut = _NpmRequirement.check()
+        async with App():
+            sut = _NpmRequirement.check()
         self.assertTrue(sut.met)
 
     @parameterized.expand([
@@ -27,8 +24,6 @@ class NpmRequirementTest(TestCase):
     @sync
     async def test_check_unmet(self, e: Exception, m_npm) -> None:
         m_npm.side_effect = e
-        with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(output_directory_path, 'https://example.com')
-            async with App(configuration):
-                sut = _NpmRequirement.check()
+        async with App():
+            sut = _NpmRequirement.check()
         self.assertFalse(sut.met)

--- a/betty/tests/privatizer/test__init__.py
+++ b/betty/tests/privatizer/test__init__.py
@@ -1,10 +1,9 @@
 from datetime import datetime
-from tempfile import TemporaryDirectory
 from typing import Optional
 
 from parameterized import parameterized
 
-from betty.app import App, Configuration, AppExtensionConfiguration
+from betty.app import App, AppExtensionConfiguration
 from betty.asyncio import sync
 from betty.load import load
 from betty.locale import Date, DateRange
@@ -95,15 +94,12 @@ class PrivatizerTest(TestCase):
         citation.private = True
         citation.files.append(citation_file)
 
-        with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(
-                output_directory_path, 'https://example.com')
-            configuration.extensions.add(AppExtensionConfiguration(Privatizer))
-            async with App(configuration) as app:
-                app.ancestry.entities.append(person)
-                app.ancestry.entities.append(source)
-                app.ancestry.entities.append(citation)
-                await load(app)
+        async with App() as app:
+            app.configuration.extensions.add(AppExtensionConfiguration(Privatizer))
+            app.ancestry.entities.append(person)
+            app.ancestry.entities.append(source)
+            app.ancestry.entities.append(citation)
+            await load(app)
 
             self.assertTrue(person.private)
             self.assertTrue(source_file.private)

--- a/betty/tests/test_config.py
+++ b/betty/tests/test_config.py
@@ -10,13 +10,13 @@ from betty.tests import TestCase
 class FromJsonTest(TestCase):
     def test_should_error_if_invalid_json(self) -> None:
         with self.assertRaises(ConfigurationError):
-            from_json('', Configuration)
+            from_json('')
 
 
 class FromYamlTest(TestCase):
     def test_should_error_if_invalid_yaml(self) -> None:
         with self.assertRaises(ConfigurationError):
-            from_yaml('"foo', Configuration)
+            from_yaml('"foo')
 
 
 class FromFileTest(TestCase):
@@ -32,4 +32,4 @@ class FromFileTest(TestCase):
     def test_should_error_unknown_format(self) -> None:
         with self._writes('', 'abc') as f:
             with self.assertRaises(ConfigurationError):
-                from_file(f, Configuration)
+                from_file(f, Configuration())

--- a/betty/tests/test_generate.py
+++ b/betty/tests/test_generate.py
@@ -8,7 +8,7 @@ import html5lib
 from lxml import etree
 
 from betty import json
-from betty.app import App, Configuration, LocaleConfiguration
+from betty.app import App, LocaleConfiguration
 from betty.asyncio import sync
 from betty.generate import generate
 from betty.model.ancestry import Person, Place, Source, PlaceName, File, Event, Citation
@@ -17,12 +17,6 @@ from betty.tests import TestCase
 
 
 class GenerateTestCase(TestCase):
-    def setUp(self):
-        self._output_directory = TemporaryDirectory()
-
-    def tearDown(self):
-        self._output_directory.cleanup()
-
     def assert_betty_html(self, app: App, url_path: str) -> Path:
         file_path = app.configuration.www_directory_path / Path(url_path.lstrip('/'))
         self.assertTrue(file_path.exists(), '%s does not exist' % file_path)
@@ -42,26 +36,20 @@ class GenerateTestCase(TestCase):
 class GenerateTest(GenerateTestCase):
     @sync
     async def test_front_page(self):
-        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
-        app = App(configuration)
-        async with app:
+        async with App() as app:
             await generate(app)
         self.assert_betty_html(app, '/index.html')
 
     @sync
     async def test_files(self):
-        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
-        app = App(configuration)
-        async with app:
+        async with App() as app:
             await generate(app)
         self.assert_betty_html(app, '/file/index.html')
         self.assert_betty_json(app, '/file/index.json', 'fileCollection')
 
     @sync
     async def test_file(self):
-        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
-        app = App(configuration)
-        async with app:
+        async with App() as app:
             with NamedTemporaryFile() as f:
                 file = File('FILE1', Path(f.name))
                 app.ancestry.entities.append(file)
@@ -71,18 +59,14 @@ class GenerateTest(GenerateTestCase):
 
     @sync
     async def test_places(self):
-        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
-        app = App(configuration)
-        async with app:
+        async with App() as app:
             await generate(app)
         self.assert_betty_html(app, '/place/index.html')
         self.assert_betty_json(app, '/place/index.json', 'placeCollection')
 
     @sync
     async def test_place(self):
-        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
-        app = App(configuration)
-        async with app:
+        async with App() as app:
             place = Place('PLACE1', [PlaceName('one')])
             app.ancestry.entities.append(place)
             await generate(app)
@@ -91,18 +75,14 @@ class GenerateTest(GenerateTestCase):
 
     @sync
     async def test_people(self):
-        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
-        app = App(configuration)
-        async with app:
+        async with App() as app:
             await generate(app)
         self.assert_betty_html(app, '/person/index.html')
         self.assert_betty_json(app, '/person/index.json', 'personCollection')
 
     @sync
     async def test_person(self):
-        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
-        app = App(configuration)
-        async with app:
+        async with App() as app:
             person = Person('PERSON1')
             app.ancestry.entities.append(person)
             await generate(app)
@@ -111,18 +91,14 @@ class GenerateTest(GenerateTestCase):
 
     @sync
     async def test_events(self):
-        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
-        app = App(configuration)
-        async with app:
+        async with App() as app:
             await generate(app)
         self.assert_betty_html(app, '/event/index.html')
         self.assert_betty_json(app, '/event/index.json', 'eventCollection')
 
     @sync
     async def test_event(self):
-        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
-        app = App(configuration)
-        async with app:
+        async with App() as app:
             event = Event('EVENT1', Birth())
             app.ancestry.entities.append(event)
             await generate(app)
@@ -131,11 +107,9 @@ class GenerateTest(GenerateTestCase):
 
     @sync
     async def test_citation(self):
-        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
-        app = App(configuration)
-        citation = Citation('CITATION1', Source('A Little Birdie'))
-        app.ancestry.entities.append(citation)
-        async with app:
+        async with App() as app:
+            citation = Citation('CITATION1', Source('A Little Birdie'))
+            app.ancestry.entities.append(citation)
             await generate(app)
         self.assert_betty_html(app, '/citation/%s/index.html' % citation.id)
         self.assert_betty_json(app, '/citation/%s/index.json' %
@@ -143,20 +117,16 @@ class GenerateTest(GenerateTestCase):
 
     @sync
     async def test_sources(self):
-        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
-        app = App(configuration)
-        async with app:
+        async with App() as app:
             await generate(app)
         self.assert_betty_html(app, '/source/index.html')
         self.assert_betty_json(app, '/source/index.json', 'sourceCollection')
 
     @sync
     async def test_source(self):
-        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
-        app = App(configuration)
-        source = Source('SOURCE1', 'A Little Birdie')
-        app.ancestry.entities.append(source)
-        async with app:
+        async with App() as app:
+            source = Source('SOURCE1', 'A Little Birdie')
+            app.ancestry.entities.append(source)
             await generate(app)
         self.assert_betty_html(app, '/source/%s/index.html' % source.id)
         self.assert_betty_json(app, '/source/%s/index.json' % source.id, 'source')
@@ -165,12 +135,12 @@ class GenerateTest(GenerateTestCase):
 class MultilingualTest(GenerateTestCase):
     @sync
     async def test_root_redirect(self):
-        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
-        configuration.locales.replace([
+        app = App()
+        app.configuration.locales.replace([
             LocaleConfiguration('nl'),
             LocaleConfiguration('en'),
         ])
-        async with App(configuration) as app:
+        async with app:
             await generate(app)
         with open(self.assert_betty_html(app, '/index.html')) as f:
             meta_redirect = '<meta http-equiv="refresh" content="0; url=/nl/index.html">'
@@ -178,12 +148,12 @@ class MultilingualTest(GenerateTestCase):
 
     @sync
     async def test_public_localized_resource(self):
-        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
-        configuration.locales.replace([
+        app = App()
+        app.configuration.locales.replace([
             LocaleConfiguration('nl'),
             LocaleConfiguration('en'),
         ])
-        async with App(configuration) as app:
+        async with app:
             await generate(app)
         with open(self.assert_betty_html(app, '/nl/index.html')) as f:
             translation_link = '<a href="/en/index.html" hreflang="en" lang="en" rel="alternate">English</a>'
@@ -194,15 +164,14 @@ class MultilingualTest(GenerateTestCase):
 
     @sync
     async def test_entity(self):
-        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
-        configuration.locales.replace([
+        app = App()
+        app.configuration.locales.replace([
             LocaleConfiguration('nl'),
             LocaleConfiguration('en'),
         ])
-        app = App(configuration)
-        person = Person('PERSON1')
-        app.ancestry.entities.append(person)
         async with app:
+            person = Person('PERSON1')
+            app.ancestry.entities.append(person)
             await generate(app)
         with open(self.assert_betty_html(app, '/nl/person/%s/index.html' % person.id)) as f:
             translation_link = '<a href="/en/person/%s/index.html" hreflang="en" lang="en" rel="alternate">English</a>' % person.id
@@ -215,28 +184,24 @@ class MultilingualTest(GenerateTestCase):
 class ResourceOverrideTest(GenerateTestCase):
     @sync
     async def test(self):
-        with TemporaryDirectory() as output_directory_path:
-            with TemporaryDirectory() as assets_directory_path_str:
-                assets_directory_path = Path(assets_directory_path_str)
-                localized_assets_directory_path = Path(assets_directory_path) / 'public' / 'localized'
-                localized_assets_directory_path.mkdir(parents=True)
-                with open(str(localized_assets_directory_path / 'index.html.j2'), 'w') as f:
-                    f.write('{% block page_content %}Betty was here{% endblock %}')
-                configuration = Configuration(
-                    output_directory_path, 'https://ancestry.example.com')
-                configuration.assets_directory_path = assets_directory_path
-                async with App(configuration) as app:
-                    await generate(app)
-            with open(configuration.www_directory_path / 'index.html') as f:
-                self.assertIn('Betty was here', f.read())
+        with TemporaryDirectory() as assets_directory_path_str:
+            assets_directory_path = Path(assets_directory_path_str)
+            localized_assets_directory_path = Path(assets_directory_path) / 'public' / 'localized'
+            localized_assets_directory_path.mkdir(parents=True)
+            with open(str(localized_assets_directory_path / 'index.html.j2'), 'w') as f:
+                f.write('{% block page_content %}Betty was here{% endblock %}')
+            async with App() as app:
+                app.configuration.assets_directory_path = assets_directory_path
+                await generate(app)
+        with open(app.configuration.www_directory_path / 'index.html') as f:
+            self.assertIn('Betty was here', f.read())
 
 
 @unittest.skipIf(sys.platform == 'win32', 'lxml cannot be installed directly onto vanilla Windows.')
 class SitemapGenerateTest(GenerateTestCase):
     @sync
     async def test_validate(self):
-        configuration = Configuration(self._output_directory.name, 'https://ancestry.example.com')
-        async with App(configuration) as app:
+        async with App() as app:
             await generate(app)
         with open(Path(__file__).parent / 'test_generate_assets' / 'sitemap.xsd') as f:
             schema_doc = etree.parse(f)

--- a/betty/tests/test_json.py
+++ b/betty/tests/test_json.py
@@ -1,10 +1,10 @@
 import json as stdjson
-from tempfile import TemporaryDirectory, NamedTemporaryFile
+from tempfile import NamedTemporaryFile
 
 from geopy import Point
 
 from betty import json
-from betty.app import App, Configuration, LocaleConfiguration
+from betty.app import App, LocaleConfiguration
 from betty.asyncio import sync
 from betty.json import JSONEncoder
 from betty.locale import Date, DateRange
@@ -17,16 +17,15 @@ from betty.tests import TestCase
 
 class JSONEncoderTest(TestCase):
     async def assert_encodes(self, expected, data, schema_definition: str):
-        with TemporaryDirectory() as output_directory:
-            configuration = Configuration(output_directory, 'https://example.com')
-            configuration.locales.replace([
-                LocaleConfiguration('en-US', 'en'),
-                LocaleConfiguration('nl-NL', 'nl'),
-            ])
-            async with App(configuration) as app:
-                encoded_data = stdjson.loads(stdjson.dumps(data, cls=JSONEncoder.get_factory(app)))
-            json.validate(encoded_data, schema_definition, app)
-            self.assertEquals(expected, encoded_data)
+        app = App()
+        app.configuration.locales.replace([
+            LocaleConfiguration('en-US', 'en'),
+            LocaleConfiguration('nl-NL', 'nl'),
+        ])
+        async with app:
+            encoded_data = stdjson.loads(stdjson.dumps(data, cls=JSONEncoder.get_factory(app)))
+        json.validate(encoded_data, schema_definition, app)
+        self.assertEquals(expected, encoded_data)
 
     @sync
     async def test_coordinates_should_encode(self):

--- a/betty/tests/test_locale.py
+++ b/betty/tests/test_locale.py
@@ -6,8 +6,9 @@ from typing import List, Optional
 
 from parameterized import parameterized
 
+from betty.fs import FileSystem
 from betty.locale import Localized, negotiate_localizeds, Date, format_datey, DateRange, Translations, negotiate_locale, \
-    Datey, open_translations, TranslationsInstallationError
+    Datey, TranslationsInstallationError, TranslationsRepository
 from betty.tests import TestCase
 
 
@@ -445,11 +446,13 @@ class FormatDateyTest(TestCase):
             self.assertEquals(expected, format_datey(datey, locale))
 
 
-class OpenTranslationsTest(TestCase):
-    def test(self) -> None:
+class TranslationsRepositoryTest(TestCase):
+    def test_getitem(self) -> None:
         locale = 'nl-NL'
         locale_path_name = 'nl_NL'
         with TemporaryDirectory() as assets_directory_path_str:
+            fs = FileSystem((assets_directory_path_str, None))
+            sut = TranslationsRepository(fs)
             assets_directory_path = Path(assets_directory_path_str)
             lc_messages_directory_path = assets_directory_path / 'locale' / locale_path_name / 'LC_MESSAGES'
             lc_messages_directory_path.mkdir(parents=True)
@@ -480,4 +483,4 @@ msgstr "Onderwerp"
 """
             with open(lc_messages_directory_path / 'betty.po', 'w') as f:
                 f.write(po)
-            self.assertIsInstance(open_translations(locale, assets_directory_path), NullTranslations)
+            self.assertIsInstance(sut[locale], NullTranslations)

--- a/betty/tests/test_openapi.py
+++ b/betty/tests/test_openapi.py
@@ -1,13 +1,12 @@
 import json as stdjson
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
 import jsonschema
 from parameterized import parameterized
 
 from betty.asyncio import sync
 from betty.openapi import build_specification
-from betty.app import App, Configuration
+from betty.app import App
 from betty.tests import TestCase
 
 
@@ -20,10 +19,7 @@ class BuildSpecificationTest(TestCase):
     async def test(self, content_negotiation: str):
         with open(Path(__file__).parent / 'test_openapi_assets' / 'schema.json') as f:
             schema = stdjson.load(f)
-        with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(
-                output_directory_path, 'https://example.com')
-            configuration.content_negotiation = content_negotiation
-            async with App(configuration) as app:
+            async with App() as app:
+                app.configuration.content_negotiation = content_negotiation
                 specification = build_specification(app)
         jsonschema.validate(specification, schema)

--- a/betty/tests/test_search.py
+++ b/betty/tests/test_search.py
@@ -1,8 +1,6 @@
-from tempfile import TemporaryDirectory
-
 from parameterized import parameterized
 
-from betty.app import App, Configuration, LocaleConfiguration
+from betty.app import App, LocaleConfiguration
 from betty.asyncio import sync
 from betty.model.ancestry import Person, Place, PlaceName, PersonName, File
 from betty.search import Index
@@ -12,15 +10,13 @@ from betty.tests import TestCase
 class IndexTest(TestCase):
     @sync
     async def test_empty(self):
-        with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(
-                output_directory_path, 'https://example.com')
-            configuration.locales.replace([
-                LocaleConfiguration('en-US', 'en'),
-                LocaleConfiguration('nl-NL', 'nl'),
-            ])
-            async with App(configuration) as app:
-                indexed = [item for item in Index(app).build()]
+        app = App()
+        app.configuration.locales.replace([
+            LocaleConfiguration('en-US', 'en'),
+            LocaleConfiguration('nl-NL', 'nl'),
+        ])
+        async with app:
+            indexed = [item for item in Index(app).build()]
 
         self.assertEquals([], indexed)
 
@@ -29,16 +25,14 @@ class IndexTest(TestCase):
         person_id = 'P1'
         person = Person(person_id)
 
-        with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(
-                output_directory_path, 'https://example.com')
-            configuration.locales.replace([
-                LocaleConfiguration('en-US', 'en'),
-                LocaleConfiguration('nl-NL', 'nl'),
-            ])
-            async with App(configuration) as app:
-                app.ancestry.entities.append(person)
-                indexed = [item for item in Index(app).build()]
+        app = App()
+        app.configuration.locales.replace([
+            LocaleConfiguration('en-US', 'en'),
+            LocaleConfiguration('nl-NL', 'nl'),
+        ])
+        async with app:
+            app.ancestry.entities.append(person)
+            indexed = [item for item in Index(app).build()]
 
         self.assertEquals([], indexed)
 
@@ -50,16 +44,14 @@ class IndexTest(TestCase):
         PersonName(person, individual_name)
         person.private = True
 
-        with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(
-                output_directory_path, 'https://example.com')
-            configuration.locales.replace([
-                LocaleConfiguration('en-US', 'en'),
-                LocaleConfiguration('nl-NL', 'nl'),
-            ])
-            async with App(configuration) as app:
-                app.ancestry.entities.append(person)
-                indexed = [item for item in Index(app).build()]
+        app = App()
+        app.configuration.locales.replace([
+            LocaleConfiguration('en-US', 'en'),
+            LocaleConfiguration('nl-NL', 'nl'),
+        ])
+        async with app:
+            app.ancestry.entities.append(person)
+            indexed = [item for item in Index(app).build()]
 
         self.assertEquals([], indexed)
 
@@ -74,14 +66,13 @@ class IndexTest(TestCase):
         person = Person(person_id)
         PersonName(person, individual_name)
 
-        with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(
-                output_directory_path, 'https://example.com')
-            configuration.locales.replace([
-                LocaleConfiguration('en-US', 'en'),
-                LocaleConfiguration('nl-NL', 'nl'),
-            ])
-            async with App(configuration).with_locale(locale) as app:
+        app = App()
+        app.configuration.locales.replace([
+            LocaleConfiguration('en-US', 'en'),
+            LocaleConfiguration('nl-NL', 'nl'),
+        ])
+        async with app:
+            with app.activate_locale(locale):
                 app.ancestry.entities.append(person)
                 indexed = [item for item in Index(app).build()]
 
@@ -99,14 +90,13 @@ class IndexTest(TestCase):
         person = Person(person_id)
         PersonName(person, None, affiliation_name)
 
-        with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(
-                output_directory_path, 'https://example.com')
-            configuration.locales.replace([
-                LocaleConfiguration('en-US', 'en'),
-                LocaleConfiguration('nl-NL', 'nl'),
-            ])
-            async with App(configuration).with_locale(locale) as app:
+        app = App()
+        app.configuration.locales.replace([
+            LocaleConfiguration('en-US', 'en'),
+            LocaleConfiguration('nl-NL', 'nl'),
+        ])
+        async with app:
+            with app.activate_locale(locale):
                 app.ancestry.entities.append(person)
                 indexed = [item for item in Index(app).build()]
 
@@ -125,14 +115,13 @@ class IndexTest(TestCase):
         person = Person(person_id)
         PersonName(person, individual_name, affiliation_name)
 
-        with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(
-                output_directory_path, 'https://example.com')
-            configuration.locales.replace([
-                LocaleConfiguration('en-US', 'en'),
-                LocaleConfiguration('nl-NL', 'nl'),
-            ])
-            async with App(configuration).with_locale(locale) as app:
+        app = App()
+        app.configuration.locales.replace([
+            LocaleConfiguration('en-US', 'en'),
+            LocaleConfiguration('nl-NL', 'nl'),
+        ])
+        async with app:
+            with app.activate_locale(locale):
                 app.ancestry.entities.append(person)
                 indexed = [item for item in Index(app).build()]
 
@@ -148,14 +137,13 @@ class IndexTest(TestCase):
         place_id = 'P1'
         place = Place(place_id, [PlaceName('Netherlands', 'en'), PlaceName('Nederland', 'nl')])
 
-        with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(
-                output_directory_path, 'https://example.com')
-            configuration.locales.replace([
-                LocaleConfiguration('en-US', 'en'),
-                LocaleConfiguration('nl-NL', 'nl'),
-            ])
-            async with App(configuration).with_locale(locale) as app:
+        app = App()
+        app.configuration.locales.replace([
+            LocaleConfiguration('en-US', 'en'),
+            LocaleConfiguration('nl-NL', 'nl'),
+        ])
+        async with app:
+            with app.activate_locale(locale):
                 app.ancestry.entities.append(place)
                 indexed = [item for item in Index(app).build()]
 
@@ -167,16 +155,14 @@ class IndexTest(TestCase):
         file_id = 'F1'
         file = File(file_id, __file__)
 
-        with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(
-                output_directory_path, 'https://example.com')
-            configuration.locales.replace([
-                LocaleConfiguration('en-US', 'en'),
-                LocaleConfiguration('nl-NL', 'nl'),
-            ])
-            async with App(configuration) as app:
-                app.ancestry.entities.append(file)
-                indexed = [item for item in Index(app).build()]
+        app = App()
+        app.configuration.locales.replace([
+            LocaleConfiguration('en-US', 'en'),
+            LocaleConfiguration('nl-NL', 'nl'),
+        ])
+        async with app:
+            app.ancestry.entities.append(file)
+            indexed = [item for item in Index(app).build()]
 
         self.assertEquals([], indexed)
 
@@ -190,14 +176,13 @@ class IndexTest(TestCase):
         file = File(file_id, __file__)
         file.description = '"file" is Dutch for "traffic jam"'
 
-        with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(
-                output_directory_path, 'https://example.com')
-            configuration.locales.replace([
-                LocaleConfiguration('en-US', 'en'),
-                LocaleConfiguration('nl-NL', 'nl'),
-            ])
-            async with App(configuration).with_locale(locale) as app:
+        app = App()
+        app.configuration.locales.replace([
+            LocaleConfiguration('en-US', 'en'),
+            LocaleConfiguration('nl-NL', 'nl'),
+        ])
+        async with app:
+            with app.activate_locale(locale):
                 app.ancestry.entities.append(file)
                 indexed = [item for item in Index(app).build()]
 

--- a/betty/tests/trees/test__init__.py
+++ b/betty/tests/trees/test__init__.py
@@ -1,9 +1,7 @@
-from tempfile import TemporaryDirectory
-
 from betty.asyncio import sync
 from betty.generate import generate
 from betty.trees import Trees
-from betty.app import App, Configuration, AppExtensionConfiguration
+from betty.app import App, AppExtensionConfiguration
 from betty.tests import patch_cache, TestCase
 
 
@@ -11,15 +9,13 @@ class TreesTest(TestCase):
     @patch_cache
     @sync
     async def test_post_generate_event(self):
-        with TemporaryDirectory() as output_directory_path:
-            configuration = Configuration(output_directory_path, 'https://ancestry.example.com')
-            configuration.debug = True
-            configuration.extensions.add(AppExtensionConfiguration(Trees))
-            async with App(configuration) as app:
-                await generate(app)
-            with open(configuration.www_directory_path / 'trees.js', encoding='utf-8') as f:
-                betty_js = f.read()
-            self.assertIn('trees.js', betty_js)
-            with open(configuration.www_directory_path / 'trees.css', encoding='utf-8') as f:
-                betty_css = f.read()
-            self.assertIn('.tree', betty_css)
+        async with App() as app:
+            app.configuration.debug = True
+            app.configuration.extensions.add(AppExtensionConfiguration(Trees))
+            await generate(app)
+        with open(app.configuration.www_directory_path / 'trees.js', encoding='utf-8') as f:
+            betty_js = f.read()
+        self.assertIn('trees.js', betty_js)
+        with open(app.configuration.www_directory_path / 'trees.css', encoding='utf-8') as f:
+            betty_css = f.read()
+        self.assertIn('.tree', betty_css)

--- a/betty/wikipedia/__init__.py
+++ b/betty/wikipedia/__init__.py
@@ -199,7 +199,7 @@ class _Populator:
         if link.description is None:
             # There are valid reasons for links in locales that aren't supported.
             with suppress(ValueError):
-                async with self._app.with_locale(link.locale):
+                with self._app.activate_locale(link.locale):
                     link.description = _('Read more on Wikipedia.')
         if entry is not None and link.label is None:
             link.label = entry.title


### PR DESCRIPTION
Let App initialize its own Configuration, and require all configuration to have defaults. This allows us to simplify hundreds of lines of code and remove a workaround from the GUI.