### PR TITLE
Make string translations lazy

### DIFF
--- a/babel.ini
+++ b/babel.ini
@@ -3,3 +3,4 @@
 [jinja2: **.j2]
 encoding = utf-8
 extensions = jinja2.ext.do
+ext.i18n.trimmed = True

--- a/betty/assets/betty.pot
+++ b/betty/assets/betty.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-12-17 15:48+0000\n"
+"POT-Creation-Date: 2023-12-18 17:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -32,6 +32,13 @@ msgid ""
 "                history. You can browse the pages about her and some of her family to get an idea of what a Betty site\n"
 "                looks like.\n"
 "            "
+msgstr ""
+
+#, python-format
+msgid ""
+"\n"
+"        Welcome to %(project_title)s\n"
+"    "
 msgstr ""
 
 #, python-format
@@ -198,6 +205,9 @@ msgid "Cannot determine the entity type for \"{entity_type}\". Did you perhaps m
 msgstr ""
 
 msgid "Cannot determine the extension type for \"{extension_type}\". Did you perhaps make a typo, or could it be that the extension type comes from another package that is not yet installed?"
+msgstr ""
+
+msgid "Cannot find an available port to bind the web server to."
 msgstr ""
 
 msgid "Cannot find and import \"{entity_type}\"."
@@ -697,6 +707,9 @@ msgstr ""
 msgid "The entity reference must be for an entity of type {expected_entity_type_name} ({expected_entity_type_label}), but instead is for an entity of type {actual_entity_type_name} ({actual_entity_type_label})"
 msgstr ""
 
+msgid "The following errors occurred"
+msgstr ""
+
 msgid "The lifetime threshold must consist of digits only."
 msgstr ""
 
@@ -786,6 +799,9 @@ msgstr ""
 msgid "Unknown"
 msgstr ""
 
+msgid "Unknown file format \".{extension}\". Supported formats are: {supported_formats}."
+msgstr ""
+
 msgid "Unknown key: {unknown_key}. Did you mean {known_keys}?"
 msgstr ""
 
@@ -809,10 +825,6 @@ msgid "View demo site..."
 msgstr ""
 
 msgid "View site"
-msgstr ""
-
-#, python-format
-msgid "Welcome to %(title)s"
 msgstr ""
 
 msgid "Welcome to Betty"
@@ -975,6 +987,15 @@ msgid "{entity_type_label} ID"
 msgstr ""
 
 msgid "{entity_type} {entity_id}"
+msgstr ""
+
+msgid "{event_type}"
+msgstr ""
+
+msgid "{event_type} ({event_description})"
+msgstr ""
+
+msgid "{event_type} ({event_description}) of {subjects}"
 msgstr ""
 
 msgid "{event_type} of {subjects}"

--- a/betty/assets/locale/fr-FR/betty.po
+++ b/betty/assets/locale/fr-FR/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-12-17 15:48+0000\n"
+"POT-Creation-Date: 2023-12-18 17:07+0000\n"
 "PO-Revision-Date: 2020-11-27 19:49+0100\n"
 "Last-Translator: \n"
 "Language: fr\n"
@@ -39,6 +39,13 @@ msgid ""
 "                looks like.\n"
 "            "
 msgstr ""
+
+#, python-format
+msgid ""
+"\n"
+"        Welcome to %(project_title)s\n"
+"    "
+msgstr "Bienvenue à %(project_title)s"
 
 #, python-format
 msgid ""
@@ -247,6 +254,9 @@ msgid ""
 "another package that is not yet installed?"
 msgstr ""
 
+msgid "Cannot find an available port to bind the web server to."
+msgstr ""
+
 msgid "Cannot find and import \"{entity_type}\"."
 msgstr ""
 
@@ -281,9 +291,8 @@ msgstr ""
 msgid "Clear all caches"
 msgstr ""
 
-#, fuzzy
 msgid "Conference"
-msgstr "Références"
+msgstr ""
 
 msgid "Configuration"
 msgstr ""
@@ -793,6 +802,9 @@ msgid ""
 "({actual_entity_type_label})"
 msgstr ""
 
+msgid "The following errors occurred"
+msgstr ""
+
 msgid "The lifetime threshold must consist of digits only."
 msgstr ""
 
@@ -887,6 +899,11 @@ msgstr "Non autorisé"
 msgid "Unknown"
 msgstr "Inconnu"
 
+msgid ""
+"Unknown file format \".{extension}\". Supported formats are: "
+"{supported_formats}."
+msgstr ""
+
 msgid "Unknown key: {unknown_key}. Did you mean {known_keys}?"
 msgstr ""
 
@@ -918,10 +935,6 @@ msgstr ""
 
 msgid "View site"
 msgstr ""
-
-#, python-format
-msgid "Welcome to %(title)s"
-msgstr "Bienvenue à %(title)s"
 
 msgid "Welcome to Betty"
 msgstr "Bienvenue à Betty"
@@ -1113,6 +1126,15 @@ msgstr ""
 
 msgid "{entity_type} {entity_id}"
 msgstr ""
+
+msgid "{event_type}"
+msgstr "{event_type}"
+
+msgid "{event_type} ({event_description})"
+msgstr "{event_type} ({event_description})"
+
+msgid "{event_type} ({event_description}) of {subjects}"
+msgstr "{event_type} ({event_description}) de {subjects}"
 
 msgid "{event_type} of {subjects}"
 msgstr "{event_type} de {subjects}"

--- a/betty/assets/locale/nl-NL/betty.po
+++ b/betty/assets/locale/nl-NL/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-12-17 15:48+0000\n"
+"POT-Creation-Date: 2023-12-18 17:07+0000\n"
 "PO-Revision-Date: 2022-04-08 01:58+0100\n"
 "Last-Translator: \n"
 "Language: nl\n"
@@ -49,6 +49,13 @@ msgstr ""
 " pagina's over haar en haar familie bekijken om een idee te krijgen van "
 "hoe een Betty-site eruit ziet.\n"
 "            "
+
+#, python-format
+msgid ""
+"\n"
+"        Welcome to %(project_title)s\n"
+"    "
+msgstr "Welkom bij %(project_title)s"
 
 #, python-format
 msgid ""
@@ -269,6 +276,9 @@ msgstr ""
 "Het entiteitstype van \"{entity_type}\" kan niet gevonden worden. Heb je "
 "misschien een typefout gemaakt, of zou het kunnen dat het entiteitstype "
 "uit een package komt dat nog niet geïnstalleerd is?"
+
+msgid "Cannot find an available port to bind the web server to."
+msgstr "Kan geen beschikbare poort voor de webserver vinden."
 
 msgid "Cannot find and import \"{entity_type}\"."
 msgstr "Kan \"{entity_type}\" niet vinden en importeren."
@@ -753,16 +763,16 @@ msgid "Save your project to..."
 msgstr "Sla je project op naar..."
 
 msgid "Serve site"
-msgstr ""
+msgstr "Serveer site"
 
 msgid "Serving the Betty demo..."
-msgstr ""
+msgstr "De Betty-demo aan het serveren..."
 
 msgid "Serving your site at {url}..."
-msgstr ""
+msgstr "Je site op {url} aan het serveren..."
 
 msgid "Serving your site..."
-msgstr ""
+msgstr "Je site aan het serveren..."
 
 msgid "Settings..."
 msgstr "Instellingen..."
@@ -777,7 +787,7 @@ msgid "Speaker"
 msgstr "Spreker"
 
 msgid "Starting Python's built-in web server..."
-msgstr ""
+msgstr "Pythons ingebouwde webserver aan het starten..."
 
 msgid "Stop the site"
 msgstr "Stop de site"
@@ -810,16 +820,11 @@ msgstr ""
 msgid "The collection of {entity_type} entities."
 msgstr "De verzameling van {entity_type}-entiteiten."
 
-#, fuzzy
 msgid ""
 "The entity reference must be for an entity of type "
 "{expected_entity_type_name} ({expected_entity_type_label}), but instead "
 "does not specify an entity type at all."
 msgstr ""
-"De entiteitsverwijzing moet verwijzen naar een entiteit van het type "
-"{expected_entity_type_name} ({expected_entity_type_label}), maar verwijst"
-" echter naar een entiteit van het type {actual_entity_type_name} "
-"({actual_entity_type_label})"
 
 msgid ""
 "The entity reference must be for an entity of type "
@@ -831,6 +836,9 @@ msgstr ""
 "{expected_entity_type_name} ({expected_entity_type_label}), maar verwijst"
 " echter naar een entiteit van het type {actual_entity_type_name} "
 "({actual_entity_type_label})"
+
+msgid "The following errors occurred"
+msgstr "De volgende problemen zijn voorgekomen"
 
 msgid "The lifetime threshold must consist of digits only."
 msgstr "De levensgrens mag alleen uit cijfers bestaan."
@@ -891,9 +899,8 @@ msgstr "Dit moet een positief getal zijn."
 msgid "This must be a string."
 msgstr "Dit moet een tekenreeks zijn."
 
-#, fuzzy
 msgid "This must be a whole number."
-msgstr "Dit moet een getal zijn."
+msgstr "Dit moet een geheel getal zijn."
 
 msgid "This person's details are unavailable to protect their privacy."
 msgstr "De gegevens van deze persoon zijn niet beschikbaar vanwege privacyredenen."
@@ -928,6 +935,13 @@ msgstr "Onbevoegd"
 msgid "Unknown"
 msgstr "Onbekend"
 
+msgid ""
+"Unknown file format \".{extension}\". Supported formats are: "
+"{supported_formats}."
+msgstr ""
+"Onbekend bestandstype \".{extension}\". Ondersteunde bestandstypes zijn: "
+"{supported_formats}."
+
 msgid "Unknown key: {unknown_key}. Did you mean {known_keys}?"
 msgstr "Onbekende sleutel: {unknown_key}. Bedoel je {known_keys}?"
 
@@ -959,10 +973,6 @@ msgstr "Bekijk een demonstratiesite..."
 
 msgid "View site"
 msgstr "Bekijk site"
-
-#, python-format
-msgid "Welcome to %(title)s"
-msgstr "Welkom bij %(title)s"
 
 msgid "Welcome to Betty"
 msgstr "Welkom bij Betty"
@@ -1135,6 +1145,15 @@ msgstr "{entity_type_label}-ID"
 
 msgid "{entity_type} {entity_id}"
 msgstr ""
+
+msgid "{event_type}"
+msgstr "{event_type}"
+
+msgid "{event_type} ({event_description})"
+msgstr "{event_type} ({event_description})"
+
+msgid "{event_type} ({event_description}) of {subjects}"
+msgstr "{event_type} ({event_description}) van {subjects}"
 
 msgid "{event_type} of {subjects}"
 msgstr "{event_type} van {subjects}"

--- a/betty/assets/locale/uk/betty.po
+++ b/betty/assets/locale/uk/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-12-17 15:48+0000\n"
+"POT-Creation-Date: 2023-12-18 17:07+0000\n"
 "PO-Revision-Date: 2020-05-02 22:29+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: uk\n"
@@ -40,6 +40,13 @@ msgid ""
 "                looks like.\n"
 "            "
 msgstr ""
+
+#, python-format
+msgid ""
+"\n"
+"        Welcome to %(project_title)s\n"
+"    "
+msgstr "Ласкаво просимо на %(project_title)s"
 
 #, python-format
 msgid ""
@@ -245,6 +252,9 @@ msgid ""
 "Cannot determine the extension type for \"{extension_type}\". Did you "
 "perhaps make a typo, or could it be that the extension type comes from "
 "another package that is not yet installed?"
+msgstr ""
+
+msgid "Cannot find an available port to bind the web server to."
 msgstr ""
 
 msgid "Cannot find and import \"{entity_type}\"."
@@ -789,6 +799,9 @@ msgid ""
 "({actual_entity_type_label})"
 msgstr ""
 
+msgid "The following errors occurred"
+msgstr ""
+
 msgid "The lifetime threshold must consist of digits only."
 msgstr ""
 
@@ -884,6 +897,11 @@ msgstr "Несанкціонована"
 msgid "Unknown"
 msgstr "Невідомо"
 
+msgid ""
+"Unknown file format \".{extension}\". Supported formats are: "
+"{supported_formats}."
+msgstr ""
+
 msgid "Unknown key: {unknown_key}. Did you mean {known_keys}?"
 msgstr ""
 
@@ -915,10 +933,6 @@ msgstr ""
 
 msgid "View site"
 msgstr ""
-
-#, python-format
-msgid "Welcome to %(title)s"
-msgstr "Ласкаво просимо на %(title)s"
 
 msgid "Welcome to Betty"
 msgstr "Ласкаво просимо на Betty"
@@ -1088,6 +1102,15 @@ msgid "{entity_type_label} ID"
 msgstr ""
 
 msgid "{entity_type} {entity_id}"
+msgstr ""
+
+msgid "{event_type}"
+msgstr ""
+
+msgid "{event_type} ({event_description})"
+msgstr ""
+
+msgid "{event_type} ({event_description}) of {subjects}"
 msgstr ""
 
 msgid "{event_type} of {subjects}"

--- a/betty/assets/public/localized/index.html.j2
+++ b/betty/assets/public/localized/index.html.j2
@@ -1,4 +1,8 @@
 {% extends 'base.html.j2' %}
-{% set page_title = 'Welcome to Betty' %}
+{% set page_title %}
+    {% trans project_title=app.project.configuration.title %}
+        Welcome to {{ project_title }}
+    {% endtrans %}
+{% endset %}
 {% block page_content %}
 {% endblock %}

--- a/betty/assets/templates/base.html.j2
+++ b/betty/assets/templates/base.html.j2
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ app.locale }}"
+<html lang="{{ localizer.locale }}"
       prefix="foaf: http://xmlns.com/foaf/0.1/ og: http://ogp.me/ns# rel: http://purl.org/vocab/relationship/">
 <head>
     {% include 'head.html.j2' %}

--- a/betty/assets/templates/entity/page-list.html.j2
+++ b/betty/assets/templates/entity/page-list.html.j2
@@ -1,5 +1,5 @@
 {% extends 'base.html.j2' %}
-{% set page_title = entity_type.entity_type_label_plural(app.localizer) %}
+{% set page_title = entity_type.entity_type_label_plural() | localize %}
 {% do breadcrumbs.append(
     page_title,
     page_resource | url(absolute=true)

--- a/betty/assets/templates/entity/page.html.j2
+++ b/betty/assets/templates/entity/page.html.j2
@@ -1,8 +1,8 @@
 {% extends 'base.html.j2' %}
-{% set page_title = entity.label %}
+{% set page_title = entity.label | localize %}
 {% set entity_contexts = entity_contexts(entity) %}
 {% do breadcrumbs.append(
-    entity_type.entity_type_label_plural(app.localizer),
+    entity_type.entity_type_label_plural() | localize,
     entity_type | entity_type_name | camel_case_to_kebab_case | url(absolute=true)
 ) %}
 {% do breadcrumbs.append(

--- a/betty/assets/templates/head.html.j2
+++ b/betty/assets/templates/head.html.j2
@@ -18,10 +18,10 @@
             {% endif %}
         {% endfor %}
     {% endif %}
-    <link rel="canonical" href="{{ page_resource | url(absolute=true) }}" hreflang="{{ app.locale }}" type="text/html"/>
-    {% for locale in app.project.configuration.locales %}
-        {% if locale != app.locale %}
-            <link rel="alternate" href="{{ page_resource | url(locale=locale) }}" hreflang="{{ locale }}" type="text/html"/>
+    <link rel="canonical" href="{{ page_resource | url(absolute=true) }}" hreflang="{{ localizer.locale }}" type="text/html"/>
+    {% for project_locale in app.project.configuration.locales %}
+        {% if project_locale != localizer.locale %}
+            <link rel="alternate" href="{{ page_resource | url(locale=project_locale) }}" hreflang="{{ project_locale }}" type="text/html"/>
 
         {% endif %}
     {% endfor %}
@@ -29,7 +29,6 @@
         <script type="application/ld+json">
           {{ page_resource | tojson }}
         </script>
-        {% set current_locale = app.locale %}
         <link rel="alternate" href="{{ page_resource | url(media_type='application/json') }}" hreflang="und" type="application/json"/>
     {% endif %}
 {% endif %}

--- a/betty/cache.py
+++ b/betty/cache.py
@@ -4,7 +4,7 @@ from contextlib import suppress
 from enum import unique, IntFlag, auto
 
 from betty import fs
-from betty.locale import Localizable
+from betty.locale import Localizer
 
 
 @unique
@@ -13,8 +13,11 @@ class CacheScope(IntFlag):
     PROJECT = auto()
 
 
-class Cache(Localizable):
+class Cache:
+    def __init__(self, localizer: Localizer):
+        self._localizer = localizer
+
     async def clear(self) -> None:
         with suppress(FileNotFoundError):
             shutil.rmtree(fs.CACHE_DIRECTORY_PATH)
-        logging.getLogger().info(self.localizer._('All caches cleared.'))
+        logging.getLogger().info(self._localizer._('All caches cleared.'))

--- a/betty/deriver.py
+++ b/betty/deriver.py
@@ -4,7 +4,7 @@ import logging
 from enum import Enum
 from typing import Iterable, cast
 
-from betty.locale import DateRange, Date, Localizable, Localizer
+from betty.locale import DateRange, Date, Str
 from betty.model.ancestry import Person, Presence, Event, Subject, Ancestry
 from betty.model.event_type import DerivableEventType, CreatableDerivableEventType, EventType
 
@@ -15,16 +15,14 @@ class Derivation(Enum):
     UPDATE = 3
 
 
-class Deriver(Localizable):
+class Deriver:
     def __init__(
         self,
         ancestry: Ancestry,
         lifetime_threshold: int,
         derivable_event_types: set[type[DerivableEventType]],
-        *,
-        localizer: Localizer | None = None,
     ):
-        super().__init__(localizer=localizer)
+        super().__init__()
         self._ancestry = ancestry
         self._lifetime_threshold = lifetime_threshold
         self._derivable_event_type = derivable_event_types
@@ -39,14 +37,16 @@ class Deriver(Localizable):
                 created_derivations += created
                 updated_derivations += updated
             if updated_derivations > 0:
-                logger.info(self.localizer._('Updated {updated_derivations} {event_type} events based on existing information.').format(
-                    updated_derivations=updated_derivations,
-                    event_type=derivable_event_type.label(self.localizer)),
+                logger.info(Str._(
+                    'Updated {updated_derivations} {event_type} events based on existing information.',
+                    updated_derivations=str(updated_derivations),
+                    event_type=derivable_event_type.label()),
                 )
             if created_derivations > 0:
-                logger.info(self.localizer._('Created {created_derivations} additional {event_type} events based on existing information.').format(
-                    created_derivations=created_derivations,
-                    event_type=derivable_event_type.label(self.localizer)),
+                logger.info(Str._(
+                    'Created {created_derivations} additional {event_type} events based on existing information.',
+                    created_derivations=str(created_derivations),
+                    event_type=derivable_event_type.label()),
                 )
 
     def _derive_person(self, person: Person, derivable_event_type: type[DerivableEventType]) -> tuple[int, int]:

--- a/betty/error.py
+++ b/betty/error.py
@@ -1,12 +1,22 @@
-from typing import Any
+from betty.locale import DEFAULT_LOCALIZER, Localizable, Localizer
 
 
-class UserFacingError(Exception):
+class UserFacingError(Exception, Localizable):
     """
-    A user-facing error.
+    A localizable, user-facing error.
 
     This type of error is fatal, but fixing it does not require knowledge of Betty's internals or the stack trace
     leading to the error. It must therefore have an end-user-friendly message, and its stack trace must not be shown.
     """
-    def __init__(self, *args: Any, **kwargs: Any):
-        super().__init__(*args, **kwargs)
+    def __init__(self, message: Localizable):
+        super().__init__(
+            # Provide a default localization so this exception can be displayed like any other.
+            message.localize(DEFAULT_LOCALIZER),
+        )
+        self._localizable_message = message
+
+    def __str__(self) -> str:
+        return self.localize(DEFAULT_LOCALIZER)
+
+    def localize(self, localizer: Localizer) -> str:
+        return self._localizable_message.localize(localizer)

--- a/betty/extension/cotton_candy/assets/public/localized/index.html.j2
+++ b/betty/extension/cotton_candy/assets/public/localized/index.html.j2
@@ -1,5 +1,9 @@
 {% extends 'base.html.j2' %}
-{% set page_title = _('Welcome to %(title)s') | format(title=app.project.configuration.title) %}
+{% set page_title %}
+    {% trans project_title=app.project.configuration.title %}
+        Welcome to {{ project_title }}
+    {% endtrans %}
+{% endset %}
 {% block page_content %}
     {% if 'betty.extension.Demo' in app.extensions %}
         <p>

--- a/betty/extension/cotton_candy/assets/templates/base.html.j2
+++ b/betty/extension/cotton_candy/assets/templates/base.html.j2
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ app.locale }}"
+<html lang="{{ localizer.locale }}"
       prefix="foaf: http://xmlns.com/foaf/0.1/ og: http://ogp.me/ns# rel: http://purl.org/vocab/relationship/">
 <head>
     {% include 'head.html.j2' %}
@@ -25,7 +25,7 @@
                 {% if search_keywords_example_person_name %}
                     {% set search_keywords_example -%}
                         {% filter forceescape %}
-                            {% trans example = search_keywords_example_person_name.label -%}
+                            {% trans example = search_keywords_example_person_name.label | localize -%}
                                 E.g. "{{ example }}"
                             {%- endtrans %}
                         {% endfilter %}
@@ -55,7 +55,7 @@
                                 {% if 'Event' == entity_type_configuration.entity_type | entity_type_name %}
                                     {% trans %}Timeline{% endtrans %}
                                 {% else %}
-                                    {{ entity_type_configuration.entity_type.entity_type_label_plural(app.localizer) }}
+                                    {{ entity_type_configuration.entity_type.entity_type_label_plural() | localize }}
                                 {% endif %}
                             </a>
                         </li>
@@ -63,7 +63,7 @@
                 </ul>
             </div>
         </div>
-        {% if page_resource is defined and app.project.configuration.multilingual %}
+        {% if page_resource is defined and app.project.configuration.locales.multilingual %}
             <div id="nav-locale" class="nav-primary-expandable">
                 <h2 class="nav-primary-action">{% trans %}Language{% endtrans %}</h2>
                 <div class="nav-primary-expanded">

--- a/betty/extension/cotton_candy/assets/templates/entity/label--citation.html.j2
+++ b/betty/extension/cotton_candy/assets/templates/entity/label--citation.html.j2
@@ -11,7 +11,19 @@
         {%- endif -%}
     {% endif %}
     {%- if entity.location -%}
-            <span class="citation-location">{% if citation_context == entity %}{{ entity.location }}{% else %}{% if entity is not has_generated_entity_id %}<a href="{{ entity | url }}">{% endif %}{{ entity.location }}{% if entity is not has_generated_entity_id %}</a>{% endif %}{% endif %}</span>
+            <span class="citation-location">
+                {% if citation_context == entity %}
+                    {{ entity.location | localize }}
+                    {% else %}
+                    {% if entity is not has_generated_entity_id %}
+                        <a href="{{ entity | url }}">
+                    {% endif %}
+                {{ entity.location | localize }}
+                {% if entity is not has_generated_entity_id %}
+                    </a>
+                {% endif %}
+                {% endif %}
+            </span>
     {%- endif -%}
     {%- if entity.date -%}
         <span class="citation-date">{% trans date = entity.date | format_datey %}Accessed {{ date }}{% endtrans %}</span>

--- a/betty/extension/cotton_candy/assets/templates/entity/label--event.html.j2
+++ b/betty/extension/cotton_candy/assets/templates/entity/label--event.html.j2
@@ -3,7 +3,7 @@
 {%- macro person_label(entity) -%}
     {% include ['entity/label--person.html.j2', 'entity/label.html.j2'] %}
 {%- endmacro -%}
-{%- set formatted_event = entity.event_type.label(app.localizer) -%}
+{%- set formatted_event = entity.event_type.label() | localize -%}
 {%- if entity is not has_generated_entity_id and not embedded -%}
     {% set formatted_event = ('<a href="' + entity | url + '">' + formatted_event + '</a>') | safe %}
 {%- endif -%}

--- a/betty/extension/cotton_candy/assets/templates/entity/label.html.j2
+++ b/betty/extension/cotton_candy/assets/templates/entity/label.html.j2
@@ -2,7 +2,7 @@
 {%- if not embedded and entity is not has_generated_entity_id -%}
     <a href="{{ entity | url }}">
 {%- endif -%}
-{{ entity.label }}
+{{ entity.label | localize }}
 {%- if not embedded and entity is not has_generated_entity_id -%}
     </a>
 {%- endif -%}

--- a/betty/extension/cotton_candy/assets/templates/entity/meta--person.html.j2
+++ b/betty/extension/cotton_candy/assets/templates/entity/meta--person.html.j2
@@ -30,10 +30,10 @@
         {%- if formatted_start or formatted_end -%}
             <dl>
                 {%- if formatted_start -%}
-                    <div><dt>{{ entity.start.event.event_type.label(app.localizer) }}</dt><dd>{{ formatted_start }}</dd></div>
+                    <div><dt>{{ entity.start.event.event_type.label() | localize }}</dt><dd>{{ formatted_start }}</dd></div>
                 {%- endif -%}
                 {%- if formatted_end -%}
-                    <div><dt>{{ entity.end.event.event_type.label(app.localizer) }}</dt><dd>{{ formatted_end }}</dd></div>
+                    <div><dt>{{ entity.end.event.event_type.label() | localize }}</dt><dd>{{ formatted_end }}</dd></div>
                 {%- endif -%}
             </dl>
         {%- endif -%}

--- a/betty/extension/cotton_candy/assets/templates/entity/meta--place.html.j2
+++ b/betty/extension/cotton_candy/assets/templates/entity/meta--place.html.j2
@@ -15,6 +15,8 @@
 <div class="meta">
     {%- set enclosed_by_label = _enclosed_by_place_label(entity) -%}
     {%- if enclosed_by_label -%}
-        in {{ enclosed_by_label }}
+        {%- trans place=enclosed_by_label -%}
+            in {{ place }}
+        {%- endtrans -%}
     {%- endif -%}
 </div>

--- a/betty/extension/cotton_candy/assets/templates/footer.html.j2
+++ b/betty/extension/cotton_candy/assets/templates/footer.html.j2
@@ -5,5 +5,5 @@
 {% endif %}
 <p>{% trans %}A family history as told by <a href="https://github.com/bartfeenstra/betty">Betty👵</a>{% endtrans %}</p>
 {% if 'betty.extension.HttpApiDoc' in app.extensions %}
-    <p><a href="{{ '/api/index.html' | url }}">{% trans %}API documentation{% endtrans %}</a></p>
+    <p><a href="{{ '/api/index.html' | static_url }}">{% trans %}API documentation{% endtrans %}</a></p>
 {% endif %}

--- a/betty/extension/cotton_candy/search.py
+++ b/betty/extension/cotton_candy/search.py
@@ -3,16 +3,18 @@ from __future__ import annotations
 from typing import Iterable, Any
 
 from betty.app import App
+from betty.locale import Localizer
 from betty.model import get_entity_type_name, Entity
 from betty.model.ancestry import Person, Place, File
 from betty.string import camel_case_to_snake_case
 
 
 class Index:
-    def __init__(self, app: App):
+    def __init__(self, app: App, localizer: Localizer):
         self._app = app
+        self._localizer = localizer
 
-    def build(self) -> Iterable[dict[Any, Any]]:
+    def build(self) -> Iterable[dict[str, str]]:
         return filter(None, [
             *[
                 self._build_person(person)
@@ -39,6 +41,7 @@ class Index:
             f'search/result-{camel_case_to_snake_case(entity_type_name)}.html.j2',
             'search/result.html.j2',
         ]).render({
+            'localizer': self._localizer,
             'entity': entity,
         })
 

--- a/betty/extension/demo/__init__.py
+++ b/betty/extension/demo/__init__.py
@@ -6,7 +6,7 @@ from betty import load, generate
 from betty.app import App
 from betty.app.extension import Extension
 from betty.load import Loader
-from betty.locale import Date, DateRange, Localizer
+from betty.locale import Date, DateRange, Str, Localizer
 from betty.model import Entity
 from betty.model.ancestry import Place, PlaceName, Person, Presence, Subject, PersonName, Link, Source, Citation, Event, \
     Enclosure
@@ -256,7 +256,7 @@ class _Demo(Extension, Loader):
         cite_birth_of_liberta_lankester_from_bevolkingsregister_amsterdam = Citation(
             id='betty-demo-birth-of-liberta-lankester-from-bevolkingsregister-amsterdam',
             source=bevolkingsregister_amsterdam,
-            location='Amsterdam',
+            location=Str.plain('Amsterdam'),
         )
         self._load(cite_birth_of_liberta_lankester_from_bevolkingsregister_amsterdam)
 
@@ -359,13 +359,13 @@ class _Demo(Extension, Loader):
 
 
 class DemoServer(Server):
-    def __init__(self, *, localizer: Localizer | None = None):
-        super().__init__(localizer=localizer)
+    def __init__(self, localizer: Localizer):
+        super().__init__(localizer)
         self._server: Server | None = None
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Demo')
+    def label(cls) -> Str:
+        return Str._('Demo')
 
     @property
     def public_url(self) -> str:
@@ -374,7 +374,7 @@ class DemoServer(Server):
         raise NoPublicUrlBecauseServerNotStartedError()
 
     async def start(self) -> None:
-        app = App(locale=self.localizer.locale)
+        app = App()
         app.project.configuration.extensions.append(ExtensionConfiguration(_Demo))
         # Include all of the translations Betty ships with.
         app.project.configuration.locales.replace(

--- a/betty/extension/deriver/__init__.py
+++ b/betty/extension/deriver/__init__.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 from betty.app.extension import Extension, UserFacingExtension
 from betty.deriver import Deriver
 from betty.load import PostLoader, getLogger
-from betty.locale import Localizer
+from betty.locale import Str
 from betty.model.event_type import DerivableEventType
 
 
 class _Deriver(UserFacingExtension, PostLoader):
     async def post_load(self) -> None:
         logger = getLogger()
-        logger.info(self._app.localizer._('Deriving...'))
+        logger.info(Str._('Deriving...'))
 
         deriver = Deriver(
             self.app.project.ancestry,
@@ -21,7 +21,6 @@ class _Deriver(UserFacingExtension, PostLoader):
                 in self.app.event_types
                 if issubclass(event_type, DerivableEventType)
             },
-            localizer=self.app.localizer,
         )
         await deriver.derive()
 
@@ -32,9 +31,9 @@ class _Deriver(UserFacingExtension, PostLoader):
         return {Privatizer}
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Deriver')
+    def label(cls) -> Str:
+        return Str._('Deriver')
 
     @classmethod
-    def description(cls, localizer: Localizer) -> str:
-        return localizer._('Create events such as births and deaths by deriving their details from existing information.')
+    def description(cls) -> Str:
+        return Str._('Create events such as births and deaths by deriving their details from existing information.')

--- a/betty/extension/gramps/__init__.py
+++ b/betty/extension/gramps/__init__.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from betty.app.extension import ConfigurableExtension, UserFacingExtension
 from betty.gramps.loader import GrampsLoader
-from betty.locale import Localizer
+from betty.locale import Str
 
 if TYPE_CHECKING:
     from betty.extension.gramps.gui import _GrampsGuiWidget
@@ -23,15 +23,15 @@ class _Gramps(ConfigurableExtension[GrampsConfiguration], UserFacingExtension, L
         for family_tree in self.configuration.family_trees:
             file_path = family_tree.file_path
             if file_path:
-                await GrampsLoader(self._app.project.ancestry, localizer=self.app.localizer).load_file(file_path)
+                await GrampsLoader(self._app.project.ancestry).load_file(file_path)
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return 'Gramps'
+    def label(cls) -> Str:
+        return Str.plain('Gramps')
 
     @classmethod
-    def description(cls, localizer: Localizer) -> str:
-        return localizer._('Load <a href="https://gramps-project.org/">Gramps</a> family trees.')
+    def description(cls) -> Str:
+        return Str._('Load <a href="https://gramps-project.org/">Gramps</a> family trees.')
 
     def gui_build(self) -> _GrampsGuiWidget:
         from betty.extension.gramps.gui import _GrampsGuiWidget

--- a/betty/extension/gramps/config.py
+++ b/betty/extension/gramps/config.py
@@ -6,7 +6,6 @@ from typing import Iterable, Any, Self
 from reactives.instance.property import reactive_property
 
 from betty.config import Configuration, ConfigurationSequence
-from betty.locale import Localizer
 from betty.serde.dump import minimize, Dump, VoidableDump
 from betty.serde.load import Asserter, Fields, RequiredField, Assertions, OptionalField
 
@@ -35,12 +34,10 @@ class FamilyTreeConfiguration(Configuration):
             cls,
             dump: Dump,
             configuration: Self | None = None,
-            *,
-            localizer: Localizer | None = None,
     ) -> Self:
         if configuration is None:
             configuration = cls()
-        asserter = Asserter(localizer=localizer)
+        asserter = Asserter()
         asserter.assert_record(Fields(
             RequiredField(
                 'file',
@@ -87,12 +84,10 @@ class GrampsConfiguration(Configuration):
             cls,
             dump: Dump,
             configuration: Self | None = None,
-            *,
-            localizer: Localizer | None = None,
     ) -> Self:
         if configuration is None:
             configuration = cls()
-        asserter = Asserter(localizer=localizer)
+        asserter = Asserter()
         asserter.assert_record(Fields(
             OptionalField(
                 'family_trees',

--- a/betty/extension/http_api_doc/__init__.py
+++ b/betty/extension/http_api_doc/__init__.py
@@ -10,7 +10,7 @@ from betty.app.extension import Extension, UserFacingExtension
 from betty.cache import CacheScope
 from betty.extension.npm import _Npm, NpmBuilder
 from betty.generate import Generator
-from betty.locale import Localizer
+from betty.locale import Str
 
 
 class _HttpApiDoc(UserFacingExtension, Generator, NpmBuilder):
@@ -21,7 +21,7 @@ class _HttpApiDoc(UserFacingExtension, Generator, NpmBuilder):
     async def npm_build(self, working_directory_path: Path, assets_directory_path: Path) -> None:
         await self.app.extensions[_Npm].install(type(self), working_directory_path)
         copy2(working_directory_path / 'node_modules' / 'redoc' / 'bundles' / 'redoc.standalone.js', assets_directory_path / 'http-api-doc.js')
-        logging.getLogger().info(self.app.localizer._('Built the HTTP API documentation.'))
+        logging.getLogger().info(Str._('Built the HTTP API documentation.'))
 
     @classmethod
     def npm_cache_scope(cls) -> CacheScope:
@@ -29,17 +29,17 @@ class _HttpApiDoc(UserFacingExtension, Generator, NpmBuilder):
 
     async def generate(self) -> None:
         assets_directory_path = await self.app.extensions[_Npm].ensure_assets(self)
-        await makedirs(self.app.static_www_directory_path, exist_ok=True)
-        copy2(assets_directory_path / 'http-api-doc.js', self.app.static_www_directory_path / 'http-api-doc.js')
+        await makedirs(self.app.project.configuration.www_directory_path, exist_ok=True)
+        copy2(assets_directory_path / 'http-api-doc.js', self.app.project.configuration.www_directory_path / 'http-api-doc.js')
 
     @classmethod
     def assets_directory_path(cls) -> Path | None:
         return Path(__file__).parent / 'assets'
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('HTTP API Documentation')
+    def label(cls) -> Str:
+        return Str._('HTTP API Documentation')
 
     @classmethod
-    def description(cls, localizer: Localizer) -> str:
-        return localizer._('Display the HTTP API documentation in a user-friendly way using <a href="https://github.com/Redocly/redoc">ReDoc</a>.')
+    def description(cls) -> Str:
+        return Str._('Display the HTTP API documentation in a user-friendly way using <a href="https://github.com/Redocly/redoc">ReDoc</a>.')

--- a/betty/extension/http_api_doc/assets/public/static/api/index.html.j2
+++ b/betty/extension/http_api_doc/assets/public/static/api/index.html.j2
@@ -13,7 +13,7 @@
     </style>
 </head>
 <body>
-<redoc spec-url='{{ '/api/index.json' | url }}'></redoc>
+<redoc spec-url='{{ '/api/index.json' | static_url }}'></redoc>
 <script src="/http-api-doc.js"></script>
 </body>
 </html>

--- a/betty/extension/maps/__init__.py
+++ b/betty/extension/maps/__init__.py
@@ -12,7 +12,7 @@ from betty.cache import CacheScope
 from betty.extension.npm import _Npm, NpmBuilder, npm
 from betty.generate import Generator
 from betty.html import CssProvider, JsProvider
-from betty.locale import Localizer
+from betty.locale import Str
 
 
 class _Maps(UserFacingExtension, CssProvider, JsProvider, Generator, NpmBuilder):
@@ -24,7 +24,7 @@ class _Maps(UserFacingExtension, CssProvider, JsProvider, Generator, NpmBuilder)
         await self.app.extensions[_Npm].install(type(self), working_directory_path)
         await npm(('run', 'webpack'), cwd=working_directory_path)
         await self._copy_npm_build(working_directory_path / 'webpack-build', assets_directory_path)
-        logging.getLogger().info(self.app.localizer._('Built the interactive maps.'))
+        logging.getLogger().info(Str._('Built the interactive maps.'))
 
     async def _copy_npm_build(self, source_directory_path: Path, destination_directory_path: Path) -> None:
         await makedirs(destination_directory_path, exist_ok=True)
@@ -39,8 +39,8 @@ class _Maps(UserFacingExtension, CssProvider, JsProvider, Generator, NpmBuilder)
 
     async def generate(self) -> None:
         assets_directory_path = await self.app.extensions[_Npm].ensure_assets(self)
-        await makedirs(self.app.static_www_directory_path, exist_ok=True)
-        await self._copy_npm_build(assets_directory_path, self.app.static_www_directory_path)
+        await makedirs(self.app.project.configuration.www_directory_path, exist_ok=True)
+        await self._copy_npm_build(assets_directory_path, self.app.project.configuration.www_directory_path)
 
     @classmethod
     def assets_directory_path(cls) -> Path | None:
@@ -59,9 +59,9 @@ class _Maps(UserFacingExtension, CssProvider, JsProvider, Generator, NpmBuilder)
         ]
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Maps')
+    def label(cls) -> Str:
+        return Str._('Maps')
 
     @classmethod
-    def description(cls, localizer: Localizer) -> str:
-        return localizer._('Display lists of places as interactive maps using <a href="https://leafletjs.com/">Leaflet</a>.')
+    def description(cls) -> Str:
+        return Str._('Display lists of places as interactive maps using <a href="https://leafletjs.com/">Leaflet</a>.')

--- a/betty/extension/privatizer/__init__.py
+++ b/betty/extension/privatizer/__init__.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 
 from betty.app.extension import UserFacingExtension
 from betty.load import PostLoader, getLogger
-from betty.locale import Localizer
+from betty.locale import Str
 from betty.model import Entity
 from betty.model.ancestry import Person, HasMutablePrivacy
 from betty.privatizer import Privatizer as PrivatizerApi
@@ -15,16 +15,16 @@ class _Privatizer(UserFacingExtension, PostLoader):
         self.privatize()
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Privatizer')
+    def label(cls) -> Str:
+        return Str._('Privatizer')
 
     @classmethod
-    def description(cls, localizer: Localizer) -> str:
-        return localizer._('Determine if people can be proven to have died. If not, mark them and their associated entities private.')
+    def description(cls) -> Str:
+        return Str._('Determine if people can be proven to have died. If not, mark them and their associated entities private.')
 
     def privatize(self) -> None:
         logger = getLogger()
-        logger.info(self._app.localizer._('Privatizing...'))
+        logger.info(Str._('Privatizing...'))
 
         privatizer = PrivatizerApi(self._app.project.configuration.lifetime_threshold)
 
@@ -46,12 +46,14 @@ class _Privatizer(UserFacingExtension, PostLoader):
                 newly_privatized[entity.type] += 1  # type: ignore[index]
 
         if newly_privatized[Person] > 0:
-            logger.info(self._app.localizer._('Privatized {count} people because they are likely still alive.').format(
-                count=newly_privatized[Person],
+            logger.info(Str._(
+                'Privatized {count} people because they are likely still alive.',
+                count=str(newly_privatized[Person]),
             ))
         for entity_type in set(newly_privatized) - {Person}:
             if newly_privatized[entity_type] > 0:
-                logger.info(self._app.localizer._('Privatized {count} {entity_type}, because they are associated with private people.').format(
-                    count=newly_privatized[entity_type],
-                    entity_type=entity_type.entity_type_label_plural(self._app.localizer),
+                logger.info(Str._(
+                    'Privatized {count} {entity_type}, because they are associated with private people.',
+                    count=str(newly_privatized[entity_type]),
+                    entity_type=entity_type.entity_type_label_plural(),
                 ))

--- a/betty/extension/trees/__init__.py
+++ b/betty/extension/trees/__init__.py
@@ -12,7 +12,7 @@ from betty.cache import CacheScope
 from betty.extension.npm import _Npm, NpmBuilder, npm
 from betty.generate import Generator
 from betty.html import CssProvider, JsProvider
-from betty.locale import Localizer
+from betty.locale import Str
 
 
 class _Trees(UserFacingExtension, CssProvider, JsProvider, Generator, NpmBuilder):
@@ -24,7 +24,7 @@ class _Trees(UserFacingExtension, CssProvider, JsProvider, Generator, NpmBuilder
         await self.app.extensions[_Npm].install(type(self), working_directory_path)
         await npm(('run', 'webpack'), cwd=working_directory_path, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         await self._copy_npm_build(working_directory_path / 'webpack-build', assets_directory_path)
-        logging.getLogger().info(self.app.localizer._('Built the interactive family trees.'))
+        logging.getLogger().info(Str._('Built the interactive family trees.'))
 
     async def _copy_npm_build(self, source_directory_path: Path, destination_directory_path: Path) -> None:
         await makedirs(destination_directory_path, exist_ok=True)
@@ -37,7 +37,7 @@ class _Trees(UserFacingExtension, CssProvider, JsProvider, Generator, NpmBuilder
 
     async def generate(self) -> None:
         assets_directory_path = await self.app.extensions[_Npm].ensure_assets(self)
-        await self._copy_npm_build(assets_directory_path, self.app.static_www_directory_path)
+        await self._copy_npm_build(assets_directory_path, self.app.project.configuration.www_directory_path)
 
     @classmethod
     def assets_directory_path(cls) -> Path | None:
@@ -56,9 +56,9 @@ class _Trees(UserFacingExtension, CssProvider, JsProvider, Generator, NpmBuilder
         ]
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Trees')
+    def label(cls) -> Str:
+        return Str._('Trees')
 
     @classmethod
-    def description(cls, localizer: Localizer) -> str:
-        return localizer._('Display interactive family trees using <a href="https://cytoscape.org/">Cytoscape</a>.')
+    def description(cls) -> Str:
+        return Str._('Display interactive family trees using <a href="https://cytoscape.org/">Cytoscape</a>.')

--- a/betty/extension/trees/assets/public/localized/people.json.j2
+++ b/betty/extension/trees/assets/public/localized/people.json.j2
@@ -3,7 +3,7 @@
     {% do ns.people.update({
         person.id: {
             'id': person.id,
-            'label': person.label,
+            'label': person.label | localize,
             'url': person | url,
             'parentIds': person.parents | map(attribute='id') | list,
             'childIds': person.children | map(attribute='id') | list,

--- a/betty/extension/wikipedia/__init__.py
+++ b/betty/extension/wikipedia/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Callable, Iterable, cast, Any
+from typing import Callable, Iterable, Any
 
 from jinja2 import pass_context
 from jinja2.runtime import Context
@@ -10,9 +10,9 @@ from reactives.instance.property import reactive_property
 
 from betty.app.extension import UserFacingExtension
 from betty.asyncio import sync, gather
-from betty.jinja2 import Jinja2Provider, Environment
+from betty.jinja2 import Jinja2Provider, context_localizer
 from betty.load import PostLoader
-from betty.locale import negotiate_locale, Localizer
+from betty.locale import negotiate_locale, Str
 from betty.model.ancestry import Link
 from betty.wikipedia import _Retriever, _Populator, Entry, _parse_url, NotAnEntryError, RetrievalError
 
@@ -61,7 +61,7 @@ class _Wikipedia(UserFacingExtension, Jinja2Provider, PostLoader, ReactiveInstan
             None,
             await gather(*(
                 self._filter_wikipedia_link(
-                    cast(Environment, context.environment).app.locale,
+                    context_localizer(context).locale,
                     link,
                 )
                 for link
@@ -86,12 +86,12 @@ class _Wikipedia(UserFacingExtension, Jinja2Provider, PostLoader, ReactiveInstan
         return Path(__file__).parent / 'assets'
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Wikipedia')
+    def label(cls) -> Str:
+        return Str._('Wikipedia')
 
     @classmethod
-    def description(cls, localizer: Localizer) -> str:
-        return localizer._("""
+    def description(cls) -> Str:
+        return Str._("""
 Display <a href="https://www.wikipedia.org/">Wikipedia</a> summaries for resources with external links. In your custom <a href="https://jinja2docs.readthedocs.io/en/stable/">Jinja2</a> templates, use the following: <pre><code>
 {% with resource=resource_with_links %}
     {% include 'wikipedia.html.j2' %}

--- a/betty/gramps/error.py
+++ b/betty/gramps/error.py
@@ -1,8 +1,5 @@
-from typing import Any
-
 from betty.error import UserFacingError
 
 
 class GrampsError(UserFacingError):
-    def __init__(self, *args: Any, **kwargs: Any):
-        super().__init__(*args, **kwargs)
+    pass

--- a/betty/gui/__init__.py
+++ b/betty/gui/__init__.py
@@ -12,21 +12,23 @@ from betty.app import App
 from betty.error import UserFacingError
 from betty.gui.error import ExceptionError, UnexpectedExceptionError
 from betty.gui.locale import LocalizedWindow
-from betty.locale import Localizer
+from betty.locale import Str
 from betty.serde.format import FormatRepository
-
 
 QWidgetT = TypeVar('QWidgetT', bound=QWidget)
 
 
-def get_configuration_file_filter(localizer: Localizer) -> str:
-    formats = FormatRepository(localizer=localizer)
-    supported_formats = ', '.join([
-        f'.{extension} ({format.label})'
+def get_configuration_file_filter() -> Str:
+    formats = FormatRepository()
+    supported_formats = Str.call(lambda localizer: ', '.join([
+        f'.{extension} ({format.label.localize(localizer)})'
         for extension in formats.extensions
         for format in formats.formats
-    ])
-    return localizer._('Betty project configuration ({supported_formats})').format(supported_formats=supported_formats)
+    ]))
+    return Str._(
+        'Betty project configuration ({supported_formats})',
+        supported_formats=supported_formats,
+    )
 
 
 class GuiBuilder:

--- a/betty/gui/app.py
+++ b/betty/gui/app.py
@@ -153,7 +153,7 @@ class BettyMainWindow(BettyWindow):
             self,
             self._app.localizer._('Open your project from...'),
             '',
-            get_configuration_file_filter(self._app.localizer),
+            get_configuration_file_filter().localize(self._app.localizer),
         )
         if not configuration_file_path_str:
             return
@@ -170,7 +170,7 @@ class BettyMainWindow(BettyWindow):
             self,
             self._app.localizer._('Save your new project to...'),
             '',
-            get_configuration_file_filter(self._app.localizer),
+            get_configuration_file_filter().localize(self._app.localizer),
         )
         if not configuration_file_path_str:
             return
@@ -261,7 +261,10 @@ class WelcomeWindow(BettyMainWindow):
     def _do_set_translatables(self) -> None:
         super()._do_set_translatables()
         self._welcome.setText(self._app.localizer._('Welcome to Betty'))
-        self._welcome_caption.setText(self._app.localizer._('Betty helps you visualize and publish your family history by building interactive genealogy websites out of your <a href="{gramps_url}">Gramps</a> and <a href="{gedcom_url}">GEDCOM</a> family trees.').format(gramps_url='https://gramps-project.org/', gedcom_url='https://en.wikipedia.org/wiki/GEDCOM'))
+        self._welcome_caption.setText(self._app.localizer._('Betty helps you visualize and publish your family history by building interactive genealogy websites out of your <a href="{gramps_url}">Gramps</a> and <a href="{gedcom_url}">GEDCOM</a> family trees.').format(
+            gramps_url='https://gramps-project.org/',
+            gedcom_url='https://en.wikipedia.org/wiki/GEDCOM',
+        ))
         self._project_instruction.setText(self._app.localizer._('Work on a new or existing site of your own'))
         self.open_project_button.setText(self._app.localizer._('Open an existing project'))
         self.new_project_button.setText(self._app.localizer._('Create a new project'))
@@ -283,8 +286,12 @@ class _AboutBettyWindow(BettyWindow):
     def _do_set_translatables(self) -> None:
         super()._do_set_translatables()
         self._label.setText(''.join(map(lambda x: '<p>%s</p>' % x, [
-            self._app.localizer._('Version: {version}').format(version=about.version_label()),
-            self._app.localizer._('Copyright 2019-{year} <a href="twitter.com/bartFeenstra">Bart Feenstra</a> & contributors. Betty is made available to you under the <a href="https://www.gnu.org/licenses/gpl-3.0.en.html">GNU General Public License, Version 3</a> (GPLv3).').format(year=datetime.now().year),
+            self._app.localizer._('Version: {version}').format(
+                version=about.version_label(),
+            ),
+            self._app.localizer._('Copyright 2019-{year} <a href="twitter.com/bartFeenstra">Bart Feenstra</a> & contributors. Betty is made available to you under the <a href="https://www.gnu.org/licenses/gpl-3.0.en.html">GNU General Public License, Version 3</a> (GPLv3).').format(
+                year=datetime.now().year,
+            ),
             self._app.localizer._('Follow Betty on <a href="https://twitter.com/Betty_Project">Twitter</a> and <a href="https://github.com/bartfeenstra/betty">Github</a>.'),
         ])))
 

--- a/betty/gui/error.py
+++ b/betty/gui/error.py
@@ -117,6 +117,8 @@ class ExceptionError(Error):
 class UnexpectedExceptionError(ExceptionError):
     def __init__(self, app: App, exception: Exception, *args: Any, **kwargs: Any):
         super().__init__(app, exception, *args, **kwargs)
-        self.setText(app.localizer._('An unexpected error occurred and Betty could not complete the task. Please <a href="{report_url}">report this problem</a> and include the following details, so the team behind Betty can address it.').format(report_url='https://github.com/bartfeenstra/betty/issues'))
+        self.setText(self._app.localizer._('An unexpected error occurred and Betty could not complete the task. Please <a href="{report_url}">report this problem</a> and include the following details, so the team behind Betty can address it.').format(
+            report_url='https://github.com/bartfeenstra/betty/issues',
+        ))
         self.setTextFormat(Qt.TextFormat.RichText)
         self.setDetailedText(''.join(traceback.format_exception(type(exception), exception, exception.__traceback__)))

--- a/betty/gui/locale.py
+++ b/betty/gui/locale.py
@@ -64,7 +64,7 @@ class TranslationsLocaleCollector(ReactiveInstance):
             )
             if translations_locale is None:
                 self._configuration_locale_caption.setText(self._app.localizer._('There are no translations for {locale_name}.').format(
-                    locale_name=get_display_name(locale, self._app.locale),
+                    locale_name=get_display_name(locale, self._app.localizer.locale),
                 ))
             else:
                 negotiated_locale_translations_coverage = self._app.localizers.coverage(translations_locale)
@@ -73,7 +73,7 @@ class TranslationsLocaleCollector(ReactiveInstance):
                 else:
                     negotiated_locale_translations_coverage_percentage = round(100 / (negotiated_locale_translations_coverage[1] / negotiated_locale_translations_coverage[0]))
                 self._configuration_locale_caption.setText(self._app.localizer._('The translations for {locale_name} are {coverage_percentage}% complete.').format(
-                    locale_name=get_display_name(translations_locale, self._app.locale),
+                    locale_name=get_display_name(translations_locale, self._app.localizer.locale),
                     coverage_percentage=round(negotiated_locale_translations_coverage_percentage)
                 ))
 

--- a/betty/gui/model.py
+++ b/betty/gui/model.py
@@ -37,9 +37,9 @@ class EntityReferenceCollector(LocalizedWidget):
             entity_types = enumerate(sorted(cast(Iterator['UserFacingEntity & Entity'], filter(
                 lambda entity_type: issubclass(entity_type, UserFacingEntity),
                 self._app.entity_types,
-            )), key=lambda entity_type: entity_type.entity_type_label(self._app.localizer)))
+            )), key=lambda entity_type: entity_type.entity_type_label().localize(self._app.localizer)))
             for i, entity_type in entity_types:
-                self._entity_type.addItem(entity_type.entity_type_label(self._app.localizer), entity_type)
+                self._entity_type.addItem(entity_type.entity_type_label().localize(self._app.localizer), entity_type)
                 if entity_type == self._entity_reference.entity_type:
                     self._entity_type.setCurrentIndex(i)
             self._entity_type_label = QLabel()
@@ -57,7 +57,7 @@ class EntityReferenceCollector(LocalizedWidget):
     def _do_set_translatables(self) -> None:
         if self._entity_reference.entity_type:
             self._entity_id_label.setText(self._app.localizer._('{entity_type_label} ID').format(
-                entity_type_label=self._entity_reference.entity_type.entity_type_label(self._app.localizer),
+                entity_type_label=self._entity_reference.entity_type.entity_type_label().localize(self._app.localizer),
             ))
         else:
             self._entity_id_label.setText(self._app.localizer._('Entity ID'))

--- a/betty/gui/project.py
+++ b/betty/gui/project.py
@@ -65,7 +65,7 @@ class _GenerateHtmlListForm(LocalizedWidget):
                 in self._app.entity_types
                 if issubclass(entity_type, UserFacingEntity)
             ],
-            key=lambda x: x.entity_type_label_plural(self._app.localizer),
+            key=lambda x: x.entity_type_label_plural().localize(self._app.localizer),
         ))
         for entity_type in self._checkboxes.keys():
             if entity_type not in entity_types:
@@ -90,7 +90,7 @@ class _GenerateHtmlListForm(LocalizedWidget):
         self._form_label.setText(self._app.localizer._('Generate entity listing pages'))
         for entity_type in self._app.entity_types:
             if issubclass(entity_type, UserFacingEntity):
-                self._checkboxes[entity_type].setText(entity_type.entity_type_label_plural(self._app.localizer))
+                self._checkboxes[entity_type].setText(entity_type.entity_type_label_plural().localize(self._app.localizer))
 
 
 class _GeneralPane(LocalizedWidget):
@@ -272,7 +272,7 @@ class _LocalesConfigurationWidget(LocalizedWidget):
     def _do_set_translatables(self) -> None:
         self._add_locale_button.setText(self._app.localizer._('Add a locale'))
         for locale, button in self._default_buttons.items():
-            button.setText(get_display_name(locale, self._app.locale))
+            button.setText(get_display_name(locale, self._app.localizer.locale))
         for button in self._remove_buttons.values():
             if button is not None:
                 button.setText(self._app.localizer._('Remove'))
@@ -423,17 +423,15 @@ class _ExtensionPane(LocalizedWidget):
                 self._extension_enabled_caption.setText(str(disable_requirement.reduce()))
         else:
             self._extension_enabled.setChecked(False)
-            enable_requirement = self._extension_type.enable_requirement(localizer=self._app.localizer)
+            enable_requirement = self._extension_type.enable_requirement()
             if not enable_requirement.is_met():
                 self._extension_enabled.setDisabled(True)
                 self._extension_enabled_caption.setText(str(enable_requirement.reduce()))
 
     def _do_set_translatables(self) -> None:
-        self._extension_description.setText(
-            self._extension_type.description(self._app.localizer),
-        )
+        self._extension_description.setText(self._extension_type.description().localize(self._app.localizer))
         self._extension_enabled.setText(self._app.localizer._('Enable {extension}').format(
-            extension=self._extension_type.label(self._app.localizer),
+            extension=self._extension_type.label(),
         ))
 
 
@@ -520,7 +518,7 @@ class ProjectWindow(BettyMainWindow):
         self._pane_selectors['general'].setText(self._app.localizer._('General'))
         self._pane_selectors['localization'].setText(self._app.localizer._('Localization'))
         for extension_type in self._extension_types:
-            self._pane_selectors[f'extension-{extension_type.name()}'].setText(extension_type.label(self._app.localizer))
+            self._pane_selectors[f'extension-{extension_type.name()}'].setText(extension_type.label().localize(self._app.localizer))
 
     @reactive_method(on_trigger_call=True)
     def _set_window_title(self) -> None:
@@ -532,7 +530,7 @@ class ProjectWindow(BettyMainWindow):
             self,
             self._app.localizer._('Save your project to...'),
             '',
-            get_configuration_file_filter(self._app.localizer),
+            get_configuration_file_filter().localize(self._app.localizer),
         )
         wait(self._app.project.configuration.write(Path(configuration_file_path_str)))
 
@@ -626,5 +624,6 @@ class _GenerateWindow(BettyWindow):
         generate.getLogger().removeHandler(self._logging_handler)
 
     def _do_set_translatables(self) -> None:
+        self._cancel_button.setText(self._app.localizer._('Cancel'))
         self._cancel_button.setText(self._app.localizer._('Cancel'))
         self._serve_button.setText(self._app.localizer._('View site'))

--- a/betty/gui/serve.py
+++ b/betty/gui/serve.py
@@ -133,7 +133,9 @@ class ServeProjectWindow(_ServeWindow):
         return self._app.localizer._('Serving your site...')
 
     def _build_instruction(self) -> str:
-        return self._app.localizer._('You can now view your site at <a href="{url}">{url}</a>.').format(url=self._thread.server.public_url)
+        return self._app.localizer._('You can now view your site at <a href="{url}">{url}</a>.').format(
+            url=self._thread.server.public_url,
+        )
 
 
 class ServeDemoWindow(_ServeWindow):
@@ -143,7 +145,9 @@ class ServeDemoWindow(_ServeWindow):
         return demo.DemoServer.name()
 
     def _build_instruction(self) -> str:
-        return self._app.localizer._('You can now view a Betty demonstration site at <a href="{url}">{url}</a>.').format(url=self._thread.server.public_url)
+        return self._app.localizer._('You can now view a Betty demonstration site at <a href="{url}">{url}</a>.').format(
+            url=self._thread.server.public_url,
+        )
 
     @property
     def title(self) -> str:

--- a/betty/json.py
+++ b/betty/json.py
@@ -11,7 +11,7 @@ from jsonschema import RefResolver
 
 from betty.app import App
 from betty.asyncio import sync
-from betty.locale import Date, DateRange, Localized, Localey
+from betty.locale import Date, DateRange, Localized, Localey, Str
 from betty.media_type import MediaType
 from betty.model import Entity, get_entity_type_name, GeneratedEntityId
 from betty.model.ancestry import Place, Person, PlaceName, Event, Described, HasLinks, HasCitations, Link, Dated, File, \
@@ -44,6 +44,7 @@ class JSONEncoder(stdjson.JSONEncoder):
         stdjson.JSONEncoder.__init__(self, *args, **kwargs)
         self._app = app
         self._mappers: dict[type[Any], Callable[[Any], Any]] = {
+            Str: str,
             Path: str,
             PlaceName: self._encode_localized_name,
             Place: self._encode_place,

--- a/betty/model/ancestry.py
+++ b/betty/model/ancestry.py
@@ -10,7 +10,7 @@ from typing import Iterable, Any
 from geopy import Point
 
 from betty.classtools import repr_instance
-from betty.locale import Localized, Datey, Localizer, Localizable
+from betty.locale import Localized, Datey, Str
 from betty.media_type import MediaType
 from betty.model import many_to_many, Entity, one_to_many, many_to_one, many_to_one_to_many, \
     MultipleTypesEntityCollection, EntityCollection, UserFacingEntity, EntityTypeAssociationRegistry, \
@@ -178,20 +178,20 @@ class Note(HasMutablePrivacy, UserFacingEntity, Entity):
         return dict_state, slots_state
 
     @classmethod
-    def entity_type_label(cls, localizer: Localizer) -> str:
-        return localizer._('Note')
+    def entity_type_label(cls) -> Str:
+        return Str._('Note')
 
     @classmethod
-    def entity_type_label_plural(cls, localizer: Localizer) -> str:
-        return localizer._('Notes')
+    def entity_type_label_plural(cls) -> Str:
+        return Str._('Notes')
 
     @property
     def text(self) -> str:
         return self._text
 
     @property
-    def label(self) -> str:
-        return self.text
+    def label(self) -> Str:
+        return Str.plain(self.text)
 
 
 @one_to_many('notes', 'betty.model.ancestry.Note', 'entity')
@@ -348,7 +348,6 @@ class File(Described, HasMutablePrivacy, HasMediaType, HasNotes, HasCitations, U
         privacy: Privacy | None = None,
         public: bool | None = None,
         private: bool | None = None,
-        localizer: Localizer | None = None
     ):
         super().__init__(
             id,
@@ -359,7 +358,6 @@ class File(Described, HasMutablePrivacy, HasMediaType, HasNotes, HasCitations, U
             privacy=privacy,
             public=public,
             private=private,
-            localizer=localizer,
         )
         self._path = path
 
@@ -381,20 +379,20 @@ class File(Described, HasMutablePrivacy, HasMediaType, HasNotes, HasCitations, U
         pass
 
     @classmethod
-    def entity_type_label(cls, localizer: Localizer) -> str:
-        return localizer._('File')
+    def entity_type_label(cls) -> Str:
+        return Str._('File')
 
     @classmethod
-    def entity_type_label_plural(cls, localizer: Localizer) -> str:
-        return localizer._('Files')
+    def entity_type_label_plural(cls) -> Str:
+        return Str._('Files')
 
     @property
     def path(self) -> Path:
         return self._path
 
     @property
-    def label(self) -> str:
-        return self.description if self.description else super().label
+    def label(self) -> Str:
+        return Str.plain(self.description) if self.description else super().label
 
 
 @many_to_many('files', 'betty.model.ancestry.File', 'entities')
@@ -450,11 +448,9 @@ class Source(Dated, HasFiles, HasLinks, HasMutablePrivacy, UserFacingEntity, Ent
         privacy: Privacy | None = None,
         public: bool | None = None,
         private: bool | None = None,
-        localizer: Localizer | None = None,
     ):
         super().__init__(
             id,
-            localizer=localizer,
             date=date,
             files=files,
             links=links,
@@ -508,22 +504,22 @@ class Source(Dated, HasFiles, HasLinks, HasMutablePrivacy, UserFacingEntity, Ent
         pass
 
     @classmethod
-    def entity_type_label(cls, localizer: Localizer) -> str:
-        return localizer._('Source')
+    def entity_type_label(cls) -> Str:
+        return Str._('Source')
 
     @classmethod
-    def entity_type_label_plural(cls, localizer: Localizer) -> str:
-        return localizer._('Sources')
+    def entity_type_label_plural(cls) -> Str:
+        return Str._('Sources')
 
     @property
-    def label(self) -> str:
-        return self.name if self.name else super().label
+    def label(self) -> Str:
+        return Str.plain(self.name) if self.name else super().label
 
 
 class AnonymousSource(Source):
     @property  # type: ignore[override]
     def name(self) -> str:
-        return self.localizer._('private')
+        return 'private'
 
     @name.setter
     def name(self, _) -> None:
@@ -545,13 +541,12 @@ class Citation(Dated, HasFiles, HasMutablePrivacy, UserFacingEntity, Entity):
         id: str | None = None,
         facts: Iterable[HasCitations] | None = None,
         source: Source | None = None,
-        location: str | None = None,
+        location: Str | None = None,
         date: Datey | None = None,
         files: Iterable[File] | None = None,
         privacy: Privacy | None = None,
         public: bool | None = None,
         private: bool | None = None,
-        localizer: Localizer | None = None,
     ):
         super().__init__(
             id,
@@ -560,7 +555,6 @@ class Citation(Dated, HasFiles, HasMutablePrivacy, UserFacingEntity, Entity):
             privacy=privacy,
             public=public,
             private=private,
-            localizer=localizer,
         )
         if facts is not None:
             self.facts = facts  # type: ignore[assignment]
@@ -591,22 +585,22 @@ class Citation(Dated, HasFiles, HasMutablePrivacy, UserFacingEntity, Entity):
         pass
 
     @classmethod
-    def entity_type_label(cls, localizer: Localizer) -> str:
-        return localizer._('Citation')
+    def entity_type_label(cls) -> Str:
+        return Str._('Citation')
 
     @classmethod
-    def entity_type_label_plural(cls, localizer: Localizer) -> str:
-        return localizer._('Citations')
+    def entity_type_label_plural(cls) -> Str:
+        return Str._('Citations')
 
     @property
-    def label(self) -> str:
-        return self.location or super().label
+    def label(self) -> Str:
+        return self.location or Str.plain('')
 
 
 class AnonymousCitation(Citation):
     @property  # type: ignore[override]
-    def location(self) -> str:
-        return self.localizer._("private (in order to protect people's privacy)")
+    def location(self) -> Str:
+        return Str._("private (in order to protect people's privacy)")
 
     @location.setter
     def location(self, _) -> None:
@@ -671,20 +665,18 @@ class Enclosure(Dated, HasCitations, Entity):
         self,
         encloses: Place | None,
         enclosed_by: Place | None,
-        *,
-        localizer: Localizer | None = None,
     ):
-        super().__init__(localizer=localizer)
+        super().__init__()
         self.encloses = encloses
         self.enclosed_by = enclosed_by
 
     @classmethod
-    def entity_type_label(cls, localizer: Localizer) -> str:
-        return localizer._('Enclosure')
+    def entity_type_label(cls) -> Str:
+        return Str._('Enclosure')
 
     @classmethod
-    def entity_type_label_plural(cls, localizer: Localizer) -> str:
-        return localizer._('Enclosures')
+    def entity_type_label_plural(cls) -> Str:
+        return Str._('Enclosures')
 
 
 @one_to_many('events', 'betty.model.ancestry.Event', 'place')
@@ -699,12 +691,10 @@ class Place(HasLinks, UserFacingEntity, Entity):
         events: Iterable[Event] | None = None,
         coordinates: Point | None = None,
         links: set[Link] | None = None,
-        localizer: Localizer | None = None,
     ):
         super().__init__(
             id,
             links=links,
-            localizer=localizer,
         )
         self._names = [] if names is None else names
         self._coordinates = coordinates
@@ -754,12 +744,12 @@ class Place(HasLinks, UserFacingEntity, Entity):
         pass
 
     @classmethod
-    def entity_type_label(cls, localizer: Localizer) -> str:
-        return localizer._('Place')
+    def entity_type_label(cls) -> Str:
+        return Str._('Place')
 
     @classmethod
-    def entity_type_label_plural(cls, localizer: Localizer) -> str:
-        return localizer._('Places')
+    def entity_type_label_plural(cls) -> Str:
+        return Str._('Places')
 
     @property
     def names(self) -> list[PlaceName]:
@@ -774,20 +764,20 @@ class Place(HasLinks, UserFacingEntity, Entity):
         self._coordinates = coordinates
 
     @property
-    def label(self) -> str:
+    def label(self) -> Str:
         # @todo Negotiate this by locale and date.
         with suppress(IndexError):
-            return self.names[0].name
+            return Str.plain(self.names[0].name)
         return super().label
 
 
-class PresenceRole(Localizable):
+class PresenceRole:
     @classmethod
     def name(cls) -> str:
         raise NotImplementedError(repr(cls))
 
     @property
-    def label(self) -> str:
+    def label(self) -> Str:
         raise NotImplementedError(repr(self))
 
 
@@ -797,8 +787,8 @@ class Subject(PresenceRole):
         return 'subject'
 
     @property
-    def label(self) -> str:
-        return self.localizer._('Subject')
+    def label(self) -> Str:
+        return Str._('Subject')
 
 
 class Witness(PresenceRole):
@@ -807,8 +797,8 @@ class Witness(PresenceRole):
         return 'witness'
 
     @property
-    def label(self) -> str:
-        return self.localizer._('Witness')
+    def label(self) -> Str:
+        return Str._('Witness')
 
 
 class Beneficiary(PresenceRole):
@@ -817,8 +807,8 @@ class Beneficiary(PresenceRole):
         return 'beneficiary'
 
     @property
-    def label(self) -> str:
-        return self.localizer._('Beneficiary')
+    def label(self) -> Str:
+        return Str._('Beneficiary')
 
 
 class Attendee(PresenceRole):
@@ -827,8 +817,8 @@ class Attendee(PresenceRole):
         return 'attendee'
 
     @property
-    def label(self) -> str:
-        return self.localizer._('Attendee')
+    def label(self) -> Str:
+        return Str._('Attendee')
 
 
 class Speaker(PresenceRole):
@@ -837,8 +827,8 @@ class Speaker(PresenceRole):
         return 'speaker'
 
     @property
-    def label(self) -> str:
-        return self.localizer._('Speaker')
+    def label(self) -> Str:
+        return Str._('Speaker')
 
 
 class Celebrant(PresenceRole):
@@ -847,8 +837,8 @@ class Celebrant(PresenceRole):
         return 'celebrant'
 
     @property
-    def label(self) -> str:
-        return self.localizer._('Celebrant')
+    def label(self) -> Str:
+        return Str._('Celebrant')
 
 
 class Organizer(PresenceRole):
@@ -857,8 +847,8 @@ class Organizer(PresenceRole):
         return 'organizer'
 
     @property
-    def label(self) -> str:
-        return self.localizer._('Organizer')
+    def label(self) -> Str:
+        return Str._('Organizer')
 
 
 @many_to_one_to_many(
@@ -879,10 +869,8 @@ class Presence(HasPrivacy, Entity):
         person: Person | None,
         role: PresenceRole,
         event: Event | None,
-        *,
-        localizer: Localizer | None = None,
     ):
-        super().__init__(None, localizer=localizer)
+        super().__init__(None)
         self.person = person
         self.role = role
         self.event = event
@@ -893,12 +881,12 @@ class Presence(HasPrivacy, Entity):
         return dict_state, slots_state
 
     @classmethod
-    def entity_type_label(cls, localizer: Localizer) -> str:
-        return localizer._('Presence')
+    def entity_type_label(cls) -> Str:
+        return Str._('Presence')
 
     @classmethod
-    def entity_type_label_plural(cls, localizer: Localizer) -> str:
-        return localizer._('Presences')
+    def entity_type_label_plural(cls) -> Str:
+        return Str._('Presences')
 
     def _get_privacy(self) -> Privacy:
         return merge_privacies(self.person, self.event)
@@ -922,7 +910,6 @@ class Event(Dated, HasFiles, HasCitations, Described, HasMutablePrivacy, UserFac
         private: bool | None = None,
         place: Place | None = None,
         description: str | None = None,
-        localizer: Localizer | None = None,
     ):
         super().__init__(
             id,
@@ -933,29 +920,44 @@ class Event(Dated, HasFiles, HasCitations, Described, HasMutablePrivacy, UserFac
             public=public,
             private=private,
             description=description,
-            localizer=localizer,
         )
         self._event_type = event_type
         if place is not None:
             self.place = place
 
     @property
-    def label(self) -> str:
-        label = self.event_type.label(self.localizer)
-        if self.description is not None:
-            label += f' ({self.description})'
+    def label(self) -> Str:
         subjects = [
             presence.person
             for presence
             in self.presences
             if presence.public and isinstance(presence.role, Subject) and presence.person is not None and presence.person.public
         ]
+        format_kwargs = {
+            'event_type': self._event_type.label(),
+        }
         if subjects:
-            return self.localizer._('{event_type} of {subjects}').format(
-                event_type=label,
-                subjects=', '.join(person.label for person in subjects),
+            format_kwargs['subjects'] = Str.call(lambda localizer: ', '.join(person.label.localize(localizer) for person in subjects))
+            if self.description is None:
+                return Str._(
+                    '{event_type} of {subjects}',
+                    **format_kwargs,
+                )
+            else:
+                return Str._(
+                    '{event_type} ({event_description})',
+                    **format_kwargs,
+                )
+        if self.description is None:
+            return Str._(
+                '{event_type}',
+                **format_kwargs,
             )
-        return label
+        else:
+            return Str._(
+                '{event_type} ({event_description}) of {subjects}',
+                **format_kwargs,
+            )
 
     def __getstate__(self) -> State:
         dict_state, slots_state = super().__getstate__()
@@ -979,12 +981,12 @@ class Event(Dated, HasFiles, HasCitations, Described, HasMutablePrivacy, UserFac
         pass
 
     @classmethod
-    def entity_type_label(cls, localizer: Localizer) -> str:
-        return localizer._('Event')
+    def entity_type_label(cls) -> Str:
+        return Str._('Event')
 
     @classmethod
-    def entity_type_label_plural(cls, localizer: Localizer) -> str:
-        return localizer._('Events')
+    def entity_type_label_plural(cls) -> Str:
+        return Str._('Events')
 
     @property
     def event_type(self) -> type[EventType]:
@@ -1020,7 +1022,6 @@ class PersonName(Localized, HasCitations, HasMutablePrivacy, Entity):
         privacy: Privacy | None = None,
         public: bool | None = None,
         private: bool | None = None,
-        localizer: Localizer | None = None
     ):
         if not individual and not affiliation:
             raise ValueError('The individual and affiliation names must not both be empty.')
@@ -1029,7 +1030,6 @@ class PersonName(Localized, HasCitations, HasMutablePrivacy, Entity):
             privacy=privacy,
             public=public,
             private=private,
-            localizer=localizer,
         )
         self._individual = individual
         self._affiliation = affiliation
@@ -1065,12 +1065,12 @@ class PersonName(Localized, HasCitations, HasMutablePrivacy, Entity):
         return (self._individual or '') > (other._individual or '') and (self._affiliation or '') > (other._affiliation or '')
 
     @classmethod
-    def entity_type_label(cls, localizer: Localizer) -> str:
-        return localizer._('Person name')
+    def entity_type_label(cls) -> Str:
+        return Str._('Person name')
 
     @classmethod
-    def entity_type_label_plural(cls, localizer: Localizer) -> str:
-        return localizer._('Person names')
+    def entity_type_label_plural(cls) -> Str:
+        return Str._('Person names')
 
     @property
     def individual(self) -> str | None:
@@ -1081,10 +1081,11 @@ class PersonName(Localized, HasCitations, HasMutablePrivacy, Entity):
         return self._affiliation
 
     @property
-    def label(self) -> str:
+    def label(self) -> Str:
         if self.private:
-            return self.localizer._('private')
-        return self.localizer._('{individual_name} {affiliation_name}').format(
+            return Str._('private')
+        return Str._(
+            '{individual_name} {affiliation_name}',
             individual_name='…' if not self.individual else self.individual,
             affiliation_name='…' if not self.affiliation else self.affiliation,
         )
@@ -1108,7 +1109,6 @@ class Person(HasFiles, HasCitations, HasLinks, HasMutablePrivacy, UserFacingEnti
         private: bool | None = None,
         parents: Iterable[Person] | None = None,
         children: Iterable[Person] | None = None,
-        localizer: Localizer | None = None,
     ):
         super().__init__(
             id,
@@ -1118,7 +1118,6 @@ class Person(HasFiles, HasCitations, HasLinks, HasMutablePrivacy, UserFacingEnti
             privacy=privacy,
             public=public,
             private=private,
-            localizer=localizer,
         )
         if children is not None:
             self.children = children  # type: ignore[assignment]
@@ -1174,12 +1173,12 @@ class Person(HasFiles, HasCitations, HasLinks, HasMutablePrivacy, UserFacingEnti
         pass
 
     @classmethod
-    def entity_type_label(cls, localizer: Localizer) -> str:
-        return localizer._('Person')
+    def entity_type_label(cls) -> Str:
+        return Str._('Person')
 
     @classmethod
-    def entity_type_label_plural(cls, localizer: Localizer) -> str:
-        return localizer._('People')
+    def entity_type_label_plural(cls) -> Str:
+        return Str._('People')
 
     def __eq__(self, other: Any) -> bool:
         return super().__eq__(other) and self.name == other.name
@@ -1271,13 +1270,13 @@ class Person(HasFiles, HasCitations, HasLinks, HasMutablePrivacy, UserFacingEnti
             yield file
 
     @property
-    def label(self) -> str:
+    def label(self) -> Str:
         return self.name.label if self.name else super().label
 
 
 class Ancestry(MultipleTypesEntityCollection[Entity]):
-    def __init__(self, *, localizer: Localizer | None = None):
-        super().__init__(localizer=localizer)
+    def __init__(self):
+        super().__init__()
         self._check_graph = True
 
     def __getstate__(self) -> PickleableEntityGraph:

--- a/betty/model/event_type.py
+++ b/betty/model/event_type.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from betty.locale import Localizer
+from betty.locale import Str
 
 if TYPE_CHECKING:
     from betty.model.ancestry import Person
@@ -23,7 +23,7 @@ class EventType:
         raise NotImplementedError(repr(cls))
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
+    def label(cls) -> Str:
         raise NotImplementedError(repr(cls))
 
     @classmethod
@@ -41,8 +41,8 @@ class UnknownEventType(EventType):
         return 'unknown'
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Unknown')
+    def label(cls) -> Str:
+        return Str._('Unknown')
 
 
 class DerivableEventType(EventType):
@@ -91,8 +91,8 @@ class Birth(CreatableDerivableEventType, StartOfLifeEventType):
         return 'birth'
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Birth')
+    def label(cls) -> Str:
+        return Str._('Birth')
 
     @classmethod
     def comes_before(cls) -> set[type[EventType]]:
@@ -105,8 +105,8 @@ class Baptism(DuringLifeEventType, StartOfLifeEventType):
         return 'baptism'
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Baptism')
+    def label(cls) -> Str:
+        return Str._('Baptism')
 
 
 class Adoption(DuringLifeEventType):
@@ -115,8 +115,8 @@ class Adoption(DuringLifeEventType):
         return 'adoption'
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Adoption')
+    def label(cls) -> Str:
+        return Str._('Adoption')
 
 
 class Death(CreatableDerivableEventType, EndOfLifeEventType):
@@ -125,8 +125,8 @@ class Death(CreatableDerivableEventType, EndOfLifeEventType):
         return 'death'
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Death')
+    def label(cls) -> Str:
+        return Str._('Death')
 
     @classmethod
     def comes_after(cls) -> set[type[EventType]]:
@@ -149,8 +149,8 @@ class Funeral(FinalDispositionEventType):
         return 'funeral'
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Funeral')
+    def label(cls) -> Str:
+        return Str._('Funeral')
 
 
 class Cremation(FinalDispositionEventType):
@@ -159,8 +159,8 @@ class Cremation(FinalDispositionEventType):
         return 'cremation'
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Cremation')
+    def label(cls) -> Str:
+        return Str._('Cremation')
 
 
 class Burial(FinalDispositionEventType):
@@ -169,8 +169,8 @@ class Burial(FinalDispositionEventType):
         return 'burial'
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Burial')
+    def label(cls) -> Str:
+        return Str._('Burial')
 
 
 class Will(PostDeathEventType):
@@ -179,8 +179,8 @@ class Will(PostDeathEventType):
         return 'will'
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Will')
+    def label(cls) -> Str:
+        return Str._('Will')
 
 
 class Engagement(DuringLifeEventType):
@@ -189,8 +189,8 @@ class Engagement(DuringLifeEventType):
         return 'engagement'
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Engagement')
+    def label(cls) -> Str:
+        return Str._('Engagement')
 
     @classmethod
     def comes_before(cls) -> set[type[EventType]]:
@@ -203,8 +203,8 @@ class Marriage(DuringLifeEventType):
         return 'marriage'
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Marriage')
+    def label(cls) -> Str:
+        return Str._('Marriage')
 
 
 class MarriageAnnouncement(DuringLifeEventType):
@@ -213,8 +213,8 @@ class MarriageAnnouncement(DuringLifeEventType):
         return 'marriage-announcement'
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Announcement of marriage')
+    def label(cls) -> Str:
+        return Str._('Announcement of marriage')
 
     @classmethod
     def comes_before(cls) -> set[type[EventType]]:
@@ -227,8 +227,8 @@ class Divorce(DuringLifeEventType):
         return 'divorce'
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Divorce')
+    def label(cls) -> Str:
+        return Str._('Divorce')
 
     @classmethod
     def comes_after(cls) -> set[type[EventType]]:
@@ -241,8 +241,8 @@ class DivorceAnnouncement(DuringLifeEventType):
         return 'divorce-announcement'
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Announcement of divorce')
+    def label(cls) -> Str:
+        return Str._('Announcement of divorce')
 
     @classmethod
     def comes_after(cls) -> set[type[EventType]]:
@@ -259,8 +259,8 @@ class Residence(DuringLifeEventType):
         return 'residence'
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Residence')
+    def label(cls) -> Str:
+        return Str._('Residence')
 
 
 class Immigration(DuringLifeEventType):
@@ -269,8 +269,8 @@ class Immigration(DuringLifeEventType):
         return 'immigration'
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Immigration')
+    def label(cls) -> Str:
+        return Str._('Immigration')
 
 
 class Emigration(DuringLifeEventType):
@@ -279,8 +279,8 @@ class Emigration(DuringLifeEventType):
         return 'emigration'
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Emigration')
+    def label(cls) -> Str:
+        return Str._('Emigration')
 
 
 class Occupation(DuringLifeEventType):
@@ -289,8 +289,8 @@ class Occupation(DuringLifeEventType):
         return 'occupation'
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Occupation')
+    def label(cls) -> Str:
+        return Str._('Occupation')
 
 
 class Retirement(DuringLifeEventType):
@@ -299,8 +299,8 @@ class Retirement(DuringLifeEventType):
         return 'retirement'
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Retirement')
+    def label(cls) -> Str:
+        return Str._('Retirement')
 
 
 class Correspondence(EventType):
@@ -309,8 +309,8 @@ class Correspondence(EventType):
         return 'correspondence'
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Correspondence')
+    def label(cls) -> Str:
+        return Str._('Correspondence')
 
 
 class Confirmation(DuringLifeEventType):
@@ -319,8 +319,8 @@ class Confirmation(DuringLifeEventType):
         return 'confirmation'
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Confirmation')
+    def label(cls) -> Str:
+        return Str._('Confirmation')
 
 
 class Missing(DuringLifeEventType):
@@ -329,8 +329,8 @@ class Missing(DuringLifeEventType):
         return 'missing'
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Missing')
+    def label(cls) -> Str:
+        return Str._('Missing')
 
 
 class Conference(DuringLifeEventType):
@@ -339,5 +339,5 @@ class Conference(DuringLifeEventType):
         return 'conference'
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return localizer._('Conference')
+    def label(cls) -> Str:
+        return Str._('Conference')

--- a/betty/openapi.py
+++ b/betty/openapi.py
@@ -6,10 +6,12 @@ from betty.string import camel_case_to_kebab_case
 
 
 class Specification:
-    def __init__(self, app: App):
+    def __init__(self, app: App, locale: str):
         self._app = app
+        self._locale = locale
 
     def build(self) -> DictDump[Dump]:
+        localizer = self._app.localizers[self._locale]
         specification: DictDump[Dump] = {
             'openapi': '3.1.0',
             'servers': [
@@ -25,7 +27,7 @@ class Specification:
             'components': {
                 'responses': {
                     '401': {
-                        'description': self._app.localizer._('Unauthorized'),
+                        'description': localizer._('Unauthorized'),
                         'content': {
                             'application/json': {
                                 'schema': {
@@ -35,7 +37,7 @@ class Specification:
                         },
                     },
                     '403': {
-                        'description': self._app.localizer._('Forbidden'),
+                        'description': localizer._('Forbidden'),
                         'content': {
                             'application/json': {
                                 'schema': {
@@ -45,7 +47,7 @@ class Specification:
                         },
                     },
                     '404': {
-                        'description': self._app.localizer._('Not found'),
+                        'description': localizer._('Not found'),
                         'content': {
                             'application/json': {
                                 'schema': {
@@ -60,9 +62,9 @@ class Specification:
                         'name': 'id',
                         'in': 'path',
                         'required': True,
-                        'description': self._app.localizer._('The ID for the resource to retrieve.'),
+                        'description': localizer._('The ID for the resource to retrieve.'),
                         'schema': {
-                            'type': 'string',
+                            'type': 'localizering',
                         },
                     },
                 },
@@ -87,12 +89,12 @@ class Specification:
             specification['paths'].update({  # type: ignore[union-attr]
                 collection_path: {
                     'get': {
-                        'summary': self._app.localizer._('Retrieve the collection of {entity_type} entities.').format(
+                        'summary': localizer._('Retrieve the collection of {entity_type} entities.').format(
                             entity_type=entity_type_name,
                         ),
                         'responses': {
                             '200': {
-                                'description': self._app.localizer._('The collection of {entity_type} entities.').format(
+                                'description': localizer._('The collection of {entity_type} entities.').format(
                                     entity_type=entity_type_name,
                                 ),
                                 'content': {
@@ -104,12 +106,12 @@ class Specification:
                 },
                 single_path: {
                     'get': {
-                        'summary': self._app.localizer._('Retrieve a single {entity_type} entity.').format(
+                        'summary': localizer._('Retrieve a single {entity_type} entity.').format(
                             entity_type=entity_type_name,
                         ),
                         'responses': {
                             '200': {
-                                'description': self._app.localizer._('The {entity_type} entity.').format(
+                                'description': localizer._('The {entity_type} entity.').format(
                                     entity_type=entity_type_name,
                                 ),
                                 'content': {

--- a/betty/render.py
+++ b/betty/render.py
@@ -1,12 +1,14 @@
 from pathlib import Path
 
+from betty.locale import Localizer
+
 
 class Renderer:
     @property
     def file_extensions(self) -> set[str]:
         raise NotImplementedError(repr(self))
 
-    async def render_file(self, file_path: Path) -> Path:
+    async def render_file(self, file_path: Path, *, localizer: Localizer | None = None) -> Path:
         raise NotImplementedError(repr(self))
 
 
@@ -25,8 +27,8 @@ class SequentialRenderer(Renderer):
     def file_extensions(self) -> set[str]:
         return self._file_extensions
 
-    async def render_file(self, file_path: Path) -> Path:
+    async def render_file(self, file_path: Path, *, localizer: Localizer | None = None) -> Path:
         for renderer in self._renderers:
             if file_path.suffix in renderer.file_extensions:
-                return await self.render_file(await renderer.render_file(file_path))
+                return await self.render_file(await renderer.render_file(file_path, localizer=localizer))
         return file_path

--- a/betty/tests/__init__.py
+++ b/betty/tests/__init__.py
@@ -73,10 +73,12 @@ class TemplateTestCase:
         else:
             class_name = self.__class__.__name__
             raise RuntimeError(f'You must define one of `template_string`, `template_file`, `{class_name}.template_string`, or `{class_name}.template_file`.')
+        app = App()
+        app.project.configuration.debug = True
         if data is None:
             data = {}
-        app = App(locale=locale)
-        app.project.configuration.debug = True
+        if locale is not None:
+            data['localizer'] = app.localizers[locale]
         async with app:
             app.project.configuration.extensions.enable(*self.extensions)
             rendered = template_factory(app.jinja2_environment, template).render(**data)
@@ -90,7 +92,7 @@ def assert_betty_html(
     *,
     check_links: bool = False,
 ) -> Path:
-    betty_html_file_path = app.static_www_directory_path / Path(url_path.lstrip('/'))
+    betty_html_file_path = app.project.configuration.www_directory_path / Path(url_path.lstrip('/'))
     with open(betty_html_file_path) as f:
         betty_html = f.read()
     try:

--- a/betty/tests/app/extension/test_requirement.py
+++ b/betty/tests/app/extension/test_requirement.py
@@ -5,13 +5,14 @@ import pytest
 from betty.app import App
 from betty.app.extension.requirement import RequirementCollection, RequirementError, AllRequirements, AnyRequirement, \
     Requirement
+from betty.locale import Str, DEFAULT_LOCALIZER
 
 
 class TestRequirement:
     async def test_assert_met_should_raise_error_if_unmet(self) -> None:
         class _Requirement(Requirement):
-            def summary(self) -> str:
-                return 'Lorem ipsum'
+            def summary(self) -> Str:
+                return Str._('Lorem ipsum')
 
             def is_met(self) -> bool:
                 return False
@@ -24,20 +25,20 @@ class TestRequirement:
                 return True
         _Requirement().assert_met()
 
-    async def test___str___with_details(self) -> None:
+    async def test_localize_with_details(self) -> None:
         class _Requirement(Requirement):
-            def summary(self) -> str:
-                return 'Lorem ipsum'
+            def summary(self) -> Str:
+                return Str._('Lorem ipsum')
 
-            def details(self) -> str:
-                return 'Dolor sit amet'
-        assert 'Lorem ipsum\n-----------\nDolor sit amet' == str(_Requirement())
+            def details(self) -> Str:
+                return Str._('Dolor sit amet')
+        assert 'Lorem ipsum\n-----------\nDolor sit amet' == _Requirement().localize(DEFAULT_LOCALIZER)
 
-    async def test___str___without_details(self) -> None:
+    async def test_localize_without_details(self) -> None:
         class _Requirement(Requirement):
-            def summary(self) -> str:
-                return 'Lorem ipsum'
-        assert 'Lorem ipsum' == str(_Requirement())
+            def summary(self) -> Str:
+                return Str._('Lorem ipsum')
+        assert 'Lorem ipsum' == _Requirement().localize(DEFAULT_LOCALIZER)
 
 
 class TestRequirementCollection:
@@ -77,21 +78,21 @@ class TestRequirementCollection:
         sut += requirement_2
         assert [requirement_1, requirement_2] == sut._requirements
 
-    async def test___str___without_requirements(self) -> None:
+    async def test_localize_without_requirements(self) -> None:
         class _RequirementCollection(RequirementCollection):
-            def summary(self) -> str:
-                return 'Lorem ipsum'
-        assert 'Lorem ipsum' == str(_RequirementCollection())
+            def summary(self) -> Str:
+                return Str._('Lorem ipsum')
+        assert 'Lorem ipsum' == _RequirementCollection().localize(DEFAULT_LOCALIZER)
 
-    async def test___str___with_requirements(self) -> None:
+    async def test_localize_with_requirements(self) -> None:
         class _RequirementCollection(RequirementCollection):
-            def summary(self) -> str:
-                return 'Lorem ipsum'
+            def summary(self) -> Str:
+                return Str._('Lorem ipsum')
 
         class _Requirement(Requirement):
-            def summary(self) -> str:
-                return 'Lorem ipsum'
-        assert 'Lorem ipsum\n- Lorem ipsum' == str(_RequirementCollection(_Requirement()))
+            def summary(self) -> Str:
+                return Str._('Lorem ipsum')
+        assert 'Lorem ipsum\n- Lorem ipsum' == _RequirementCollection(_Requirement()).localize(DEFAULT_LOCALIZER)
 
     async def test_reduce_without_requirements(self) -> None:
         class _RequirementCollection(RequirementCollection):
@@ -166,7 +167,7 @@ class TestAnyRequirement:
 
     async def test_summary(self) -> None:
         async with App():
-            assert isinstance(AnyRequirement().summary(), str)
+            assert isinstance(AnyRequirement().summary(), Str)
 
 
 class TestAllRequirements:
@@ -192,4 +193,4 @@ class TestAllRequirements:
 
     async def test_summary(self) -> None:
         async with App():
-            assert isinstance(AllRequirements().summary(), str)
+            assert isinstance(AllRequirements().summary(), Str)

--- a/betty/tests/app/test___init__.py
+++ b/betty/tests/app/test___init__.py
@@ -7,7 +7,6 @@ import pytest
 from betty.app import App
 from betty.app.extension import ConfigurableExtension as GenericConfigurableExtension, Extension, CyclicDependencyError
 from betty.config import Configuration
-from betty.locale import Localizer
 from betty.model import Entity
 from betty.project import ExtensionConfiguration
 from betty.serde.dump import Dump, VoidableDump
@@ -42,12 +41,10 @@ class ConfigurableExtensionConfiguration(Configuration):
             cls,
             dump: Dump,
             configuration: Self | None = None,
-            *,
-            localizer: Localizer | None = None,
     ) -> Self:
         if configuration is None:
             configuration = cls()
-        asserter = Asserter(localizer=localizer)
+        asserter = Asserter()
         asserter.assert_record(Fields(
             RequiredField(
                 'check',

--- a/betty/tests/extension/cotton_candy/assets/templates/entity/test_page__citation_html_j2.py
+++ b/betty/tests/extension/cotton_candy/assets/templates/entity/test_page__citation_html_j2.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from betty.extension import CottonCandy
+from betty.locale import Str, DEFAULT_LOCALIZER
 from betty.model.ancestry import Citation, Source, File, Person, PersonName
 from betty.tests import TemplateTestCase
 
@@ -15,7 +16,7 @@ class TestTemplate(TemplateTestCase):
 
         citation = Citation(
             source=source,
-            location='citation location',
+            location=Str.plain('citation location'),
         )
 
         public_file = File(
@@ -58,7 +59,7 @@ class TestTemplate(TemplateTestCase):
             },
         ) as (actual, _):
             assert citation.location is not None
-            assert citation.location in actual
+            assert citation.location.localize(DEFAULT_LOCALIZER) in actual
             assert public_file.description is not None
             assert public_file.description in actual
             assert public_fact_name in actual

--- a/betty/tests/extension/cotton_candy/assets/templates/entity/test_page__event_html_j2.py
+++ b/betty/tests/extension/cotton_candy/assets/templates/entity/test_page__event_html_j2.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from betty.extension import CottonCandy
+from betty.locale import DEFAULT_LOCALIZER, Str
 from betty.model.ancestry import Event, File, Place, PlaceName, Person, Presence, Subject, Citation, Source
 from betty.model.event_type import UnknownEventType
 from betty.tests import TemplateTestCase
@@ -39,14 +40,14 @@ class TestTemplate(TemplateTestCase):
 
         public_citation = Citation(
             source=source,
-            location='public citation location',
+            location=Str.plain('public citation location'),
         )
         public_citation.facts.add(event)
 
         private_citation = Citation(
             source=source,
             private=True,
-            location='private citation location',
+            location=Str.plain('private citation location'),
         )
         private_citation.facts.add(event)
 
@@ -60,12 +61,12 @@ class TestTemplate(TemplateTestCase):
             assert public_file.description is not None
             assert public_file.description in actual
             assert place_name.name in actual
-            assert public_person_for_presence.label in actual
+            assert public_person_for_presence.label.localize(DEFAULT_LOCALIZER) in actual
             assert public_citation.location is not None
-            assert public_citation.location in actual
+            assert public_citation.location.localize(DEFAULT_LOCALIZER) in actual
 
             assert private_file.description is not None
             assert private_file.description not in actual
-            assert private_person_for_presence.label not in actual
+            assert private_person_for_presence.label.localize(DEFAULT_LOCALIZER) not in actual
             assert private_citation.location is not None
-            assert private_citation.location not in actual
+            assert private_citation.location.localize(DEFAULT_LOCALIZER) not in actual

--- a/betty/tests/extension/cotton_candy/assets/templates/entity/test_page__file_html_j2.py
+++ b/betty/tests/extension/cotton_candy/assets/templates/entity/test_page__file_html_j2.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from betty.extension import CottonCandy
-from betty.locale import Localizer
+from betty.locale import Str, DEFAULT_LOCALIZER
 from betty.model import Entity
 from betty.model.ancestry import File, HasFiles, HasMutablePrivacy
 from betty.tests import TemplateTestCase
@@ -9,12 +9,12 @@ from betty.tests import TemplateTestCase
 
 class TemplateTestEntity(HasFiles, HasMutablePrivacy, Entity):
     @classmethod
-    def entity_type_label(cls, localizer: Localizer) -> str:
-        return 'Test'
+    def entity_type_label(cls) -> Str:
+        return Str._('Test')
 
     @classmethod
-    def entity_type_label_plural(cls, localizer: Localizer) -> str:
-        return 'Tests'
+    def entity_type_label_plural(cls) -> Str:
+        return Str._('Tests')
 
 
 class TestTemplate(TemplateTestCase):
@@ -43,6 +43,6 @@ class TestTemplate(TemplateTestCase):
         ) as (actual, _):
             assert file.description is not None
             assert file.description in actual
-            assert public_entity.label in actual
+            assert str(public_entity.label.localize(DEFAULT_LOCALIZER)) in actual
 
-            assert private_entity.label not in actual
+            assert str(private_entity.label.localize(DEFAULT_LOCALIZER)) not in actual

--- a/betty/tests/extension/cotton_candy/assets/templates/entity/test_page__source_html_j2.py
+++ b/betty/tests/extension/cotton_candy/assets/templates/entity/test_page__source_html_j2.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from betty.extension import CottonCandy
+from betty.locale import Str
 from betty.model.ancestry import Source, File, Citation, Person, PersonName
 from betty.tests import TemplateTestCase
 
@@ -28,7 +29,7 @@ class TestTemplate(TemplateTestCase):
 
         public_citation = Citation(
             source=source,
-            location='public citation location',
+            location=Str.plain('public citation location'),
         )
         public_citation.source = source
 
@@ -67,7 +68,7 @@ class TestTemplate(TemplateTestCase):
         private_citation = Citation(
             source=source,
             private=True,
-            location='private citation location',
+            location=Str.plain('private citation location'),
         )
         private_citation.source = source
 
@@ -121,7 +122,7 @@ class TestTemplate(TemplateTestCase):
 
         public_citation_for_public_contained_source = Citation(
             source=source,
-            location='public citation for public contained source location',
+            location=Str.plain('public citation for public contained source location'),
         )
         public_citation_for_public_contained_source.source = public_contained_source
 
@@ -160,7 +161,7 @@ class TestTemplate(TemplateTestCase):
         private_citation_for_public_contained_source = Citation(
             source=source,
             private=True,
-            location='private citation for public contained source location',
+            location=Str.plain('private citation for public contained source location'),
         )
         private_citation_for_public_contained_source.source = public_contained_source
 
@@ -217,7 +218,7 @@ class TestTemplate(TemplateTestCase):
 
         public_citation_for_private_contained_source = Citation(
             source=source,
-            location='public citation for private contained source location',
+            location=Str.plain('public citation for private contained source location'),
         )
         public_citation_for_private_contained_source.source = private_contained_source
 
@@ -256,7 +257,7 @@ class TestTemplate(TemplateTestCase):
         private_citation_for_private_contained_source = Citation(
             source=source,
             private=True,
-            location='private citation for private contained source location',
+            location=Str.plain('private citation for private contained source location'),
         )
         private_citation_for_private_contained_source.source = private_contained_source
 

--- a/betty/tests/extension/cotton_candy/test_gui.py
+++ b/betty/tests/extension/cotton_candy/test_gui.py
@@ -8,7 +8,7 @@ from betty.app import App
 from betty.extension import CottonCandy
 from betty.extension.cotton_candy import _ColorConfiguration
 from betty.extension.cotton_candy.gui import _CottonCandyGuiWidget, _ColorConfigurationWidget
-from betty.locale import Localizer
+from betty.locale import Str
 from betty.model import Entity, UserFacingEntity
 from betty.project import EntityReference
 
@@ -36,12 +36,12 @@ class TestColorConfigurationWidget:
 
 class CottonCandyGuiWidgetTestEntity(UserFacingEntity, Entity):
     @classmethod
-    def entity_type_label(cls, localizer: Localizer) -> str:
-        return cls.__name__
+    def entity_type_label(cls) -> Str:
+        return Str._(cls.__name__)
 
     @classmethod
-    def entity_type_label_plural(cls, localizer: Localizer) -> str:
-        return cls.__name__
+    def entity_type_label_plural(cls) -> Str:
+        return Str._(cls.__name__)
 
 
 class TestCottonCandyGuiWidget:

--- a/betty/tests/extension/cotton_candy/test_search.py
+++ b/betty/tests/extension/cotton_candy/test_search.py
@@ -5,6 +5,7 @@ import pytest
 from betty.app import App
 from betty.extension import CottonCandy
 from betty.extension.cotton_candy.search import Index
+from betty.locale import DEFAULT_LOCALIZER
 from betty.model.ancestry import Person, Place, PlaceName, PersonName, File
 from betty.project import LocaleConfiguration
 
@@ -15,7 +16,7 @@ class TestIndex:
         app.project.configuration.extensions.enable(CottonCandy)
         app.project.configuration.locales['en-US'].alias = 'en'
         app.project.configuration.locales.append(LocaleConfiguration('nl-NL', 'nl'))
-        indexed = [item for item in Index(app).build()]
+        indexed = [item for item in Index(app, DEFAULT_LOCALIZER).build()]
 
         assert [] == indexed
 
@@ -28,7 +29,7 @@ class TestIndex:
         app.project.configuration.locales['en-US'].alias = 'en'
         app.project.configuration.locales.append(LocaleConfiguration('nl-NL', 'nl'))
         app.project.ancestry.add(person)
-        indexed = [item for item in Index(app).build()]
+        indexed = [item for item in Index(app, DEFAULT_LOCALIZER).build()]
 
         assert [] == indexed
 
@@ -49,7 +50,7 @@ class TestIndex:
         app.project.configuration.locales['en-US'].alias = 'en'
         app.project.configuration.locales.append(LocaleConfiguration('nl-NL', 'nl'))
         app.project.ancestry.add(person)
-        indexed = [item for item in Index(app).build()]
+        indexed = [item for item in Index(app, DEFAULT_LOCALIZER).build()]
 
         assert [] == indexed
 
@@ -66,12 +67,12 @@ class TestIndex:
             individual=individual_name,
         )
 
-        app = App(locale=locale)
+        app = App()
         app.project.configuration.extensions.enable(CottonCandy)
         app.project.configuration.locales['en-US'].alias = 'en'
         app.project.configuration.locales.append(LocaleConfiguration('nl-NL', 'nl'))
         app.project.ancestry.add(person)
-        indexed = [item for item in Index(app).build()]
+        indexed = [item for item in Index(app, app.localizers[locale]).build()]
 
         assert 'jane' == indexed[0]['text']
         assert expected in indexed[0]['result']
@@ -89,12 +90,12 @@ class TestIndex:
             affiliation=affiliation_name,
         )
 
-        app = App(locale=locale)
+        app = App()
         app.project.configuration.extensions.enable(CottonCandy)
         app.project.configuration.locales['en-US'].alias = 'en'
         app.project.configuration.locales.append(LocaleConfiguration('nl-NL', 'nl'))
         app.project.ancestry.add(person)
-        indexed = [item for item in Index(app).build()]
+        indexed = [item for item in Index(app, app.localizers[locale]).build()]
 
         assert 'doughnut' == indexed[0]['text']
         assert expected in indexed[0]['result']
@@ -114,12 +115,12 @@ class TestIndex:
             affiliation=affiliation_name,
         )
 
-        app = App(locale=locale)
+        app = App()
         app.project.configuration.extensions.enable(CottonCandy)
         app.project.configuration.locales['en-US'].alias = 'en'
         app.project.configuration.locales.append(LocaleConfiguration('nl-NL', 'nl'))
         app.project.ancestry.add(person)
-        indexed = [item for item in Index(app).build()]
+        indexed = [item for item in Index(app, app.localizers[locale]).build()]
 
         assert 'jane doughnut' == indexed[0]['text']
         assert expected in indexed[0]['result']
@@ -144,12 +145,12 @@ class TestIndex:
             ],
         )
 
-        app = App(locale=locale)
+        app = App()
         app.project.configuration.extensions.enable(CottonCandy)
         app.project.configuration.locales['en-US'].alias = 'en'
         app.project.configuration.locales.append(LocaleConfiguration('nl-NL', 'nl'))
         app.project.ancestry.add(place)
-        indexed = [item for item in Index(app).build()]
+        indexed = [item for item in Index(app, app.localizers[locale]).build()]
 
         assert 'netherlands nederland' == indexed[0]['text']
         assert expected in indexed[0]['result']
@@ -166,7 +167,7 @@ class TestIndex:
         app.project.configuration.locales['en-US'].alias = 'en'
         app.project.configuration.locales.append(LocaleConfiguration('nl-NL', 'nl'))
         app.project.ancestry.add(file)
-        indexed = [item for item in Index(app).build()]
+        indexed = [item for item in Index(app, DEFAULT_LOCALIZER).build()]
 
         assert [] == indexed
 
@@ -182,12 +183,12 @@ class TestIndex:
             description='"file" is Dutch for "traffic jam"',
         )
 
-        app = App(locale=locale)
+        app = App()
         app.project.configuration.extensions.enable(CottonCandy)
         app.project.configuration.locales['en-US'].alias = 'en'
         app.project.configuration.locales.append(LocaleConfiguration('nl-NL', 'nl'))
         app.project.ancestry.add(file)
-        indexed = [item for item in Index(app).build()]
+        indexed = [item for item in Index(app, app.localizers[locale]).build()]
 
         assert '"file" is dutch for "traffic jam"' == indexed[0]['text']
         assert expected in indexed[0]['result']

--- a/betty/tests/extension/npm/test___init__.py
+++ b/betty/tests/extension/npm/test___init__.py
@@ -4,14 +4,13 @@ import pytest
 from pytest_mock import MockerFixture
 
 from betty.app import App
-from betty.locale import DEFAULT_LOCALIZER
 from betty.extension.npm import _NpmRequirement
 
 
 class TestNpmRequirement:
     async def test_check_met(self) -> None:
         async with App():
-            sut = _NpmRequirement.check(DEFAULT_LOCALIZER)
+            sut = _NpmRequirement.check()
         assert sut.is_met()
 
     @pytest.mark.parametrize('e', [
@@ -22,5 +21,5 @@ class TestNpmRequirement:
         m_npm = mocker.patch('betty.extension.npm.npm')
         m_npm.side_effect = e
         async with App():
-            sut = _NpmRequirement.check(DEFAULT_LOCALIZER)
+            sut = _NpmRequirement.check()
         assert not sut.is_met()

--- a/betty/tests/model/test_ancestry.py
+++ b/betty/tests/model/test_ancestry.py
@@ -8,12 +8,12 @@ import dill
 import pytest
 from geopy import Point
 
-from betty.locale import Date
+from betty.locale import Date, Str
 from betty.media_type import MediaType
 from betty.model import Entity, one_to_one
 from betty.model.ancestry import Person, Event, Place, File, Note, Presence, PlaceName, PersonName, Subject, \
     Enclosure, Described, Dated, HasPrivacy, HasMediaType, Link, HasLinks, HasNotes, HasFiles, Source, Citation, \
-    HasCitations, PresenceRole, Attendee, Beneficiary, Witness, Ancestry, is_private, is_public, Privacy, \
+    HasCitations, PresenceRole, Ancestry, is_private, is_public, Privacy, \
     merge_privacies
 from betty.model.event_type import Burial, Birth, UnknownEventType
 
@@ -366,7 +366,7 @@ class TestCitation:
     async def test_location(self) -> None:
         sut = Citation(source=Source())
         assert sut.location is None
-        location = 'Somewhere'
+        location = Str.plain('Somewhere')
         sut.location = location
         assert location == sut.location
 
@@ -566,50 +566,6 @@ class TestPlace:
         coordinates = Point()
         sut.coordinates = coordinates
         assert coordinates == sut.coordinates
-
-
-class TestSubject:
-    async def test_name(self) -> None:
-        assert isinstance(Subject.name(), str)
-        assert '' != Subject.name()
-
-    async def test_label(self) -> None:
-        sut = Subject()
-        assert isinstance(sut.label, str)
-        assert '' != sut.label
-
-
-class TestWitness:
-    async def test_name(self) -> None:
-        assert isinstance(Witness.name(), str)
-        assert '' != Witness.name()
-
-    async def test_label(self) -> None:
-        sut = Witness()
-        assert isinstance(sut.label, str)
-        assert '' != sut.label
-
-
-class TestBeneficiary:
-    async def test_name(self) -> None:
-        assert isinstance(Beneficiary.name(), str)
-        assert '' != Beneficiary.name()
-
-    async def test_label(self) -> None:
-        sut = Beneficiary()
-        assert isinstance(sut.label, str)
-        assert '' != sut.label
-
-
-class TestAttendee:
-    async def test_name(self) -> None:
-        assert isinstance(Attendee.name(), str)
-        assert '' != Attendee.name()
-
-    async def test_label(self) -> None:
-        sut = Attendee()
-        assert isinstance(sut.label, str)
-        assert '' != sut.label
 
 
 class TestPresence:

--- a/betty/tests/serde/test_error.py
+++ b/betty/tests/serde/test_error.py
@@ -1,75 +1,82 @@
+from betty.locale import Str, DEFAULT_LOCALIZER
 from betty.serde.error import SerdeError, SerdeErrorCollection
 from betty.serde.load import LoadError
 from betty.tests.serde import assert_error
 
 
 class TestSerdeError:
-    async def test__str__without_contexts(self) -> None:
-        sut = SerdeError('Something went wrong!')
-        assert 'Something went wrong!' == str(sut)
+    async def test_localizewithout_contexts(self) -> None:
+        sut = SerdeError(Str.plain('Something went wrong!'))
+        assert 'Something went wrong!' == sut.localize(DEFAULT_LOCALIZER)
 
-    async def test__str___with_contexts(self) -> None:
-        sut = SerdeError('Something went wrong!')
-        sut = sut.with_context('Somewhere, at some point...')
-        sut = sut.with_context('Somewhere else, too...')
-        assert 'Something went wrong!\n- Somewhere, at some point...\n- Somewhere else, too...' == str(sut)
+    async def test_localize_with_contexts(self) -> None:
+        sut = SerdeError(Str.plain('Something went wrong!'))
+        sut = sut.with_context(Str.plain('Somewhere, at some point...'))
+        sut = sut.with_context(Str.plain('Somewhere else, too...'))
+        assert 'Something went wrong!\n- Somewhere, at some point...\n- Somewhere else, too...' == sut.localize(DEFAULT_LOCALIZER)
 
     async def test_with_context(self) -> None:
-        sut = SerdeError('Something went wrong!')
-        sut_with_context = sut.with_context('Somewhere, at some point...')
+        sut = SerdeError(Str.plain('Something went wrong!'))
+        sut_with_context = sut.with_context(Str.plain('Somewhere, at some point...'))
         assert sut != sut_with_context
-        assert sut_with_context.contexts == ('Somewhere, at some point...',)
+        assert ['Somewhere, at some point...'] == [
+            context.localize(DEFAULT_LOCALIZER)
+            for context in sut_with_context.contexts
+        ]
 
 
-class TestConfigurationErrorCollection:
-    async def test__str__without_errors(self) -> None:
+class TestSerdeErrorCollection:
+    async def test_localizewithout_errors(self) -> None:
         sut = SerdeErrorCollection()
-        assert '' == str(sut)
+        assert '' == sut.localize(DEFAULT_LOCALIZER)
 
-    async def test__str___with_one_error(self) -> None:
+    async def test_localize_with_one_error(self) -> None:
         sut = SerdeErrorCollection()
-        sut.append(SerdeError('Something went wrong!'))
-        assert 'Something went wrong!' == str(sut)
+        sut.append(SerdeError(Str.plain('Something went wrong!')))
+        assert 'Something went wrong!' == sut.localize(DEFAULT_LOCALIZER)
 
-    async def test__str___with_multiple_errors(self) -> None:
+    async def test_localize_with_multiple_errors(self) -> None:
         sut = SerdeErrorCollection()
-        sut.append(SerdeError('Something went wrong!'))
-        sut.append(SerdeError('Something else went wrong, too!'))
-        assert 'Something went wrong!\n\nSomething else went wrong, too!' == str(sut)
+        sut.append(SerdeError(Str.plain('Something went wrong!')))
+        sut.append(SerdeError(Str.plain('Something else went wrong, too!')))
+        assert 'Something went wrong!\n\nSomething else went wrong, too!' == sut.localize(DEFAULT_LOCALIZER)
 
-    async def test__str___with_predefined_contexts(self) -> None:
+    async def test_localize_with_predefined_contexts(self) -> None:
         sut = SerdeErrorCollection()
-        sut = sut.with_context('Somewhere, at some point...')
-        sut = sut.with_context('Somewhere else, too...')
-        error_1 = SerdeError('Something went wrong!')
-        error_2 = SerdeError('Something else went wrong, too!')
+        sut = sut.with_context(Str.plain('Somewhere, at some point...'))
+        sut = sut.with_context(Str.plain('Somewhere else, too...'))
+        error_1 = SerdeError(Str.plain('Something went wrong!'))
+        error_2 = SerdeError(Str.plain('Something else went wrong, too!'))
         sut.append(error_1)
         sut.append(error_2)
         assert not len(error_1.contexts)
         assert not len(error_2.contexts)
-        assert 'Something went wrong!\n- Somewhere, at some point...\n- Somewhere else, too...\n\nSomething else went wrong, too!\n- Somewhere, at some point...\n- Somewhere else, too...' == str(sut)
+        assert 'Something went wrong!\n- Somewhere, at some point...\n- Somewhere else, too...\n\nSomething else went wrong, too!\n- Somewhere, at some point...\n- Somewhere else, too...' == sut.localize(DEFAULT_LOCALIZER)
 
-    async def test__str___with_postdefined_contexts(self) -> None:
+    async def test_localize_with_postdefined_contexts(self) -> None:
         sut = SerdeErrorCollection()
-        error_1 = SerdeError('Something went wrong!')
-        error_2 = SerdeError('Something else went wrong, too!')
+        error_1 = SerdeError(Str.plain('Something went wrong!'))
+        error_2 = SerdeError(Str.plain('Something else went wrong, too!'))
         sut.append(error_1)
         sut.append(error_2)
-        sut = sut.with_context('Somewhere, at some point...')
-        sut = sut.with_context('Somewhere else, too...')
+        sut = sut.with_context(Str.plain('Somewhere, at some point...'))
+        sut = sut.with_context(Str.plain('Somewhere else, too...'))
         assert not len(error_1.contexts)
         assert not len(error_2.contexts)
-        assert 'Something went wrong!\n- Somewhere, at some point...\n- Somewhere else, too...\n\nSomething else went wrong, too!\n- Somewhere, at some point...\n- Somewhere else, too...' == str(sut)
+        assert 'Something went wrong!\n- Somewhere, at some point...\n- Somewhere else, too...\n\nSomething else went wrong, too!\n- Somewhere, at some point...\n- Somewhere else, too...' == sut.localize(DEFAULT_LOCALIZER)
 
     async def test_with_context(self) -> None:
         sut = SerdeErrorCollection()
-        sut_with_context = sut.with_context('Somewhere, at some point...')
+        sut_with_context = sut.with_context(Str.plain('Somewhere, at some point...'))
         assert sut is not sut_with_context
-        assert sut_with_context.contexts == ('Somewhere, at some point...',)
+        assert ['Somewhere, at some point...'] == [
+            context.localize(DEFAULT_LOCALIZER)
+            for context in sut_with_context.contexts
+        ]
 
     async def test_catch_without_contexts(self) -> None:
         sut = SerdeErrorCollection()
-        error = LoadError('Help!')
+        error = LoadError(Str.plain('Help!'))
         with sut.catch() as errors:
             raise error
         assert_error(errors, error=error)
@@ -77,8 +84,8 @@ class TestConfigurationErrorCollection:
 
     async def test_catch_with_contexts(self) -> None:
         sut = SerdeErrorCollection()
-        error = LoadError('Help!')
-        with sut.catch('Somewhere') as errors:
+        error = LoadError(Str.plain('Help!'))
+        with sut.catch(Str.plain('Somewhere')) as errors:
             raise error
-        assert_error(errors, error=error.with_context('Somewhere'))
-        assert_error(sut, error=error.with_context('Somewhere'))
+        assert_error(errors, error=error.with_context(Str.plain('Somewhere')))
+        assert_error(sut, error=error.with_context(Str.plain('Somewhere')))

--- a/betty/tests/serde/test_load.py
+++ b/betty/tests/serde/test_load.py
@@ -97,7 +97,7 @@ class TestAsserter:
 
     async def test_assert_sequence_with_invalid_item(self) -> None:
         sut = Asserter()
-        with raises_error(error_type=AssertionFailed, error_contexts=('0',)):
+        with raises_error(error_type=AssertionFailed, error_contexts=['0']):
             sut.assert_sequence(Assertions(sut.assert_str()))([123])
 
     async def test_assert_sequence_with_empty_list(self) -> None:
@@ -127,7 +127,7 @@ class TestAsserter:
 
     async def test_assert_fields_required_without_key(self) -> None:
         sut = Asserter()
-        with raises_error(error_type=AssertionFailed, error_contexts=('hello',)):
+        with raises_error(error_type=AssertionFailed, error_contexts=['hello']):
             sut.assert_fields(Fields(RequiredField(
                 'hello',
                 Assertions(sut.assert_str()),
@@ -174,7 +174,7 @@ class TestAsserter:
 
     async def test_assert_field_required_without_key(self) -> None:
         sut = Asserter()
-        with raises_error(error_type=AssertionFailed, error_contexts=('hello',)):
+        with raises_error(error_type=AssertionFailed, error_contexts=['hello']):
             sut.assert_field(RequiredField(
                 'hello',
                 Assertions(sut.assert_str()),
@@ -214,7 +214,7 @@ class TestAsserter:
 
     async def test_assert_mapping_with_invalid_item(self) -> None:
         sut = Asserter()
-        with raises_error(error_type=AssertionFailed, error_contexts=('hello',)):
+        with raises_error(error_type=AssertionFailed, error_contexts=['hello']):
             sut.assert_mapping(Assertions(sut.assert_str()))({'hello': False})
 
     async def test_assert_mapping_with_empty_dict(self) -> None:

--- a/betty/tests/test_cli.py
+++ b/betty/tests/test_cli.py
@@ -13,6 +13,7 @@ from pytest_mock import MockerFixture
 
 from betty import fs
 from betty.error import UserFacingError
+from betty.locale import DEFAULT_LOCALIZER, Str
 from betty.os import ChDir
 from betty.project import ProjectConfiguration, ExtensionConfiguration, Project
 from betty.serde.dump import Dump
@@ -128,7 +129,7 @@ class TestMain:
 
 class TestCatchExceptions:
     async def test_logging_user_facing_error(self, caplog: LogCaptureFixture) -> None:
-        error_message = 'Something went wrong!'
+        error_message = Str.plain('Something went wrong!')
         with pytest.raises(SystemExit):
             with catch_exceptions():
                 raise UserFacingError(error_message)
@@ -200,7 +201,7 @@ class TestGenerate:
 
 class _KeyboardInterruptedProjectServer(ProjectServer):
     def __init__(self, *_: Any, **__: Any):
-        super().__init__(Project())
+        super().__init__(DEFAULT_LOCALIZER, Project())
 
     async def start(self) -> None:
         raise KeyboardInterrupt

--- a/betty/tests/test_config.py
+++ b/betty/tests/test_config.py
@@ -9,7 +9,6 @@ from reactives.tests import assert_reactor_called, assert_in_scope, assert_scope
 
 from betty.config import FileBasedConfiguration, ConfigurationMapping, Configuration, \
     ConfigurationCollection, ConfigurationSequence, ConfigurationKeyT, ConfigurationT
-from betty.locale import Localizer
 from betty.serde.dump import Dump, VoidableDump
 from betty.serde.load import FormatError, Asserter
 
@@ -218,10 +217,8 @@ class ConfigurationMappingTestConfigurationMapping(ConfigurationMapping[str, Con
         cls,
         item_dump: Dump,
         key_dump: str,
-        *,
-        localizer: Localizer | None = None,
     ) -> Dump:
-        asserter = Asserter(localizer=localizer)
+        asserter = Asserter()
         dict_item_dump = asserter.assert_dict()(item_dump)
         dict_item_dump[key_dump] = key_dump
         return dict_item_dump

--- a/betty/tests/test_deriver.py
+++ b/betty/tests/test_deriver.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from betty.deriver import Deriver
-from betty.locale import DateRange, Date, Datey, Localizer
+from betty.locale import DateRange, Date, Datey, Str
 from betty.model import record_added
 from betty.model.ancestry import Person, Presence, Subject, Event, Ancestry
 from betty.model.event_type import DerivableEventType, CreatableDerivableEventType, EventType
@@ -16,8 +16,8 @@ class DeriverTestEventType(EventType):
         return repr(cls)
 
     @classmethod
-    def label(cls, localizer: Localizer) -> str:
-        return repr(cls)
+    def label(cls) -> Str:
+        return Str._(repr(cls))
 
 
 class Ignored(DeriverTestEventType):

--- a/betty/tests/test_jinja2.py
+++ b/betty/tests/test_jinja2.py
@@ -8,7 +8,7 @@ from aiofiles.tempfile import TemporaryDirectory
 
 from betty.app import App
 from betty.jinja2 import Jinja2Renderer, _Citer, Jinja2Provider
-from betty.locale import Date, Datey, DateRange, Localized, DEFAULT_LOCALIZER
+from betty.locale import Date, Datey, DateRange, Localized
 from betty.media_type import MediaType
 from betty.model import get_entity_type_name, Entity
 from betty.model.ancestry import File, PlaceName, Subject, Attendee, Witness, Dated, Person, Place, Citation
@@ -224,7 +224,7 @@ class TestGlobalCiter(TemplateTestCase):
     async def test_cite(self) -> None:
         citation1 = Citation()
         citation2 = Citation()
-        sut = _Citer(DEFAULT_LOCALIZER)
+        sut = _Citer()
         assert 1 == sut.cite(citation1)
         assert 2 == sut.cite(citation2)
         assert 1 == sut.cite(citation1)
@@ -232,7 +232,7 @@ class TestGlobalCiter(TemplateTestCase):
     async def test_iter(self) -> None:
         citation1 = Citation()
         citation2 = Citation()
-        sut = _Citer(DEFAULT_LOCALIZER)
+        sut = _Citer()
         sut.cite(citation1)
         sut.cite(citation2)
         sut.cite(citation1)
@@ -241,7 +241,7 @@ class TestGlobalCiter(TemplateTestCase):
     async def test_len(self) -> None:
         citation1 = Citation()
         citation2 = Citation()
-        sut = _Citer(DEFAULT_LOCALIZER)
+        sut = _Citer()
         sut.cite(citation1)
         sut.cite(citation2)
         sut.cite(citation1)

--- a/betty/tests/test_openapi.py
+++ b/betty/tests/test_openapi.py
@@ -6,6 +6,7 @@ import pytest
 
 from betty.app import App
 from betty.fs import ASSETS_DIRECTORY_PATH
+from betty.locale import DEFAULT_LOCALE
 from betty.openapi import Specification
 
 
@@ -19,7 +20,7 @@ class TestSpecification:
             schema = stdjson.load(f)
         app = App()
         app.project.configuration.content_negotiation = content_negotiation
-        sut = Specification(app)
+        sut = Specification(app, DEFAULT_LOCALE)
         specification = sut.build()
         jsonschema.validate(specification, schema)
 

--- a/betty/tests/test_project.py
+++ b/betty/tests/test_project.py
@@ -8,7 +8,7 @@ from reactives.tests import assert_reactor_called, assert_scope_empty
 
 from betty.app.extension import Extension, ConfigurableExtension
 from betty.config import Configuration, Configurable
-from betty.locale import Localizer
+from betty.locale import Str
 from betty.model import Entity, get_entity_type_name, UserFacingEntity
 from betty.project import ExtensionConfiguration, ExtensionConfigurationMapping, ProjectConfiguration, \
     LocaleConfiguration, LocaleConfigurationMapping, EntityReference, EntityReferenceSequence, \
@@ -253,8 +253,8 @@ class TestLocaleConfigurationMapping(ConfigurationMappingTestBase[str, LocaleCon
 
 class _DummyExtension(Extension):
     @classmethod
-    def label(cls) -> str:
-        return 'Dummy'
+    def label(cls) -> Str:
+        return Str._('Dummy')
 
 
 class _DummyConfiguration(Configuration):
@@ -263,8 +263,8 @@ class _DummyConfiguration(Configuration):
 
 class _DummyConfigurableExtension(Extension, Configurable[_DummyConfiguration]):
     @classmethod
-    def label(cls) -> str:
-        return 'Configurable dummy'
+    def label(cls) -> Str:
+        return Str._('Configurable dummy')
 
     @classmethod
     def configuration_type(cls) -> type[_DummyConfiguration]:
@@ -752,12 +752,10 @@ class DummyConfigurableExtensionConfiguration(Configuration):
             cls,
             dump: Dump,
             configuration: Self | None = None,
-            *,
-            localizer: Localizer | None = None,
     ) -> Self:
         if configuration is None:
             configuration = cls()
-        asserter = Asserter(localizer=localizer)
+        asserter = Asserter()
         asserter.assert_record(Fields(
             RequiredField(
                 'check',

--- a/betty/tests/test_serve.py
+++ b/betty/tests/test_serve.py
@@ -5,6 +5,7 @@ import requests
 from pytest_mock import MockerFixture
 
 from betty.app import App
+from betty.locale import DEFAULT_LOCALIZER
 from betty.serve import BuiltinServer
 
 
@@ -16,7 +17,7 @@ class TestBuiltinServer:
         os.makedirs(app.project.configuration.www_directory_path)
         with open(app.project.configuration.www_directory_path / 'index.html', 'w') as f:
             f.write(content)
-        async with BuiltinServer(app.project) as server:
+        async with BuiltinServer(DEFAULT_LOCALIZER, app.project) as server:
             # Wait for the server to start.
             sleep(1)
             response = requests.get(server.public_url)

--- a/betty/tests/test_url.py
+++ b/betty/tests/test_url.py
@@ -51,19 +51,17 @@ class TestLocalizedPathUrlGenerator:
             sut = ContentNegotiationPathUrlGenerator(app)
             assert expected == sut.generate(resource, 'text/html', absolute=True)
 
-    @pytest.mark.parametrize('expected, app_locale, url_generator_locale', [
-        ('/nl/index.html', 'nl', None),
-        ('/en/index.html', 'en', None),
-        ('/nl/index.html', None, 'nl'),
-        ('/en/index.html', None, 'en'),
+    @pytest.mark.parametrize('expected, url_generator_locale', [
+        ('/en/index.html', None),
+        ('/nl/index.html', 'nl'),
+        ('/en/index.html', 'en'),
     ])
     async def test_generate_multilingual(
         self,
         expected: str,
-        app_locale: Localey | None,
         url_generator_locale: Localey | None,
     ) -> None:
-        app = App(locale=app_locale)
+        app = App()
         app.project.configuration.locales.replace(
             LocaleConfiguration('nl-NL', 'nl'),
             LocaleConfiguration('en-US', 'en'),

--- a/betty/url.py
+++ b/betty/url.py
@@ -29,7 +29,7 @@ class ContentNegotiationPathUrlGenerator(ContentNegotiationUrlGenerator):
             self._app.project.configuration,
             resource,
             absolute,
-            self._app.locale if locale is None else locale,
+            self._app.localizer.locale if locale is None else locale,
         )
 
 
@@ -54,7 +54,7 @@ class _EntityUrlGenerator(ContentNegotiationUrlGenerator):
         if 'text/html' == media_type:
             extension = 'html'
             if locale is None:
-                locale = self._app.locale
+                locale = self._app.localizer.locale
         elif 'application/json' == media_type:
             extension = 'json'
             locale = None
@@ -95,7 +95,7 @@ def _generate_from_path(configuration: ProjectConfiguration, path: str, absolute
     url += '/'
     if configuration.root_path:
         url += configuration.root_path + '/'
-    if localey and configuration.multilingual:
+    if localey and configuration.locales.multilingual:
         locale = to_locale(localey)
         try:
             locale_configuration = configuration.locales[locale]


### PR DESCRIPTION
Stop injecting the localizer into everything, and introduce a new solution to lazily translate strings at the point of use. This
- simplifies dependencies between application services
- means a single application instance can be used for tasks in any locale (unblocking performance improvements)
- 'consumers' such as template developers will have to ensure lazy strings are localized before rendering them