### PR TITLE
Remove the PyInstaller build for Linux

### DIFF
--- a/.github/workflows/pull-request-create-release.yml
+++ b/.github/workflows/pull-request-create-release.yml
@@ -35,10 +35,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: Linux
-            os: ubuntu-20.04
-            dist_name: betty-linux
-            python: '3.12'
           - name: macOS
             os: macos-11
             dist_name: betty-macos
@@ -89,25 +85,8 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install APT dependencies
-        if: startsWith(runner.os, 'Linux')
-        run: |
-          sudo apt-get update
-          apt_packages=(
-            libegl1-mesa # For Qt
-            libx11-xcb-dev # For Qt
-            '^libxcb.*-dev' # For Qt
-            libxkbcommon-x11-0 # For Qt
-          )
-          sudo apt-get install "${apt_packages[@]}"
-
       - name: Build the executable
         run: ./bin/build-pyinstaller ${{ env.betty_tag }}-${{ github.event.pull_request.head.sha }}
-        shell: bash
-
-      - name: Zip the Linux package
-        if: startsWith(runner.os, 'Linux')
-        run: zip -r -X ./dist/${{ matrix.dist_name }}-${{ github.event.pull_request.head.sha }}.zip ./dist/betty
         shell: bash
 
       - name: Zip the macOS package
@@ -137,7 +116,7 @@ jobs:
         shell: bash
 
       - name: Notify collaborators of the release
-        run: gh pr comment ${{ github.event.pull_request.number }} --body $'Uploaded Betty for commit ${{ github.event.pull_request.head.sha }}. You can download it, test it, and post your feedback in a comment to this pull request 💕\n\n- [Betty Desktop for **Linux** 🐧](https://github.com/bartfeenstra/betty/releases/download/${{ env.betty_tag }}/betty-linux-${{ github.event.pull_request.head.sha }}.zip)\n- [Betty Desktop for **macOS** 🍎](https://github.com/bartfeenstra/betty/releases/download/${{ env.betty_tag }}/betty-macos-${{ github.event.pull_request.head.sha }}.zip)\n- [Betty Desktop for **Windows** 🪟](https://github.com/bartfeenstra/betty/releases/download/${{ env.betty_tag }}/betty-windows-${{ github.event.pull_request.head.sha }}.zip)\n\nThese downloads will stop working when the pull request is closed.'
+        run: gh pr comment ${{ github.event.pull_request.number }} --body $'Uploaded Betty for commit ${{ github.event.pull_request.head.sha }}. You can download it, test it, and post your feedback in a comment to this pull request 💕\n- [Betty Desktop for **macOS** 🍎](https://github.com/bartfeenstra/betty/releases/download/${{ env.betty_tag }}/betty-macos-${{ github.event.pull_request.head.sha }}.zip)\n- [Betty Desktop for **Windows** 🪟](https://github.com/bartfeenstra/betty/releases/download/${{ env.betty_tag }}/betty-windows-${{ github.event.pull_request.head.sha }}.zip)\n\nThese downloads will stop working when the pull request is closed.'
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-build-pyinstaller.yml
+++ b/.github/workflows/release-build-pyinstaller.yml
@@ -11,10 +11,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: Linux
-            os: ubuntu-20.04
-            dist_name: betty-linux
-            python: '3.12'
           - name: macOS
             os: macos-11
             dist_name: betty-macos
@@ -56,25 +52,8 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install APT dependencies
-        if: startsWith(runner.os, 'Linux')
-        run: |
-          sudo apt-get update
-          apt_packages=(
-            libegl1-mesa # For Qt
-            libx11-xcb-dev # For Qt
-            '^libxcb.*-dev' # For Qt
-            libxkbcommon-x11-0 # For Qt
-          )
-          sudo apt-get install "${apt_packages[@]}"
-
       - name: Build the executable
         run: ./bin/build-pyinstaller ${{ github.event.release.tag_name }}
-        shell: bash
-
-      - name: Zip the Linux package
-        if: startsWith(runner.os, 'Linux')
-        run: zip -r -X ./dist/${{ matrix.dist_name }}.zip ./dist/betty
         shell: bash
 
       - name: Zip the macOS package


### PR DESCRIPTION
Remove the PyInstaller build for Linux because it is not portable across distributions.