### PR TITLE
Fix a bug where the demo site could not be accessed

### DIFF
--- a/betty/extension/demo/__init__.py
+++ b/betty/extension/demo/__init__.py
@@ -386,16 +386,13 @@ class DemoServer(Server):
         raise NoPublicUrlBecauseServerNotStartedError()
 
     async def start(self) -> None:
-        try:
-            await super().start()
-            await self._exit_stack.enter_async_context(self._app)
-            await load.load(self._app)
-            self._server = AppServer.get(self._app)
-            await self._exit_stack.enter_async_context(self._server)
-            self._app.project.configuration.base_url = self._server.public_url
-            await generate.generate(self._app)
-        finally:
-            await self.stop()
+        await super().start()
+        await self._exit_stack.enter_async_context(self._app)
+        await load.load(self._app)
+        self._server = AppServer.get(self._app)
+        await self._exit_stack.enter_async_context(self._server)
+        self._app.project.configuration.base_url = self._server.public_url
+        await generate.generate(self._app)
 
     async def stop(self) -> None:
         await self._exit_stack.aclose()


### PR DESCRIPTION
Fix a bug where the demo site could not be accessed because the internal server would be shut down too early.

This fixes https://github.com/bartfeenstra/betty/issues/1092