### PR TITLE
Work around an error in Qt where the reference to a QObject would be invalid

### DIFF
--- a/betty/extension/cotton_candy/gui.py
+++ b/betty/extension/cotton_candy/gui.py
@@ -26,7 +26,12 @@ class _ColorConfigurationSwatch(LocalizedObject, QWidget):
         self.setFixedWidth(24)
 
     def paintEvent(self, a0: QPaintEvent | None) -> None:
-        painter = QPainter(self)
+        try:
+            painter = QPainter(self)
+        except TypeError:
+            # Work around a so far inexplicable bug where this method would be called, but `self` would no longer refer
+            # to a valid QObject.
+            return
         swatch = QRect(self.rect())
         painter.fillRect(swatch, QBrush(QColor.fromString(self._color.hex)))
         painter.drawRect(swatch)


### PR DESCRIPTION
Work around an error in Qt where the reference to a QObject would be invalid while an event handler on said object is being called