### PR TITLE
Remove reactivity

### DIFF
--- a/betty/app/extension/__init__.py
+++ b/betty/app/extension/__init__.py
@@ -8,9 +8,6 @@ from pathlib import Path
 from typing import Any, TypeVar, Iterable, TYPE_CHECKING, Generic, \
     Iterator, Sequence, Self
 
-from reactives import scope
-from reactives.instance import ReactiveInstance
-
 from betty import fs
 from betty.app.extension.requirement import Requirement
 from betty.asyncio import gather
@@ -251,7 +248,7 @@ class ConfigurableExtension(Extension, Generic[ConfigurationT], Configurable[Con
         raise NotImplementedError(repr(cls))
 
 
-class Extensions(ReactiveInstance):
+class Extensions:
     def __getitem__(self, extension_type: type[ExtensionT] | str) -> ExtensionT:
         raise NotImplementedError(repr(self))
 
@@ -270,7 +267,6 @@ class ListExtensions(Extensions):
         super().__init__()
         self._extensions = extensions
 
-    @scope.register_self
     def __getitem__(self, extension_type: type[ExtensionT] | str) -> ExtensionT:
         if isinstance(extension_type, str):
             extension_type = import_any(extension_type)
@@ -279,7 +275,6 @@ class ListExtensions(Extensions):
                 return extension  # type: ignore[return-value]
         raise KeyError(f'Unknown extension of type "{extension_type}"')
 
-    @scope.register_self
     def __iter__(self) -> Iterator[Iterator[Extension]]:
         # Use a generator so we discourage calling code from storing the result.
         for batch in self._extensions:
@@ -289,7 +284,6 @@ class ListExtensions(Extensions):
         for batch in self:
             yield from batch
 
-    @scope.register_self
     def __contains__(self, extension_type: type[Extension] | str) -> bool:
         if isinstance(extension_type, str):
             try:

--- a/betty/extension/cotton_candy/__init__.py
+++ b/betty/extension/cotton_candy/__init__.py
@@ -14,8 +14,6 @@ from PyQt6.QtWidgets import QWidget
 from aiofiles.os import makedirs
 from jinja2 import pass_context
 from jinja2.runtime import Context
-from reactives.instance import ReactiveInstance
-from reactives.instance.property import reactive_property
 
 from betty.app.extension import ConfigurableExtension, Extension, Theme
 from betty.config import Configuration
@@ -51,7 +49,6 @@ class _ColorConfiguration(Configuration):
         return hex_value
 
     @property
-    @reactive_property
     def hex(self) -> str:
         return self._hex
 
@@ -63,6 +60,7 @@ class _ColorConfiguration(Configuration):
                 hex_value=hex_value,
             ))
         self._hex = hex_value
+        self._dispatch_change()
 
     def update(self, other: Self) -> None:
         self.hex = other.hex
@@ -102,15 +100,15 @@ class CottonCandyConfiguration(Configuration):
     ):
         super().__init__()
         self._featured_entities = EntityReferenceSequence['UserFacingEntity & Entity'](featured_entities or ())
-        self._featured_entities.react(self)
+        self._featured_entities.on_change(self)
         self._primary_inactive_color = _ColorConfiguration(primary_inactive_color)
-        self._primary_inactive_color.react(self)
+        self._primary_inactive_color.on_change(self)
         self._primary_active_color = _ColorConfiguration(primary_active_color)
-        self._primary_active_color.react(self)
+        self._primary_active_color.on_change(self)
         self._link_inactive_color = _ColorConfiguration(link_inactive_color)
-        self._link_inactive_color.react(self)
+        self._link_inactive_color.on_change(self)
         self._link_active_color = _ColorConfiguration(link_active_color)
-        self._link_active_color.react(self)
+        self._link_active_color.on_change(self)
 
     @property
     def featured_entities(self) -> EntityReferenceSequence[UserFacingEntity & Entity]:
@@ -175,7 +173,7 @@ class CottonCandyConfiguration(Configuration):
         })
 
 
-class _CottonCandy(Theme, ConfigurableExtension[CottonCandyConfiguration], Generator, GuiBuilder, ReactiveInstance, NpmBuilder, Jinja2Provider):
+class _CottonCandy(Theme, ConfigurableExtension[CottonCandyConfiguration], Generator, GuiBuilder, NpmBuilder, Jinja2Provider):
     @classmethod
     def depends_on(cls) -> set[type[Extension]]:
         return {_Npm}

--- a/betty/extension/cotton_candy/gui.py
+++ b/betty/extension/cotton_candy/gui.py
@@ -20,12 +20,9 @@ class _ColorConfigurationSwatch(LocalizedWidget):
     def __init__(self, app: App, color: _ColorConfiguration, *args: Any, **kwargs: Any):
         super().__init__(app, *args, **kwargs)
         self._color = color
-        self._color.react(self.repaint)
+        self._color.on_change(self.repaint)
         self.setFixedHeight(24)
         self.setFixedWidth(24)
-
-    def __del__(self) -> None:
-        self._color.react.shutdown(self.repaint)
 
     def paintEvent(self, a0: QPaintEvent | None) -> None:
         painter = QPainter(self)
@@ -64,7 +61,7 @@ class _ColorConfigurationWidget(LocalizedWidget):
 
         self._reset.clicked.connect(_reset)
 
-    def _do_set_translatables(self) -> None:
+    def _set_translatables(self) -> None:
         self._configure.setText(self._app.localizer._('Configure'))
         self._reset.setText(self._app.localizer._('Reset'))
 
@@ -85,7 +82,7 @@ class _ColorConfigurationsWidget(LocalizedWidget):
             self._color_configurations.append(color_widget)
             self._layout.addRow(color_label, color_widget)
 
-    def _do_set_translatables(self) -> None:
+    def _set_translatables(self) -> None:
         for i, (__, color_label, ___) in enumerate(self._colors):
             self._color_labels[i].setText(color_label())
 

--- a/betty/extension/gramps/config.py
+++ b/betty/extension/gramps/config.py
@@ -6,8 +6,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Iterable, Any, Self
 
-from reactives.instance.property import reactive_property
-
 from betty.config import Configuration, ConfigurationSequence
 from betty.serde.dump import minimize, Dump, VoidableDump
 from betty.serde.load import Asserter, Fields, RequiredField, Assertions, OptionalField
@@ -28,7 +26,6 @@ class FamilyTreeConfiguration(Configuration):
         return self._file_path == other.file_path
 
     @property
-    @reactive_property
     def file_path(self) -> Path | None:
         return self._file_path
 
@@ -61,7 +58,7 @@ class FamilyTreeConfiguration(Configuration):
 
 class FamilyTreeConfigurationSequence(ConfigurationSequence[FamilyTreeConfiguration]):
     def update(self, other: Self) -> None:
-        self._clear_without_trigger()
+        self._clear_without_dispatch()
         self.append(*other)
 
     @classmethod
@@ -81,7 +78,7 @@ class GrampsConfiguration(Configuration):
     ):
         super().__init__()
         self._family_trees = FamilyTreeConfigurationSequence(family_trees)
-        self._family_trees.react(self)
+        self._family_trees.on_change(self)
 
     @property
     def family_trees(self) -> FamilyTreeConfigurationSequence:

--- a/betty/extension/gramps/gui.py
+++ b/betty/extension/gramps/gui.py
@@ -10,7 +10,6 @@ from typing import Any
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QWidget, QFormLayout, QPushButton, QFileDialog, QLineEdit, QHBoxLayout, QVBoxLayout, \
     QGridLayout, QLabel
-from reactives.instance.method import reactive_method
 
 from betty.app import App
 from betty.extension import Gramps
@@ -34,12 +33,12 @@ class _FamilyTrees(LocalizedWidget):
         self._family_trees_remove_buttons: list[QPushButton]
 
         self._build_family_trees()
+        self._app.extensions[Gramps].configuration.family_trees.on_change(self._build_family_trees)
 
         self._add_family_tree_button = QPushButton()
         self._add_family_tree_button.released.connect(self._add_family_tree)
         self._layout.addWidget(self._add_family_tree_button, 1)
 
-    @reactive_method(on_trigger_call=True)
     def _build_family_trees(self) -> None:
         with suppress(AttributeError):
             self._family_trees_widget.setParent(None)
@@ -58,7 +57,7 @@ class _FamilyTrees(LocalizedWidget):
             self._family_trees_layout.addWidget(self._family_trees_remove_buttons[i], i, 1)
         self._layout.insertWidget(0, self._family_trees_widget, alignment=Qt.AlignmentFlag.AlignTop)
 
-    def _do_set_translatables(self) -> None:
+    def _set_translatables(self) -> None:
         self._add_family_tree_button.setText(self._app.localizer._('Add a family tree'))
         for button in self._family_trees_remove_buttons:
             button.setText(self._app.localizer._('Remove'))
@@ -140,7 +139,7 @@ class _AddFamilyTreeWindow(BettyWindow):
         self._cancel.released.connect(self.close)
         buttons_layout.addWidget(self._cancel)
 
-    def _do_set_translatables(self) -> None:
+    def _set_translatables(self) -> None:
         self._file_path_label.setText(self._app.localizer._('File path'))
         self._save_and_close.setText(self._app.localizer._('Save and close'))
         self._cancel.setText(self._app.localizer._('Cancel'))

--- a/betty/extension/nginx/__init__.py
+++ b/betty/extension/nginx/__init__.py
@@ -5,7 +5,6 @@ from typing import Any, Self
 
 from PyQt6.QtWidgets import QFormLayout, QButtonGroup, QRadioButton, QWidget, QHBoxLayout, QLineEdit, \
     QFileDialog, QPushButton
-from reactives.instance.property import reactive_property
 
 from betty.app import App
 from betty.app.extension import ConfigurableExtension
@@ -32,26 +31,27 @@ class NginxConfiguration(Configuration):
         self.www_directory_path = www_directory_path
 
     @property
-    @reactive_property
     def https(self) -> bool | None:
         return self._https
 
     @https.setter
     def https(self, https: bool | None) -> None:
         self._https = https
+        self._dispatch_change()
 
     @property
-    @reactive_property
     def www_directory_path(self) -> str | None:
         return self._www_directory_path
 
     @www_directory_path.setter
     def www_directory_path(self, www_directory_path: str | None) -> None:
         self._www_directory_path = www_directory_path
+        self._dispatch_change()
 
     def update(self, other: Self) -> None:
         self._https = other._https
         self._www_directory_path = other._www_directory_path
+        self._dispatch_change()
 
     @classmethod
     def load(

--- a/betty/extension/wikipedia/__init__.py
+++ b/betty/extension/wikipedia/__init__.py
@@ -7,8 +7,6 @@ from typing import Callable, Iterable, Any
 
 from jinja2 import pass_context
 from jinja2.runtime import Context
-from reactives.instance import ReactiveInstance
-from reactives.instance.property import reactive_property
 
 from betty import wikipedia
 from betty.app.extension import UserFacingExtension
@@ -20,7 +18,7 @@ from betty.model.ancestry import Link
 from betty.wikipedia import Summary, _parse_url, NotAPageError, RetrievalError
 
 
-class _Wikipedia(UserFacingExtension, Jinja2Provider, PostLoader, ReactiveInstance):
+class _Wikipedia(UserFacingExtension, Jinja2Provider, PostLoader):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
         self.__retriever: wikipedia._Retriever | None = None
@@ -31,7 +29,6 @@ class _Wikipedia(UserFacingExtension, Jinja2Provider, PostLoader, ReactiveInstan
         await populator.populate()
 
     @property
-    @reactive_property(on_trigger_delete=True)
     def _retriever(self) -> wikipedia._Retriever:
         if self.__retriever is None:
             self.__retriever = wikipedia._Retriever(self.app.http_client, self.cache_directory_path)

--- a/betty/gui/__init__.py
+++ b/betty/gui/__init__.py
@@ -67,7 +67,7 @@ class BettyWindow(LocalizedWindow):
         geometry.moveCenter(screen.availableGeometry().center())
         self.move(geometry.topLeft())
 
-    def _do_set_translatables(self) -> None:
+    def _set_translatables(self) -> None:
         self.setWindowTitle(f'{self.title} - Betty')
 
     @property

--- a/betty/gui/app.py
+++ b/betty/gui/app.py
@@ -104,8 +104,8 @@ class BettyMainWindow(BettyWindow):
     def title(self) -> str:
         return 'Betty'
 
-    def _do_set_translatables(self) -> None:
-        super()._do_set_translatables()
+    def _set_translatables(self) -> None:
+        super()._set_translatables()
         self.new_project_action.setText(self._app.localizer._('New project...'))
         self.open_project_action.setText(self._app.localizer._('Open project...'))
         self._demo_action.setText(self._app.localizer._('View demo site...'))
@@ -273,8 +273,8 @@ class WelcomeWindow(BettyMainWindow):
         self.demo_button.released.connect(self._demo)
         central_layout.addWidget(self.demo_button)
 
-    def _do_set_translatables(self) -> None:
-        super()._do_set_translatables()
+    def _set_translatables(self) -> None:
+        super()._set_translatables()
         self._welcome.setText(self._app.localizer._('Welcome to Betty'))
         self._welcome_caption.setText(self._app.localizer._('Betty helps you visualize and publish your family history by building interactive genealogy websites out of your <a href="{gramps_url}">Gramps</a> and <a href="{gedcom_url}">GEDCOM</a> family trees.').format(
             gramps_url='https://gramps-project.org/',
@@ -298,8 +298,8 @@ class _AboutBettyWindow(BettyWindow):
         self._label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.setCentralWidget(self._label)
 
-    def _do_set_translatables(self) -> None:
-        super()._do_set_translatables()
+    def _set_translatables(self) -> None:
+        super()._set_translatables()
         self._label.setText(''.join(map(lambda x: '<p>%s</p>' % x, [
             self._app.localizer._('Version: {version}').format(
                 version=about.version_label(),
@@ -326,8 +326,8 @@ class ApplicationConfiguration(BettyWindow):
         form_widget = QWidget()
         form_widget.setLayout(self._form)
         self.setCentralWidget(form_widget)
-        locale_collector = TranslationsLocaleCollector(self._app, set(self._app.localizers.locales))
-        for row in locale_collector.rows:
+        self._locale_collector = TranslationsLocaleCollector(self._app, set(self._app.localizers.locales))
+        for row in self._locale_collector.rows:
             self._form.addRow(*row)
 
     @property

--- a/betty/gui/model.py
+++ b/betty/gui/model.py
@@ -36,7 +36,6 @@ class EntityReferenceCollector(LocalizedWidget):
                 self._entity_reference.entity_type = self._entity_type.currentData()
             self._entity_type = QComboBox()
             self._entity_type.currentIndexChanged.connect(_update_entity_type)
-            # @todo We use translated labels, and sort by them, but neither is reactive.
             entity_types = enumerate(sorted(cast(Iterator['UserFacingEntity & Entity'], filter(
                 lambda entity_type: issubclass(entity_type, UserFacingEntity),
                 self._app.entity_types,
@@ -57,7 +56,7 @@ class EntityReferenceCollector(LocalizedWidget):
 
         self._set_translatables()
 
-    def _do_set_translatables(self) -> None:
+    def _set_translatables(self) -> None:
         if self._entity_reference.entity_type:
             self._entity_id_label.setText(self._app.localizer._('{entity_type_label} ID').format(
                 entity_type_label=self._entity_reference.entity_type.entity_type_label().localize(self._app.localizer),
@@ -148,7 +147,7 @@ class EntityReferenceSequenceCollector(LocalizedWidget):
         entity_reference_remove_button.released.connect(lambda: self._remove_entity_reference(i))
         layout.addWidget(entity_reference_remove_button)
 
-    def _do_set_translatables(self) -> None:
+    def _set_translatables(self) -> None:
         if self._label_builder:
             self._label.setText(self._label_builder())
         if self._caption_builder:

--- a/betty/gui/project.py
+++ b/betty/gui/project.py
@@ -17,7 +17,6 @@ from PyQt6.QtWidgets import QFileDialog, QPushButton, QWidget, QVBoxLayout, QHBo
     QGridLayout, QCheckBox, QFormLayout, QLabel, QLineEdit, QButtonGroup, QRadioButton
 from babel import Locale
 from babel.localedata import locale_identifiers
-from reactives.instance.method import reactive_method
 
 from betty import load, generate
 from betty.app import App
@@ -59,7 +58,6 @@ class _GenerateHtmlListForm(LocalizedWidget):
         self._checkboxes: dict[type[UserFacingEntity & Entity], QCheckBox] = {}
         self._update()
 
-    @reactive_method(on_trigger_call=True)
     def _update(self) -> None:
         entity_types = list(sorted(
             [
@@ -89,7 +87,7 @@ class _GenerateHtmlListForm(LocalizedWidget):
         self._checkboxes[entity_type].toggled.connect(_update)
         self._update_for_entity_type(entity_type, row_i)
 
-    def _do_set_translatables(self) -> None:
+    def _set_translatables(self) -> None:
         self._form_label.setText(self._app.localizer._('Generate entity listing pages'))
         for entity_type in self._app.entity_types:
             if issubclass(entity_type, UserFacingEntity):
@@ -190,7 +188,7 @@ class _GeneralPane(LocalizedWidget):
         self._clean_urls_caption = Caption()
         self._form.addRow(self._clean_urls_caption)
 
-    def _do_set_translatables(self) -> None:
+    def _set_translatables(self) -> None:
         self._configuration_author_label.setText(self._app.localizer._('Author'))
         self._configuration_url_label.setText(self._app.localizer._('URL'))
         self._configuration_title_label.setText(self._app.localizer._('Title'))
@@ -255,7 +253,7 @@ class _LocalesConfigurationWidget(LocalizedWidget):
         else:
             self._remove_buttons[locale] = None
 
-    def _do_set_translatables(self) -> None:
+    def _set_translatables(self) -> None:
         self._add_locale_button.setText(self._app.localizer._('Add a locale'))
         for locale, button in self._default_buttons.items():
             button.setText(get_display_name(locale, self._app.localizer.locale))
@@ -278,7 +276,6 @@ class _LocalizationPane(LocalizedWidget):
         self._locales_configuration_widget: _LocalesConfigurationWidget | None = None
         self._build()
 
-    @reactive_method(on_trigger_call=True)
     def _build(self) -> None:
         if self._locales_configuration_widget is not None:
             self._layout.removeWidget(self._locales_configuration_widget)
@@ -330,8 +327,8 @@ class _AddLocaleWindow(BettyWindow):
         )
         buttons_layout.addWidget(self._cancel)
 
-    def _do_set_translatables(self) -> None:
-        super()._do_set_translatables()
+    def _set_translatables(self) -> None:
+        super()._set_translatables()
         self._alias_label.setText(self._app.localizer._('Alias'))
         self._alias_caption.setText(self._app.localizer._('An optional alias is used instead of the locale code to identify this locale, such as in URLs. If US English is the only English language variant on your site, you may want to alias its language code from <code>en-US</code> to <code>en</code>, for instance.'))
 
@@ -400,7 +397,6 @@ class _ExtensionPane(LocalizedWidget):
             if isinstance(extension, GuiBuilder):
                 layout.addWidget(extension.gui_build())
 
-    @reactive_method(on_trigger_call=True)
     def _set_extension_status(self) -> None:
         self._extension_enabled.setDisabled(False)
         self._extension_enabled_caption.setText('')
@@ -417,7 +413,7 @@ class _ExtensionPane(LocalizedWidget):
                 self._extension_enabled.setDisabled(True)
                 self._extension_enabled_caption.setText(str(enable_requirement.reduce()))
 
-    def _do_set_translatables(self) -> None:
+    def _set_translatables(self) -> None:
         self._extension_description.setText(self._extension_type.description().localize(self._app.localizer))
         self._extension_enabled.setText(self._app.localizer._('Enable {extension}').format(
             extension=self._extension_type.label().localize(self._app.localizer),
@@ -498,8 +494,8 @@ class ProjectWindow(BettyMainWindow):
         self._app.project.configuration.autowrite = False
         return super().close()
 
-    def _do_set_translatables(self) -> None:
-        super()._do_set_translatables()
+    def _set_translatables(self) -> None:
+        super()._set_translatables()
         self.project_menu.setTitle('&' + self._app.localizer._('Project'))
         self.save_project_as_action.setText(self._app.localizer._('Save this project as...'))
         self.generate_action.setText(self._app.localizer._('Generate site'))
@@ -509,7 +505,6 @@ class ProjectWindow(BettyMainWindow):
         for extension_type in self._extension_types:
             self._pane_selectors[f'extension-{extension_type.name()}'].setText(extension_type.label().localize(self._app.localizer))
 
-    @reactive_method(on_trigger_call=True)
     def _set_window_title(self) -> None:
         self.setWindowTitle('%s - Betty' % self._app.project.configuration.title)
 
@@ -612,7 +607,7 @@ class _GenerateWindow(BettyWindow):
         load.getLogger().removeHandler(self._logging_handler)
         generate.getLogger().removeHandler(self._logging_handler)
 
-    def _do_set_translatables(self) -> None:
+    def _set_translatables(self) -> None:
         self._cancel_button.setText(self._app.localizer._('Cancel'))
         self._cancel_button.setText(self._app.localizer._('Cancel'))
         self._serve_button.setText(self._app.localizer._('View site'))

--- a/betty/tests/test_config.py
+++ b/betty/tests/test_config.py
@@ -5,7 +5,6 @@ from tempfile import NamedTemporaryFile
 from typing import Iterable, Generic
 
 import pytest
-from reactives.tests import assert_reactor_called, assert_in_scope, assert_scope_empty
 
 from betty.config import FileBasedConfiguration, ConfigurationMapping, Configuration, \
     ConfigurationCollection, ConfigurationSequence, ConfigurationKeyT, ConfigurationT
@@ -41,29 +40,23 @@ class ConfigurationCollectionTestBase(Generic[ConfigurationKeyT, ConfigurationT]
     async def test_getitem(self) -> None:
         configuration = self.get_configurations()[0]
         sut = self.get_sut([configuration])
-        with assert_in_scope(sut):
-            assert [configuration] == list(sut.values())
+        assert [configuration] == list(sut.values())
 
     async def test_keys(self) -> None:
         configurations = self.get_configurations()
         sut = self.get_sut(configurations)
-        with assert_in_scope(sut):
-            assert [*self.get_configuration_keys()] == list(sut.keys())
+        assert [*self.get_configuration_keys()] == list(sut.keys())
 
     async def test_values(self) -> None:
         configurations = self.get_configurations()
         sut = self.get_sut(configurations)
-        with assert_in_scope(sut):
-            assert [*configurations] == list(sut.values())
+        assert [*configurations] == list(sut.values())
 
     async def test_delitem(self) -> None:
         configuration = self.get_configurations()[0]
         sut = self.get_sut([configuration])
-        with assert_scope_empty():
-            with assert_reactor_called(sut):
-                del sut[self.get_configuration_keys()[0]]
+        del sut[self.get_configuration_keys()[0]]
         assert [] == list(sut.values())
-        assert [] == list(configuration.react._reactors)
 
     async def test_iter(self) -> None:
         raise NotImplementedError(repr(self))
@@ -74,8 +67,7 @@ class ConfigurationCollectionTestBase(Generic[ConfigurationKeyT, ConfigurationT]
             configurations[0],
             configurations[1],
         ])
-        with assert_in_scope(sut):
-            assert 2 == len(sut)
+        assert 2 == len(sut)
 
     async def test_eq(self) -> None:
         configurations = self.get_configurations()
@@ -87,32 +79,23 @@ class ConfigurationCollectionTestBase(Generic[ConfigurationKeyT, ConfigurationT]
             configurations[0],
             configurations[1],
         ])
-        with assert_in_scope(sut):
-            assert other == sut
+        assert other == sut
 
     async def test_prepend(self) -> None:
         configurations = self.get_configurations()
         sut = self.get_sut([
             configurations[1],
         ])
-        with assert_scope_empty():
-            with assert_reactor_called(sut):
-                sut.prepend(configurations[0])
+        sut.prepend(configurations[0])
         assert [configurations[0], configurations[1]] == list(sut.values())
-        with assert_reactor_called(sut):
-            configurations[0].react.trigger()
 
     async def test_append(self) -> None:
         configurations = self.get_configurations()
         sut = self.get_sut([
             configurations[0],
         ])
-        with assert_scope_empty():
-            with assert_reactor_called(sut):
-                sut.append(configurations[1], configurations[2])
+        sut.append(configurations[1], configurations[2])
         assert [configurations[0], configurations[1], configurations[2]] == list(sut.values())
-        with assert_reactor_called(sut):
-            configurations[0].react.trigger()
 
     async def test_insert(self) -> None:
         configurations = self.get_configurations()
@@ -120,43 +103,31 @@ class ConfigurationCollectionTestBase(Generic[ConfigurationKeyT, ConfigurationT]
             configurations[0],
             configurations[1],
         ])
-        with assert_scope_empty():
-            with assert_reactor_called(sut):
-                sut.insert(1, configurations[2], configurations[3])
+        sut.insert(1, configurations[2], configurations[3])
         assert [configurations[0], configurations[2], configurations[3], configurations[1]] == list(sut.values())
-        with assert_reactor_called(sut):
-            configurations[0].react.trigger()
 
     async def test_move_to_beginning(self) -> None:
         configurations = self.get_configurations()
         sut = self.get_sut(configurations)
-        with assert_scope_empty():
-            with assert_reactor_called(sut):
-                sut.move_to_beginning(self.get_configuration_keys()[2], self.get_configuration_keys()[3])
+        sut.move_to_beginning(self.get_configuration_keys()[2], self.get_configuration_keys()[3])
         assert [configurations[2], configurations[3], configurations[0], configurations[1]] == list(sut.values())
 
     async def test_move_towards_beginning(self) -> None:
         configurations = self.get_configurations()
         sut = self.get_sut(configurations)
-        with assert_scope_empty():
-            with assert_reactor_called(sut):
-                sut.move_towards_beginning(self.get_configuration_keys()[2], self.get_configuration_keys()[3])
+        sut.move_towards_beginning(self.get_configuration_keys()[2], self.get_configuration_keys()[3])
         assert [configurations[0], configurations[2], configurations[3], configurations[1]] == list(sut.values())
 
     async def test_move_to_end(self) -> None:
         configurations = self.get_configurations()
         sut = self.get_sut(configurations)
-        with assert_scope_empty():
-            with assert_reactor_called(sut):
-                sut.move_to_end(self.get_configuration_keys()[0], self.get_configuration_keys()[1])
+        sut.move_to_end(self.get_configuration_keys()[0], self.get_configuration_keys()[1])
         assert [configurations[2], configurations[3], configurations[0], configurations[1]] == list(sut.values())
 
     async def test_move_towards_end(self) -> None:
         configurations = self.get_configurations()
         sut = self.get_sut(configurations)
-        with assert_scope_empty():
-            with assert_reactor_called(sut):
-                sut.move_towards_end(self.get_configuration_keys()[0], self.get_configuration_keys()[1])
+        sut.move_towards_end(self.get_configuration_keys()[0], self.get_configuration_keys()[1])
         assert [configurations[2], configurations[0], configurations[1], configurations[3]] == list(sut.values())
 
 
@@ -170,8 +141,7 @@ class ConfigurationSequenceTestBase(Generic[ConfigurationT], ConfigurationCollec
             configurations[0],
             configurations[1],
         ])
-        with assert_in_scope(sut):
-            assert [configurations[0], configurations[1]] == list(iter(sut))
+        assert [configurations[0], configurations[1]] == list(iter(sut))
 
 
 class ConfigurationSequenceTestConfigurationSequence(ConfigurationSequence[ConfigurationCollectionTestConfiguration[int]]):
@@ -200,8 +170,7 @@ class ConfigurationMappingTestBase(Generic[ConfigurationKeyT, ConfigurationT], C
             configurations[0],
             configurations[1],
         ])
-        with assert_in_scope(sut):
-            assert [self.get_configuration_keys()[0], self.get_configuration_keys()[1]] == list(iter(sut))
+        assert [self.get_configuration_keys()[0], self.get_configuration_keys()[1]] == list(iter(sut))
 
 
 class ConfigurationMappingTestConfigurationMapping(ConfigurationMapping[str, ConfigurationCollectionTestConfiguration[str]]):

--- a/betty/tests/test_project.py
+++ b/betty/tests/test_project.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Iterable, Self
 
-import dill
 import pytest
-from reactives.tests import assert_reactor_called, assert_scope_empty
 
 from betty.app.extension import Extension, ConfigurableExtension
 from betty.config import Configuration, Configurable
@@ -242,9 +240,7 @@ class TestLocaleConfigurationMapping(ConfigurationMappingTestBase[str, LocaleCon
     async def test_delitem(self) -> None:
         configurations = self.get_configurations()
         sut = self.get_sut([configurations[0], configurations[1]])
-        with assert_scope_empty():
-            with assert_reactor_called(sut):
-                del sut[self.get_configuration_keys()[1]]
+        del sut[self.get_configuration_keys()[1]]
         assert [configurations[0]] == list(sut.values())
 
     async def test_delitem_with_one_remaining_locale_configuration(self) -> None:
@@ -311,8 +307,7 @@ class TestExtensionConfiguration:
             enabled=enabled,
         )
         assert enabled == sut.enabled
-        with assert_reactor_called(sut):
-            sut.enabled = False
+        sut.enabled = False
 
     async def test_configuration(self) -> None:
         extension_type_configuration = Configuration()
@@ -321,8 +316,6 @@ class TestExtensionConfiguration:
             extension_configuration=extension_type_configuration,
         )
         assert extension_type_configuration == sut.extension_configuration
-        with assert_reactor_called(sut):
-            extension_type_configuration.react.trigger()
 
     @pytest.mark.parametrize('expected, one, other', [
         (
@@ -411,8 +404,7 @@ class TestEntityTypeConfiguration:
     ])
     async def test_generate_html_list(self, generate_html_list: bool) -> None:
         sut = EntityTypeConfiguration(EntityTypeConfigurationTestEntityOne)
-        with assert_reactor_called(sut):
-            sut.generate_html_list = generate_html_list
+        sut.generate_html_list = generate_html_list
         assert generate_html_list == sut.generate_html_list
 
     async def test_load_with_empty_configuration(self) -> None:
@@ -528,15 +520,6 @@ class TestEntityTypeConfigurationMapping(ConfigurationMappingTestBase[type[Entit
 
 
 class TestProjectConfiguration:
-    async def test_pickle(self) -> None:
-        sut = ProjectConfiguration()
-        sut.extensions.append(ExtensionConfiguration(Extension))
-        sut.locales.append(LocaleConfiguration(
-            'nl-NL',
-            alias='nl',
-        ))
-        dill.dumps(sut)
-
     async def test_base_url(self) -> None:
         sut = ProjectConfiguration()
         base_url = 'https://example.com'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     'Pillow ~= 10.1, >= 10.1.0',
     'PyQt6 ~= 6.5, >= 6.5.0',
     'pyyaml ~= 6.0, >= 6.0.0',
-    'reactives ~= 0.5, >= 0.5.1',
     'sphinx ~= 7.2.6',
     'sphinx-design ~= 0.5.0',
     'sphinx-tabs ~= 3.4.4',


### PR DESCRIPTION
Reactives is not fully concurrency-safe. Additionaly, now `Configuration.update()` exists, we can internally make it invoke a new notification API that provides sufficient functionality for what Betty needs, and that is concurrency safe due to its simpler and more explicit nature (e.g. no automatic scope collection).