### PR TITLE
Do not alias dill as pickle

### DIFF
--- a/betty/generate.py
+++ b/betty/generate.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import cast, AsyncContextManager, Callable, Generic, Any, Awaitable
 
 import aiofiles
-import dill as pickle
+import dill
 from aiofiles import os as aiofiles_os
 from aiofiles.threadpool.text import AsyncTextIOWrapper
 from typing_extensions import ParamSpec, Concatenate
@@ -88,7 +88,7 @@ class _ConcurrentGenerator:
         # generated before anything else.
         await _generate_static_public(app, app.locale)
         generation_queue = cls._build_generation_queue(app)
-        pickled_project = pickle.dumps(app.project)
+        pickled_project = dill.dumps(app.project)
         await asyncio.gather(*[
             app.wait_for_process(cls(generation_queue, pickled_project, app.async_concurrency, app.locale))
             for _ in range(0, app.concurrency)
@@ -131,7 +131,7 @@ class _ConcurrentGenerator:
 
     @sync
     async def __call__(self) -> None:
-        self._project = pickle.loads(self._pickled_project)
+        self._project = dill.loads(self._pickled_project)
         self._apps: dict[str | None, App] = {
             None: App(project=self._project),
         }

--- a/betty/tests/model/test___init__.py
+++ b/betty/tests/model/test___init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Iterator
 
-import dill as pickle
+import dill
 import pytest
 
 from betty.model import get_entity_type_name, Entity, get_entity_type, _EntityTypeAssociation, \
@@ -677,7 +677,7 @@ class TestFlattenedEntityCollection:
         flattened_entities.add_association(self._ManyToMany_Many, entity_many.id, 'other_many', self._ManyToMany_OtherMany, entity_other_many.id)
 
         # Assert the result is pickleable.
-        pickle.dumps(flattened_entities)
+        dill.dumps(flattened_entities)
 
         unflattened_entities = flattened_entities.unflatten()
 
@@ -702,7 +702,7 @@ class TestFlattenedEntityCollection:
         assert entity_many in entity_other_many.many
         assert entity_other_many in entity_many.other_many
         # Assert the result is pickleable.
-        pickle.dumps(flattened_entities)
+        dill.dumps(flattened_entities)
 
         unflattened_entities = flattened_entities.unflatten()
 
@@ -727,7 +727,7 @@ class TestFlattenedEntityCollection:
         assert entity_many is entity_one.many
         assert entity_other_many is entity_one.other_many
         # Assert the result is pickleable.
-        pickle.dumps(flattened_entities)
+        dill.dumps(flattened_entities)
 
         unflattened_entities: tuple[
             TestFlattenedEntityCollection._ManyToOneToMany_Many,
@@ -802,7 +802,7 @@ class TestOneToOne:
 
         entity_one.other_one = entity_other_one
 
-        unpickled_entity_one, unpickled_entity_other_one = pickle.loads(pickle.dumps((entity_one, entity_other_one)))
+        unpickled_entity_one, unpickled_entity_other_one = dill.loads(dill.dumps((entity_one, entity_other_one)))
         assert entity_other_one.id == unpickled_entity_one.other_one.id
         assert entity_one.id == unpickled_entity_other_one.one.id
 
@@ -839,7 +839,7 @@ class TestManyToOne:
         entity_one = self._One()
 
         entity_many.one = entity_one
-        unpickled_entity_many, unpickled_entity_one = pickle.loads(pickle.dumps((entity_many, entity_one)))
+        unpickled_entity_many, unpickled_entity_one = dill.loads(dill.dumps((entity_many, entity_one)))
         assert unpickled_entity_many.id == unpickled_entity_one.many[0].id
         assert unpickled_entity_one.id == unpickled_entity_many.one.id
 
@@ -872,7 +872,7 @@ class TestToMany:
         entity_one = self._One()
         entity_other = self._Many()
         entity_one.many.append(entity_other)
-        unpickled_entity_one = pickle.loads(pickle.dumps(entity_one))
+        unpickled_entity_one = dill.loads(dill.dumps(entity_one))
         assert entity_other.id == unpickled_entity_one.many[0].id
 
 
@@ -909,7 +909,7 @@ class TestOneToMany:
 
         entity_one.many.append(entity_many)
 
-        unpickled_entity_one, unpickled_entity_many = pickle.loads(pickle.dumps((entity_one, entity_many)))
+        unpickled_entity_one, unpickled_entity_many = dill.loads(dill.dumps((entity_one, entity_many)))
         assert entity_many.id == unpickled_entity_one.many[0].id
         assert entity_one.id == unpickled_entity_many.one.id
 
@@ -947,7 +947,7 @@ class TestManyToMany:
 
         entity_many.other_many.append(entity_other_many)
 
-        unpickled_entity_many, unpickled_entity_other_many = pickle.loads(pickle.dumps((entity_many, entity_other_many)))
+        unpickled_entity_many, unpickled_entity_other_many = dill.loads(dill.dumps((entity_many, entity_other_many)))
         assert entity_many.id == unpickled_entity_other_many.many[0].id
         assert entity_other_many.id == unpickled_entity_many.other_many[0].id
 
@@ -995,6 +995,6 @@ class TestManyToOneToMany:
         entity_one.left_many = entity_left_many
         entity_one.right_many = entity_right_many
 
-        unpickled_entity_one = pickle.loads(pickle.dumps(entity_one))
+        unpickled_entity_one = dill.loads(dill.dumps(entity_one))
         assert entity_left_many.id == unpickled_entity_one.left_many.id
         assert entity_right_many.id == unpickled_entity_one.right_many.id

--- a/betty/tests/model/test_ancestry.py
+++ b/betty/tests/model/test_ancestry.py
@@ -4,7 +4,7 @@ from tempfile import NamedTemporaryFile
 from typing import Any
 from unittest.mock import Mock
 
-import dill as pickle
+import dill
 import pytest
 from geopy import Point
 
@@ -749,7 +749,7 @@ class TestAncestry:
         entity = DummyEntity()
         sut = Ancestry()
         sut.entities.append(entity)
-        unpickled_sut = pickle.loads(pickle.dumps(sut))
+        unpickled_sut = dill.loads(dill.dumps(sut))
         assert 1 == len(unpickled_sut.entities)
         assert entity.id == unpickled_sut.entities[0].id
 

--- a/betty/tests/test_project.py
+++ b/betty/tests/test_project.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Iterable
 
-import dill as pickle
+import dill
 import pytest
 from reactives.tests import assert_reactor_called, assert_scope_empty
 from typing_extensions import Self
@@ -443,7 +443,7 @@ class TestProjectConfiguration:
         sut = ProjectConfiguration()
         sut.extensions.append(ExtensionConfiguration(Extension, True, None))
         sut.locales.append(LocaleConfiguration('nl-NL', 'nl'))
-        pickle.dumps(sut)
+        dill.dumps(sut)
 
     def test_base_url(self) -> None:
         sut = ProjectConfiguration()


### PR DESCRIPTION
Do not alias dill as pickle, so it is clear that we require the dill API.