### PR TITLE
Fix a bug where the interactive family trees would no longer show people with links to their pages

### DIFF
--- a/betty/extension/trees/assets/betty.extension.npm._Npm/src/trees.js
+++ b/betty/extension/trees/assets/betty.extension.npm._Npm/src/trees.js
@@ -97,7 +97,8 @@ function personToNode (person, nodes) {
     },
     selectable: false,
     grabbable: false,
-    pannable: true
+    pannable: true,
+    classes: person.private ? [] : ['public']
   })
 }
 


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/1100