### PR TITLE
Add a workaround for a bug in Python 3.12 that would randomly cause RuntimeError to be raised when cleaning up thread pools during interpreter shutdown

### DIFF
--- a/betty/__init__.py
+++ b/betty/__init__.py
@@ -1,5 +1,8 @@
 """The Betty package root."""
 from pathlib import Path
 
+from betty import _patch  # noqa: F401
+
+
 # This lives here so it can be imported before any third-party Python modules are available.
 _ROOT_DIRECTORY_PATH = Path(__file__).resolve().parents[1]

--- a/betty/_patch.py
+++ b/betty/_patch.py
@@ -1,0 +1,15 @@
+from asyncio import BaseEventLoop
+from typing import Any
+
+_original_shutdown_default_executor = BaseEventLoop.shutdown_default_executor
+
+
+async def _shutdown_default_executor(loop: BaseEventLoop, *args: Any, **kwargs: Any) -> None:
+    try:
+        await _original_shutdown_default_executor(loop, *args, **kwargs)
+    except RuntimeError as error:
+        # Work around a bug in Python 3.12 that will randomly cause a RuntimeError with the
+        # following message to be raised.
+        if "can't create new thread at interpreter shutdown" not in str(error):
+            raise
+BaseEventLoop.shutdown_default_executor = _shutdown_default_executor  # type: ignore[assignment, method-assign]


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/1173