### PR TITLE
Fix Docker failures by adding a workaround for its urllib3 2 incompatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,8 @@ SETUP = {
         'babel ~= 2.9',
         'click ~= 7.1',
         'docker ~= 4.4',
+        # Work around https://github.com/docker/docker-py/issues/3113 by pinning urllib3 to a compatible version.
+        'urllib3 < 2',
         'geopy ~= 2.0',
         'jinja2 ~= 2.11',
         'jsonschema ~= 3.2',


### PR DESCRIPTION
Fix Docker failures by adding a workaround for its urllib3 2 incompatibility. See https://github.com/docker/docker-py/issues/3113.