### PR TITLE
Add a workaround for an ongoing Github Actions failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,9 @@ jobs:
       - name: Install APT dependencies
         if: startsWith(runner.os, 'Linux')
         run: |
-          sudo apt-get update
+          # Allow the update to fail due to https://github.com/microsoft/linux-package-repositories/issues/130
+          # @todo Remove this workaround once the original problem is fixed.
+          sudo apt-get update || true
           apt_packages=(
             libegl1-mesa # For Qt
             libx11-xcb-dev # For Qt


### PR DESCRIPTION
This adds a workaround for https://github.com/microsoft/linux-package-repositories/issues/130