### PR TITLE
Remove a temporary workaround for the PyQt6/PyQt6-Qt6 installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,6 @@ dependencies = [
     'polib ~= 1.2, >= 1.2.0',
     'Pillow ~= 10.1, >= 10.1.0',
     'PyQt6 ~= 6.5, >= 6.5.0',
-    # PyQt6-Qt6 6.7.0 appears to cause
-    # "ImportError: (...)/lib/python3.12/site-packages/PyQt6/QtGui.abi3.so: undefined symbol: _ZN5QFont11tagToStringEj, version Qt_6"
-    'PyQt6-Qt6 < 6.7',
     'pyyaml ~= 6.0, >= 6.0.0',
     'referencing ~= 0.34, >= 0.34.0',
     'sphinx ~= 7.2, >= 7.2.6',


### PR DESCRIPTION
Remove a temporary workaround for the PyQt6/PyQt6-Qt6 installation now that the upstream problems have been fixed

This obsoletes https://github.com/bartfeenstra/betty/pull/1432