### PR TITLE
Deprecate redundant logging functionality

### DIFF
--- a/betty/extension/deriver/__init__.py
+++ b/betty/extension/deriver/__init__.py
@@ -1,16 +1,18 @@
 """Expand an ancestry by deriving additional data from existing data."""
 from __future__ import annotations
 
+from logging import getLogger
+
 from betty.app.extension import Extension, UserFacingExtension
 from betty.deriver import Deriver
-from betty.load import PostLoader, getLogger
+from betty.load import PostLoader
 from betty.locale import Str
 from betty.model.event_type import DerivableEventType
 
 
 class _Deriver(UserFacingExtension, PostLoader):
     async def post_load(self) -> None:
-        logger = getLogger()
+        logger = getLogger(__name__)
         logger.info(self._app.localizer._('Deriving...'))
 
         deriver = Deriver(

--- a/betty/extension/privatizer/__init__.py
+++ b/betty/extension/privatizer/__init__.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from logging import getLogger
 
 from betty.app.extension import UserFacingExtension
-from betty.load import PostLoader, getLogger
+from betty.load import PostLoader
 from betty.locale import Str
 from betty.model import Entity
 from betty.model.ancestry import Person, HasPrivacy
@@ -24,7 +25,7 @@ class _Privatizer(UserFacingExtension, PostLoader):
         return Str._('Determine if people can be proven to have died. If not, mark them and their associated entities private.')
 
     def privatize(self) -> None:
-        logger = getLogger()
+        logger = getLogger(__name__)
         logger.info(self._app.localizer._('Privatizing...'))
 
         privatizer = PrivatizerApi(

--- a/betty/generate.py
+++ b/betty/generate.py
@@ -29,8 +29,10 @@ from betty.openapi import Specification
 from betty.serde.dump import DictDump, Dump
 from betty.string import camel_case_to_kebab_case, camel_case_to_snake_case, upper_camel_case_to_lower_camel_case
 from betty.job import Context
+from betty.warnings import deprecated
 
 
+@deprecated('This function is deprecated as of Betty 0.3.2, and will be removed in Betty 0.4.x. Instead, use `logging.logging.getLogger(__name__)`.')
 def getLogger() -> logging.Logger:
     """
     Get the site generation logger.
@@ -57,7 +59,7 @@ async def generate(app: App) -> None:
     """
     Generate a new site.
     """
-    logger = getLogger()
+    logger = logging.getLogger(__name__)
     job_context = GenerationContext(app)
 
     with suppress(FileNotFoundError):
@@ -88,7 +90,7 @@ async def generate(app: App) -> None:
 async def _log_jobs(app: App, jobs: Sequence[Task[None]]) -> None:
     total_job_count = len(jobs)
     completed_job_count = len([job for job in jobs if job.done()])
-    getLogger().info(app.localizer._(
+    logging.getLogger(__name__).info(app.localizer._(
         'Generated {completed_job_count} out of {total_job_count} items ({completed_job_percentage}%).').format(
         completed_job_count=completed_job_count,
         total_job_count=total_job_count,
@@ -177,7 +179,7 @@ async def _generate_public(
 ) -> None:
     app = job_context.app
     locale_label = get_display_name(locale, app.localizer.locale)
-    getLogger().debug(app.localizer._('Generating localized public files in {locale}...').format(
+    logging.getLogger(__name__).debug(app.localizer._('Generating localized public files in {locale}...').format(
         locale=locale_label,
     ))
     async for file_path in app.assets.copytree(Path('public') / 'localized', app.project.configuration.localize_www_directory_path(locale)):
@@ -192,7 +194,7 @@ async def _generate_static_public(
     app: App,
     job_context: Context,
 ) -> None:
-    getLogger().info(app.localizer._('Generating static public files...'))
+    logging.getLogger(__name__).info(app.localizer._('Generating static public files...'))
     async for file_path in app.assets.copytree(Path('public') / 'static', app.project.configuration.www_directory_path):
         await app.renderer.render_file(
             file_path,
@@ -337,7 +339,7 @@ async def _generate_json_schema(
     job_context: GenerationContext,
 ) -> None:
     app = job_context.app
-    getLogger().debug(app.localizer._('Generating JSON Schema...'))
+    logging.getLogger(__name__).debug(app.localizer._('Generating JSON Schema...'))
     schema = Schema(app)
     rendered_json = json.dumps(await schema.build())
     async with await create_file(app.project.configuration.www_directory_path / 'schema.json') as f:
@@ -348,7 +350,7 @@ async def _generate_openapi(
     job_context: GenerationContext,
 ) -> None:
     app = job_context.app
-    getLogger().debug(app.localizer._('Generating OpenAPI specification...'))
+    logging.getLogger(__name__).debug(app.localizer._('Generating OpenAPI specification...'))
     api_directory_path = app.project.configuration.www_directory_path / 'api'
     rendered_json = json.dumps(await Specification(app).build())
     async with await create_json_resource(api_directory_path) as f:

--- a/betty/gramps/loader.py
+++ b/betty/gramps/loader.py
@@ -8,6 +8,7 @@ import re
 import tarfile
 from collections import defaultdict
 from contextlib import suppress
+from logging import getLogger
 from pathlib import Path
 from typing import Iterable, Any, IO, cast
 from xml.etree import ElementTree
@@ -17,7 +18,6 @@ from aiofiles.tempfile import TemporaryDirectory
 from geopy import Point
 
 from betty.gramps.error import GrampsError
-from betty.load import getLogger
 from betty.locale import DateRange, Datey, Date, Str, Localizer
 from betty.media_type import MediaType
 from betty.model import Entity, EntityGraphBuilder, AliasedEntity, AliasableEntity
@@ -60,7 +60,7 @@ class GrampsLoader:
 
     async def load_file(self, file_path: Path) -> None:
         file_path = file_path.resolve()
-        logger = getLogger()
+        logger = getLogger(__name__)
         logger.info(self._localizer._('Loading "{file_path}"...').format(
             file_path=str(file_path),
         ))
@@ -143,7 +143,7 @@ class GrampsLoader:
         self._tree = tree
         self._gramps_tree_directory_path = gramps_tree_directory_path.resolve()
 
-        logger = getLogger()
+        logger = getLogger(__name__)
 
         database = self._tree.getroot()
 
@@ -445,7 +445,7 @@ class GrampsLoader:
             role = self._PRESENCE_ROLE_MAP[gramps_presence_role]
         except KeyError:
             role = Attendee()
-            getLogger().warning(
+            getLogger(__name__).warning(
                 Str._(
                     'Betty is unfamiliar with person "{person_id}"\'s Gramps presence role of "{gramps_presence_role}" for the event with Gramps handle "{event_handle}". The role was imported, but set to "{betty_presence_role}".',
                     person_id=person_id,
@@ -520,7 +520,7 @@ class GrampsLoader:
             try:
                 return Point.from_string(coordinates)
             except ValueError:
-                getLogger().warning(Str._(
+                getLogger(__name__).warning(Str._(
                     'Cannot load coordinates "{coordinates}", because they are in an unknown format.',
                     coordinates=coordinates,
                 ))
@@ -566,7 +566,7 @@ class GrampsLoader:
             event_type: type[EventType] = self._EVENT_TYPE_MAP[gramps_type]
         except KeyError:
             event_type = UnknownEventType
-            getLogger().warning(
+            getLogger(__name__).warning(
                 Str._(
                     'Betty is unfamiliar with Gramps event "{event_id}"\'s type of "{gramps_event_type}". The event was imported, but its type was set to "{betty_event_type}".',
                     event_id=event_id,
@@ -745,7 +745,7 @@ class GrampsLoader:
         if privacy_value == 'public':
             entity.public = True
             return
-        getLogger().warning(
+        getLogger(__name__).warning(
             Str._(
                 'The betty:privacy Gramps attribute must have a value of "public" or "private", but "{privacy_value}" was given for {entity_type} {entity_id} ({entity_label}), which was ignored.',
                 privacy_value=privacy_value,

--- a/betty/gui/project.py
+++ b/betty/gui/project.py
@@ -8,6 +8,7 @@ import copy
 import re
 from asyncio import Task, CancelledError
 from contextlib import suppress
+from logging import getLogger
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -653,8 +654,7 @@ class _GenerateWindow(BettyMainWindow):
         central_layout.addWidget(self._log_record_viewer)
 
         self._logging_handler = LogRecordViewerHandler(self._log_record_viewer)
-        load.getLogger().addHandler(self._logging_handler)
-        generate.getLogger().addHandler(self._logging_handler)
+        getLogger(__name__).addHandler(self._logging_handler)
 
         self._thread = _GenerateThread(self._app.project, self)
         self._thread.finished.connect(self._finish_generate)
@@ -680,8 +680,7 @@ class _GenerateWindow(BettyMainWindow):
         self._finalize()
 
     def _finalize(self) -> None:
-        load.getLogger().removeHandler(self._logging_handler)
-        generate.getLogger().removeHandler(self._logging_handler)
+        getLogger(__name__).removeHandler(self._logging_handler)
 
     def _set_translatables(self) -> None:
         super()._set_translatables()

--- a/betty/load.py
+++ b/betty/load.py
@@ -4,8 +4,10 @@ Provide the Ancestry loading API.
 import logging
 
 from betty.app import App
+from betty.warnings import deprecated
 
 
+@deprecated('This function is deprecated as of Betty 0.3.2, and will be removed in Betty 0.4.x. Instead, use `logging.getLogger()`.')
 def getLogger() -> logging.Logger:
     """
     Get the ancestry loading logger.


### PR DESCRIPTION
This deprecates `betty.load.getLogger()` and `betty.generate.getLogger()`. Instead, `logging.getLogger()` should be used.