### PR TITLE
Unblock thumbnail generation by replacing image.window_height/window_width

### DIFF
--- a/betty/jinja2.py
+++ b/betty/jinja2.py
@@ -422,10 +422,11 @@ def _execute_filter_image(image: Image, file_path: Path, cache_directory_path: P
     except FileNotFoundError:
         cache_directory_path.mkdir(exist_ok=True, parents=True)
         with image:
+            (originalWidth,originalHeight)=image.size
             if width is not None:
-                width = min(width, image.window_width)
+                width = min(width, originalWidth)
             if height is not None:
-                height = min(height, image.window_height)
+                height = min(height, originalHeight)
 
             if width is None:
                 size = height


### PR DESCRIPTION
When trying to generate a website, I saw that no picture thumbnail were generated. After looking around, it is due to image.window_height and image.window_width attributes not existing, which blocks the process. I simply replaced them by a call to image.size and then I could see my thumbnails.

What is strange is that it was failing silently, no exception raised. It should have raised an AttributeError exception, are they suppressed or caught somewhere in the application?