### PR TITLE
Improve the memory usage of entity collections

### DIFF
--- a/betty/model/__init__.py
+++ b/betty/model/__init__.py
@@ -491,7 +491,7 @@ class ToMany(Generic[OwnerT, AssociateT], ToManyEntityTypeAssociation[OwnerT, As
         setattr(
             owner,
             self._owner_private_attr_name,
-            SingleTypeEntityCollection[AssociateT](self.associate_type)
+            UnownedSingleTypeEntityCollection[AssociateT](self.associate_type)
         )
 
 
@@ -882,7 +882,7 @@ class MultipleTypesEntityCollection(Generic[TargetT], EntityCollection[TargetT])
         try:
             return cast(SingleTypeEntityCollection[EntityT], self._collections[entity_type])
         except KeyError:
-            self._collections[entity_type] = SingleTypeEntityCollection(entity_type)
+            self._collections[entity_type] = self._create_collection(entity_type)
             return cast(SingleTypeEntityCollection[EntityT], self._collections[entity_type])
 
     def _create_collection(self, entity_type: type[EntityT]) -> SingleTypeEntityCollection[EntityT]:
@@ -1156,7 +1156,7 @@ class EntityGraphBuilder(_EntityGraphBuilder):
 
 
 @contextmanager
-def record_added(entities: EntityCollection[EntityT]) -> Iterator[OwnedMultipleTypesEntityCollection[EntityT]]:
+def record_added(entities: EntityCollection[EntityT]) -> Iterator[MultipleTypesEntityCollection[EntityT]]:
     """
     Record all entities that are added to a collection.
     """

--- a/betty/model/__init__.py
+++ b/betty/model/__init__.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import builtins
 import functools
-import weakref
-from _weakref import ReferenceType
+from weakref import ref, ReferenceType
 from collections import defaultdict
 from contextlib import contextmanager
 from reprlib import recursive_repr
 from typing import TypeVar, Generic, Iterable, Any, overload, cast, Iterator, Callable, Self, TypeAlias, TYPE_CHECKING
 from uuid import uuid4
+
+from typing_extensions import deprecated
 
 from betty.classtools import repr_instance
 from betty.importlib import import_any, fully_qualified_type_name
@@ -709,14 +710,14 @@ class SingleTypeEntityCollection(Generic[TargetT], EntityCollection[TargetT]):
     def add(self, *entities: TargetT & Entity) -> None:
         added_entities = [*self._unknown(*entities)]
         for entity in added_entities:
-            self._entities.append(weakref.ref(entity))
+            self._entities.append(ref(entity))
         if added_entities:
             self._on_add(*added_entities)
 
     def remove(self, *entities: TargetT & Entity) -> None:
         removed_entities = [*self._known(*entities)]
         for entity in removed_entities:
-            self._entities.remove(weakref.ref(entity))
+            self._entities.remove(ref(entity))
         if removed_entities:
             self._on_remove(*removed_entities)
 
@@ -751,12 +752,14 @@ class SingleTypeEntityCollection(Generic[TargetT], EntityCollection[TargetT]):
             return self._getitem_by_indices(key)
         return self._getitem_by_entity_id(key)
 
+    @deprecated(f'Getting an entity by index is deprecated as of Betty 0.3.2, and will be removed in Betty 0.4.x. No direct replacement is available.')
     def _getitem_by_index(self, index: int) -> TargetT & Entity:
         entity = self._entities[index]()
         if entity is None:
             raise IndexError
         return entity
 
+    @deprecated(f'Getting entities by indices is deprecated as of Betty 0.3.2, and will be removed in Betty 0.4.x. No direct replacement is available.')
     def _getitem_by_indices(self, indices: slice) -> list[TargetT & Entity]:
         return self.view[indices]
 
@@ -864,9 +867,11 @@ class MultipleTypesEntityCollection(Generic[TargetT], EntityCollection[TargetT])
             get_entity_type(entity_type_name),
         )
 
+    @deprecated(f'Getting an entity by index is deprecated as of Betty 0.3.2, and will be removed in Betty 0.4.x. No direct replacement is available.')
     def _getitem_by_index(self, index: int) -> TargetT & Entity:
         return self.view[index]
 
+    @deprecated(f'Getting entities by indices is deprecated as of Betty 0.3.2, and will be removed in Betty 0.4.x. No direct replacement is available.')
     def _getitem_by_indices(self, indices: slice) -> list[TargetT & Entity]:
         return self.view[indices]
 
@@ -945,7 +950,7 @@ class _BidirectionalAssociateCollection(Generic[AssociateT, OwnerT], SingleTypeE
         association: BidirectionalEntityTypeAssociation[OwnerT, AssociateT],
     ):
         super().__init__(association.associate_type)
-        self.__owner = weakref.ref(owner)
+        self.__owner = ref(owner)
         self._association = association
 
     @property

--- a/betty/model/ancestry.py
+++ b/betty/model/ancestry.py
@@ -12,7 +12,6 @@ from typing import Iterable, Any, TYPE_CHECKING
 from urllib.parse import quote
 
 from geopy import Point
-from typing_extensions import deprecated
 
 from betty.classtools import repr_instance
 from betty.json.linked_data import LinkedDataDumpable, dump_context, dump_link, add_json_ld
@@ -20,11 +19,12 @@ from betty.json.schema import add_property, ref_json_schema
 from betty.locale import Localized, Datey, Str, Localizable, ref_datey
 from betty.media_type import MediaType
 from betty.model import many_to_many, Entity, one_to_many, many_to_one, many_to_one_to_many, \
-    MultipleTypesEntityCollection, EntityCollection, UserFacingEntity, EntityTypeAssociationRegistry, \
-    GeneratedEntityId, get_entity_type_name
+    EntityCollection, UserFacingEntity, EntityTypeAssociationRegistry, \
+    GeneratedEntityId, get_entity_type_name, OwnedMultipleTypesEntityCollection
 from betty.model.event_type import EventType, UnknownEventType
 from betty.serde.dump import DictDump, Dump, dump_default
 from betty.string import camel_case_to_kebab_case
+from betty.warnings import deprecated
 
 if TYPE_CHECKING:
     from betty.app import App
@@ -1804,7 +1804,7 @@ class Person(HasFiles, HasCitations, HasNotes, HasLinksEntity, HasPrivacy, UserF
         return schema
 
 
-class Ancestry(MultipleTypesEntityCollection[Entity]):
+class Ancestry(OwnedMultipleTypesEntityCollection[Entity]):
     def __init__(self):
         super().__init__()
         self._check_graph = True

--- a/betty/tests/extension/cotton_candy/assets/templates/entity/test_meta_place_html_j2.py
+++ b/betty/tests/extension/cotton_candy/assets/templates/entity/test_meta_place_html_j2.py
@@ -28,12 +28,12 @@ class Test(TemplateTestCase):
             id='P1',
             names=[PlaceName(name='The Enclosing Place')],
         )
-        Enclosure(encloses=place, enclosed_by=enclosing_place)
+        enclose_by = Enclosure(encloses=place, enclosed_by=enclosing_place)  # noqa: F841
         all_enclosing_place = Place(
             id='P2',
             names=[PlaceName(name='The All-enclosing Place')],
         )
-        Enclosure(encloses=enclosing_place, enclosed_by=all_enclosing_place)
+        enclosed_by_2nd = Enclosure(encloses=enclosing_place, enclosed_by=all_enclosing_place)  # noqa: F841
         expected = '<div class="meta">in <span><a href="/place/P1/index.html"><span>The Enclosing Place</span></a></span>, <span><a href="/place/P2/index.html"><span>The All-enclosing Place</span></a></span></div>'
         async with self._render(data={
             'entity': place,

--- a/betty/tests/extension/cotton_candy/assets/templates/entity/test_page__place_html_j2.py
+++ b/betty/tests/extension/cotton_candy/assets/templates/entity/test_page__place_html_j2.py
@@ -30,11 +30,11 @@ class TestTemplate(TemplateTestCase):
 
         enclosed_name = PlaceName(name='public enclosed name')
         enclosed = Place(names=[enclosed_name])
-        Enclosure(encloses=enclosed, enclosed_by=place)
+        encloses = Enclosure(encloses=enclosed, enclosed_by=place)  # noqa: F841
 
         enclosing_name = PlaceName(name='public enclosing name')
         enclosing = Place(names=[enclosing_name])
-        Enclosure(encloses=place, enclosed_by=enclosing)
+        enclosed_by = Enclosure(encloses=place, enclosed_by=enclosing)  # noqa: F841
 
         public_enclosed_event = Event(
             event_type=Birth,

--- a/betty/tests/gramps/test_loader.py
+++ b/betty/tests/gramps/test_loader.py
@@ -84,7 +84,7 @@ class TestGrampsLoader:
 """)
         place = ancestry[Place]['P0000']
         assert place.notes
-        note = place.notes[0]
+        note = place.notes.view[0]
         assert note.id == 'N0000'
 
     @pytest.mark.parametrize('expected_latitude, expected_longitude, latitude, longitude', [
@@ -156,10 +156,10 @@ class TestGrampsLoader:
     </placeobj>
 </places>
 """)
-        assert ancestry[Place]['P0000'] == ancestry[Place]['P0002'].enclosed_by[0].enclosed_by
-        assert ancestry[Place]['P0001'] == ancestry[Place]['P0002'].enclosed_by[1].enclosed_by
-        assert ancestry[Place]['P0002'] == ancestry[Place]['P0000'].encloses[0].encloses
-        assert ancestry[Place]['P0002'] == ancestry[Place]['P0001'].encloses[0].encloses
+        assert ancestry[Place]['P0000'] == ancestry[Place]['P0002'].enclosed_by.view[0].enclosed_by
+        assert ancestry[Place]['P0001'] == ancestry[Place]['P0002'].enclosed_by.view[1].enclosed_by
+        assert ancestry[Place]['P0002'] == ancestry[Place]['P0000'].encloses.view[0].encloses
+        assert ancestry[Place]['P0002'] == ancestry[Place]['P0001'].encloses.view[0].encloses
 
     async def test_person_should_include_names(self) -> None:
         ancestry = await self._load_partial("""
@@ -182,12 +182,12 @@ class TestGrampsLoader:
 """)
         person = ancestry[Person]['I0000']
 
-        assert 'Jane' == person.names[0].individual
-        assert 'Doe' == person.names[0].affiliation
-        assert 'Jane' == person.names[1].individual
-        assert 'Doh' == person.names[1].affiliation
-        assert 'Jen' == person.names[2].individual
-        assert 'Van Doughie' == person.names[2].affiliation
+        assert 'Jane' == person.names.view[0].individual
+        assert 'Doe' == person.names.view[0].affiliation
+        assert 'Jane' == person.names.view[1].individual
+        assert 'Doh' == person.names.view[1].affiliation
+        assert 'Jen' == person.names.view[2].individual
+        assert 'Van Doughie' == person.names.view[2].affiliation
 
     async def test_person_should_include_birth(self) -> None:
         ancestry = await self._load_partial("""
@@ -288,7 +288,7 @@ class TestGrampsLoader:
 """)
         person = ancestry[Person]['I0000']
         assert person.notes
-        note = person.notes[0]
+        note = person.notes.view[0]
         assert note.id == 'N0000'
 
     async def test_family_should_set_parents(self) -> None:
@@ -474,7 +474,7 @@ class TestGrampsLoader:
 """)
         event = ancestry[Event]['E0000']
         assert event.notes
-        note = event.notes[0]
+        note = event.notes.view[0]
         assert note.id == 'N0000'
 
     @pytest.mark.parametrize('expected, dateval_val', [
@@ -811,7 +811,7 @@ class TestGrampsLoader:
 """)
         source = ancestry[Source]['R0000']
         assert source.notes
-        note = source.notes[0]
+        note = source.notes.view[0]
         assert note.id == 'N0000'
 
     async def test_source_from_source_should_include_note(self) -> None:
@@ -829,7 +829,7 @@ class TestGrampsLoader:
 """)
         source = ancestry[Source]['S0000']
         assert source.notes
-        note = source.notes[0]
+        note = source.notes.view[0]
         assert note.id == 'N0000'
 
     @pytest.mark.parametrize('expected, attribute_value', [
@@ -902,7 +902,7 @@ class TestGrampsLoader:
 """)
         file = ancestry[File]['O0000']
         assert file.notes
-        note = file.notes[0]
+        note = file.notes.view[0]
         assert note.id == 'N0000'
 
     @pytest.mark.parametrize('expected, attribute_value', [

--- a/betty/tests/model/test_ancestry.py
+++ b/betty/tests/model/test_ancestry.py
@@ -477,18 +477,21 @@ class TestFile:
                 path=Path(f.name),
                 media_type=MediaType('text/plain'),
             )
-            file.notes.add(Note(
+            note = Note(
                 id='the_note',
                 text='The Note',
-            ))
-            file.entities.add(Person(id='the_person'))
-            file.citations.add(Citation(
+            )
+            file.notes.add(note)
+            person = Person(id='the_person')
+            file.entities.add(person)
+            citation = Citation(
                 id='the_citation',
                 source=Source(
                     id='the_source',
                     name='The Source',
                 ),
-            ))
+            )
+            file.citations.add(citation)
             expected: dict[str, Any] = {
                 '$schema': 'https://example.com/schema.json#/definitions/entity/file',
                 '@id': 'https://example.com/file/the_file/index.json',
@@ -538,18 +541,21 @@ class TestFile:
                 private=True,
                 media_type=MediaType('text/plain'),
             )
-            file.notes.add(Note(
+            note = Note(
                 id='the_note',
                 text='The Note',
-            ))
-            file.entities.add(Person(id='the_person'))
-            file.citations.add(Citation(
+            )
+            file.notes.add(note)
+            person = Person(id='the_person')
+            file.entities.add(person)
+            citation = Citation(
                 id='the_citation',
                 source=Source(
                     id='the_source',
                     name='The Source',
                 ),
-            ))
+            )
+            file.citations.add(citation)
             expected: dict[str, Any] = {
                 '$schema': 'https://example.com/schema.json#/definitions/entity/file',
                 '@id': 'https://example.com/file/the_file/index.json',
@@ -694,23 +700,25 @@ class TestSource:
     async def test_dump_linked_data_should_dump_full(self) -> None:
         link = Link('https://example.com/the-source')
         link.label = 'The Source Online'
+        contained_by = Source(
+            id='the_containing_source',
+            name='The Containing Source',
+        )
+        contains = Source(
+            id='the_contained_source',
+            name='The Contained Source',
+        )
         source = Source(
             id='the_source',
             name='The Source',
             author='The Author',
             publisher='The Publisher',
             date=Date(2000, 1, 1),
-            contained_by=Source(
-                id='the_containing_source',
-                name='The Containing Source',
-            ),
-            contains=[Source(
-                id='the_contained_source',
-                name='The Contained Source',
-            )],
+            contained_by=contained_by,
+            contains=[contains],
             links=[link],
         )
-        Citation(
+        citation = Citation(  # noqa: F841
             id='the_citation',
             source=source,
         )
@@ -774,24 +782,26 @@ class TestSource:
     async def test_dump_linked_data_should_dump_private(self) -> None:
         link = Link('https://example.com/the-source')
         link.label = 'The Source Online'
+        contained_by = Source(
+            id='the_containing_source',
+            name='The Containing Source',
+        )
+        contains = Source(
+            id='the_contained_source',
+            name='The Contained Source',
+        )
         source = Source(
             id='the_source',
             name='The Source',
             author='The Author',
             publisher='The Publisher',
             date=Date(2000, 1, 1),
-            contained_by=Source(
-                id='the_containing_source',
-                name='The Containing Source',
-            ),
-            contains=[Source(
-                id='the_contained_source',
-                name='The Contained Source',
-            )],
+            contained_by=contained_by,
+            contains=[contains],
             links=[link],
             private=True,
         )
-        Citation(
+        citation = Citation(  # noqa: F841
             id='the_citation',
             source=source,
         )
@@ -829,7 +839,7 @@ class TestSource:
             contained_by=contained_by_source,
             contains=[contains_source],
         )
-        Citation(
+        citation = Citation(  # noqa: F841
             id='the_citation',
             source=source,
             private=True,
@@ -946,10 +956,11 @@ class TestCitation:
                 name='The Source',
             ),
         )
-        citation.facts.add(Event(
+        event = Event(
             id='the_event',
             event_type=Birth,
-        ))
+        )
+        citation.facts.add(event)
         expected: dict[str, Any] = {
             '$schema': 'https://example.com/schema.json#/definitions/entity/citation',
             '@id': 'https://example.com/citation/the_citation/index.json',
@@ -995,10 +1006,11 @@ class TestCitation:
             ),
             private=True,
         )
-        citation.facts.add(Event(
+        event = Event(
             id='the_event',
             event_type=Birth,
-        ))
+        )
+        citation.facts.add(event)
         expected: dict[str, Any] = {
             '$schema': 'https://example.com/schema.json#/definitions/entity/citation',
             '@id': 'https://example.com/citation/the_citation/index.json',
@@ -1265,6 +1277,10 @@ class TestPlace:
         latitude = 12.345
         longitude = -54.321
         coordinates = Point(latitude, longitude)
+        event = Event(
+            id='E1',
+            event_type=Birth,
+        )
         link = Link('https://example.com/the-place')
         link.label = 'The Place Online'
         place = Place(
@@ -1273,15 +1289,12 @@ class TestPlace:
                 name=name,
                 locale=locale,
             )],
-            events=[Event(
-                id='E1',
-                event_type=Birth,
-            )],
+            events=[event],
             links=[link],
         )
         place.coordinates = coordinates
-        Enclosure(encloses=place, enclosed_by=Place(id='the_enclosing_place'))
-        Enclosure(encloses=Place(id='the_enclosed_place'), enclosed_by=place)
+        enclosed_by = Enclosure(encloses=place, enclosed_by=Place(id='the_enclosing_place'))  # noqa: F841
+        encloses = Enclosure(encloses=Place(id='the_enclosed_place'), enclosed_by=place)  # noqa: F841
         expected: dict[str, Any] = {
             '$schema': 'https://example.com/schema.json#/definitions/entity/place',
             '@context': {
@@ -1517,14 +1530,15 @@ class TestEvent:
                 names=[PlaceName(name='The Place')],
             ),
         )
-        Presence(Person(id='the_person'), Subject(), event)
-        event.citations.add(Citation(
+        presence = Presence(Person(id='the_person'), Subject(), event)  # noqa: F841
+        citation = Citation(
             id='the_citation',
             source=Source(
                 id='the_source',
                 name='The Source',
             ),
-        ))
+        )
+        event.citations.add(citation)
         expected: dict[str, Any] = {
             '$schema': 'https://example.com/schema.json#/definitions/entity/event',
             '@context': {
@@ -1607,14 +1621,15 @@ class TestEvent:
                 names=[PlaceName(name='The Place')],
             ),
         )
-        Presence(Person(id='the_person'), Subject(), event)
-        event.citations.add(Citation(
+        presence = Presence(Person(id='the_person'), Subject(), event)  # noqa: F841
+        citation = Citation(
             id='the_citation',
             source=Source(
                 id='the_source',
                 name='The Source',
             ),
-        ))
+        )
+        event.citations.add(citation)
         expected: dict[str, Any] = {
             '$schema': 'https://example.com/schema.json#/definitions/entity/event',
             '@context': {
@@ -1873,7 +1888,7 @@ class TestPerson:
             id=person_id,
             public=True,
         )
-        PersonName(
+        person_name = PersonName(  # noqa: F841
             person=person,
             individual=person_individual_name,
             affiliation=person_affiliation_name,
@@ -1886,14 +1901,15 @@ class TestPerson:
             label='The Person Online',
         )
         person.links.append(link)
-        person.citations.add(Citation(
+        citation = Citation(
             id='the_citation',
             source=Source(
                 id='the_source',
                 name='The Source',
             ),
-        ))
-        Presence(person, Subject(), Event(
+        )
+        person.citations.add(citation)
+        presence = Presence(person, Subject(), Event(  # noqa: F841
             id='the_event',
             event_type=Birth,
         ))
@@ -2005,14 +2021,15 @@ class TestPerson:
         link = Link('https://example.com/the-person')
         link.label = 'The Person Online'
         person.links.append(link)
-        person.citations.add(Citation(
+        citation = Citation(
             id='the_citation',
             source=Source(
                 id='the_source',
                 name='The Source',
             ),
-        ))
-        Presence(person, Subject(), Event(
+        )
+        person.citations.add(citation)
+        presence = Presence(person, Subject(), Event(  # noqa: F841
             id='the_event',
             event_type=Birth,
         ))


### PR DESCRIPTION
## To do
- Create follow-ups to remove deprecated functionality
- Consider the DX impact of this, as merging this change requires hard references everywhere.