### PR TITLE
Extend the Github Actions timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           - name: 'Windows'
             os: windows-latest
             python: '3.12'
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Check out the source code
         uses: actions/checkout@v4


### PR DESCRIPTION
Extend the Github Actions timeout now we have introduced some more long-running integration tests