### PR TITLE
Restrict the Python requirement to 3.7, 3.8, and 3.9, becauyse 3.10 a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ secure**.
 ## Installation
 
 ### Requirements
-- **Python 3.7+**
+- **Python 3.7, 3.8, or 3.9** (support for newer versions is included in Betty 0.3)
 - Node.js 10+ (optional)
 - Linux, Mac OS, or Windows. On Windows you are encouraged to use Python 3.7 or 3.8, because one of Betty's
   dependencies (libsass) cannot be installed automatically when using Python 3.9.

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ SETUP = {
         'Natural Language :: English',
         'Natural Language :: Ukrainian',
     ],
-    'python_requires': '~= 3.7',
+    'python_requires': '~= 3.7, < 3.10',
     'install_requires': [
         'aiohttp ~= 3.7',
         'babel ~= 2.9',


### PR DESCRIPTION
Restrict the Python requirement to 3.7, 3.8, and 3.9, because 3.10 and newer are not supported. This will allow installations to fail more gracefully.