### PR TITLE
Skip ShellCheck, Flake8, mypy, Stylelint, ESLint, and Cypress during Mac OS and Windows builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,7 @@ jobs:
             npm-${{ runner.os }}-
 
       - name: Cache Mypy
+        if: startsWith(runner.os, 'Linux')
         uses: actions/cache@v3
         with:
           path: ./.mypy_cache
@@ -96,24 +97,18 @@ jobs:
           )
           sudo apt-get install "${apt_packages[@]}"
 
-      - name: Install Homebrew dependencies
-        if: startsWith(runner.os, 'macOS')
-        run: brew install shellcheck
-
-      - name: Install Chocolatey dependencies
-        if: startsWith(runner.os, 'Windows')
-        run: choco install shellcheck
-
       - name: Build the development environment
         run: |
           ./bin/build-dev
         shell: bash
 
       - name: Get the Cypress cache directory
+        if: startsWith(runner.os, 'Linux')
         run: echo "cypress_cache_dir=$(./node_modules/.bin/cypress cache path)" >> $GITHUB_ENV
         shell: bash
 
       - name: Cache Cypress
+        if: startsWith(runner.os, 'Linux')
         uses: actions/cache@v3
         with:
           path: ${{ env.cypress_cache_dir }}
@@ -122,8 +117,15 @@ jobs:
             cypress-
 
       - name: Run the tests
+        if: startsWith(runner.os, 'Linux')
         run: |
           ./bin/test
+        shell: bash
+
+      - name: Run the tests
+        if: ${{ ! startsWith(runner.os, 'Linux') }}
+        run: |
+          BETTY_TEST_SKIP_SHELLCHECK=true BETTY_TEST_SKIP_FLAKE8=true BETTY_TEST_SKIP_MYPY=true BETTY_TEST_SKIP_STYLELINT=true BETTY_TEST_SKIP_ESLINT=true BETTY_TEST_SKIP_CYPRESS=true ./bin/test
         shell: bash
 
       - name: Upload code coverage

--- a/README.md
+++ b/README.md
@@ -349,6 +349,15 @@ Then, with this PO file editor, open and change the `*.po` file for the translat
 
 In any existing Python environment, run `./bin/test`.
 
+#### Environment variables
+These impact the `./bin/test` command:
+- `BETTY_TEST_SKIP_SHELLCHECK`: Skip ShellCheck tests.
+- `BETTY_TEST_SKIP_FLAKE8`: Skip Flake8 tests.
+- `BETTY_TEST_SKIP_MYPY`: Skip mypy tests.
+- `BETTY_TEST_SKIP_STYLELINT`: Skip Stylelint tests.
+- `BETTY_TEST_SKIP_ESLINT`: Skip ESLint tests.
+- `BETTY_TEST_SKIP_CYPRESS`: Skip Cypress tests.
+
 ### Fixing problems automatically
 
 In any existing Python environment, run `./bin/fix`.

--- a/bin/test
+++ b/bin/test
@@ -4,12 +4,24 @@ set -Eeuo pipefail
 
 cd "$(dirname "$0")/.."
 
-./bin/test-shellcheck
-./bin/test-flake8
-./bin/test-mypy
-./bin/test-stylelint
-./bin/test-eslint
+if [ -z "${BETTY_TEST_SKIP_SHELLCHECK-}" ]; then
+  ./bin/test-shellcheck
+fi
+if [ -z "${BETTY_TEST_SKIP_FLAKE8-}" ]; then
+  ./bin/test-flake8
+fi
+if [ -z "${BETTY_TEST_SKIP_MYPY-}" ]; then
+  ./bin/test-mypy
+fi
+if [ -z "${BETTY_TEST_SKIP_STYLELINT-}" ]; then
+  ./bin/test-stylelint
+fi
+if [ -z "${BETTY_TEST_SKIP_ESLINT-}" ]; then
+  ./bin/test-eslint
+fi
 ./bin/test-pytest
-./bin/test-cypress
+if [ -z "${BETTY_TEST_SKIP_CYPRESS-}" ]; then
+  ./bin/test-cypress
+fi
 ./bin/test-build-pyinstaller
 ./bin/test-build-setuptools


### PR DESCRIPTION
Skip ShellCheck, Flake8, mypy, Stylelint, ESLint, and Cypress during Mac OS and Windows builds, because their results are identical and those builds are slow enough as they are.

This fixes https://github.com/bartfeenstra/betty/issues/1041