### PR TITLE
Make the Wikipedia extension's functionality to download images configurable

### DIFF
--- a/betty/assets/betty.pot
+++ b/betty/assets/betty.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-05-08 16:40+0100\n"
+"POT-Creation-Date: 2024-05-08 17:53+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -328,6 +328,9 @@ msgstr ""
 msgid "Divorce"
 msgstr ""
 
+msgid "Download images from the Wikipedia links in your ancestry"
+msgstr ""
+
 #, python-format
 msgid "E.g. \"%(example)s\""
 msgstr ""
@@ -579,6 +582,9 @@ msgid "Place"
 msgstr ""
 
 msgid "Places"
+msgstr ""
+
+msgid "Populate images"
 msgstr ""
 
 msgid "Pre-built Webpack front-end assets are available"

--- a/betty/assets/locale/de-DE/betty.po
+++ b/betty/assets/locale/de-DE/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-05-08 16:40+0100\n"
+"POT-Creation-Date: 2024-05-08 17:53+0100\n"
 "PO-Revision-Date: 2024-02-08 13:24+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: de\n"
@@ -482,6 +482,9 @@ msgstr ""
 msgid "Divorce"
 msgstr "Scheidung"
 
+msgid "Download images from the Wikipedia links in your ancestry"
+msgstr ""
+
 #, python-format
 msgid "E.g. \"%(example)s\""
 msgstr "Z.B. \"%(example)s\""
@@ -750,6 +753,9 @@ msgstr "Ort"
 
 msgid "Places"
 msgstr "Orte"
+
+msgid "Populate images"
+msgstr ""
 
 msgid "Pre-built Webpack front-end assets are available"
 msgstr "Vorgefertigte Webpack front-end assets sind verfügbar"

--- a/betty/assets/locale/fr-FR/betty.po
+++ b/betty/assets/locale/fr-FR/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-05-08 16:40+0100\n"
+"POT-Creation-Date: 2024-05-08 17:53+0100\n"
 "PO-Revision-Date: 2024-02-08 13:24+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: fr\n"
@@ -402,6 +402,9 @@ msgstr ""
 msgid "Divorce"
 msgstr "Divorce"
 
+msgid "Download images from the Wikipedia links in your ancestry"
+msgstr ""
+
 #, python-format
 msgid "E.g. \"%(example)s\""
 msgstr "Par exemple \"%(example)s\""
@@ -664,6 +667,9 @@ msgstr "Lieu"
 
 msgid "Places"
 msgstr "Lieux"
+
+msgid "Populate images"
+msgstr ""
 
 msgid "Pre-built Webpack front-end assets are available"
 msgstr ""

--- a/betty/assets/locale/nl-NL/betty.po
+++ b/betty/assets/locale/nl-NL/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-05-08 16:40+0100\n"
+"POT-Creation-Date: 2024-05-08 17:53+0100\n"
 "PO-Revision-Date: 2024-02-11 15:31+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: nl\n"
@@ -475,6 +475,9 @@ msgstr ""
 msgid "Divorce"
 msgstr "Echtscheiding"
 
+msgid "Download images from the Wikipedia links in your ancestry"
+msgstr "Download afbeeldingen gebaseerd op de Wikipedialinks in je familiegeschiedenis"
+
 #, python-format
 msgid "E.g. \"%(example)s\""
 msgstr "Bijvoorbeeld \"%(example)s\""
@@ -745,6 +748,9 @@ msgstr "Plaats"
 
 msgid "Places"
 msgstr "Plaatsen"
+
+msgid "Populate images"
+msgstr "Afbeeldingen aanvullen"
 
 msgid "Pre-built Webpack front-end assets are available"
 msgstr "Vooraf gebouwde Webpack front-end assets zijn beschikbaar."

--- a/betty/assets/locale/uk/betty.po
+++ b/betty/assets/locale/uk/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-05-08 16:40+0100\n"
+"POT-Creation-Date: 2024-05-08 17:53+0100\n"
 "PO-Revision-Date: 2024-02-08 13:08+0000\n"
 "Last-Translator: Rainer Thieringer <rainerthi@gmail.com>\n"
 "Language: uk\n"
@@ -403,6 +403,9 @@ msgstr ""
 msgid "Divorce"
 msgstr "Розлучення"
 
+msgid "Download images from the Wikipedia links in your ancestry"
+msgstr ""
+
 #, python-format
 msgid "E.g. \"%(example)s\""
 msgstr "Наприклад «%(example)s»"
@@ -664,6 +667,9 @@ msgstr "Місце"
 
 msgid "Places"
 msgstr "Місця"
+
+msgid "Populate images"
+msgstr ""
 
 msgid "Pre-built Webpack front-end assets are available"
 msgstr ""

--- a/betty/extension/wikipedia/__init__.py
+++ b/betty/extension/wikipedia/__init__.py
@@ -10,8 +10,11 @@ from jinja2 import pass_context
 from jinja2.runtime import Context
 
 from betty import wikipedia
-from betty.app.extension import UserFacingExtension
+from betty.app.extension import UserFacingExtension, ConfigurableExtension
 from betty.asyncio import gather
+from betty.extension.wikipedia.config import WikipediaConfiguration
+from betty.extension.wikipedia.gui import _WikipediaGuiWidget
+from betty.gui import GuiBuilder
 from betty.jinja2 import Jinja2Provider, context_localizer
 from betty.load import PostLoader
 from betty.locale import negotiate_locale, Str
@@ -19,7 +22,13 @@ from betty.model.ancestry import Link
 from betty.wikipedia import Summary, _parse_url, NotAPageError, RetrievalError
 
 
-class Wikipedia(UserFacingExtension, Jinja2Provider, PostLoader):
+class Wikipedia(
+    ConfigurableExtension[WikipediaConfiguration],
+    UserFacingExtension,
+    Jinja2Provider,
+    PostLoader,
+    GuiBuilder,
+):
     @classmethod
     def name(cls) -> str:
         return "betty.extension.Wikipedia"
@@ -102,3 +111,10 @@ Display <a href="https://www.wikipedia.org/">Wikipedia</a> summaries for resourc
 {{% endwith %}}
 </code></pre>"""
         )
+
+    @classmethod
+    def default_configuration(cls) -> WikipediaConfiguration:
+        return WikipediaConfiguration()
+
+    def gui_build(self) -> _WikipediaGuiWidget:
+        return _WikipediaGuiWidget(self._app, self._configuration)

--- a/betty/extension/wikipedia/config.py
+++ b/betty/extension/wikipedia/config.py
@@ -1,0 +1,53 @@
+"""
+Provide configuration for the Wikipedia extension.
+"""
+
+from typing import Self
+
+from betty.config import Configuration
+from betty.serde.dump import Dump, VoidableDump, minimize, VoidableDictDump
+from betty.serde.load import Asserter, Fields, OptionalField, Assertions
+
+
+class WikipediaConfiguration(Configuration):
+    def __init__(self):
+        super().__init__()
+        self._populate_images = True
+
+    @property
+    def populate_images(self) -> bool:
+        return self._populate_images
+
+    @populate_images.setter
+    def populate_images(self, populate_images: bool) -> None:
+        self._populate_images = populate_images
+
+    def update(self, other: Self) -> None:
+        self._populate_images = other._populate_images
+        self._dispatch_change()
+
+    @classmethod
+    def load(
+        cls,
+        dump: Dump,
+        configuration: Self | None = None,
+    ) -> Self:
+        if configuration is None:
+            configuration = cls()
+        asserter = Asserter()
+        asserter.assert_record(
+            Fields(
+                OptionalField(
+                    "populate_images",
+                    Assertions(asserter.assert_bool())
+                    | asserter.assert_setattr(configuration, "populate_images"),
+                ),
+            )
+        )(dump)
+        return configuration
+
+    def dump(self) -> VoidableDump:
+        dump: VoidableDictDump[VoidableDump] = {
+            "populate_images": self.populate_images,
+        }
+        return minimize(dump, True)

--- a/betty/extension/wikipedia/gui.py
+++ b/betty/extension/wikipedia/gui.py
@@ -1,0 +1,47 @@
+"""
+Provide the GRaphical User Interface for the Wikipedia extension.
+"""
+
+from typing import Any
+
+from PyQt6.QtWidgets import (
+    QFormLayout,
+    QWidget,
+    QCheckBox,
+)
+
+from betty.app import App
+from betty.extension.wikipedia.config import WikipediaConfiguration
+from betty.gui.locale import LocalizedObject
+from betty.gui.text import Caption
+
+
+class _WikipediaGuiWidget(LocalizedObject, QWidget):
+    def __init__(
+        self, app: App, configuration: WikipediaConfiguration, *args: Any, **kwargs: Any
+    ):
+        super().__init__(app, *args, **kwargs)
+        self._app = app
+        self._configuration = configuration
+        layout = QFormLayout()
+
+        self.setLayout(layout)
+
+        def _update_configuration_populate_images(checked: bool) -> None:
+            self._configuration.populate_images = checked
+
+        self._populate_images = QCheckBox()
+        self._populate_images.setChecked(self._configuration.populate_images)
+        self._populate_images.toggled.connect(_update_configuration_populate_images)
+        layout.addRow(self._populate_images)
+        self._populate_images_caption = Caption()
+        layout.addRow(self._populate_images_caption)
+
+    def _set_translatables(self) -> None:
+        super()._set_translatables()
+        self._populate_images.setText(self._app.localizer._("Populate images"))
+        self._populate_images_caption.setText(
+            self._app.localizer._(
+                "Download images from the Wikipedia links in your ancestry"
+            )
+        )

--- a/betty/tests/extension/wikipedia/test_config.py
+++ b/betty/tests/extension/wikipedia/test_config.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from betty.extension.wikipedia.config import WikipediaConfiguration
+from betty.serde.dump import Dump
+from betty.serde.load import AssertionFailed
+from betty.tests.serde import raises_error
+
+
+class TestWikipediaConfiguration:
+    async def test_load_with_minimal_configuration(self) -> None:
+        dump: dict[str, Any] = {}
+        WikipediaConfiguration().load(dump)
+
+    async def test_load_without_dict_should_error(self) -> None:
+        dump = None
+        with raises_error(error_type=AssertionFailed):
+            WikipediaConfiguration().load(dump)
+
+    @pytest.mark.parametrize(
+        "populate_images",
+        [
+            True,
+            False,
+        ],
+    )
+    async def test_load_with_populate_images(
+        self, populate_images: bool | None
+    ) -> None:
+        dump: Dump = {
+            "populate_images": populate_images,
+        }
+        sut = WikipediaConfiguration.load(dump)
+        assert sut.populate_images == populate_images
+
+    async def test_dump_with_minimal_configuration(self) -> None:
+        sut = WikipediaConfiguration()
+        expected = {
+            "populate_images": True,
+        }
+        assert expected == sut.dump()
+
+    async def test_dump_with_populate_images(self) -> None:
+        sut = WikipediaConfiguration()
+        sut.populate_images = False
+        expected = {
+            "populate_images": False,
+        }
+        assert expected == sut.dump()
+
+    async def test_update(self, tmp_path: Path) -> None:
+        sut = WikipediaConfiguration()
+        other = WikipediaConfiguration()
+        other.populate_images = False
+        sut.update(other)
+        assert sut.populate_images is False

--- a/betty/tests/extension/wikipedia/test_gui.py
+++ b/betty/tests/extension/wikipedia/test_gui.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from betty.extension import Wikipedia
+from betty.tests.conftest import BettyQtBot
+
+
+class TestWikipediaGuiWidget:
+    async def test_https_with_base_url(
+        self,
+        betty_qtbot: BettyQtBot,
+    ) -> None:
+        betty_qtbot.app.project.configuration.extensions.enable(Wikipedia)
+        wikipedia = betty_qtbot.app.extensions[Wikipedia]
+        sut = wikipedia.gui_build()
+        betty_qtbot.qtbot.addWidget(sut)
+        sut.show()
+
+        betty_qtbot.set_checked(sut._populate_images, False)
+        assert not wikipedia.configuration.populate_images

--- a/documentation/usage/extension/gramps.rst
+++ b/documentation/usage/extension/gramps.rst
@@ -3,7 +3,6 @@ The *Gramps* extension
 The :py:class:`betty.extension.Gramps` extension loads entities from `Gramps <https://gramps-project.org>`_ family trees into your Betty ancestry.
 
 Enable this extension through Betty Desktop, or in your project's :doc:`configuration file </usage/project/configuration>` as follows:
-
 .. md-tab-set::
 
    .. md-tab-item:: YAML

--- a/documentation/usage/extension/wikipedia.rst
+++ b/documentation/usage/extension/wikipedia.rst
@@ -27,4 +27,35 @@ Enable this extension through Betty Desktop, or in your project's :doc:`configur
 
 Configuration
 -------------
-This extension is not configurable.
+This extension is configurable through Betty Desktop or in the configuration file:
+
+.. md-tab-set::
+
+   .. md-tab-item:: YAML
+
+      .. code-block:: yaml
+
+          extensions:
+            betty.extension.Wikipedia:
+              configuration:
+                populate_images: false
+
+   .. md-tab-item:: JSON
+
+      .. code-block:: json
+
+          {
+            "extensions": {
+              "betty.extension.Wikipedia": {
+                "configuration" : {
+                  "populate_images": false
+                }
+              }
+            }
+          }
+
+
+All configuration options
+^^^^^^^^^^^^^^^^^^^^^^^^^
+- ``populate_images`` (optional): A boolean indicating whether to download images from the Wikipedia
+  links in the ancestry. Defaults to ``true``.


### PR DESCRIPTION
This allows site owners to disable a potentially very slow (because lots of work to do) feature, and lays the groundwork for https://github.com/bartfeenstra/betty/issues/1478