### PR TITLE
Increase coverage of the Wikipedia API

### DIFF
--- a/betty/media_type.py
+++ b/betty/media_type.py
@@ -27,6 +27,9 @@ class MediaType:
         if not self._subtype:
             raise InvalidMediaType("The subtype must not be empty.")
 
+    def __hash__(self) -> int:
+        return hash(self._str)
+
     @property
     def type(self) -> str:
         return self._type


### PR DESCRIPTION
This leverages the fact that there is now a separate `_Fetcher`, allowing us to make `TestRetriever` significantly less complex while increasing coverage of the possible execution paths.