### PR TITLE
Allow Codecov.io to aggregate coverage reports submitted by all parallel CI builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
     strategy:
       matrix:
         include:
+          # The number of builds that submit code coverage configured here MUST be identical
+          # to the number of `after_n_builds` in /home/bart/code/bartfeenstra/betty/codecov.yml.
           - name: 'Python 3.12'
             os: ubuntu-latest
             python: '3.12'
@@ -139,3 +141,5 @@ jobs:
 
       - name: Upload code coverage
         uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+codecov:
+  notify:
+    # The number of builds configured here MUST be identical to the number
+    # of matrix options in /.github/workflows/test.yml that submit code coverage
+    # reports to Codecov.io.
+    after_n_builds: 4


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/1252 (using a slightly different, but better solution).