### PR TITLE
Fix an outdated .stylelingignore rule

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,1 +1,1 @@
-betty/*/assets/betty.extension.npm._Npm/build/*
+betty/**/assets/betty.extension.npm._Npm/build/*


### PR DESCRIPTION
Fix an outdated .stylelingignore rule that caused Styleint to erroneously test build artifacts.