### PR TITLE
Give the application and project configuration classes more specific names

### DIFF
--- a/betty/app/__init__.py
+++ b/betty/app/__init__.py
@@ -68,7 +68,7 @@ class _AppExtensions(ListExtensions):
         self.react.trigger()
 
 
-class Configuration(FileBasedConfiguration):
+class AppConfiguration(FileBasedConfiguration):
     def __init__(self):
         super().__init__()
         self._locale = None
@@ -110,12 +110,12 @@ class Configuration(FileBasedConfiguration):
 
 
 @reactive
-class App(Acquirer, Releaser, Configurable[Configuration], ReactiveInstance):
+class App(Acquirer, Releaser, Configurable[AppConfiguration], ReactiveInstance):
     def __init__(self, *args, **kwargs):
         from betty.url import AppUrlGenerator, StaticPathUrlGenerator
 
         super().__init__(*args, **kwargs)
-        self._configuration = Configuration()
+        self._configuration = AppConfiguration()
         with suppress(FileNotFoundError):
             self.configuration.read()
 

--- a/betty/gui/app.py
+++ b/betty/gui/app.py
@@ -16,7 +16,7 @@ from betty.gui.serve import ServeDemoWindow
 from betty.gui.text import Text
 from betty.gui.locale import TranslationsLocaleCollector
 from betty.importlib import import_any
-from betty.project import Configuration
+from betty.project import ProjectConfiguration
 
 if TYPE_CHECKING:
     from betty.builtins import _
@@ -127,7 +127,7 @@ class BettyMainWindow(BettyWindow):
         )
         if not configuration_file_path:
             return
-        configuration = Configuration()
+        configuration = ProjectConfiguration()
         configuration.write(configuration_file_path)
         project_window = ProjectWindow(self._app)
         project_window.show()

--- a/betty/jinja2.py
+++ b/betty/jinja2.py
@@ -40,7 +40,7 @@ from betty.model import Entity, get_entity_type_name, GeneratedEntityId
 from betty.model.ancestry import File, Citation, HasLinks, HasFiles, Subject, Witness, Dated
 from betty.os import link_or_copy, PathLike
 from betty.path import rootname
-from betty.project import Configuration
+from betty.project import ProjectConfiguration
 from betty.render import Renderer
 from betty.search import Index
 from betty.string import camel_case_to_snake_case, camel_case_to_kebab_case, upper_camel_case_to_lower_camel_case
@@ -223,7 +223,7 @@ Template.environment_class = Environment
 
 
 class Jinja2Renderer(Renderer):
-    def __init__(self, environment: Environment, configuration: Configuration):
+    def __init__(self, environment: Environment, configuration: ProjectConfiguration):
         self._environment = environment
         self._configuration = configuration
 

--- a/betty/project.py
+++ b/betty/project.py
@@ -11,8 +11,8 @@ from reactives import reactive, scope
 from reactives.factory.type import ReactiveInstance
 
 from betty.app import Extension, ConfigurableExtension
-from betty.config import Configuration as GenericConfiguration, DumpedConfiguration, ConfigurationError, \
-    minimize_dumped_configuration, Configurable, FileBasedConfiguration
+from betty.config import Configuration, DumpedConfiguration, ConfigurationError, minimize_dumped_configuration, \
+    Configurable, FileBasedConfiguration
 from betty.error import ensure_context
 from betty.importlib import import_any
 from betty.locale import bcp_47_to_rfc_1766
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from betty.builtins import _
 
 
-class EntityReference(GenericConfiguration):
+class EntityReference(Configuration):
     def __init__(self, entity_type: Optional[Type[Entity]] = None, entity_id: Optional[str] = None, /, entity_type_constraint: Optional[Type[Entity]] = None):
         super().__init__()
         self._entity_type = entity_type
@@ -103,7 +103,7 @@ class EntityReference(GenericConfiguration):
         return self.entity_type == other.entity_type and self.entity_id == other.entity_id
 
 
-class EntityReferences(GenericConfiguration):
+class EntityReferences(Configuration):
     def __init__(self, entity_references: Optional[List[EntityReference]] = None, /, entity_type_constraint: Optional[Type[Entity]] = None):
         super().__init__()
         self._entity_type_constraint = entity_type_constraint
@@ -161,7 +161,7 @@ class EntityReferences(GenericConfiguration):
 
 @reactive
 class ProjectExtensionConfiguration(ReactiveInstance):
-    def __init__(self, extension_type: Type[Extension], enabled: bool = True, extension_configuration: Optional[GenericConfiguration] = None):
+    def __init__(self, extension_type: Type[Extension], enabled: bool = True, extension_configuration: Optional[Configuration] = None):
         super().__init__()
         self._extension_type = extension_type
         self._enabled = enabled
@@ -199,11 +199,11 @@ class ProjectExtensionConfiguration(ReactiveInstance):
         self._enabled = enabled
 
     @property
-    def extension_configuration(self) -> Optional[GenericConfiguration]:
+    def extension_configuration(self) -> Optional[Configuration]:
         return self._extension_configuration
 
 
-class ProjectExtensionsConfiguration(GenericConfiguration):
+class ProjectExtensionsConfiguration(Configuration):
     def __init__(self, configurations: Optional[Iterable[ProjectExtensionConfiguration]] = None):
         super().__init__()
         self._configurations: Dict[Type[Extension], ProjectExtensionConfiguration] = OrderedDict()
@@ -342,7 +342,7 @@ class LocaleConfiguration:
         return self._alias
 
 
-class LocalesConfiguration(GenericConfiguration):
+class LocalesConfiguration(Configuration):
     def __init__(self, configurations: Optional[Sequence[LocaleConfiguration]] = None):
         super().__init__()
         self._configurations: OrderedDict[str, LocaleConfiguration] = OrderedDict()
@@ -432,7 +432,7 @@ class LocalesConfiguration(GenericConfiguration):
         return dumped_configuration
 
 
-class ThemeConfiguration(GenericConfiguration):
+class ThemeConfiguration(Configuration):
     def __init__(self):
         super().__init__()
         self._background_image = EntityReference(entity_type_constraint=File)
@@ -467,7 +467,7 @@ class ThemeConfiguration(GenericConfiguration):
         })
 
 
-class Configuration(FileBasedConfiguration):
+class ProjectConfiguration(FileBasedConfiguration):
     def __init__(self, base_url: Optional[str] = None):
         super().__init__()
         self._base_url = 'https://example.com' if base_url is None else base_url
@@ -679,10 +679,10 @@ class Configuration(FileBasedConfiguration):
         return minimize_dumped_configuration(dumped_configuration)
 
 
-class Project(Configurable[Configuration]):
+class Project(Configurable[ProjectConfiguration]):
     def __init__(self):
         super().__init__()
-        self._configuration = Configuration()
+        self._configuration = ProjectConfiguration()
         self._ancestry = Ancestry()
 
     @property

--- a/betty/pytests/gui/test_app.py
+++ b/betty/pytests/gui/test_app.py
@@ -12,7 +12,7 @@ from betty.gui.app import WelcomeWindow, _AboutBettyWindow, BettyMainWindow, App
 from betty.gui.error import ExceptionError
 from betty.gui.project import ProjectWindow
 from betty.gui.serve import ServeDemoWindow
-from betty.project import Configuration
+from betty.project import ProjectConfiguration
 from betty.tests import patch_cache
 
 
@@ -74,7 +74,7 @@ class TestWelcomeWindow:
 
     def test_open_project_with_valid_file_should_show_project_window(self, assert_window, mocker, qtbot) -> None:
         title = 'My First Ancestry Site'
-        configuration = Configuration()
+        configuration = ProjectConfiguration()
         configuration.title = title
         configuration.write()
         with App() as app:

--- a/betty/pytests/gui/test_project.py
+++ b/betty/pytests/gui/test_project.py
@@ -10,12 +10,12 @@ from betty.gui.project import ProjectWindow, _AddLocaleWindow, _GenerateWindow, 
 from betty.gui.serve import ServeAppWindow
 from betty.locale import bcp_47_to_rfc_1766
 from betty.model import Entity
-from betty.project import Configuration, LocaleConfiguration, EntityReference
+from betty.project import ProjectConfiguration, LocaleConfiguration, EntityReference
 
 
 class TestProjectWindow:
     async def test_save_project_as_should_create_duplicate_configuration_file(self, mocker, navigate, qtbot, tmpdir) -> None:
-        configuration = Configuration()
+        configuration = ProjectConfiguration()
         configuration.write(tmpdir.join('betty.json'))
         with App() as app:
             sut = ProjectWindow(app)

--- a/betty/tests/__init__.py
+++ b/betty/tests/__init__.py
@@ -14,7 +14,7 @@ except ImportError:
 from jinja2 import Environment, Template
 
 from betty import fs
-from betty.app import App, Configuration as AppConfiguration
+from betty.app import App, AppConfiguration
 from betty.typing import Void
 
 T = TypeVar('T')

--- a/betty/tests/app/test___init__.py
+++ b/betty/tests/app/test___init__.py
@@ -3,7 +3,7 @@ from typing import Type, List, Set
 from betty.app import Extension, App, CyclicDependencyError
 from betty.app.extension import ConfigurableExtension
 from betty.asyncio import sync
-from betty.config import Configuration as GenericConfiguration, ConfigurationError, DumpedConfiguration
+from betty.config import Configuration, ConfigurationError, DumpedConfiguration
 from betty.project import ProjectExtensionConfiguration
 from betty.tests import TestCase
 
@@ -22,7 +22,7 @@ class NonConfigurableExtension(TrackableExtension):
     pass  # pragma: no cover
 
 
-class ConfigurableExtensionConfiguration(GenericConfiguration):
+class ConfigurableExtensionConfiguration(Configuration):
     def __init__(self, check):
         super().__init__()
         self.check = check

--- a/betty/tests/test_cli.py
+++ b/betty/tests/test_cli.py
@@ -12,7 +12,7 @@ from click.testing import CliRunner
 from betty import fs
 from betty.error import UserFacingError
 from betty.os import ChDir
-from betty.project import Configuration
+from betty.project import ProjectConfiguration
 from betty.serve import Server
 from betty.tests import patch_cache, TestCase
 
@@ -210,7 +210,7 @@ class _KeyboardInterruptedServer(Server):
 class ServeTest(TestCase):
     @patch('betty.serve.AppServer', new_callable=lambda: _KeyboardInterruptedServer)
     def test(self, m_server):
-        configuration = Configuration()
+        configuration = ProjectConfiguration()
         configuration.write()
         os.makedirs(configuration.www_directory_path)
         runner = CliRunner()

--- a/betty/url.py
+++ b/betty/url.py
@@ -7,7 +7,7 @@ from betty.locale import negotiate_locale
 from betty.model import Entity
 from betty.model.ancestry import PersonName, Event, Place, File, Source, Citation, Note, Person
 from betty.media_type import EXTENSIONS
-from betty.project import Configuration
+from betty.project import ProjectConfiguration
 
 
 class ContentNegotiationUrlGenerator:
@@ -29,7 +29,7 @@ class ContentNegotiationPathUrlGenerator(ContentNegotiationUrlGenerator):
 
 
 class StaticPathUrlGenerator(StaticUrlGenerator):
-    def __init__(self, configuration: Configuration):
+    def __init__(self, configuration: ProjectConfiguration):
         self._configuration = configuration
 
     def generate(self, resource: Any, absolute: bool = False, ) -> str:
@@ -81,7 +81,7 @@ class AppUrlGenerator(ContentNegotiationUrlGenerator):
             resource if isinstance(resource, str) else type(resource)))
 
 
-def _generate_from_path(configuration: Configuration, path: str, absolute: bool = False, locale: Optional[str] = None) -> str:
+def _generate_from_path(configuration: ProjectConfiguration, path: str, absolute: bool = False, locale: Optional[str] = None) -> str:
     if not isinstance(path, str):
         raise ValueError('%s is not a string.' % type(path))
     url = configuration.base_url if absolute else ''


### PR DESCRIPTION
Give the application and project configuration classes more specific names to prevent confusion from having too many Configuration types imported with different meanings.