### PR TITLE
Fix a warning about an unstopped app in the Demo server

### DIFF
--- a/betty/extension/demo/__init__.py
+++ b/betty/extension/demo/__init__.py
@@ -398,12 +398,15 @@ class DemoServer(Server):
 
     async def start(self) -> None:
         await super().start()
-        await self._exit_stack.enter_async_context(self._app)
-        await load.load(self._app)
-        self._server = AppServer.get(self._app)
-        await self._exit_stack.enter_async_context(self._server)
-        self._app.project.configuration.base_url = self._server.public_url
-        await generate.generate(self._app)
+        try:
+            await self._exit_stack.enter_async_context(self._app)
+            await load.load(self._app)
+            self._server = AppServer.get(self._app)
+            await self._exit_stack.enter_async_context(self._server)
+            self._app.project.configuration.base_url = self._server.public_url
+            await generate.generate(self._app)
+        finally:
+            await self.stop()
 
     async def stop(self) -> None:
         await self._exit_stack.aclose()


### PR DESCRIPTION
Fix a warning about an unstopped app in the Demo server by ensuring the app is stopped even if an error is raised.