### PR TITLE
Upgrade to Docker 6 (the Python package)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ SETUP = {
         'aiohttp ~= 3.7',
         'babel ~= 2.9',
         'click ~= 7.1',
-        'docker ~= 4.4',
+        'docker ~= 6.0, >= 6.0.1',
         # Work around https://github.com/docker/docker-py/issues/3113 by pinning urllib3 to a compatible version.
         'urllib3 < 2',
         'geopy ~= 2.0',


### PR DESCRIPTION
Upgrade to Docker 6 (the Python package) in order to meet pywin32 requirements.