### PR TITLE
Update Github Actions

### DIFF
--- a/.github/workflows/tag-dev.yml
+++ b/.github/workflows/tag-dev.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Check out the source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Tag the development release
         run: git tag "$(git rev-parse --abbrev-ref HEAD)-dev"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,6 @@ jobs:
             os: ubuntu-latest
             python: '3.7'
             node: '15'
-          - name: 'Python 3.6'
-            os: ubuntu-latest
-            python: '3.6'
-            node: '15'
           - name: 'Node.js 16'
             os: ubuntu-latest
             python: '3.9'
@@ -52,15 +48,38 @@ jobs:
 
     steps:
       - name: Check out the source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      - name: Get the pip cache directory
+        run: echo "pip_cache_dir=$(pip cache dir)" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.pip_cache_dir }}
+          key: pip-${{ runner.os }}-${{ matrix.python }}-${{ hashFiles('./setup.py') }}
+          restore-keys: |
+            pip-${{ runner.os }}-${{ matrix.python }}-
+      - name: Get the npm cache directory
+        run: echo "npm_cache_dir=$(npm config get cache)" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Cache npm
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.npm_cache_dir }}
+          key: npm-${{ runner.os }}-${{ hashFiles('./package.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
       - name: Set up Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
 
@@ -77,35 +96,8 @@ jobs:
         run: choco install shellcheck
 
       - name: Build the development environment
-        run: |
-          ./bin/build-dev
+        run: ./bin/build-dev
         shell: bash
-
-      - name: Get the pip cache directory path
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: Cache the pip cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Get the npm cache directory path
-        id: npm-cache
-        run: |
-          echo "::set-output name=dir::$(npm config get cache)"
-
-      - name: Cache the npm cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.npm-cache.outputs.dir }}
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
 
       - name: Run the tests
         run: |
@@ -113,4 +105,4 @@ jobs:
         shell: bash
 
       - name: Upload code coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ secure**.
 ## Installation
 
 ### Requirements
-- **Python 3.6+**
+- **Python 3.7+**
 - Node.js 10+ (optional)
-- Linux, Mac OS, or Windows. On Windows you are encouraged to use Python 3.6, 3.7, or 3.8, because one of Betty's
+- Linux, Mac OS, or Windows. On Windows you are encouraged to use Python 3.7 or 3.8, because one of Betty's
   dependencies (libsass) cannot be installed automatically when using Python 3.9.
 
 ### Instructions

--- a/betty/site.py
+++ b/betty/site.py
@@ -11,10 +11,7 @@ from betty.lock import Locks
 from betty.render import Renderer, SequentialRenderer
 from betty.sass import SassRenderer
 
-try:
-    from contextlib import AsyncExitStack
-except ImportError:
-    from async_exit_stack import AsyncExitStack
+from contextlib import AsyncExitStack
 from copy import copy
 from os.path import abspath, dirname, join
 from typing import Type, Dict

--- a/betty/tests/__init__.py
+++ b/betty/tests/__init__.py
@@ -1,9 +1,5 @@
 import logging
-from contextlib import suppress
-try:
-    from contextlib import asynccontextmanager
-except ImportError:
-    from async_generator import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from tempfile import TemporaryDirectory
 from typing import Optional, Dict, Callable, Tuple
 import unittest
@@ -24,7 +20,7 @@ def patch_cache(f):
             f(*args, **kwargs)
         finally:
             betty._CACHE_DIRECTORY_PATH = original_cache_directory_path
-            # Pythons 3.6 and 3.7 do not allow the temporary directory to have been removed already.
+            # Python 3.7 does not allow the temporary directory to have been removed already.
             with suppress(FileNotFoundError):
                 cache_directory.cleanup()
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ SETUP = {
     'url': 'https://github.com/bartfeenstra/betty',
     'classifiers': [
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -41,11 +40,9 @@ SETUP = {
         'Natural Language :: English',
         'Natural Language :: Ukrainian',
     ],
-    'python_requires': '~= 3.6',
+    'python_requires': '~= 3.7',
     'install_requires': [
         'aiohttp ~= 3.7',
-        'async-exit-stack ~= 1.0; python_version <= "3.6"',
-        'async_generator ~= 1.10; python_version <= "3.6"',
         'babel ~= 2.9',
         'click ~= 7.1',
         'docker ~= 4.4',
@@ -73,8 +70,8 @@ SETUP = {
             'nose2 ~= 0.9',
             'parameterized ~= 0.7',
             'setuptools ~= 50.3',
-            'twine ~= 3.2',
-            'wheel ~= 0.36',
+            'twine ~= 4.0, >= 4.0.0',
+            'wheel ~= 0.40, >= 0.40.0',
         ],
     },
     'entry_points': {

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,11 @@
 [tox]
-envlist = py36, py37, py38, py39
+envlist = py37, py38, py39
 skip_missing_interpreters = true
 
 [testenv]
 install_command = {toxinidir}/bin/build-dev {opts} {packages}
 commands = {toxinidir}/bin/test
 usedevelop = True
-
-[testenv:py36]
-basepython = python3.6
 
 [testenv:py37]
 basepython = python3.7


### PR DESCRIPTION
This unfortunately requires the removal of Python 3.6 support as the GA infra no longer seems to support it out of the box, and we have limited maintenance hours available to replace this.