### PR TITLE
Require Python 3.11, and drop support for Python 3.9 and 3.10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Build the development environment
         run: ./bin/build-dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,12 +22,6 @@ jobs:
           - name: 'Python 3.11'
             os: ubuntu-latest
             python: '3.11'
-          - name: 'Python 3.10'
-            os: ubuntu-latest
-            python: '3.10'
-          - name: 'Python 3.9'
-            os: ubuntu-latest
-            python: '3.9'
           - name: 'Mac OS'
             os: macos-latest
             python: '3.12'

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For Windows, download [betty.exe](https://github.com/bartfeenstra/betty/releases
 
 #### Requirements
 
-- **Python 3.9+**
+- **Python 3.11+**
 - [Node.js](https://nodejs.org/) (optional)
 
 #### Instructions
@@ -312,7 +312,7 @@ directory.
 
 ### Requirements
 
-- **Python 3.9+**
+- **Python 3.11+**
 - [Node.js](https://nodejs.org/)
 - [ShellCheck](https://www.shellcheck.net/)
 - [Xvfb](https://x.org/releases/X11R7.7/doc/man/man1/Xvfb.1.xhtml)

--- a/betty/app/__init__.py
+++ b/betty/app/__init__.py
@@ -9,12 +9,11 @@ from contextlib import suppress
 from graphlib import CycleError, TopologicalSorter
 from pathlib import Path
 from types import TracebackType
-from typing import TYPE_CHECKING, Callable, Mapping, Any, Awaitable
+from typing import TYPE_CHECKING, Callable, Mapping, Any, Awaitable, ParamSpec, Self
 
 import aiohttp
 from reactives.instance import ReactiveInstance
 from reactives.instance.property import reactive_property
-from typing_extensions import Self, ParamSpec
 
 from betty.app.extension import ListExtensions, Extension, Extensions, build_extension_type_graph, \
     CyclicDependencyError, ExtensionDispatcher, ConfigurableExtension, discover_extension_types

--- a/betty/app/extension/__init__.py
+++ b/betty/app/extension/__init__.py
@@ -2,16 +2,14 @@ from __future__ import annotations
 
 import asyncio
 import functools
-import sys
 from collections import defaultdict
 from importlib.metadata import entry_points, EntryPoint
 from pathlib import Path
 from typing import Any, TypeVar, Iterable, TYPE_CHECKING, Generic, \
-    Iterator, Sequence
+    Iterator, Sequence, Self
 
 from reactives import scope
 from reactives.instance import ReactiveInstance
-from typing_extensions import Self
 
 from betty import fs
 from betty.app.extension.requirement import Requirement
@@ -337,10 +335,7 @@ def _extend_extension_type_graph(graph: ExtensionTypeGraph, extension_type: type
 
 def discover_extension_types() -> set[type[Extension]]:
     betty_entry_points: Sequence[EntryPoint]
-    if (sys.version_info.major, sys.version_info.minor) >= (3, 10):
-        betty_entry_points = entry_points(  # type: ignore[assignment, unused-ignore]
-            group='betty.extensions',  # type: ignore[call-arg, unused-ignore]
-        )
-    else:
-        betty_entry_points = entry_points()['betty.extensions']
+    betty_entry_points = entry_points(  # type: ignore[assignment, unused-ignore]
+        group='betty.extensions',  # type: ignore[call-arg, unused-ignore]
+    )
     return {import_any(betty_entry_point.value) for betty_entry_point in betty_entry_points}

--- a/betty/app/extension/requirement.py
+++ b/betty/app/extension/requirement.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 from textwrap import indent
-from typing import cast, Any
-
-from typing_extensions import Self
+from typing import cast, Any, Self
 
 from betty.error import UserFacingError
 from betty.locale import Localizer, Localizable

--- a/betty/asyncio.py
+++ b/betty/asyncio.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 import asyncio
 from functools import wraps
 from threading import Thread
-from typing import Callable, Awaitable, TypeVar, Generic, cast
-
-from typing_extensions import ParamSpec
+from typing import Callable, Awaitable, TypeVar, Generic, cast, ParamSpec
 
 P = ParamSpec('P')
 T = TypeVar('T')

--- a/betty/cli.py
+++ b/betty/cli.py
@@ -7,12 +7,11 @@ import time
 from contextlib import suppress, contextmanager
 from functools import wraps
 from pathlib import Path
-from typing import Callable, TypeVar, cast, Iterator, Awaitable
+from typing import Callable, TypeVar, cast, Iterator, Awaitable, ParamSpec, Concatenate
 
 import click
 from PyQt6.QtWidgets import QMainWindow
 from click import get_current_context, Context, Option, Command, Parameter
-from typing_extensions import ParamSpec, Concatenate
 
 from betty import about, generate, load
 from betty.extension import demo

--- a/betty/concurrent.py
+++ b/betty/concurrent.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 from concurrent.futures._base import Executor, wait, Future
-from typing import Any, Iterator, Callable, TypeVar, Iterable
-
-from typing_extensions import ParamSpec
+from typing import Any, Iterator, Callable, TypeVar, Iterable, ParamSpec
 
 T = TypeVar('T')
 U = TypeVar('U')

--- a/betty/config.py
+++ b/betty/config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from reprlib import recursive_repr
 from tempfile import TemporaryDirectory
 from typing import Generic, Iterable, Iterator, SupportsIndex, Hashable, \
-    MutableSequence, MutableMapping, TypeVar, Any, Sequence, overload, cast
+    MutableSequence, MutableMapping, TypeVar, Any, Sequence, overload, cast, Self, TypeAlias
 
 import aiofiles
 from aiofiles.os import makedirs
@@ -14,7 +14,6 @@ from ordered_set import OrderedSet
 from reactives import scope
 from reactives.instance import ReactiveInstance
 from reactives.instance.property import reactive_property
-from typing_extensions import Self, TypeAlias
 
 from betty.asyncio import wait, sync
 from betty.classtools import repr_instance
@@ -158,7 +157,7 @@ class FileBasedConfiguration(Configuration):
         self._configuration_file_path = None
 
 
-ConfigurationKey: TypeAlias = 'SupportsIndex | Hashable | type[Any]'
+ConfigurationKey: TypeAlias = SupportsIndex | Hashable | type[Any]
 ConfigurationKeyT = TypeVar('ConfigurationKeyT', bound=ConfigurationKey)
 
 

--- a/betty/deriver.py
+++ b/betty/deriver.py
@@ -87,7 +87,7 @@ class Deriver(Localizable):
             dates_derived = False
             # We know _get_derivable_events() only returns events without a date or a with a date range, but Python
             # does not let us express that in a(n intersection) type, so we must instead cast here.
-            derivable_date = cast('DateRange | None', derivable_event.date)
+            derivable_date = cast(DateRange | None, derivable_event.date)
 
             if derivable_date is None or derivable_date.end is None:
                 dates_derived = dates_derived or _ComesBeforeDateDeriver.derive(person, derivable_event, comes_before_event_types)

--- a/betty/extension/cotton_candy/__init__.py
+++ b/betty/extension/cotton_candy/__init__.py
@@ -4,13 +4,12 @@ import logging
 import re
 from pathlib import Path
 from shutil import copy2
-from typing import Any, Callable, Iterable, cast
+from typing import Any, Callable, Iterable, cast, Self
 
 from PyQt6.QtWidgets import QWidget
 from aiofiles.os import makedirs
 from reactives.instance import ReactiveInstance
 from reactives.instance.property import reactive_property
-from typing_extensions import Self
 
 from betty.app.extension import ConfigurableExtension, Extension, Theme
 from betty.config import Configuration

--- a/betty/extension/gramps/config.py
+++ b/betty/extension/gramps/config.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Iterable, Any
+from typing import Iterable, Any, Self
 
 from reactives.instance.property import reactive_property
-from typing_extensions import Self
 
 from betty.config import Configuration, ConfigurationSequence
 from betty.locale import Localizer

--- a/betty/generate.py
+++ b/betty/generate.py
@@ -9,14 +9,13 @@ import queue
 import shutil
 from contextlib import suppress
 from pathlib import Path
-from typing import cast, AsyncContextManager, Callable, Generic, Any, Awaitable
+from typing import cast, AsyncContextManager, Callable, Generic, Any, Awaitable, ParamSpec, Concatenate
 
 import aiofiles
 import dill
 from aiofiles import os as aiofiles_os
 from aiofiles.os import makedirs
 from aiofiles.threadpool.text import AsyncTextIOWrapper
-from typing_extensions import ParamSpec, Concatenate
 
 from betty.app import App
 from betty.asyncio import sync

--- a/betty/gui/error.py
+++ b/betty/gui/error.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 import functools
 import traceback
 from types import TracebackType
-from typing import Callable, Any, TypeVar, Generic, TYPE_CHECKING
+from typing import Callable, Any, TypeVar, Generic, TYPE_CHECKING, ParamSpec
 
 from PyQt6.QtCore import QMetaObject, Qt, Q_ARG, QObject
 from PyQt6.QtGui import QCloseEvent, QIcon
 from PyQt6.QtWidgets import QWidget, QMessageBox
-from typing_extensions import ParamSpec
 
 from betty.app import App
 from betty.gui.locale import LocalizedMessageBox

--- a/betty/locale.py
+++ b/betty/locale.py
@@ -11,7 +11,7 @@ from contextlib import suppress
 from functools import total_ordering, lru_cache
 from io import StringIO
 from pathlib import Path
-from typing import Any, Iterator, Sequence, Mapping, Callable
+from typing import Any, Iterator, Sequence, Mapping, Callable, TypeAlias
 
 import babel
 from aiofiles.os import makedirs
@@ -20,7 +20,6 @@ from babel import dates, Locale
 from babel.messages.frontend import CommandLineInterface
 from langcodes import Language
 from polib import pofile
-from typing_extensions import TypeAlias
 
 from betty import fs
 from betty.fs import hashfile, FileSystem, ASSETS_DIRECTORY_PATH, ROOT_DIRECTORY_PATH
@@ -69,7 +68,7 @@ def to_locale(locale: Localey) -> str:
     )
 
 
-Localey: TypeAlias = 'str | Locale'
+Localey: TypeAlias = str | Locale
 
 
 def get_data(locale: Localey) -> Locale:
@@ -332,10 +331,10 @@ class DateRange:
         return (self.start, self.end, self.start_is_boundary, self.end_is_boundary) == (other.start, other.end, other.start_is_boundary, other.end_is_boundary)
 
 
-Datey: TypeAlias = 'Date | DateRange'
+Datey: TypeAlias = Date | DateRange
 DatePartsFormatters: TypeAlias = Mapping[tuple[bool, bool, bool], str]
-DateFormatters: TypeAlias = Mapping[tuple['bool | None'], str]
-DateRangeFormatters: TypeAlias = Mapping[tuple['bool | None', 'bool | None', 'bool | None', 'bool | None'], str]
+DateFormatters: TypeAlias = Mapping[tuple[bool | None], str]
+DateRangeFormatters: TypeAlias = Mapping[tuple[bool | None, bool | None, bool | None, bool | None], str]
 
 
 class Localizer:

--- a/betty/model/__init__.py
+++ b/betty/model/__init__.py
@@ -5,10 +5,8 @@ import functools
 from collections import defaultdict
 from contextlib import contextmanager
 from reprlib import recursive_repr
-from typing import TypeVar, Generic, Iterable, Any, overload, cast, Iterator, Union, Callable
+from typing import TypeVar, Generic, Iterable, Any, overload, cast, Iterator, Callable, Self, TypeAlias
 from uuid import uuid4
-
-from typing_extensions import Self, TypeAlias
 
 from betty.classtools import repr_instance
 from betty.importlib import import_any, fully_qualified_type_name
@@ -468,7 +466,7 @@ class ManyToMany(Generic[OwnerT, AssociateT], BidirectionalToManyEntityTypeAssoc
     pass
 
 
-ToAny: TypeAlias = Union[ToOneEntityTypeAssociation[OwnerT, AssociateT], ToManyEntityTypeAssociation[OwnerT, AssociateT]]
+ToAny: TypeAlias = ToOneEntityTypeAssociation[OwnerT, AssociateT] | ToManyEntityTypeAssociation[OwnerT, AssociateT]
 
 
 def to_one(
@@ -921,7 +919,7 @@ class AliasedEntity(Generic[EntityT]):
         return self._entity
 
 
-AliasableEntity: TypeAlias = Union[EntityT, AliasedEntity[EntityT]]
+AliasableEntity: TypeAlias = EntityT | AliasedEntity[EntityT]
 
 
 def unalias(entity: AliasableEntity[EntityT]) -> EntityT:

--- a/betty/pickle.py
+++ b/betty/pickle.py
@@ -1,6 +1,4 @@
-from typing import Any
-
-from typing_extensions import TypeAlias
+from typing import Any, TypeAlias
 
 DictState: TypeAlias = dict[str, Any]
 

--- a/betty/privatizer.py
+++ b/betty/privatizer.py
@@ -1,16 +1,14 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Iterator
-
-from typing_extensions import TypeAlias
+from typing import Iterator, TypeAlias
 
 from betty.functools import walk
 from betty.locale import DateRange, Date
 from betty.model.ancestry import Person, Event, Citation, HasFiles, HasCitations, HasNotes, Source, \
     Presence, Privacy, HasMutablePrivacy, HasPrivacy
 
-Expirable: TypeAlias = 'Person | Event | Date | None'
+Expirable: TypeAlias = Person | Event | Date | None
 
 
 class Privatizer:

--- a/betty/project.py
+++ b/betty/project.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 from contextlib import suppress
 from pathlib import Path
 from reprlib import recursive_repr
-from typing import Any, Generic, final, Iterable, cast
+from typing import Any, Generic, final, Iterable, cast, Self
 from urllib.parse import urlparse
 
 from reactives import scope
 from reactives.instance.property import reactive_property
-from typing_extensions import Self
 
 from betty.app.extension import Extension, ConfigurableExtension
 from betty.classtools import repr_instance

--- a/betty/serde/dump.py
+++ b/betty/serde/dump.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from typing import TypeVar, Sequence, Mapping, overload, Literal
-
-from typing_extensions import TypeAlias
+from typing import TypeVar, Sequence, Mapping, overload, Literal, TypeAlias
 
 T = TypeVar('T')
 U = TypeVar('U')
@@ -12,14 +10,14 @@ class Void:
     pass
 
 
-DumpType: TypeAlias = 'bool | int | float | str | None | list | dict'
+DumpType: TypeAlias = bool | int | float | str | None | list | dict
 DumpTypeT = TypeVar('DumpTypeT', bound=DumpType)
 
-Dump: TypeAlias = 'bool | int | float | str | None | Sequence[Dump] | Mapping[str, Dump]'
+Dump: TypeAlias = bool | int | float | str | None | Sequence['Dump'] | Mapping[str, 'Dump']
 DumpT = TypeVar('DumpT', bound=Dump)
 DumpU = TypeVar('DumpU', bound=Dump)
 
-VoidableDump: TypeAlias = 'Dump | type[Void]'
+VoidableDump: TypeAlias = Dump | type[Void]
 VoidableDumpT = TypeVar('VoidableDumpT', bound=VoidableDump)
 VoidableDumpU = TypeVar('VoidableDumpU', bound=VoidableDump)
 
@@ -31,7 +29,7 @@ VoidableListDump: TypeAlias = list[VoidableDumpT]
 
 VoidableDictDump: TypeAlias = dict[str, VoidableDumpT]
 
-_MinimizableDump: TypeAlias = 'VoidableDump | VoidableListDump[VoidableDumpT] | VoidableDictDump[VoidableDumpT]'
+_MinimizableDump: TypeAlias = VoidableDump | VoidableListDump[VoidableDumpT] | VoidableDictDump[VoidableDumpT]
 
 
 @overload

--- a/betty/serde/error.py
+++ b/betty/serde/error.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 import copy
 from contextlib import contextmanager
 from textwrap import indent
-from typing import Iterator, cast, Any
-
-from typing_extensions import Self
+from typing import Iterator, cast, Any, Self
 
 from betty.error import UserFacingError
 

--- a/betty/serde/load.py
+++ b/betty/serde/load.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator, Callable, Any, Generic, TYPE_CHECKING, TypeVar, MutableSequence, MutableMapping, overload, \
-    cast
-
-from typing_extensions import TypeAlias
+    cast, TypeAlias
 
 from betty.functools import _Result
 from betty.locale import LocaleNotFoundError, get_data, Localizable
@@ -24,7 +22,7 @@ CallValueT = TypeVar('CallValueT')
 CallReturnT = TypeVar('CallReturnT')
 FValueT = TypeVar('FValueT')
 MapReturnT = TypeVar('MapReturnT')
-Number: TypeAlias = 'int | float'
+Number: TypeAlias = int | float
 NumberT = TypeVar('NumberT', bound=Number)
 
 

--- a/betty/subprocess.py
+++ b/betty/subprocess.py
@@ -3,9 +3,8 @@ import os
 import subprocess as stdsubprocess
 from asyncio import subprocess
 from textwrap import indent
-from typing import Sequence, Any, Callable, Awaitable
+from typing import Sequence, Any, Callable, Awaitable, ParamSpec
 
-from typing_extensions import ParamSpec
 
 P = ParamSpec('P')
 

--- a/betty/tests/__init__.py
+++ b/betty/tests/__init__.py
@@ -4,13 +4,12 @@ import functools
 import json as stdjson
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Callable, TypeVar, Any, AsyncIterator, Awaitable
+from typing import Callable, TypeVar, Any, AsyncIterator, Awaitable, ParamSpec
 
 import html5lib
 from aiofiles.tempfile import TemporaryDirectory
 from html5lib.html5parser import ParseError
 from jinja2.environment import Template
-from typing_extensions import ParamSpec
 
 from betty import fs, json
 from betty.app import App

--- a/betty/tests/app/test___init__.py
+++ b/betty/tests/app/test___init__.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from typing import Self
+
 import pytest
-from typing_extensions import Self
 
 from betty.app import App
 from betty.app.extension import ConfigurableExtension as GenericConfigurableExtension, Extension, CyclicDependencyError

--- a/betty/tests/conftest.py
+++ b/betty/tests/conftest.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import gc
 import logging
-from typing import Callable, Iterator, TypeVar, cast, Union, AsyncIterator
+from typing import Callable, Iterator, TypeVar, cast, AsyncIterator, TypeAlias
 
 import pytest
 from PyQt6.QtCore import Qt
@@ -10,7 +10,6 @@ from PyQt6.QtGui import QAction
 from PyQt6.QtWidgets import QMainWindow, QMenu, QWidget
 from _pytest.logging import LogCaptureFixture
 from pytestqt.qtbot import QtBot
-from typing_extensions import TypeAlias
 
 from betty.app import AppConfiguration, App
 from betty.gui import BettyApplication
@@ -64,7 +63,7 @@ async def qapp(qapp_args: list[str]) -> AsyncIterator[BettyApplication]:
     gc.collect()
 
 
-Navigate: TypeAlias = Callable[['QMainWindow | QMenu', list[str]], None]
+Navigate: TypeAlias = Callable[[QMainWindow | QMenu, list[str]], None]
 
 
 @pytest.fixture
@@ -135,7 +134,7 @@ def assert_not_top_level_widget(qapp: BettyApplication, qtbot: QtBot) -> AssertN
 QMainWindowT = TypeVar('QMainWindowT', bound=QMainWindow)
 
 
-AssertWindow: TypeAlias = Callable[[Union[type[QMainWindowT], QMainWindowT]], QMainWindowT]
+AssertWindow: TypeAlias = Callable[[type[QMainWindowT] | QMainWindowT], QMainWindowT]
 
 
 @pytest.fixture
@@ -145,7 +144,7 @@ def assert_window(assert_top_level_widget: AssertTopLevelWidget[QMainWindowT]) -
     return _assert_window
 
 
-AssertNotWindow: TypeAlias = Callable[[Union[type[QMainWindowT], QMainWindowT]], None]
+AssertNotWindow: TypeAlias = Callable[[type[QMainWindowT] | QMainWindowT], None]
 
 
 @pytest.fixture

--- a/betty/tests/test_jinja2.py
+++ b/betty/tests/test_jinja2.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Iterable, Any
+from typing import Iterable, Any, Self
 
 import pytest
 from aiofiles.tempfile import TemporaryDirectory
-from typing_extensions import Self
 
 from betty.app import App
 from betty.jinja2 import Jinja2Renderer, _Citer, Jinja2Provider

--- a/betty/tests/test_project.py
+++ b/betty/tests/test_project.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from typing import Any, Iterable
+from typing import Any, Iterable, Self
 
 import dill
 import pytest
 from reactives.tests import assert_reactor_called, assert_scope_empty
-from typing_extensions import Self
 
 from betty.app.extension import Extension, ConfigurableExtension
 from betty.config import Configuration, Configurable

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,6 @@ SETUP = {
     'classifiers': [
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Programming Language :: JavaScript',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: JavaScript',
@@ -42,7 +40,7 @@ SETUP = {
         'Natural Language :: Ukrainian',
         'Typing :: Typed ',
     ],
-    'python_requires': '~= 3.9',
+    'python_requires': '~= 3.11',
     'install_requires': [
         'aiofiles ~= 23.2, >= 23.2.1',
         'aiohttp == 3.9.0b0',
@@ -61,7 +59,6 @@ SETUP = {
         'PyQt6 ~= 6.5, >= 6.5.0',
         'pyyaml ~= 6.0, >= 6.0.0',
         'reactives ~= 0.5, >= 0.5.1',
-        'typing_extensions ~= 4.5, >= 4.5.0',
     ],
     'extras_require': {
         'development': [

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, py310, py311, py312
+envlist = py311, py312
 skip_missing_interpreters = true
 
 [testenv]
@@ -8,12 +8,6 @@ commands = bash {toxinidir}{/}bin{/}test
 usedevelop = True
 allowlist_externals = {toxinidir}{/}bin{/}*
                       bash
-
-[testenv:py39]
-basepython = python3.9
-
-[testenv:py310]
-basepython = python3.10
 
 [testenv:py311]
 basepython = python3.11


### PR DESCRIPTION
This will allow us to use concurrency error handling improvements introduced in Python 3.11.