### PR TITLE
Make Cache.get() return a context manager

### DIFF
--- a/betty/cache/__init__.py
+++ b/betty/cache/__init__.py
@@ -47,7 +47,7 @@ class Cache(Generic[CacheItemValueContraT]):
         """
         raise NotImplementedError
 
-    async def get(self, cache_item_id: str) -> CacheItem[CacheItemValueContraT] | None:
+    def get(self, cache_item_id: str) -> AsyncContextManager[CacheItem[CacheItemValueContraT] | None]:
         """
         Get the cache item with the given ID.
         """

--- a/betty/cache/_base.py
+++ b/betty/cache/_base.py
@@ -56,9 +56,10 @@ class _CommonCacheBase(Cache[CacheItemValueContraT], Generic[CacheItemValueContr
     def _with_scope(self, scope: str) -> Self:
         raise NotImplementedError
 
-    async def get(self, cache_item_id: str) -> CacheItem[CacheItemValueContraT] | None:
+    @asynccontextmanager
+    async def get(self, cache_item_id: str) -> AsyncIterator[CacheItem[CacheItemValueContraT] | None]:
         async with await self._lock(cache_item_id):
-            return await self._get(cache_item_id)
+            yield await self._get(cache_item_id)
 
     async def _get(self, cache_item_id: str) -> CacheItem[CacheItemValueContraT] | None:
         raise NotImplementedError

--- a/betty/tests/cache/test___init__.py
+++ b/betty/tests/cache/test___init__.py
@@ -30,7 +30,8 @@ class CacheTestBase(Generic[CacheItemValueT]):
     ])
     async def test_get_without_hit(self, scopes: Sequence[str]) -> None:
         async with self._new_sut(scopes=scopes) as sut:
-            assert await sut.get('id') is None
+            async with sut.get('id') as cache_item:
+                assert cache_item is None
 
     @pytest.mark.parametrize('scopes', [
         (),
@@ -40,9 +41,9 @@ class CacheTestBase(Generic[CacheItemValueT]):
         for value in self._values():
             async with self._new_sut(scopes=scopes) as sut:
                 await sut.set('id', value)
-                cache_item = await sut.get('id')
-                assert cache_item is not None
-                assert await cache_item.value() == value
+                async with sut.get('id') as cache_item:
+                    assert cache_item is not None
+                    assert await cache_item.value() == value
 
     @pytest.mark.parametrize('scopes', [
         (),
@@ -53,9 +54,9 @@ class CacheTestBase(Generic[CacheItemValueT]):
         for value in self._values():
             async with self._new_sut(scopes=scopes) as sut:
                 await sut.set('id', value, modified=modified)
-                cache_item = await sut.get('id')
-                assert cache_item is not None
-                assert cache_item.modified == modified
+                async with sut.get('id') as cache_item:
+                    assert cache_item is not None
+                    assert cache_item.modified == modified
 
     @pytest.mark.parametrize('scopes', [
         (),
@@ -67,9 +68,9 @@ class CacheTestBase(Generic[CacheItemValueT]):
                 async with sut.getset('id') as (cache_item, setter):
                     assert cache_item is None
                     await setter(value)
-                cache_item = await sut.get('id')
-                assert cache_item is not None
-                assert await cache_item.value() == value
+                async with sut.get('id') as cache_item:
+                    assert cache_item is not None
+                    assert await cache_item.value() == value
 
     @pytest.mark.parametrize('scopes', [
         (),
@@ -109,7 +110,8 @@ class CacheTestBase(Generic[CacheItemValueT]):
         async with self._new_sut(scopes=scopes) as sut:
             await sut.set('id', next(self._values()))
             await sut.delete('id')
-            assert await sut.get('id') is None
+            async with sut.get('id') as cache_item:
+                assert cache_item is None
 
     @pytest.mark.parametrize('scopes', [
         (),
@@ -119,4 +121,5 @@ class CacheTestBase(Generic[CacheItemValueT]):
         async with self._new_sut(scopes=scopes) as sut:
             await sut.set('id', next(self._values()))
             await sut.clear()
-            assert await sut.get('id') is None
+            async with sut.get('id') as cache_item:
+                assert cache_item is None

--- a/betty/tests/gui/test_app.py
+++ b/betty/tests/gui/test_app.py
@@ -45,7 +45,8 @@ class TestBettyMainWindow:
             await app.cache.set('KeepMeAroundPlease', '')
             betty_qtbot.navigate(sut, ['clear_caches_action'])
 
-            assert await app.cache.get('KeepMeAroundPlease') is None
+            async with app.cache.get('KeepMeAroundPlease') as cache_item:
+                assert cache_item is None
 
     async def test_open_about_window(
         self,

--- a/betty/tests/test_cli.py
+++ b/betty/tests/test_cli.py
@@ -164,7 +164,8 @@ class TestClearCaches:
         async with App() as app:
             await app.cache.set('KeepMeAroundPlease', '')
             _run('clear-caches')
-            assert await app.cache.get('KeepMeAroundPlease') is None
+            async with app.cache.get('KeepMeAroundPlease') as cache_item:
+                assert cache_item is None
 
 
 class TestDemo:


### PR DESCRIPTION
Make Cache.get() return a context manager, so cache item values can be loaded lazily, while the lock is still acquired