### PR TITLE
Remove `FileBasedConfiguration`'s automatic temporary configuration directory

### DIFF
--- a/betty/_package/pyinstaller/main.py
+++ b/betty/_package/pyinstaller/main.py
@@ -1,9 +1,13 @@
 import sys
 from asyncio import run
+from pathlib import Path
+
+from aiofiles.tempfile import TemporaryDirectory
 
 from betty.app import App
 from betty.gui import BettyApplication
 from betty.gui.app import WelcomeWindow
+from betty.project import Project, ProjectConfiguration
 
 
 def main() -> None:
@@ -14,11 +18,21 @@ def main() -> None:
 
 
 async def _main() -> None:
-    async with App.new_from_environment() as app:
-        async with BettyApplication([sys.argv[0]]).with_app(app) as qapp:
-            window = WelcomeWindow(app)
-            window.show()
-            sys.exit(qapp.exec())
+    async with TemporaryDirectory() as project_configuration_directory_path_str:
+        async with App.new_from_environment(
+            Project(
+                configuration=ProjectConfiguration(
+                    configuration_file_path=Path(
+                        project_configuration_directory_path_str
+                    )
+                    / "betty.json"
+                )
+            )
+        ) as app:
+            async with BettyApplication([sys.argv[0]]).with_app(app) as qapp:
+                window = WelcomeWindow(app)
+                window.show()
+                sys.exit(qapp.exec())
 
 
 if __name__ == "__main__":

--- a/betty/app/__init__.py
+++ b/betty/app/__init__.py
@@ -101,7 +101,8 @@ class AppConfiguration(FileBasedConfiguration):
                 stacklevel=2,
             )
             configuration_directory_path = CONFIGURATION_DIRECTORY_PATH
-        super().__init__(configuration_directory_path / "app.json")
+        super().__init__()
+        self.configuration_file_path = configuration_directory_path / "app.json"
         self._locale: str | None = locale
 
     @property

--- a/betty/app/__init__.py
+++ b/betty/app/__init__.py
@@ -101,21 +101,8 @@ class AppConfiguration(FileBasedConfiguration):
                 stacklevel=2,
             )
             configuration_directory_path = CONFIGURATION_DIRECTORY_PATH
-        super().__init__()
-        self._configuration_directory_path = configuration_directory_path
+        super().__init__(configuration_directory_path / "app.json")
         self._locale: str | None = locale
-
-    @property
-    def configuration_file_path(self) -> Path:
-        return self._configuration_directory_path / "app.json"
-
-    @configuration_file_path.setter
-    def configuration_file_path(self, __) -> None:
-        pass
-
-    @configuration_file_path.deleter
-    def configuration_file_path(self) -> None:
-        pass
 
     @property
     def locale(self) -> str | None:
@@ -196,6 +183,11 @@ class App(Configurable[AppConfiguration]):
                 f"Initializing {type(self)} without `cache_directory_path` is deprecated as of Betty 0.3.2, and will be removed in Betty 0.4.x.",
                 stacklevel=2,
             )
+        if project is None:
+            deprecate(
+                f"Initializing {type(self)} without `project` is deprecated as of Betty 0.3.6, and will be removed in Betty 0.4.x.",
+                stacklevel=2,
+            )
         self._configuration = configuration or AppConfiguration()
         self._configuration.on_change(self._on_locale_change)
         self._assets: FileSystem | None = None
@@ -248,7 +240,7 @@ class App(Configurable[AppConfiguration]):
         project: Project | None = None,
     ) -> AsyncIterator[Self]:
         yield cls(
-            AppConfiguration(app.configuration._configuration_directory_path),
+            AppConfiguration(app.configuration.configuration_file_path.parent),
             app.project if project is None else project,
             app._cache_directory_path,
         )

--- a/betty/app/__init__.py
+++ b/betty/app/__init__.py
@@ -101,8 +101,7 @@ class AppConfiguration(FileBasedConfiguration):
                 stacklevel=2,
             )
             configuration_directory_path = CONFIGURATION_DIRECTORY_PATH
-        super().__init__()
-        self.configuration_file_path = configuration_directory_path / "app.json"
+        super().__init__(configuration_directory_path / "app.json")
         self._locale: str | None = locale
 
     @property

--- a/betty/config.py
+++ b/betty/config.py
@@ -39,7 +39,6 @@ from betty.serde.dump import Dumpable, Dump, minimize, VoidableDump, Void
 from betty.serde.error import SerdeErrorCollection
 from betty.serde.format import FormatRepository
 from betty.serde.load import Asserter, Assertion, Assertions
-from betty.warnings import deprecate
 
 T = TypeVar("T")
 

--- a/betty/extension/nginx/serve.py
+++ b/betty/extension/nginx/serve.py
@@ -16,7 +16,7 @@ from betty.extension.nginx.artifact import (
     generate_configuration_file,
 )
 from betty.extension.nginx.docker import Container
-from betty.project import Project
+from betty.project import Project, ProjectConfiguration
 from betty.serve import NoPublicUrlBecauseServerNotStartedError, Server
 
 
@@ -37,7 +37,7 @@ class DockerizedNginxServer(Server):
             TemporaryDirectory()
         )
 
-        isolated_project = Project(ancestry=self._app.project.ancestry)
+        isolated_project = Project(ancestry=self._app.project.ancestry, configuration=ProjectConfiguration())
         isolated_project.configuration.autowrite = False
         isolated_project.configuration.configuration_file_path = (
             self._app.project.configuration.configuration_file_path

--- a/betty/extension/nginx/serve.py
+++ b/betty/extension/nginx/serve.py
@@ -37,7 +37,9 @@ class DockerizedNginxServer(Server):
             TemporaryDirectory()
         )
 
-        isolated_project = Project(ancestry=self._app.project.ancestry, configuration=ProjectConfiguration())
+        isolated_project = Project(
+            ancestry=self._app.project.ancestry, configuration=ProjectConfiguration()
+        )
         isolated_project.configuration.autowrite = False
         isolated_project.configuration.configuration_file_path = (
             self._app.project.configuration.configuration_file_path

--- a/betty/extension/nginx/serve.py
+++ b/betty/extension/nginx/serve.py
@@ -38,7 +38,10 @@ class DockerizedNginxServer(Server):
         )
 
         isolated_project = Project(
-            ancestry=self._app.project.ancestry, configuration=ProjectConfiguration()
+            ancestry=self._app.project.ancestry,
+            configuration=ProjectConfiguration(
+                configuration_file_path=self._app.project.configuration.configuration_file_path
+            ),
         )
         isolated_project.configuration.autowrite = False
         isolated_project.configuration.configuration_file_path = (

--- a/betty/gui/app.py
+++ b/betty/gui/app.py
@@ -229,8 +229,10 @@ class BettyPrimaryWindow(BettyMainWindow):
             )
             if not configuration_file_path_str:
                 return
-            configuration = ProjectConfiguration()
-            wait_to_thread(configuration.write(Path(configuration_file_path_str)))
+            configuration = ProjectConfiguration(
+                configuration_file_path=Path(configuration_file_path_str)
+            )
+            wait_to_thread(configuration.write())
             project_window = ProjectWindow(self._app)
             project_window.show()
             self.close()

--- a/betty/project.py
+++ b/betty/project.py
@@ -656,8 +656,10 @@ class ProjectConfiguration(FileBasedConfiguration):
         locales: Iterable[LocaleConfiguration] | None = None,
         lifetime_threshold: int = DEFAULT_LIFETIME_THRESHOLD,
         name: str | None = None,
+        *,
+        configuration_file_path: Path,
     ):
-        super().__init__()
+        super().__init__(configuration_file_path)
         self._name = name
         self._computed_name: str | None = None
         self._base_url = "https://example.com" if base_url is None else base_url
@@ -704,8 +706,8 @@ class ProjectConfiguration(FileBasedConfiguration):
         self._dispatch_change()
 
     @property
-    def project_directory_path(self) -> Path | None:
-        return self.configuration_file_path.parent if self.configuration_file_path else None
+    def project_directory_path(self) -> Path:
+        return self.configuration_file_path.parent
 
     @property
     def output_directory_path(self) -> Path:
@@ -829,7 +831,9 @@ class ProjectConfiguration(FileBasedConfiguration):
         configuration: Self | None = None,
     ) -> Self:
         if configuration is None:
-            configuration = cls()
+            raise RuntimeError(
+                f"Calling {cls}.load() without a configuration value is deprecated as of Betty 0.3.6, and will be removed in Betty 0.4.x."
+            )
         asserter = Asserter()
         asserter.assert_record(
             Fields(
@@ -920,9 +924,9 @@ class Project(Configurable[ProjectConfiguration]):
     def __init__(
         self,
         *,
+        configuration: ProjectConfiguration,
         project_id: str | None = None,
         ancestry: Ancestry | None = None,
-        configuration: ProjectConfiguration | None = None,
     ):
         super().__init__()
         if project_id is not None:
@@ -931,7 +935,7 @@ class Project(Configurable[ProjectConfiguration]):
                 stacklevel=2,
             )
         self._id = project_id
-        self._configuration = configuration or ProjectConfiguration()
+        self._configuration = configuration
         self._ancestry = Ancestry() if ancestry is None else ancestry
 
     @property

--- a/betty/project.py
+++ b/betty/project.py
@@ -656,10 +656,8 @@ class ProjectConfiguration(FileBasedConfiguration):
         locales: Iterable[LocaleConfiguration] | None = None,
         lifetime_threshold: int = DEFAULT_LIFETIME_THRESHOLD,
         name: str | None = None,
-        *,
-        configuration_file_path: Path | None = None,
     ):
-        super().__init__(configuration_file_path)
+        super().__init__()
         self._name = name
         self._computed_name: str | None = None
         self._base_url = "https://example.com" if base_url is None else base_url
@@ -706,8 +704,8 @@ class ProjectConfiguration(FileBasedConfiguration):
         self._dispatch_change()
 
     @property
-    def project_directory_path(self) -> Path:
-        return self.configuration_file_path.parent
+    def project_directory_path(self) -> Path | None:
+        return self.configuration_file_path.parent if self.configuration_file_path else None
 
     @property
     def output_directory_path(self) -> Path:

--- a/betty/project.py
+++ b/betty/project.py
@@ -656,8 +656,10 @@ class ProjectConfiguration(FileBasedConfiguration):
         locales: Iterable[LocaleConfiguration] | None = None,
         lifetime_threshold: int = DEFAULT_LIFETIME_THRESHOLD,
         name: str | None = None,
+        *,
+        configuration_file_path: Path | None = None,
     ):
-        super().__init__()
+        super().__init__(configuration_file_path)
         self._name = name
         self._computed_name: str | None = None
         self._base_url = "https://example.com" if base_url is None else base_url
@@ -922,6 +924,7 @@ class Project(Configurable[ProjectConfiguration]):
         *,
         project_id: str | None = None,
         ancestry: Ancestry | None = None,
+        configuration: ProjectConfiguration | None = None,
     ):
         super().__init__()
         if project_id is not None:
@@ -930,7 +933,7 @@ class Project(Configurable[ProjectConfiguration]):
                 stacklevel=2,
             )
         self._id = project_id
-        self._configuration = ProjectConfiguration()
+        self._configuration = configuration or ProjectConfiguration()
         self._ancestry = Ancestry() if ancestry is None else ancestry
 
     @property

--- a/betty/tests/__init__.py
+++ b/betty/tests/__init__.py
@@ -47,7 +47,7 @@ def patch_cache(f: Callable[P, Awaitable[T]]) -> Callable[P, Awaitable[T]]:
     return _patch_cache
 
 
-class TemplateTestCase:
+class TemplateAsserter:
     template_string: str | None = None
     template_file: str | None = None
     extensions = set[type[Extension]]()

--- a/betty/tests/app/extension/test___init__.py
+++ b/betty/tests/app/extension/test___init__.py
@@ -35,24 +35,23 @@ class TestExtensionDispatcher:
         async def multiply(self, term: int) -> Any:
             return self._multiplier * term
 
-    async def test(self) -> None:
-        async with App.new_temporary() as app, app:
-            extensions = ListExtensions(
+    async def test(self, new_temporary_app: App) -> None:
+        extensions = ListExtensions(
+            [
                 [
-                    [
-                        self._MultiplyingExtension(app, 1),
-                        self._MultiplyingExtension(app, 3),
-                    ],
-                    [
-                        self._MultiplyingExtension(app, 2),
-                        self._MultiplyingExtension(app, 4),
-                    ],
-                ]
-            )
-            sut = ExtensionDispatcher(extensions)
-            actual_returned_somethings = await sut.dispatch(self._Multiplier)(3)
-            expected_returned_somethings = [3, 9, 6, 12]
-            assert expected_returned_somethings == actual_returned_somethings
+                    self._MultiplyingExtension(new_temporary_app, 1),
+                    self._MultiplyingExtension(new_temporary_app, 3),
+                ],
+                [
+                    self._MultiplyingExtension(new_temporary_app, 2),
+                    self._MultiplyingExtension(new_temporary_app, 4),
+                ],
+            ]
+        )
+        sut = ExtensionDispatcher(extensions)
+        actual_returned_somethings = await sut.dispatch(self._Multiplier)(3)
+        expected_returned_somethings = [3, 9, 6, 12]
+        assert expected_returned_somethings == actual_returned_somethings
 
 
 class TestBuildExtensionTypeGraph:

--- a/betty/tests/conftest.py
+++ b/betty/tests/conftest.py
@@ -30,6 +30,7 @@ from betty.cache.file import BinaryFileCache
 from betty.gui import BettyApplication
 from betty.gui.error import ExceptionError
 from betty.locale import DEFAULT_LOCALIZER
+from betty.project import Project, ProjectConfiguration
 from betty.warnings import BettyDeprecationWarning
 
 
@@ -71,11 +72,20 @@ def qapp_cls() -> type[BettyApplication]:
 
 
 @pytest.fixture
-async def new_temporary_app() -> AsyncIterator[App]:
+async def new_temporary_app(tmp_path: Path) -> AsyncIterator[App]:
     """
     Create a new, temporary :py:class:`betty.app.App`.
     """
-    async with App.new_temporary() as app, app:
+    async with (
+        App.new_temporary(
+            project=Project(
+                configuration=ProjectConfiguration(
+                    configuration_file_path=tmp_path / "project"
+                )
+            )
+        ) as app,
+        app,
+    ):
         yield app
 
 

--- a/betty/tests/conftest.py
+++ b/betty/tests/conftest.py
@@ -78,7 +78,7 @@ async def new_temporary_app(tmp_path: Path) -> AsyncIterator[App]:
     """
     async with (
         App.new_temporary(
-            project=Project(
+            Project(
                 configuration=ProjectConfiguration(
                     configuration_file_path=tmp_path / "project"
                 )

--- a/betty/tests/extension/cotton_candy/assets/templates/entity/test_label_event_html_j2.py
+++ b/betty/tests/extension/cotton_candy/assets/templates/entity/test_label_event_html_j2.py
@@ -1,132 +1,145 @@
+import pytest
+
+from betty.app import App
 from betty.extension import CottonCandy
 from betty.jinja2 import EntityContexts
 from betty.model.ancestry import Person, Event, Presence, Subject, Witness
 from betty.model.event_type import Birth, Marriage
-from betty.tests import TemplateTestCase
+from betty.tests import TemplateTester
 
 
-class Test(TemplateTestCase):
-    extensions = {CottonCandy}
-    template_file = "entity/label--event.html.j2"
+class Test:
+    @pytest.fixture
+    def template_tester(self, new_temporary_app: App) -> TemplateTester:
+        new_temporary_app.project.configuration.extensions.enable(CottonCandy)
+        return TemplateTester(
+            new_temporary_app, template_file="entity/label--event.html.j2"
+        )
 
-    async def test_minimal(self) -> None:
+    async def test_minimal(self, template_tester: TemplateTester) -> None:
         event = Event(event_type=Birth)
         expected = "Birth"
-        async with self._render(
+        async with template_tester.render(
             data={
                 "entity": event,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_with_identifiable(self) -> None:
+    async def test_with_identifiable(self, template_tester: TemplateTester) -> None:
         event = Event(
             id="E0",
             event_type=Birth,
         )
         expected = '<a href="/event/E0/index.html">Birth</a>'
-        async with self._render(
+        async with template_tester.render(
             data={
                 "entity": event,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_embedded_with_identifiable(self) -> None:
+    async def test_embedded_with_identifiable(
+        self, template_tester: TemplateTester
+    ) -> None:
         event = Event(
             id="E0",
             event_type=Birth,
         )
         Presence(Person(id="P0"), Subject(), event)
         expected = 'Birth of <span class="nn" title="This person\'s name is unknown.">n.n.</span>'
-        async with self._render(
+        async with template_tester.render(
             data={
                 "entity": event,
                 "embedded": True,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_with_description(self) -> None:
+    async def test_with_description(self, template_tester: TemplateTester) -> None:
         event = Event(
             event_type=Birth,
             description="Something happened!",
         )
         expected = "Birth (Something happened!)"
-        async with self._render(
+        async with template_tester.render(
             data={
                 "entity": event,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_with_witnesses(self) -> None:
+    async def test_with_witnesses(self, template_tester: TemplateTester) -> None:
         event = Event(event_type=Birth)
         Presence(Person(id="P0"), Witness(), event)
         expected = "Birth"
-        async with self._render(
+        async with template_tester.render(
             data={
                 "entity": event,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_with_person_context_as_subject(self) -> None:
+    async def test_with_person_context_as_subject(
+        self, template_tester: TemplateTester
+    ) -> None:
         event = Event(event_type=Birth)
         person = Person(id="P0")
         Presence(person, Subject(), event)
         expected = "Birth"
-        async with self._render(
+        async with template_tester.render(
             data={
                 "entity": event,
                 "entity_contexts": EntityContexts(person),
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_with_person_context_and_other_as_subject(self) -> None:
+    async def test_with_person_context_and_other_as_subject(
+        self, template_tester: TemplateTester
+    ) -> None:
         event = Event(event_type=Marriage)
         person = Person(id="P0")
         other_person = Person(id="P1")
         Presence(person, Subject(), event)
         Presence(other_person, Subject(), event)
         expected = 'Marriage with <a href="/person/P1/index.html"><span class="nn" title="This person\'s name is unknown.">n.n.</span></a>'
-        async with self._render(
+        async with template_tester.render(
             data={
                 "entity": event,
                 "entity_contexts": EntityContexts(person),
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_with_subjects(self) -> None:
+    async def test_with_subjects(self, template_tester: TemplateTester) -> None:
         event = Event(event_type=Birth)
         Presence(Person(id="P0"), Subject(), event)
         Presence(Person(id="P1"), Subject(), event)
         expected = 'Birth of <a href="/person/P0/index.html"><span class="nn" title="This person\'s name is unknown.">n.n.</span></a>, <a href="/person/P1/index.html"><span class="nn" title="This person\'s name is unknown.">n.n.</span></a>'
-        async with self._render(
+        async with template_tester.render(
             data={
                 "entity": event,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_without_subjects(self) -> None:
+    async def test_without_subjects(self, template_tester: TemplateTester) -> None:
         event = Event(event_type=Birth)
         expected = "Birth"
-        async with self._render(
+        async with template_tester.render(
             data={
                 "entity": event,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_with_entity(self) -> None:
+    async def test_with_entity(self, template_tester: TemplateTester) -> None:
         event = Event(event_type=Birth)
         expected = "Birth"
-        async with self._render(
+        async with template_tester.render(
             data={
                 "entity": event,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual

--- a/betty/tests/extension/cotton_candy/assets/templates/entity/test_label_person_html_j2.py
+++ b/betty/tests/extension/cotton_candy/assets/templates/entity/test_label_person_html_j2.py
@@ -1,14 +1,21 @@
+import pytest
+
+from betty.app import App
 from betty.extension import CottonCandy
 from betty.jinja2 import EntityContexts
 from betty.model.ancestry import Person, PersonName
-from betty.tests import TemplateTestCase
+from betty.tests import TemplateTester
 
 
-class Test(TemplateTestCase):
-    extensions = {CottonCandy}
-    template_file = "entity/label--person.html.j2"
+class Test:
+    @pytest.fixture
+    def template_tester(self, new_temporary_app: App) -> TemplateTester:
+        new_temporary_app.project.configuration.extensions.enable(CottonCandy)
+        return TemplateTester(
+            new_temporary_app, template_file="entity/label--person.html.j2"
+        )
 
-    async def test_with_name(self) -> None:
+    async def test_with_name(self, template_tester: TemplateTester) -> None:
         person = Person(id="P0")
         PersonName(
             person=person,
@@ -16,63 +23,63 @@ class Test(TemplateTestCase):
             affiliation="Dough",
         )
         expected = '<a href="/person/P0/index.html"><span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Jane</span> <span property="foaf:familyName">Dough</span></span></a>'
-        async with self._render(
+        async with template_tester.render(
             data={
                 "entity": person,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_without_name(self) -> None:
+    async def test_without_name(self, template_tester: TemplateTester) -> None:
         person = Person(id="P0")
         expected = '<a href="/person/P0/index.html"><span class="nn" title="This person\'s name is unknown.">n.n.</span></a>'
-        async with self._render(
+        async with template_tester.render(
             data={
                 "entity": person,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_embedded(self) -> None:
+    async def test_embedded(self, template_tester: TemplateTester) -> None:
         person = Person(id="P0")
         expected = (
             '<span class="nn" title="This person\'s name is unknown.">n.n.</span>'
         )
-        async with self._render(
+        async with template_tester.render(
             data={
                 "entity": person,
                 "embedded": True,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_person_is_context(self) -> None:
+    async def test_person_is_context(self, template_tester: TemplateTester) -> None:
         person = Person(id="P0")
         expected = (
             '<span class="nn" title="This person\'s name is unknown.">n.n.</span>'
         )
-        async with self._render(
+        async with template_tester.render(
             data={
                 "entity": person,
                 "entity_contexts": EntityContexts(person),
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_private(self) -> None:
+    async def test_private(self, template_tester: TemplateTester) -> None:
         person = Person(
             id="P0",
             private=True,
         )
         expected = '<span class="private" title="This person\'s details are unavailable to protect their privacy.">private</span>'
-        async with self._render(
+        async with template_tester.render(
             data={
                 "entity": person,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_with_entity(self) -> None:
+    async def test_with_entity(self, template_tester: TemplateTester) -> None:
         person = Person(id="P0")
         PersonName(
             person=person,
@@ -80,9 +87,9 @@ class Test(TemplateTestCase):
             affiliation="Dough",
         )
         expected = '<a href="/person/P0/index.html"><span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Jane</span> <span property="foaf:familyName">Dough</span></span></a>'
-        async with self._render(
+        async with template_tester.render(
             data={
                 "entity": person,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual

--- a/betty/tests/extension/cotton_candy/assets/templates/entity/test_label_person_name_html_j2.py
+++ b/betty/tests/extension/cotton_candy/assets/templates/entity/test_label_person_name_html_j2.py
@@ -1,13 +1,20 @@
+import pytest
+
+from betty.app import App
 from betty.extension import CottonCandy
 from betty.model.ancestry import PersonName, Citation, Source, Person
-from betty.tests import TemplateTestCase
+from betty.tests import TemplateTester
 
 
-class Test(TemplateTestCase):
-    extensions = {CottonCandy}
-    template_file = "entity/label--person-name.html.j2"
+class Test:
+    @pytest.fixture
+    def template_tester(self, new_temporary_app: App) -> TemplateTester:
+        new_temporary_app.project.configuration.extensions.enable(CottonCandy)
+        return TemplateTester(
+            new_temporary_app, template_file="entity/label--person-name.html.j2"
+        )
 
-    async def test_with_full_name(self) -> None:
+    async def test_with_full_name(self, template_tester: TemplateTester) -> None:
         person = Person()
         person_name = PersonName(
             person=person,
@@ -15,42 +22,42 @@ class Test(TemplateTestCase):
             affiliation="Dough",
         )
         expected = '<span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Jane</span> <span property="foaf:familyName">Dough</span></span>'
-        async with self._render(
+        async with template_tester.render(
             data={
                 "person_name": person_name,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_with_individual_name(self) -> None:
+    async def test_with_individual_name(self, template_tester: TemplateTester) -> None:
         person = Person()
         person_name = PersonName(
             person=person,
             individual="Jane",
         )
         expected = '<span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Jane</span></span>'
-        async with self._render(
+        async with template_tester.render(
             data={
                 "person_name": person_name,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_with_affiliation_name(self) -> None:
+    async def test_with_affiliation_name(self, template_tester: TemplateTester) -> None:
         person = Person()
         person_name = PersonName(
             person=person,
             affiliation="Dough",
         )
         expected = '<span class="person-label" typeof="foaf:Person">… <span property="foaf:familyName">Dough</span></span>'
-        async with self._render(
+        async with template_tester.render(
             data={
                 "person_name": person_name,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_embedded(self) -> None:
+    async def test_embedded(self, template_tester: TemplateTester) -> None:
         person = Person()
         person_name = PersonName(
             person=person,
@@ -61,15 +68,15 @@ class Test(TemplateTestCase):
         citation = Citation(source=source)
         person_name.citations.add(citation)
         expected = '<span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Jane</span> <span property="foaf:familyName">Dough</span></span>'
-        async with self._render(
+        async with template_tester.render(
             data={
                 "person_name": person_name,
                 "embedded": True,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_with_citation(self) -> None:
+    async def test_with_citation(self, template_tester: TemplateTester) -> None:
         person = Person()
         person_name = PersonName(
             person=person,
@@ -79,9 +86,9 @@ class Test(TemplateTestCase):
         citation = Citation(source=source)
         person_name.citations.add(citation)
         expected = '<span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Jane</span></span><a href="#reference-1" class="citation">[1]</a>'
-        async with self._render(
+        async with template_tester.render(
             data={
                 "person_name": person_name,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual

--- a/betty/tests/extension/cotton_candy/assets/templates/entity/test_label_place_html_j2.py
+++ b/betty/tests/extension/cotton_candy/assets/templates/entity/test_label_place_html_j2.py
@@ -4,15 +4,20 @@ from typing import Any
 
 import pytest
 
+from betty.app import App
 from betty.extension import CottonCandy
 from betty.locale import DateRange, Date
 from betty.model.ancestry import Place, PlaceName
-from betty.tests import TemplateTestCase
+from betty.tests import TemplateTester
 
 
-class Test(TemplateTestCase):
-    extensions = {CottonCandy}
-    template_file = "entity/label--place.html.j2"
+class Test:
+    @pytest.fixture
+    def template_tester(self, new_temporary_app: App) -> TemplateTester:
+        new_temporary_app.project.configuration.extensions.enable(CottonCandy)
+        return TemplateTester(
+            new_temporary_app, template_file="entity/label--place.html.j2"
+        )
 
     @pytest.mark.parametrize(
         "expected, data, locale",
@@ -97,7 +102,11 @@ class Test(TemplateTestCase):
         ],
     )
     async def test(
-        self, expected: str, data: dict[str, Any], locale: str | None
+        self,
+        expected: str,
+        data: dict[str, Any],
+        locale: str | None,
+        template_tester: TemplateTester,
     ) -> None:
-        async with self._render(data=data, locale=locale) as (actual, _):
+        async with template_tester.render(data=data, locale=locale) as actual:
             assert expected == actual

--- a/betty/tests/extension/cotton_candy/assets/templates/entity/test_meta_person_html_j2.py
+++ b/betty/tests/extension/cotton_candy/assets/templates/entity/test_meta_person_html_j2.py
@@ -1,3 +1,6 @@
+import pytest
+
+from betty.app import App
 from betty.extension import CottonCandy
 from betty.locale import Date
 from betty.model.ancestry import (
@@ -10,37 +13,43 @@ from betty.model.ancestry import (
     Subject,
 )
 from betty.model.event_type import Birth, Death
-from betty.tests import TemplateTestCase
+from betty.tests import TemplateTester
 
 
-class Test(TemplateTestCase):
-    extensions = {CottonCandy}
-    template_file = "entity/meta--person.html.j2"
+class Test:
+    @pytest.fixture
+    def template_tester(self, new_temporary_app: App) -> TemplateTester:
+        new_temporary_app.project.configuration.extensions.enable(CottonCandy)
+        return TemplateTester(
+            new_temporary_app, template_file="entity/meta--person.html.j2"
+        )
 
-    async def test_without_meta(self) -> None:
+    async def test_without_meta(self, template_tester: TemplateTester) -> None:
         person = Person(id="P0")
         expected = '<div class="meta person-meta"></div>'
-        async with self._render(
+        async with template_tester.render(
             data={
                 "entity": person,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_private(self) -> None:
+    async def test_private(self, template_tester: TemplateTester) -> None:
         person = Person(
             id="P0",
             private=True,
         )
         expected = '<div class="meta person-meta"><p>This person\'s details are unavailable to protect their privacy.</p></div>'
-        async with self._render(
+        async with template_tester.render(
             data={
                 "entity": person,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_with_one_alternative_name(self) -> None:
+    async def test_with_one_alternative_name(
+        self, template_tester: TemplateTester
+    ) -> None:
         person = Person(id="P0")
         PersonName(
             person=person,
@@ -54,14 +63,16 @@ class Test(TemplateTestCase):
         )
         name.citations.add(Citation(source=Source(name="The Source")))
         expected = '<div class="meta person-meta"><span class="aka">Also known as <span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Janet</span> <span property="foaf:familyName">Doughnut</span></span><a href="#reference-1" class="citation">[1]</a></span></div>'
-        async with self._render(
+        async with template_tester.render(
             data={
                 "entity": person,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_with_multiple_alternative_names(self) -> None:
+    async def test_with_multiple_alternative_names(
+        self, template_tester: TemplateTester
+    ) -> None:
         person = Person(id="P0")
         PersonName(
             person=person,
@@ -79,14 +90,16 @@ class Test(TemplateTestCase):
             affiliation="Of Doughnuton",
         )
         expected = '<div class="meta person-meta"><span class="aka">Also known as <span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Janet</span> <span property="foaf:familyName">Doughnut</span></span>, <span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Janetar</span> <span property="foaf:familyName">Of Doughnuton</span></span></span></div>'
-        async with self._render(
+        async with template_tester.render(
             data={
                 "entity": person,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_with_start_of_life_event(self) -> None:
+    async def test_with_start_of_life_event(
+        self, template_tester: TemplateTester
+    ) -> None:
         person = Person(id="P0")
         Presence(
             person,
@@ -97,14 +110,16 @@ class Test(TemplateTestCase):
             ),
         )
         expected = '<div class="meta person-meta"><dl><div><dt>Birth</dt><dd>1970</dd></div></dl></div>'
-        async with self._render(
+        async with template_tester.render(
             data={
                 "entity": person,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_with_end_of_life_event(self) -> None:
+    async def test_with_end_of_life_event(
+        self, template_tester: TemplateTester
+    ) -> None:
         person = Person(id="P0")
         Presence(
             person,
@@ -115,14 +130,14 @@ class Test(TemplateTestCase):
             ),
         )
         expected = '<div class="meta person-meta"><dl><div><dt>Death</dt><dd>1970</dd></div></dl></div>'
-        async with self._render(
+        async with template_tester.render(
             data={
                 "entity": person,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_embedded(self) -> None:
+    async def test_embedded(self, template_tester: TemplateTester) -> None:
         person = Person(id="P0")
         Presence(
             person,
@@ -144,10 +159,10 @@ class Test(TemplateTestCase):
         )
         name.citations.add(Citation(source=Source(name="The Source")))
         expected = '<div class="meta person-meta"><span class="aka">Also known as <span class="person-label" typeof="foaf:Person"><span property="foaf:individualName">Janet</span> <span property="foaf:familyName">Doughnut</span></span></span><dl><div><dt>Birth</dt><dd>1970</dd></div></dl></div>'
-        async with self._render(
+        async with template_tester.render(
             data={
                 "entity": person,
                 "embedded": True,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual

--- a/betty/tests/extension/cotton_candy/assets/templates/test_event_dimensions_html_j2.py
+++ b/betty/tests/extension/cotton_candy/assets/templates/test_event_dimensions_html_j2.py
@@ -1,39 +1,46 @@
+import pytest
+
+from betty.app import App
 from betty.extension import CottonCandy
 from betty.jinja2 import EntityContexts
 from betty.locale import Date
 from betty.model.ancestry import Event, Place, PlaceName, Citation, Source
 from betty.model.event_type import Birth
-from betty.tests import TemplateTestCase
+from betty.tests import TemplateTester
 
 
-class Test(TemplateTestCase):
-    extensions = {CottonCandy}
-    template_file = "event-dimensions.html.j2"
+class Test:
+    @pytest.fixture
+    def template_tester(self, new_temporary_app: App) -> TemplateTester:
+        new_temporary_app.project.configuration.extensions.enable(CottonCandy)
+        return TemplateTester(
+            new_temporary_app, template_file="event-dimensions.html.j2"
+        )
 
-    async def test_without_meta(self) -> None:
+    async def test_without_meta(self, template_tester: TemplateTester) -> None:
         event = Event(event_type=Birth)
         expected = ""
-        async with self._render(
+        async with template_tester.render(
             data={
                 "event": event,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_with_date(self) -> None:
+    async def test_with_date(self, template_tester: TemplateTester) -> None:
         event = Event(
             event_type=Birth,
             date=Date(1970),
         )
         expected = "1970"
-        async with self._render(
+        async with template_tester.render(
             data={
                 "event": event,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_with_place(self) -> None:
+    async def test_with_place(self, template_tester: TemplateTester) -> None:
         event = Event(event_type=Birth)
         event.place = Place(
             id="P0",
@@ -42,14 +49,16 @@ class Test(TemplateTestCase):
         expected = (
             'in <span><a href="/place/P0/index.html"><span>The Place</span></a></span>'
         )
-        async with self._render(
+        async with template_tester.render(
             data={
                 "event": event,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_with_place_is_place_context(self) -> None:
+    async def test_with_place_is_place_context(
+        self, template_tester: TemplateTester
+    ) -> None:
         event = Event(event_type=Birth)
         place = Place(
             id="P0",
@@ -57,15 +66,15 @@ class Test(TemplateTestCase):
         )
         event.place = place
         expected = ""
-        async with self._render(
+        async with template_tester.render(
             data={
                 "event": event,
                 "entity_contexts": EntityContexts(place),
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_with_date_and_place(self) -> None:
+    async def test_with_date_and_place(self, template_tester: TemplateTester) -> None:
         event = Event(
             event_type=Birth,
             date=Date(1970),
@@ -75,25 +84,25 @@ class Test(TemplateTestCase):
             names=[PlaceName(name="The Place")],
         )
         expected = '1970 in <span><a href="/place/P0/index.html"><span>The Place</span></a></span>'
-        async with self._render(
+        async with template_tester.render(
             data={
                 "event": event,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_with_citation(self) -> None:
+    async def test_with_citation(self, template_tester: TemplateTester) -> None:
         event = Event(event_type=Birth)
         event.citations.add(Citation(source=Source(name="The Source")))
         expected = '<a href="#reference-1" class="citation">[1]</a>'
-        async with self._render(
+        async with template_tester.render(
             data={
                 "event": event,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual
 
-    async def test_embedded(self) -> None:
+    async def test_embedded(self, template_tester: TemplateTester) -> None:
         event = Event(
             event_type=Birth,
             date=Date(1970),
@@ -104,10 +113,10 @@ class Test(TemplateTestCase):
         )
         event.citations.add(Citation(source=Source(name="The Source")))
         expected = "1970 in <span><span>The Place</span></span>"
-        async with self._render(
+        async with template_tester.render(
             data={
                 "event": event,
                 "embedded": True,
             }
-        ) as (actual, _):
+        ) as actual:
             assert expected == actual

--- a/betty/tests/extension/cotton_candy/assets/templates/test_references_html_j2.py
+++ b/betty/tests/extension/cotton_candy/assets/templates/test_references_html_j2.py
@@ -1,25 +1,30 @@
+import pytest
+
+from betty.app import App
 from betty.extension import CottonCandy
 from betty.jinja2 import _Citer
 from betty.locale import Str
 from betty.model.ancestry import Citation
-from betty.tests import TemplateTestCase
+from betty.tests import TemplateTester
 
 
-class Test(TemplateTestCase):
-    extensions = {CottonCandy}
-    template_file = "references.html.j2"
+class Test:
+    @pytest.fixture
+    def template_tester(self, new_temporary_app: App) -> TemplateTester:
+        new_temporary_app.project.configuration.extensions.enable(CottonCandy)
+        return TemplateTester(new_temporary_app, template_file="references.html.j2")
 
-    async def test_without_references(self) -> None:
+    async def test_without_references(self, template_tester: TemplateTester) -> None:
         citer = _Citer()
-        async with self._render(
+        async with template_tester.render(
             data={
                 "citer": citer,
                 "page_resource": "/",
             }
-        ) as (actual, _):
+        ) as actual:
             assert actual == ""
 
-    async def test_with_public_citation(self) -> None:
+    async def test_with_public_citation(self, template_tester: TemplateTester) -> None:
         citation = Citation(
             id="C1",
             location=Str.plain("On the shelf over there"),
@@ -27,15 +32,15 @@ class Test(TemplateTestCase):
         )
         citer = _Citer()
         citer.cite(citation)
-        async with self._render(
+        async with template_tester.render(
             data={
                 "citer": citer,
                 "page_resource": "/",
             }
-        ) as (actual, _):
+        ) as actual:
             assert 'href="/citation/C1/index.html"' in actual
 
-    async def test_with_private_citation(self) -> None:
+    async def test_with_private_citation(self, template_tester: TemplateTester) -> None:
         citation = Citation(
             id="C1",
             location=Str.plain("On the shelf over there"),
@@ -43,12 +48,12 @@ class Test(TemplateTestCase):
         )
         citer = _Citer()
         citer.cite(citation)
-        async with self._render(
+        async with template_tester.render(
             data={
                 "citer": citer,
                 "page_resource": "/",
             }
-        ) as (actual, _):
+        ) as actual:
             assert (
                 "This citation's details are unavailable to protect people's privacy."
                 in actual

--- a/betty/tests/extension/cotton_candy/test_search.py
+++ b/betty/tests/extension/cotton_candy/test_search.py
@@ -346,7 +346,7 @@ class TestIndex:
 
         new_temporary_app.project.configuration.extensions.enable(CottonCandy)
         new_temporary_app.project.configuration.locales["en-US"].alias = "en"
-        app.project.ancestry.add(file)
+        new_temporary_app.project.ancestry.add(file)
         indexed = [
             item
             async for item in Index(

--- a/betty/tests/extension/cotton_candy/test_search.py
+++ b/betty/tests/extension/cotton_candy/test_search.py
@@ -12,43 +12,47 @@ from betty.project import LocaleConfiguration
 
 
 class TestIndex:
-    async def test_build_empty(self) -> None:
-        async with App.new_temporary() as app, app:
-            app.project.configuration.extensions.enable(CottonCandy)
-            app.project.configuration.locales["en-US"].alias = "en"
-            app.project.configuration.locales.append(
-                LocaleConfiguration(
-                    "nl-NL",
-                    alias="nl",
-                )
+    async def test_build_empty(self, new_temporary_app: App) -> None:
+        new_temporary_app.project.configuration.extensions.enable(CottonCandy)
+        new_temporary_app.project.configuration.locales["en-US"].alias = "en"
+        new_temporary_app.project.configuration.locales.append(
+            LocaleConfiguration(
+                "nl-NL",
+                alias="nl",
             )
-            indexed = [
-                item async for item in Index(app, Context(), DEFAULT_LOCALIZER).build()
-            ]
+        )
+        indexed = [
+            item
+            async for item in Index(
+                new_temporary_app, Context(), DEFAULT_LOCALIZER
+            ).build()
+        ]
 
-            assert [] == indexed
+        assert [] == indexed
 
-    async def test_build_person_without_names(self) -> None:
+    async def test_build_person_without_names(self, new_temporary_app: App) -> None:
         person_id = "P1"
         person = Person(id=person_id)
 
-        async with App.new_temporary() as app, app:
-            app.project.configuration.extensions.enable(CottonCandy)
-            app.project.configuration.locales["en-US"].alias = "en"
-            app.project.configuration.locales.append(
-                LocaleConfiguration(
-                    "nl-NL",
-                    alias="nl",
-                )
+        new_temporary_app.project.configuration.extensions.enable(CottonCandy)
+        new_temporary_app.project.configuration.locales["en-US"].alias = "en"
+        new_temporary_app.project.configuration.locales.append(
+            LocaleConfiguration(
+                "nl-NL",
+                alias="nl",
             )
-            app.project.ancestry.add(person)
-            indexed = [
-                item async for item in Index(app, Context(), DEFAULT_LOCALIZER).build()
-            ]
+        )
+        new_temporary_app.project.ancestry.add(person)
+        indexed = [
+            item
+            async for item in Index(
+                new_temporary_app, Context(), DEFAULT_LOCALIZER
+            ).build()
+        ]
 
-            assert [] == indexed
+        assert [] == indexed
 
-    async def test_build_private_person(self) -> None:
+    async def test_build_private_person(self, new_temporary_app: App) -> None:
         person_id = "P1"
         individual_name = "Jane"
         person = Person(
@@ -60,21 +64,23 @@ class TestIndex:
             individual=individual_name,
         )
 
-        async with App.new_temporary() as app, app:
-            app.project.configuration.extensions.enable(CottonCandy)
-            app.project.configuration.locales["en-US"].alias = "en"
-            app.project.configuration.locales.append(
-                LocaleConfiguration(
-                    "nl-NL",
-                    alias="nl",
-                )
+        new_temporary_app.project.configuration.extensions.enable(CottonCandy)
+        new_temporary_app.project.configuration.locales["en-US"].alias = "en"
+        new_temporary_app.project.configuration.locales.append(
+            LocaleConfiguration(
+                "nl-NL",
+                alias="nl",
             )
-            app.project.ancestry.add(person)
-            indexed = [
-                item async for item in Index(app, Context(), DEFAULT_LOCALIZER).build()
-            ]
+        )
+        new_temporary_app.project.ancestry.add(person)
+        indexed = [
+            item
+            async for item in Index(
+                new_temporary_app, Context(), DEFAULT_LOCALIZER
+            ).build()
+        ]
 
-            assert [] == indexed
+        assert [] == indexed
 
     @pytest.mark.parametrize(
         "expected, locale",
@@ -84,7 +90,7 @@ class TestIndex:
         ],
     )
     async def test_build_person_with_individual_name(
-        self, expected: str, locale: str
+        self, expected: str, locale: str, new_temporary_app: App
     ) -> None:
         person_id = "P1"
         individual_name = "Jane"
@@ -94,25 +100,26 @@ class TestIndex:
             individual=individual_name,
         )
 
-        async with App.new_temporary() as app, app:
-            app.project.configuration.extensions.enable(CottonCandy)
-            app.project.configuration.locales["en-US"].alias = "en"
-            app.project.configuration.locales.append(
-                LocaleConfiguration(
-                    "nl-NL",
-                    alias="nl",
-                )
+        new_temporary_app.project.configuration.extensions.enable(CottonCandy)
+        new_temporary_app.project.configuration.locales["en-US"].alias = "en"
+        new_temporary_app.project.configuration.locales.append(
+            LocaleConfiguration(
+                "nl-NL",
+                alias="nl",
             )
-            app.project.ancestry.add(person)
-            indexed = [
-                item
-                async for item in Index(
-                    app, Context(), await app.localizers.get(locale)
-                ).build()
-            ]
+        )
+        new_temporary_app.project.ancestry.add(person)
+        indexed = [
+            item
+            async for item in Index(
+                new_temporary_app,
+                Context(),
+                await new_temporary_app.localizers.get(locale),
+            ).build()
+        ]
 
-            assert "jane" == indexed[0]["text"]
-            assert expected in indexed[0]["result"]
+        assert "jane" == indexed[0]["text"]
+        assert expected in indexed[0]["result"]
 
     @pytest.mark.parametrize(
         "expected, locale",
@@ -122,7 +129,7 @@ class TestIndex:
         ],
     )
     async def test_build_person_with_affiliation_name(
-        self, expected: str, locale: str
+        self, expected: str, locale: str, new_temporary_app: App
     ) -> None:
         person_id = "P1"
         affiliation_name = "Doughnut"
@@ -132,25 +139,26 @@ class TestIndex:
             affiliation=affiliation_name,
         )
 
-        async with App.new_temporary() as app, app:
-            app.project.configuration.extensions.enable(CottonCandy)
-            app.project.configuration.locales["en-US"].alias = "en"
-            app.project.configuration.locales.append(
-                LocaleConfiguration(
-                    "nl-NL",
-                    alias="nl",
-                )
+        new_temporary_app.project.configuration.extensions.enable(CottonCandy)
+        new_temporary_app.project.configuration.locales["en-US"].alias = "en"
+        new_temporary_app.project.configuration.locales.append(
+            LocaleConfiguration(
+                "nl-NL",
+                alias="nl",
             )
-            app.project.ancestry.add(person)
-            indexed = [
-                item
-                async for item in Index(
-                    app, Context(), await app.localizers.get(locale)
-                ).build()
-            ]
+        )
+        new_temporary_app.project.ancestry.add(person)
+        indexed = [
+            item
+            async for item in Index(
+                new_temporary_app,
+                Context(),
+                await new_temporary_app.localizers.get(locale),
+            ).build()
+        ]
 
-            assert "doughnut" == indexed[0]["text"]
-            assert expected in indexed[0]["result"]
+        assert "doughnut" == indexed[0]["text"]
+        assert expected in indexed[0]["result"]
 
     @pytest.mark.parametrize(
         "expected, locale",
@@ -160,7 +168,7 @@ class TestIndex:
         ],
     )
     async def test_build_person_with_individual_and_affiliation_names(
-        self, expected: str, locale: str
+        self, expected: str, locale: str, new_temporary_app: App
     ) -> None:
         person_id = "P1"
         individual_name = "Jane"
@@ -172,25 +180,26 @@ class TestIndex:
             affiliation=affiliation_name,
         )
 
-        async with App.new_temporary() as app, app:
-            app.project.configuration.extensions.enable(CottonCandy)
-            app.project.configuration.locales["en-US"].alias = "en"
-            app.project.configuration.locales.append(
-                LocaleConfiguration(
-                    "nl-NL",
-                    alias="nl",
-                )
+        new_temporary_app.project.configuration.extensions.enable(CottonCandy)
+        new_temporary_app.project.configuration.locales["en-US"].alias = "en"
+        new_temporary_app.project.configuration.locales.append(
+            LocaleConfiguration(
+                "nl-NL",
+                alias="nl",
             )
-            app.project.ancestry.add(person)
-            indexed = [
-                item
-                async for item in Index(
-                    app, Context(), await app.localizers.get(locale)
-                ).build()
-            ]
+        )
+        new_temporary_app.project.ancestry.add(person)
+        indexed = [
+            item
+            async for item in Index(
+                new_temporary_app,
+                Context(),
+                await new_temporary_app.localizers.get(locale),
+            ).build()
+        ]
 
-            assert "jane doughnut" == indexed[0]["text"]
-            assert expected in indexed[0]["result"]
+        assert "jane doughnut" == indexed[0]["text"]
+        assert expected in indexed[0]["result"]
 
     @pytest.mark.parametrize(
         "expected, locale",
@@ -199,7 +208,9 @@ class TestIndex:
             ("/en/place/P1/index.html", "en-US"),
         ],
     )
-    async def test_build_place(self, expected: str, locale: str) -> None:
+    async def test_build_place(
+        self, expected: str, locale: str, new_temporary_app: App
+    ) -> None:
         place_id = "P1"
         place = Place(
             id=place_id,
@@ -215,27 +226,28 @@ class TestIndex:
             ],
         )
 
-        async with App.new_temporary() as app, app:
-            app.project.configuration.extensions.enable(CottonCandy)
-            app.project.configuration.locales["en-US"].alias = "en"
-            app.project.configuration.locales.append(
-                LocaleConfiguration(
-                    "nl-NL",
-                    alias="nl",
-                )
+        new_temporary_app.project.configuration.extensions.enable(CottonCandy)
+        new_temporary_app.project.configuration.locales["en-US"].alias = "en"
+        new_temporary_app.project.configuration.locales.append(
+            LocaleConfiguration(
+                "nl-NL",
+                alias="nl",
             )
-            app.project.ancestry.add(place)
-            indexed = [
-                item
-                async for item in Index(
-                    app, Context(), await app.localizers.get(locale)
-                ).build()
-            ]
+        )
+        new_temporary_app.project.ancestry.add(place)
+        indexed = [
+            item
+            async for item in Index(
+                new_temporary_app,
+                Context(),
+                await new_temporary_app.localizers.get(locale),
+            ).build()
+        ]
 
-            assert "netherlands nederland" == indexed[0]["text"]
-            assert expected in indexed[0]["result"]
+        assert "netherlands nederland" == indexed[0]["text"]
+        assert expected in indexed[0]["result"]
 
-    async def test_build_private_place(self) -> None:
+    async def test_build_private_place(self, new_temporary_app: App) -> None:
         place_id = "P1"
         place = Place(
             id=place_id,
@@ -248,38 +260,42 @@ class TestIndex:
             private=True,
         )
 
-        async with App.new_temporary() as app, app:
-            app.project.configuration.extensions.enable(CottonCandy)
-            app.project.configuration.locales["en-US"].alias = "en"
-            app.project.ancestry.add(place)
-            indexed = [
-                item async for item in Index(app, Context(), DEFAULT_LOCALIZER).build()
-            ]
+        new_temporary_app.project.configuration.extensions.enable(CottonCandy)
+        new_temporary_app.project.configuration.locales["en-US"].alias = "en"
+        new_temporary_app.project.ancestry.add(place)
+        indexed = [
+            item
+            async for item in Index(
+                new_temporary_app, Context(), DEFAULT_LOCALIZER
+            ).build()
+        ]
 
-            assert [] == indexed
+        assert [] == indexed
 
-    async def test_build_file_without_description(self) -> None:
+    async def test_build_file_without_description(self, new_temporary_app: App) -> None:
         file_id = "F1"
         file = File(
             id=file_id,
             path=Path(__file__),
         )
 
-        async with App.new_temporary() as app, app:
-            app.project.configuration.extensions.enable(CottonCandy)
-            app.project.configuration.locales["en-US"].alias = "en"
-            app.project.configuration.locales.append(
-                LocaleConfiguration(
-                    "nl-NL",
-                    alias="nl",
-                )
+        new_temporary_app.project.configuration.extensions.enable(CottonCandy)
+        new_temporary_app.project.configuration.locales["en-US"].alias = "en"
+        new_temporary_app.project.configuration.locales.append(
+            LocaleConfiguration(
+                "nl-NL",
+                alias="nl",
             )
-            app.project.ancestry.add(file)
-            indexed = [
-                item async for item in Index(app, Context(), DEFAULT_LOCALIZER).build()
-            ]
+        )
+        new_temporary_app.project.ancestry.add(file)
+        indexed = [
+            item
+            async for item in Index(
+                new_temporary_app, Context(), DEFAULT_LOCALIZER
+            ).build()
+        ]
 
-            assert [] == indexed
+        assert [] == indexed
 
     @pytest.mark.parametrize(
         "expected, locale",
@@ -288,7 +304,9 @@ class TestIndex:
             ("/en/file/F1/index.html", "en-US"),
         ],
     )
-    async def test_build_file(self, expected: str, locale: str) -> None:
+    async def test_build_file(
+        self, expected: str, locale: str, new_temporary_app: App
+    ) -> None:
         file_id = "F1"
         file = File(
             id=file_id,
@@ -296,27 +314,28 @@ class TestIndex:
             description='"file" is Dutch for "traffic jam"',
         )
 
-        async with App.new_temporary() as app, app:
-            app.project.configuration.extensions.enable(CottonCandy)
-            app.project.configuration.locales["en-US"].alias = "en"
-            app.project.configuration.locales.append(
-                LocaleConfiguration(
-                    "nl-NL",
-                    alias="nl",
-                )
+        new_temporary_app.project.configuration.extensions.enable(CottonCandy)
+        new_temporary_app.project.configuration.locales["en-US"].alias = "en"
+        new_temporary_app.project.configuration.locales.append(
+            LocaleConfiguration(
+                "nl-NL",
+                alias="nl",
             )
-            app.project.ancestry.add(file)
-            indexed = [
-                item
-                async for item in Index(
-                    app, Context(), await app.localizers.get(locale)
-                ).build()
-            ]
+        )
+        new_temporary_app.project.ancestry.add(file)
+        indexed = [
+            item
+            async for item in Index(
+                new_temporary_app,
+                Context(),
+                await new_temporary_app.localizers.get(locale),
+            ).build()
+        ]
 
-            assert '"file" is dutch for "traffic jam"' == indexed[0]["text"]
-            assert expected in indexed[0]["result"]
+        assert '"file" is dutch for "traffic jam"' == indexed[0]["text"]
+        assert expected in indexed[0]["result"]
 
-    async def test_build_private_file(self) -> None:
+    async def test_build_private_file(self, new_temporary_app: App) -> None:
         file_id = "F1"
         file = File(
             id=file_id,
@@ -325,12 +344,14 @@ class TestIndex:
             private=True,
         )
 
-        async with App.new_temporary() as app, app:
-            app.project.configuration.extensions.enable(CottonCandy)
-            app.project.configuration.locales["en-US"].alias = "en"
-            app.project.ancestry.add(file)
-            indexed = [
-                item async for item in Index(app, Context(), DEFAULT_LOCALIZER).build()
-            ]
+        new_temporary_app.project.configuration.extensions.enable(CottonCandy)
+        new_temporary_app.project.configuration.locales["en-US"].alias = "en"
+        app.project.ancestry.add(file)
+        indexed = [
+            item
+            async for item in Index(
+                new_temporary_app, Context(), DEFAULT_LOCALIZER
+            ).build()
+        ]
 
-            assert [] == indexed
+        assert [] == indexed

--- a/betty/tests/extension/demo/test___init__.py
+++ b/betty/tests/extension/demo/test___init__.py
@@ -14,30 +14,25 @@ from betty.project import ExtensionConfiguration
 
 
 class TestDemo:
-    async def test_load(self, mocker: MockerFixture) -> None:
+    async def test_load(self, mocker: MockerFixture, new_temporary_app: App) -> None:
         mocker.patch("betty.wikipedia._Populator.populate")
-        async with App.new_temporary() as app, app:
-            app.project.configuration.extensions.append(ExtensionConfiguration(Demo))
-            await load(app)
-            assert 0 != len(app.project.ancestry[Person])
-            assert 0 != len(app.project.ancestry[Place])
-            assert 0 != len(app.project.ancestry[Event])
-            assert 0 != len(app.project.ancestry[Source])
-            assert 0 != len(app.project.ancestry[Citation])
+        new_temporary_app.project.configuration.extensions.enable(Demo)
+        await load(new_temporary_app)
+        assert 0 != len(new_temporary_app.project.ancestry[Person])
+        assert 0 != len(new_temporary_app.project.ancestry[Place])
+        assert 0 != len(new_temporary_app.project.ancestry[Event])
+        assert 0 != len(new_temporary_app.project.ancestry[Source])
+        assert 0 != len(new_temporary_app.project.ancestry[Citation])
 
 
 class TestDemoServer:
-    async def test(
-        self,
-        mocker: MockerFixture,
-    ) -> None:
+    async def test(self, mocker: MockerFixture, new_temporary_app: App) -> None:
         mocker.patch("betty.wikipedia._Populator.populate")
         mocker.patch("webbrowser.open_new_tab")
-        async with App.new_temporary() as app, app:
-            async with DemoServer(app=app) as server:
+        async with DemoServer(app=new_temporary_app) as server:
 
-                def _assert_response(response: Response) -> None:
-                    assert response.status_code == 200
-                    assert "Betty" in response.content.decode("utf-8")
+            def _assert_response(response: Response) -> None:
+                assert response.status_code == 200
+                assert "Betty" in response.content.decode("utf-8")
 
-                await Do(requests.get, server.public_url).until(_assert_response)
+            await Do(requests.get, server.public_url).until(_assert_response)

--- a/betty/tests/extension/demo/test___init__.py
+++ b/betty/tests/extension/demo/test___init__.py
@@ -10,7 +10,6 @@ from betty.extension.demo import DemoServer
 from betty.functools import Do
 from betty.load import load
 from betty.model.ancestry import Person, Place, Event, Source, Citation
-from betty.project import ExtensionConfiguration
 
 
 class TestDemo:

--- a/betty/tests/extension/gramps/test___init__.py
+++ b/betty/tests/extension/gramps/test___init__.py
@@ -12,7 +12,7 @@ from betty.project import ExtensionConfiguration
 
 
 class TestGramps:
-    async def test_load_multiple_family_trees(self) -> None:
+    async def test_load_multiple_family_trees(self, new_temporary_app: App) -> None:
         family_tree_one_xml = """
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE database PUBLIC "-//Gramps//DTD Gramps XML 1.7.1//EN"
@@ -125,36 +125,35 @@ class TestGramps:
             async with aiofiles.open(gramps_family_tree_two_path, mode="w") as f:
                 await f.write(family_tree_two_xml)
 
-            async with App.new_temporary() as app, app:
-                app.project.configuration.extensions.append(
-                    ExtensionConfiguration(
-                        Gramps,
-                        extension_configuration=GrampsConfiguration(
-                            family_trees=[
-                                FamilyTreeConfiguration(
-                                    file_path=gramps_family_tree_one_path
-                                ),
-                                FamilyTreeConfiguration(
-                                    file_path=gramps_family_tree_two_path
-                                ),
-                            ],
-                        ),
-                    )
+            new_temporary_app.project.configuration.extensions.append(
+                ExtensionConfiguration(
+                    Gramps,
+                    extension_configuration=GrampsConfiguration(
+                        family_trees=[
+                            FamilyTreeConfiguration(
+                                file_path=gramps_family_tree_one_path
+                            ),
+                            FamilyTreeConfiguration(
+                                file_path=gramps_family_tree_two_path
+                            ),
+                        ],
+                    ),
                 )
-                await load(app)
-            assert "O0001" in app.project.ancestry[File]
-            assert "O0002" in app.project.ancestry[File]
-            assert "I0001" in app.project.ancestry[Person]
-            assert "I0002" in app.project.ancestry[Person]
-            assert "P0001" in app.project.ancestry[Place]
-            assert "P0002" in app.project.ancestry[Place]
-            assert "E0001" in app.project.ancestry[Event]
-            assert "E0002" in app.project.ancestry[Event]
-            assert "S0001" in app.project.ancestry[Source]
-            assert "S0002" in app.project.ancestry[Source]
-            assert "R0001" in app.project.ancestry[Source]
-            assert "R0002" in app.project.ancestry[Source]
-            assert "C0001" in app.project.ancestry[Citation]
-            assert "C0002" in app.project.ancestry[Citation]
-            assert "N0001" in app.project.ancestry[Note]
-            assert "N0002" in app.project.ancestry[Note]
+            )
+            await load(new_temporary_app)
+        assert "O0001" in new_temporary_app.project.ancestry[File]
+        assert "O0002" in new_temporary_app.project.ancestry[File]
+        assert "I0001" in new_temporary_app.project.ancestry[Person]
+        assert "I0002" in new_temporary_app.project.ancestry[Person]
+        assert "P0001" in new_temporary_app.project.ancestry[Place]
+        assert "P0002" in new_temporary_app.project.ancestry[Place]
+        assert "E0001" in new_temporary_app.project.ancestry[Event]
+        assert "E0002" in new_temporary_app.project.ancestry[Event]
+        assert "S0001" in new_temporary_app.project.ancestry[Source]
+        assert "S0002" in new_temporary_app.project.ancestry[Source]
+        assert "R0001" in new_temporary_app.project.ancestry[Source]
+        assert "R0002" in new_temporary_app.project.ancestry[Source]
+        assert "C0001" in new_temporary_app.project.ancestry[Citation]
+        assert "C0002" in new_temporary_app.project.ancestry[Citation]
+        assert "N0001" in new_temporary_app.project.ancestry[Note]
+        assert "N0002" in new_temporary_app.project.ancestry[Note]

--- a/betty/tests/extension/http_api_doc/test___init__.py
+++ b/betty/tests/extension/http_api_doc/test___init__.py
@@ -5,15 +5,18 @@ from betty.project import ExtensionConfiguration
 
 
 class TestHttpApiDoc:
-    async def test_generate(self) -> None:
-        async with App.new_temporary() as app, app:
-            app.project.configuration.extensions.append(
-                ExtensionConfiguration(HttpApiDoc)
-            )
-            await generate(app)
-            assert (
-                app.project.configuration.www_directory_path / "api" / "index.html"
-            ).is_file()
-            assert (
-                app.project.configuration.www_directory_path / "js" / "http-api-doc.js"
-            ).is_file()
+    async def test_generate(self, new_temporary_app: App) -> None:
+        new_temporary_app.project.configuration.extensions.append(
+            ExtensionConfiguration(HttpApiDoc)
+        )
+        await generate(new_temporary_app)
+        assert (
+            new_temporary_app.project.configuration.www_directory_path
+            / "api"
+            / "index.html"
+        ).is_file()
+        assert (
+            new_temporary_app.project.configuration.www_directory_path
+            / "js"
+            / "http-api-doc.js"
+        ).is_file()

--- a/betty/tests/extension/maps/test___init__.py
+++ b/betty/tests/extension/maps/test___init__.py
@@ -9,7 +9,9 @@ from betty.project import ExtensionConfiguration
 class TestMaps:
     async def test_generate(self, new_temporary_app: App) -> None:
         new_temporary_app.project.configuration.debug = True
-        new_temporary_app.project.configuration.extensions.append(ExtensionConfiguration(Maps))
+        new_temporary_app.project.configuration.extensions.append(
+            ExtensionConfiguration(Maps)
+        )
         await generate(new_temporary_app)
         async with aiofiles.open(
             new_temporary_app.project.configuration.www_directory_path

--- a/betty/tests/extension/maps/test___init__.py
+++ b/betty/tests/extension/maps/test___init__.py
@@ -7,24 +7,23 @@ from betty.project import ExtensionConfiguration
 
 
 class TestMaps:
-    async def test_generate(self) -> None:
-        async with App.new_temporary() as app, app:
-            app.project.configuration.debug = True
-            app.project.configuration.extensions.append(ExtensionConfiguration(Maps))
-            await generate(app)
-            async with aiofiles.open(
-                app.project.configuration.www_directory_path
-                / "js"
-                / "betty.extension.Maps.js",
-                encoding="utf-8",
-            ) as f:
-                betty_js = await f.read()
-            assert Maps.name() in betty_js
-            async with aiofiles.open(
-                app.project.configuration.www_directory_path
-                / "css"
-                / "betty.extension.Maps.css",
-                encoding="utf-8",
-            ) as f:
-                betty_css = await f.read()
-            assert Maps.name() in betty_css
+    async def test_generate(self, new_temporary_app: App) -> None:
+        new_temporary_app.project.configuration.debug = True
+        new_temporary_app.project.configuration.extensions.append(ExtensionConfiguration(Maps))
+        await generate(new_temporary_app)
+        async with aiofiles.open(
+            new_temporary_app.project.configuration.www_directory_path
+            / "js"
+            / "betty.extension.Maps.js",
+            encoding="utf-8",
+        ) as f:
+            betty_js = await f.read()
+        assert Maps.name() in betty_js
+        async with aiofiles.open(
+            new_temporary_app.project.configuration.www_directory_path
+            / "css"
+            / "betty.extension.Maps.css",
+            encoding="utf-8",
+        ) as f:
+            betty_css = await f.read()
+        assert Maps.name() in betty_css

--- a/betty/tests/extension/nginx/test___init__.py
+++ b/betty/tests/extension/nginx/test___init__.py
@@ -5,19 +5,24 @@ from betty.project import ExtensionConfiguration
 
 
 class TestNginx:
-    async def test_generate(self):
-        async with App.new_temporary() as app, app:
-            app.project.configuration.base_url = "http://example.com"
-            app.project.configuration.extensions.append(ExtensionConfiguration(Nginx))
-            await generate(app)
-            assert (
-                app.project.configuration.output_directory_path / "nginx" / "nginx.conf"
-            ).exists()
-            assert (
-                app.project.configuration.output_directory_path
-                / "nginx"
-                / "content_negotiation.lua"
-            ).exists()
-            assert (
-                app.project.configuration.output_directory_path / "nginx" / "Dockerfile"
-            ).exists()
+    async def test_generate(self, new_temporary_app: App):
+        new_temporary_app.project.configuration.base_url = "http://example.com"
+        new_temporary_app.project.configuration.extensions.append(
+            ExtensionConfiguration(Nginx)
+        )
+        await generate(new_temporary_app)
+        assert (
+            new_temporary_app.project.configuration.output_directory_path
+            / "nginx"
+            / "nginx.conf"
+        ).exists()
+        assert (
+            new_temporary_app.project.configuration.output_directory_path
+            / "nginx"
+            / "content_negotiation.lua"
+        ).exists()
+        assert (
+            new_temporary_app.project.configuration.output_directory_path
+            / "nginx"
+            / "Dockerfile"
+        ).exists()

--- a/betty/tests/extension/nginx/test_artifact.py
+++ b/betty/tests/extension/nginx/test_artifact.py
@@ -38,12 +38,13 @@ class TestGenerateConfigurationFile:
             actual
         )
 
-    async def test(self):
-        async with App.new_temporary() as app, app:
-            app.project.configuration.base_url = "http://example.com"
-            app.project.configuration.extensions.append(ExtensionConfiguration(Nginx))
-            expected = (
-                r"""
+    async def test(self, new_temporary_app: App):
+        new_temporary_app.project.configuration.base_url = "http://example.com"
+        new_temporary_app.project.configuration.extensions.append(
+            ExtensionConfiguration(Nginx)
+        )
+        expected = (
+            r"""
 server {
     add_header Vary Accept-Language;
     add_header Cache-Control "max-age=86400";
@@ -71,26 +72,27 @@ server {
     }
 }
 """
-                % app.project.configuration.www_directory_path
-            )
-            await self._assert_configuration_equals(expected, app)
+            % new_temporary_app.project.configuration.www_directory_path
+        )
+        await self._assert_configuration_equals(expected, new_temporary_app)
 
-    async def test_multilingual(self):
-        async with App.new_temporary() as app, app:
-            app.project.configuration.base_url = "http://example.com"
-            app.project.configuration.locales.replace(
-                LocaleConfiguration(
-                    "en-US",
-                    alias="en",
-                ),
-                LocaleConfiguration(
-                    "nl-NL",
-                    alias="nl",
-                ),
-            )
-            app.project.configuration.extensions.append(ExtensionConfiguration(Nginx))
-            expected = (
-                r"""
+    async def test_multilingual(self, new_temporary_app: App):
+        new_temporary_app.project.configuration.base_url = "http://example.com"
+        new_temporary_app.project.configuration.locales.replace(
+            LocaleConfiguration(
+                "en-US",
+                alias="en",
+            ),
+            LocaleConfiguration(
+                "nl-NL",
+                alias="nl",
+            ),
+        )
+        new_temporary_app.project.configuration.extensions.append(
+            ExtensionConfiguration(Nginx)
+        )
+        expected = (
+            r"""
 server {
     add_header Vary Accept-Language;
     add_header Cache-Control "max-age=86400";
@@ -149,27 +151,28 @@ server {
     }
 }
 """
-                % app.project.configuration.www_directory_path
-            )
-            await self._assert_configuration_equals(expected, app)
+            % new_temporary_app.project.configuration.www_directory_path
+        )
+        await self._assert_configuration_equals(expected, new_temporary_app)
 
-    async def test_multilingual_with_clean_urls(self):
-        async with App.new_temporary() as app, app:
-            app.project.configuration.base_url = "http://example.com"
-            app.project.configuration.clean_urls = True
-            app.project.configuration.locales.replace(
-                LocaleConfiguration(
-                    "en-US",
-                    alias="en",
-                ),
-                LocaleConfiguration(
-                    "nl-NL",
-                    alias="nl",
-                ),
-            )
-            app.project.configuration.extensions.append(ExtensionConfiguration(Nginx))
-            expected = (
-                r"""
+    async def test_multilingual_with_clean_urls(self, new_temporary_app: App):
+        new_temporary_app.project.configuration.base_url = "http://example.com"
+        new_temporary_app.project.configuration.clean_urls = True
+        new_temporary_app.project.configuration.locales.replace(
+            LocaleConfiguration(
+                "en-US",
+                alias="en",
+            ),
+            LocaleConfiguration(
+                "nl-NL",
+                alias="nl",
+            ),
+        )
+        new_temporary_app.project.configuration.extensions.append(
+            ExtensionConfiguration(Nginx)
+        )
+        expected = (
+            r"""
 server {
     add_header Vary Accept-Language;
     add_header Cache-Control "max-age=86400";
@@ -244,17 +247,18 @@ server {
     }
 }
 """
-                % app.project.configuration.www_directory_path
-            )
-            await self._assert_configuration_equals(expected, app)
+            % new_temporary_app.project.configuration.www_directory_path
+        )
+        await self._assert_configuration_equals(expected, new_temporary_app)
 
-    async def test_with_clean_urls(self):
-        async with App.new_temporary() as app, app:
-            app.project.configuration.base_url = "http://example.com"
-            app.project.configuration.clean_urls = True
-            app.project.configuration.extensions.append(ExtensionConfiguration(Nginx))
-            expected = (
-                r"""
+    async def test_with_clean_urls(self, new_temporary_app: App):
+        new_temporary_app.project.configuration.base_url = "http://example.com"
+        new_temporary_app.project.configuration.clean_urls = True
+        new_temporary_app.project.configuration.extensions.append(
+            ExtensionConfiguration(Nginx)
+        )
+        expected = (
+            r"""
 server {
     add_header Vary Accept-Language;
     add_header Cache-Control "max-age=86400";
@@ -288,16 +292,17 @@ server {
         try_files $uri $uri/ =404;
     }
 }"""
-                % app.project.configuration.www_directory_path
-            )
-            await self._assert_configuration_equals(expected, app)
+            % new_temporary_app.project.configuration.www_directory_path
+        )
+        await self._assert_configuration_equals(expected, new_temporary_app)
 
-    async def test_with_https(self):
-        async with App.new_temporary() as app, app:
-            app.project.configuration.base_url = "https://example.com"
-            app.project.configuration.extensions.append(ExtensionConfiguration(Nginx))
-            expected = (
-                r"""
+    async def test_with_https(self, new_temporary_app: App):
+        new_temporary_app.project.configuration.base_url = "https://example.com"
+        new_temporary_app.project.configuration.extensions.append(
+            ExtensionConfiguration(Nginx)
+        )
+        expected = (
+            r"""
 server {
     listen 80;
     server_name example.com;
@@ -331,21 +336,20 @@ server {
     }
 }
 """
-                % app.project.configuration.www_directory_path
-            )
-            await self._assert_configuration_equals(expected, app)
+            % new_temporary_app.project.configuration.www_directory_path
+        )
+        await self._assert_configuration_equals(expected, new_temporary_app)
 
-    async def test_with_overridden_www_directory_path(self):
-        async with App.new_temporary() as app, app:
-            app.project.configuration.extensions.append(
-                ExtensionConfiguration(
-                    Nginx,
-                    extension_configuration=NginxConfiguration(
-                        www_directory_path="/tmp/overridden-www",
-                    ),
-                )
+    async def test_with_overridden_www_directory_path(self, new_temporary_app: App):
+        new_temporary_app.project.configuration.extensions.append(
+            ExtensionConfiguration(
+                Nginx,
+                extension_configuration=NginxConfiguration(
+                    www_directory_path="/tmp/overridden-www",
+                ),
             )
-            expected = """
+        )
+        expected = """
 server {
     listen 80;
     server_name example.com;
@@ -379,26 +383,27 @@ server {
     }
 }
 """
-            await self._assert_configuration_equals(expected, app)
+        await self._assert_configuration_equals(expected, new_temporary_app)
 
 
 class TestGenerateDockerfileFile:
-    async def test(self) -> None:
-        async with App.new_temporary() as app, app:
-            app.project.configuration.extensions.append(
-                ExtensionConfiguration(
-                    Nginx,
-                    extension_configuration=NginxConfiguration(
-                        www_directory_path="/tmp/overridden-www",
-                    ),
-                )
+    async def test(self, new_temporary_app: App) -> None:
+        new_temporary_app.project.configuration.extensions.append(
+            ExtensionConfiguration(
+                Nginx,
+                extension_configuration=NginxConfiguration(
+                    www_directory_path="/tmp/overridden-www",
+                ),
             )
-            await generate_dockerfile_file(app)
+        )
+        await generate_dockerfile_file(new_temporary_app)
         assert (
-            app.project.configuration.output_directory_path
+            new_temporary_app.project.configuration.output_directory_path
             / "nginx"
             / "content_negotiation.lua"
         ).exists()
         assert (
-            app.project.configuration.output_directory_path / "nginx" / "Dockerfile"
+            new_temporary_app.project.configuration.output_directory_path
+            / "nginx"
+            / "Dockerfile"
         ).exists()

--- a/betty/tests/extension/nginx/test_integration.py
+++ b/betty/tests/extension/nginx/test_integration.py
@@ -1,8 +1,6 @@
 import sys
 from collections.abc import Callable, AsyncIterator
 from contextlib import asynccontextmanager
-from pathlib import Path
-from typing import AsyncContextManager
 
 import html5lib
 import pytest
@@ -24,25 +22,18 @@ from betty.project import (
 from betty.serve import Server
 
 
-@pytest.mark.skipif(
-    sys.platform in {"darwin", "win32"},
-    reason="macOS and Windows do not natively support Docker.",
-)
-class TestNginx:
-    @pytest.fixture
-    def new_server(
-        self, new_temporary_app: App
-    ) -> Callable[[ProjectConfiguration], AsyncContextManager[Server]]:
-        @asynccontextmanager
-        async def _new_server(
-            configuration: ProjectConfiguration,
-        ) -> AsyncIterator[Server]:
-            new_temporary_app.project.configuration.update(configuration)
-            await generate.generate(new_temporary_app)
-            async with DockerizedNginxServer(new_temporary_app) as server:
-                yield server
+class NginxFixture:
+    def __init__(self, app: App):
+        self._app = app
 
-        return _new_server
+    @asynccontextmanager
+    async def new_server(
+        self, configuration: ProjectConfiguration
+    ) -> AsyncIterator[Server]:
+        self._app.project.configuration.update(configuration)
+        await generate.generate(self._app)
+        async with DockerizedNginxServer(self._app) as server:
+            yield server
 
     async def assert_betty_html(self, response: Response) -> None:
         assert "text/html" == response.headers["Content-Type"]
@@ -50,17 +41,13 @@ class TestNginx:
         parser.parse(response.text)
         assert "Betty" in response.text
 
-    # @todo Turn this into a fixture so we can inject a temporary App
-    async def assert_betty_json(
-        self, response: Response, new_temporary_app: App
-    ) -> None:
+    async def assert_betty_json(self, response: Response) -> None:
         assert "application/json" == response.headers["Content-Type"]
         data = response.json()
-        schema = Schema(new_temporary_app)
+        schema = Schema(self._app)
         await schema.validate(data)
 
-    @pytest.fixture
-    def monolingual_configuration(self, tmp_path: Path) -> ProjectConfiguration:
+    def monolingual_configuration(self) -> ProjectConfiguration:
         return ProjectConfiguration(
             extensions=[
                 ExtensionConfiguration(
@@ -70,13 +57,10 @@ class TestNginx:
                     ),
                 ),
             ],
-            configuration_file_path=tmp_path / "betty.json",
+            configuration_file_path=self._app.project.configuration.configuration_file_path,
         )
 
-    @pytest.fixture
-    def monolingual_clean_urls_configuration(
-        self, tmp_path: Path
-    ) -> ProjectConfiguration:
+    def monolingual_clean_urls_configuration(self) -> ProjectConfiguration:
         return ProjectConfiguration(
             extensions=[
                 ExtensionConfiguration(
@@ -87,11 +71,10 @@ class TestNginx:
                 ),
             ],
             clean_urls=True,
-            configuration_file_path=tmp_path / "betty.json",
+            configuration_file_path=self._app.project.configuration.configuration_file_path,
         )
 
-    @pytest.fixture
-    def multilingual_configuration(self, tmp_path: Path) -> ProjectConfiguration:
+    def multilingual_configuration(self) -> ProjectConfiguration:
         return ProjectConfiguration(
             extensions=[
                 ExtensionConfiguration(
@@ -111,13 +94,10 @@ class TestNginx:
                     alias="nl",
                 ),
             ],
-            configuration_file_path=tmp_path / "betty.json",
+            configuration_file_path=self._app.project.configuration.configuration_file_path,
         )
 
-    @pytest.fixture
-    def multilingual_clean_urls_configuration(
-        self, tmp_path: Path
-    ) -> ProjectConfiguration:
+    def multilingual_clean_urls_configuration(self) -> ProjectConfiguration:
         return ProjectConfiguration(
             extensions=[
                 ExtensionConfiguration(
@@ -138,9 +118,20 @@ class TestNginx:
                 ),
             ],
             clean_urls=True,
-            configuration_file_path=tmp_path / "betty.json",
+            configuration_file_path=self._app.project.configuration.configuration_file_path,
         )
 
+
+@pytest.fixture
+def nginx_fixture(new_temporary_app: App) -> NginxFixture:
+    return NginxFixture(new_temporary_app)
+
+
+@pytest.mark.skipif(
+    sys.platform in {"darwin", "win32"},
+    reason="macOS and Windows do not natively support Docker.",
+)
+class TestNginx:
     def _build_assert_status_code(
         self, http_status_code: int
     ) -> Callable[[Response], None]:
@@ -149,34 +140,28 @@ class TestNginx:
 
         return _assert
 
-    async def test_front_page(
-        self,
-        monolingual_clean_urls_configuration: ProjectConfiguration,
-        new_server: Callable[[ProjectConfiguration], Server],
-    ):
-        async with new_server(monolingual_clean_urls_configuration) as server:
+    async def test_front_page(self, nginx_fixture: NginxFixture):
+        async with nginx_fixture.new_server(
+            nginx_fixture.monolingual_clean_urls_configuration()
+        ) as server:
             await Do(requests.get, server.public_url).until(
                 self._build_assert_status_code(200),
-                self.assert_betty_html,
+                nginx_fixture.assert_betty_html,
             )
 
-    async def test_default_html_404(
-        self,
-        monolingual_clean_urls_configuration: ProjectConfiguration,
-        new_server: Callable[[ProjectConfiguration], Server],
-    ):
-        async with new_server(monolingual_clean_urls_configuration) as server:
+    async def test_default_html_404(self, nginx_fixture: NginxFixture):
+        async with nginx_fixture.new_server(
+            nginx_fixture.monolingual_clean_urls_configuration()
+        ) as server:
             await Do(requests.get, f"{server.public_url}/non-existent-path/").until(
                 self._build_assert_status_code(404),
-                self.assert_betty_html,
+                nginx_fixture.assert_betty_html,
             )
 
-    async def test_negotiated_json_404(
-        self,
-        monolingual_clean_urls_configuration: ProjectConfiguration,
-        new_server: Callable[[ProjectConfiguration], Server],
-    ):
-        async with new_server(monolingual_clean_urls_configuration) as server:
+    async def test_negotiated_json_404(self, nginx_fixture: NginxFixture):
+        async with nginx_fixture.new_server(
+            nginx_fixture.monolingual_clean_urls_configuration()
+        ) as server:
             await Do(
                 requests.get,
                 f"{server.public_url}/non-existent-path/",
@@ -185,50 +170,44 @@ class TestNginx:
                 },
             ).until(
                 self._build_assert_status_code(404),
-                self.assert_betty_json,
+                nginx_fixture.assert_betty_json,
             )
 
-    async def test_default_localized_front_page(
-        self,
-        multilingual_configuration: ProjectConfiguration,
-        new_server: Callable[[ProjectConfiguration], Server],
-    ):
+    async def test_default_localized_front_page(self, nginx_fixture: NginxFixture):
         async def _assert_response(response: Response) -> None:
             assert 200 == response.status_code
             assert "en" == response.headers["Content-Language"]
             assert f"{server.public_url}/en/" == response.url
-            await self.assert_betty_html(response)
+            await nginx_fixture.assert_betty_html(response)
 
-        async with new_server(multilingual_configuration) as server:
+        async with nginx_fixture.new_server(
+            nginx_fixture.multilingual_configuration()
+        ) as server:
             await Do(requests.get, server.public_url).until(_assert_response)
 
-    async def test_explicitly_localized_404(
-        self,
-        multilingual_configuration: ProjectConfiguration,
-        new_server: Callable[[ProjectConfiguration], Server],
-    ):
+    async def test_explicitly_localized_404(self, nginx_fixture: NginxFixture):
         async def _assert_response(response: Response) -> None:
             assert 404 == response.status_code
             assert "nl" == response.headers["Content-Language"]
-            await self.assert_betty_html(response)
+            await nginx_fixture.assert_betty_html(response)
 
-        async with new_server(multilingual_configuration) as server:
+        async with nginx_fixture.new_server(
+            nginx_fixture.multilingual_configuration()
+        ) as server:
             await Do(requests.get, f"{server.public_url}/nl/non-existent-path/").until(
                 _assert_response
             )
 
-    async def test_negotiated_localized_front_page(
-        self,
-        multilingual_clean_urls_configuration: ProjectConfiguration,
-        new_server: Callable[[ProjectConfiguration], Server],
-    ):
+    async def test_negotiated_localized_front_page(self, nginx_fixture: NginxFixture):
         async def _assert_response(response: Response) -> None:
             assert 200 == response.status_code
             assert "nl" == response.headers["Content-Language"]
             assert f"{server.public_url}/nl/" == response.url
-            await self.assert_betty_html(response)
+            await nginx_fixture.assert_betty_html(response)
 
-        async with new_server(multilingual_clean_urls_configuration) as server:
+        async with nginx_fixture.new_server(
+            nginx_fixture.multilingual_clean_urls_configuration()
+        ) as server:
             await Do(
                 requests.get,
                 server.public_url,
@@ -238,11 +217,11 @@ class TestNginx:
             ).until(_assert_response)
 
     async def test_negotiated_localized_negotiated_json_404(
-        self,
-        multilingual_clean_urls_configuration: ProjectConfiguration,
-        new_server: Callable[[ProjectConfiguration], Server],
+        self, nginx_fixture: NginxFixture
     ):
-        async with new_server(multilingual_clean_urls_configuration) as server:
+        async with nginx_fixture.new_server(
+            nginx_fixture.multilingual_clean_urls_configuration()
+        ) as server:
             await Do(
                 requests.get,
                 f"{server.public_url}/non-existent-path/",
@@ -252,26 +231,22 @@ class TestNginx:
                 },
             ).until(
                 self._build_assert_status_code(404),
-                self.assert_betty_json,
+                nginx_fixture.assert_betty_json,
             )
 
-    async def test_default_html_resource(
-        self,
-        monolingual_clean_urls_configuration: ProjectConfiguration,
-        new_server: Callable[[ProjectConfiguration], Server],
-    ):
-        async with new_server(monolingual_clean_urls_configuration) as server:
+    async def test_default_html_resource(self, nginx_fixture: NginxFixture):
+        async with nginx_fixture.new_server(
+            nginx_fixture.monolingual_clean_urls_configuration()
+        ) as server:
             await Do(requests.get, f"{server.public_url}/place/").until(
                 self._build_assert_status_code(200),
-                self.assert_betty_html,
+                nginx_fixture.assert_betty_html,
             )
 
-    async def test_negotiated_html_resource(
-        self,
-        monolingual_clean_urls_configuration: ProjectConfiguration,
-        new_server: Callable[[ProjectConfiguration], Server],
-    ):
-        async with new_server(monolingual_clean_urls_configuration) as server:
+    async def test_negotiated_html_resource(self, nginx_fixture: NginxFixture):
+        async with nginx_fixture.new_server(
+            nginx_fixture.monolingual_clean_urls_configuration()
+        ) as server:
             await Do(
                 requests.get,
                 f"{server.public_url}/place/",
@@ -280,15 +255,13 @@ class TestNginx:
                 },
             ).until(
                 self._build_assert_status_code(200),
-                self.assert_betty_html,
+                nginx_fixture.assert_betty_html,
             )
 
-    async def test_negotiated_json_resource(
-        self,
-        monolingual_clean_urls_configuration: ProjectConfiguration,
-        new_server: Callable[[ProjectConfiguration], Server],
-    ):
-        async with new_server(monolingual_clean_urls_configuration) as server:
+    async def test_negotiated_json_resource(self, nginx_fixture: NginxFixture):
+        async with nginx_fixture.new_server(
+            nginx_fixture.monolingual_clean_urls_configuration()
+        ) as server:
             await Do(
                 requests.get,
                 f"{server.public_url}/place/",
@@ -297,27 +270,22 @@ class TestNginx:
                 },
             ).until(
                 self._build_assert_status_code(200),
-                self.assert_betty_json,
+                nginx_fixture.assert_betty_json,
             )
 
-    async def test_default_html_static_resource(
-        self,
-        multilingual_clean_urls_configuration: ProjectConfiguration,
-        new_server: Callable[[ProjectConfiguration], Server],
-    ):
-        async with new_server(multilingual_clean_urls_configuration) as server:
+    async def test_default_html_static_resource(self, nginx_fixture: NginxFixture):
+        async with nginx_fixture.new_server(
+            nginx_fixture.multilingual_clean_urls_configuration()
+        ) as server:
             await Do(requests.get, f"{server.public_url}/non-existent-path/").until(
                 self._build_assert_status_code(404),
-                self.assert_betty_html,
+                nginx_fixture.assert_betty_html,
             )
 
-    async def test_negotiated_html_static_resource(
-        self,
-        multilingual_clean_urls_configuration: ProjectConfiguration,
-        new_server: Callable[[ProjectConfiguration], Server],
-        tmp_path: Path,
-    ):
-        async with new_server(multilingual_clean_urls_configuration) as server:
+    async def test_negotiated_html_static_resource(self, nginx_fixture: NginxFixture):
+        async with nginx_fixture.new_server(
+            nginx_fixture.multilingual_clean_urls_configuration()
+        ) as server:
             await Do(
                 requests.get,
                 f"{server.public_url}/non-existent-path/",
@@ -326,15 +294,13 @@ class TestNginx:
                 },
             ).until(
                 self._build_assert_status_code(404),
-                self.assert_betty_html,
+                nginx_fixture.assert_betty_html,
             )
 
-    async def test_negotiated_json_static_resource(
-        self,
-        multilingual_clean_urls_configuration: ProjectConfiguration,
-        new_server: Callable[[ProjectConfiguration], Server],
-    ):
-        async with new_server(multilingual_clean_urls_configuration) as server:
+    async def test_negotiated_json_static_resource(self, nginx_fixture: NginxFixture):
+        async with nginx_fixture.new_server(
+            nginx_fixture.multilingual_clean_urls_configuration()
+        ) as server:
             await Do(
                 requests.get,
                 f"{server.public_url}/non-existent-path/",
@@ -343,5 +309,5 @@ class TestNginx:
                 },
             ).until(
                 self._build_assert_status_code(404),
-                self.assert_betty_json,
+                nginx_fixture.assert_betty_json,
             )

--- a/betty/tests/extension/nginx/test_serve.py
+++ b/betty/tests/extension/nginx/test_serve.py
@@ -22,54 +22,50 @@ class TestDockerizedNginxServer:
         sys.platform in {"darwin", "win32"},
         reason="macOS and Windows do not natively support Docker.",
     )
-    async def test_context_manager(self):
+    async def test_context_manager(self, new_temporary_app: App):
         content = "Hello, and welcome to my site!"
-        async with App.new_temporary() as app, app:
-            app.project.configuration.extensions.append(
-                ExtensionConfiguration(
-                    Nginx,
-                    extension_configuration=NginxConfiguration(
-                        www_directory_path="/var/www/betty"
-                    ),
-                )
+        new_temporary_app.project.configuration.extensions.append(
+            ExtensionConfiguration(
+                Nginx,
+                extension_configuration=NginxConfiguration(
+                    www_directory_path="/var/www/betty"
+                ),
             )
-            await makedirs(app.project.configuration.www_directory_path)
-            async with aiofiles.open(
-                app.project.configuration.www_directory_path / "index.html", "w"
-            ) as f:
-                await f.write(content)
-            async with DockerizedNginxServer(app) as server:
+        )
+        await makedirs(new_temporary_app.project.configuration.www_directory_path)
+        async with aiofiles.open(
+            new_temporary_app.project.configuration.www_directory_path / "index.html", "w"
+        ) as f:
+            await f.write(content)
+        async with DockerizedNginxServer(new_temporary_app) as server:
 
-                def _assert_response(response: Response) -> None:
-                    assert response.status_code == 200
-                    assert content == response.content.decode("utf-8")
-                    assert "no-cache" == response.headers["Cache-Control"]
+            def _assert_response(response: Response) -> None:
+                assert response.status_code == 200
+                assert content == response.content.decode("utf-8")
+                assert "no-cache" == response.headers["Cache-Control"]
 
-                await Do(requests.get, server.public_url).until(_assert_response)
+            await Do(requests.get, server.public_url).until(_assert_response)
 
-    async def test_public_url_unstarted(self) -> None:
-        async with App.new_temporary() as app, app:
-            app.project.configuration.extensions.enable(Nginx)
-            sut = DockerizedNginxServer(app)
-            with pytest.raises(NoPublicUrlBecauseServerNotStartedError):
-                sut.public_url
+    async def test_public_url_unstarted(self, new_temporary_app: App) -> None:
+        new_temporary_app.project.configuration.extensions.enable(Nginx)
+        sut = DockerizedNginxServer(new_temporary_app)
+        with pytest.raises(NoPublicUrlBecauseServerNotStartedError):
+            sut.public_url
 
-    async def test_is_available_is_available(self, mocker: MockerFixture) -> None:
-        async with App.new_temporary() as app, app:
-            app.project.configuration.extensions.enable(Nginx)
-            sut = DockerizedNginxServer(app)
+    async def test_is_available_is_available(self, mocker: MockerFixture, new_temporary_app: App) -> None:
+        new_temporary_app.project.configuration.extensions.enable(Nginx)
+        sut = DockerizedNginxServer(new_temporary_app)
 
-            m_from_env = mocker.patch("docker.from_env")
-            m_from_env.return_value = mocker.Mock("docker.client.DockerClient")
+        m_from_env = mocker.patch("docker.from_env")
+        m_from_env.return_value = mocker.Mock("docker.client.DockerClient")
 
-            assert sut.is_available()
+        assert sut.is_available()
 
-    async def test_is_available_is_unavailable(self, mocker: MockerFixture) -> None:
-        async with App.new_temporary() as app, app:
-            app.project.configuration.extensions.enable(Nginx)
-            sut = DockerizedNginxServer(app)
+    async def test_is_available_is_unavailable(self, mocker: MockerFixture, new_temporary_app: App) -> None:
+        new_temporary_app.project.configuration.extensions.enable(Nginx)
+        sut = DockerizedNginxServer(new_temporary_app)
 
-            m_from_env = mocker.patch("docker.from_env")
-            m_from_env.side_effect = DockerException()
+        m_from_env = mocker.patch("docker.from_env")
+        m_from_env.side_effect = DockerException()
 
-            assert not sut.is_available()
+        assert not sut.is_available()

--- a/betty/tests/extension/nginx/test_serve.py
+++ b/betty/tests/extension/nginx/test_serve.py
@@ -34,7 +34,8 @@ class TestDockerizedNginxServer:
         )
         await makedirs(new_temporary_app.project.configuration.www_directory_path)
         async with aiofiles.open(
-            new_temporary_app.project.configuration.www_directory_path / "index.html", "w"
+            new_temporary_app.project.configuration.www_directory_path / "index.html",
+            "w",
         ) as f:
             await f.write(content)
         async with DockerizedNginxServer(new_temporary_app) as server:
@@ -52,7 +53,9 @@ class TestDockerizedNginxServer:
         with pytest.raises(NoPublicUrlBecauseServerNotStartedError):
             sut.public_url
 
-    async def test_is_available_is_available(self, mocker: MockerFixture, new_temporary_app: App) -> None:
+    async def test_is_available_is_available(
+        self, mocker: MockerFixture, new_temporary_app: App
+    ) -> None:
         new_temporary_app.project.configuration.extensions.enable(Nginx)
         sut = DockerizedNginxServer(new_temporary_app)
 
@@ -61,7 +64,9 @@ class TestDockerizedNginxServer:
 
         assert sut.is_available()
 
-    async def test_is_available_is_unavailable(self, mocker: MockerFixture, new_temporary_app: App) -> None:
+    async def test_is_available_is_unavailable(
+        self, mocker: MockerFixture, new_temporary_app: App
+    ) -> None:
         new_temporary_app.project.configuration.extensions.enable(Nginx)
         sut = DockerizedNginxServer(new_temporary_app)
 

--- a/betty/tests/extension/privatizer/test___init__.py
+++ b/betty/tests/extension/privatizer/test___init__.py
@@ -19,7 +19,7 @@ from betty.project import ExtensionConfiguration
 
 
 class TestPrivatizer:
-    async def test_post_load(self) -> None:
+    async def test_post_load(self, new_temporary_app: App) -> None:
         person = Person(id="P0")
         Presence(person, Subject(), Event(event_type=Birth))
 
@@ -46,12 +46,11 @@ class TestPrivatizer:
         )
         citation.files.add(citation_file)
 
-        async with App.new_temporary() as app, app:
-            app.project.configuration.extensions.append(
-                ExtensionConfiguration(Privatizer)
-            )
-            app.project.ancestry.add(person, source, citation)
-            await load(app)
+        new_temporary_app.project.configuration.extensions.append(
+            ExtensionConfiguration(Privatizer)
+        )
+        new_temporary_app.project.ancestry.add(person, source, citation)
+        await load(new_temporary_app)
 
         assert person.private
         assert source_file.private

--- a/betty/tests/extension/trees/test___init__.py
+++ b/betty/tests/extension/trees/test___init__.py
@@ -7,13 +7,14 @@ from betty.project import ExtensionConfiguration
 
 
 class TestTrees:
-    async def test_generate(self) -> None:
-        async with App.new_temporary() as app, app:
-            app.project.configuration.debug = True
-            app.project.configuration.extensions.append(ExtensionConfiguration(Trees))
-            await generate(app)
+    async def test_generate(self, new_temporary_app: App) -> None:
+        new_temporary_app.project.configuration.debug = True
+        new_temporary_app.project.configuration.extensions.append(
+            ExtensionConfiguration(Trees)
+        )
+        await generate(new_temporary_app)
         async with aiofiles.open(
-            app.project.configuration.www_directory_path
+            new_temporary_app.project.configuration.www_directory_path
             / "js"
             / "betty.extension.Trees.js",
             encoding="utf-8",
@@ -21,7 +22,7 @@ class TestTrees:
             betty_js = await f.read()
         assert Trees.name() in betty_js
         async with aiofiles.open(
-            app.project.configuration.www_directory_path
+            new_temporary_app.project.configuration.www_directory_path
             / "css"
             / "betty.extension.Trees.css",
             encoding="utf-8",

--- a/betty/tests/extension/webpack/test___init__.py
+++ b/betty/tests/extension/webpack/test___init__.py
@@ -40,7 +40,7 @@ class TestWebpack:
     _SENTINEL = "s3nt1n3l"
 
     async def test_generate_with_npm(
-        self, mocker: MockerFixture, tmp_path: Path
+        self, mocker: MockerFixture, new_temporary_app: App, tmp_path: Path
     ) -> None:
         webpack_build_directory_path = tmp_path
         m_build = mocker.patch("betty.extension.webpack.build.Builder.build")
@@ -51,17 +51,16 @@ class TestWebpack:
         ) as f:
             await f.write(self._SENTINEL)
 
-        async with App.new_temporary() as app:
-            app.project.configuration.extensions.enable(Webpack)
-            await generate(app)
+        new_temporary_app.project.configuration.extensions.enable(Webpack)
+        await generate(new_temporary_app)
 
         async with aiofiles.open(
-            app.project.configuration.www_directory_path / self._SENTINEL
+            new_temporary_app.project.configuration.www_directory_path / self._SENTINEL
         ) as f:
             assert await f.read() == self._SENTINEL
 
     async def test_generate_without_npm_with_prebuild(
-        self, mocker: MockerFixture, tmp_path: Path
+        self, mocker: MockerFixture, new_temporary_app: App, tmp_path: Path
     ) -> None:
         m_build = mocker.patch("betty.extension.webpack.build.Builder.build")
         m_build.side_effect = NpmUnavailable()
@@ -78,19 +77,18 @@ class TestWebpack:
         original_prebuilt_assets_directory_path = fs.PREBUILT_ASSETS_DIRECTORY_PATH
         fs.PREBUILT_ASSETS_DIRECTORY_PATH = tmp_path
         try:
-            async with App.new_temporary() as app:
-                app.project.configuration.extensions.enable(Webpack)
-                await generate(app)
+            new_temporary_app.project.configuration.extensions.enable(Webpack)
+            await generate(new_temporary_app)
         finally:
             fs.PREBUILT_ASSETS_DIRECTORY_PATH = original_prebuilt_assets_directory_path
 
         async with aiofiles.open(
-            app.project.configuration.www_directory_path / self._SENTINEL
+            new_temporary_app.project.configuration.www_directory_path / self._SENTINEL
         ) as f:
             assert await f.read() == self._SENTINEL
 
     async def test_generate_without_npm_without_prebuild(
-        self, mocker: MockerFixture, tmp_path: Path
+        self, mocker: MockerFixture, new_temporary_app: App, tmp_path: Path
     ) -> None:
         prebuilt_assets_directory_path = tmp_path
 
@@ -102,17 +100,18 @@ class TestWebpack:
             Path(prebuilt_assets_directory_path) / "does-not-exist"
         )
         try:
-            async with App.new_temporary() as app:
-                app.project.configuration.extensions.enable(Webpack)
-                with pytest.raises(ExceptionGroup) as exc_info:
-                    await generate(app)
-                error = exc_info.value
-                assert isinstance(error, ExceptionGroup)
-                assert error.subgroup(RequirementError) is not None
+            new_temporary_app.project.configuration.extensions.enable(Webpack)
+            with pytest.raises(ExceptionGroup) as exc_info:
+                await generate(new_temporary_app)
+            error = exc_info.value
+            assert isinstance(error, ExceptionGroup)
+            assert error.subgroup(RequirementError) is not None
         finally:
             fs.PREBUILT_ASSETS_DIRECTORY_PATH = original_prebuilt_assets_directory_path
 
-    async def test_prebuild(self, mocker: MockerFixture, tmp_path: Path) -> None:
+    async def test_prebuild(
+        self, mocker: MockerFixture, new_temporary_app: App, tmp_path: Path
+    ) -> None:
         webpack_build_directory_path = (
             tmp_path / "webpack" / f"build-{webpack_build_id(())}"
         )
@@ -131,10 +130,9 @@ class TestWebpack:
         fs.PREBUILT_ASSETS_DIRECTORY_PATH = prebuilt_assets_directory_path
         try:
             job_context = Context()
-            async with App.new_temporary() as app:
-                app.project.configuration.extensions.enable(Webpack)
-                webpack = app.extensions[Webpack]
-                await webpack.prebuild(job_context)
+            new_temporary_app.project.configuration.extensions.enable(Webpack)
+            webpack = new_temporary_app.extensions[Webpack]
+            await webpack.prebuild(job_context)
         finally:
             fs.PREBUILT_ASSETS_DIRECTORY_PATH = original_prebuilt_assets_directory_path
 

--- a/betty/tests/extension/wikipedia/test___init__.py
+++ b/betty/tests/extension/wikipedia/test___init__.py
@@ -12,7 +12,7 @@ from betty.wikipedia import Summary
 
 
 class TestWikipedia:
-    async def test_filter(self, mocker: MockerFixture) -> None:
+    async def test_filter(self, mocker: MockerFixture, new_temporary_app: App) -> None:
         language = "en"
         name = "Amsterdam"
         title = "Amstelredam"
@@ -31,27 +31,27 @@ class TestWikipedia:
             Link("https://example.com"),
         ]
 
-        async with App.new_temporary() as app, app:
-            app.project.configuration.extensions.append(
-                ExtensionConfiguration(Wikipedia)
-            )
-            actual = await app.jinja2_environment.from_string(
-                "{% for entry in (links | wikipedia) %}{{ entry.content }}{% endfor %}"
-            ).render_async(
-                job_context=Context(),
-                links=links,
-            )
+        new_temporary_app.project.configuration.extensions.append(
+            ExtensionConfiguration(Wikipedia)
+        )
+        actual = await new_temporary_app.jinja2_environment.from_string(
+            "{% for entry in (links | wikipedia) %}{{ entry.content }}{% endfor %}"
+        ).render_async(
+            job_context=Context(),
+            links=links,
+        )
 
         m_get_summary.assert_called_once()
         assert extract == actual
 
-    async def test_post_load(self, mocker: MockerFixture) -> None:
+    async def test_post_load(
+        self, mocker: MockerFixture, new_temporary_app: App
+    ) -> None:
         m_populate = mocker.patch("betty.wikipedia._Populator.populate")
 
-        async with App.new_temporary() as app, app:
-            app.project.configuration.extensions.append(
-                ExtensionConfiguration(Wikipedia)
-            )
-            await load(app)
+        new_temporary_app.project.configuration.extensions.append(
+            ExtensionConfiguration(Wikipedia)
+        )
+        await load(new_temporary_app)
 
         m_populate.assert_called_once()

--- a/betty/tests/gramps/test_loader.py
+++ b/betty/tests/gramps/test_loader.py
@@ -57,30 +57,38 @@ class GrampsTester:
         )
 
 
-# @todo Do we still need this?
 @pytest.fixture
-def gramps_tester() -> GrampsTester:
-    return GrampsTester(Project())
+def gramps_project(tmp_path: Path) -> Project:
+    return Project(
+        configuration=ProjectConfiguration(
+            configuration_file_path=tmp_path / "betty.json"
+        )
+    )
+
+
+@pytest.fixture
+def gramps_tester(gramps_project: Project) -> GrampsTester:
+    return GrampsTester(gramps_project)
 
 
 class TestGrampsLoader:
-    async def test_load_gramps(self) -> None:
-        sut = GrampsLoader(Project(), localizer=DEFAULT_LOCALIZER)
+    async def test_load_gramps(self, gramps_project: Project) -> None:
+        sut = GrampsLoader(gramps_project, localizer=DEFAULT_LOCALIZER)
         await sut.load_gramps(Path(__file__).parent / "assets" / "minimal.gramps")
 
-    async def test_load_gpkg(self) -> None:
-        sut = GrampsLoader(Project(), localizer=DEFAULT_LOCALIZER)
+    async def test_load_gpkg(self, gramps_project: Project) -> None:
+        sut = GrampsLoader(gramps_project, localizer=DEFAULT_LOCALIZER)
         await sut.load_gpkg(Path(__file__).parent / "assets" / "minimal.gpkg")
 
-    async def test_load_xml_with_string(self) -> None:
+    async def test_load_xml_with_string(self, gramps_project: Project) -> None:
         gramps_file_path = Path(__file__).parent / "assets" / "minimal.xml"
-        sut = GrampsLoader(Project(), localizer=DEFAULT_LOCALIZER)
+        sut = GrampsLoader(gramps_project, localizer=DEFAULT_LOCALIZER)
         async with aiofiles.open(gramps_file_path) as f:
             await sut.load_xml(await f.read(), rootname(gramps_file_path))
 
-    async def test_load_xml_with_file_path(self) -> None:
+    async def test_load_xml_with_file_path(self, gramps_project: Project) -> None:
         gramps_file_path = Path(__file__).parent / "assets" / "minimal.xml"
-        sut = GrampsLoader(Project(), localizer=DEFAULT_LOCALIZER)
+        sut = GrampsLoader(gramps_project, localizer=DEFAULT_LOCALIZER)
         await sut.load_xml(gramps_file_path, rootname(gramps_file_path))
 
     async def test_place_should_include_name(self, gramps_tester: GrampsTester) -> None:

--- a/betty/tests/gui/test_app.py
+++ b/betty/tests/gui/test_app.py
@@ -89,7 +89,7 @@ class TestWelcomeWindow:
     ) -> None:
         title = "My First Ancestry Site"
         configuration = ProjectConfiguration(
-            title=title,
+            title=title
         )
         await configuration.write()
         await betty_qtbot.app.project.configuration.write()
@@ -138,8 +138,10 @@ class TestApplicationConfiguration:
         locale = "nl-NL"
         betty_qtbot.app.configuration.locale = locale
 
+        configuration_file_path = betty_qtbot.app.configuration.configuration_file_path
+        assert configuration_file_path is not None
         async with aiofiles.open(
-            betty_qtbot.app.configuration.configuration_file_path
+            configuration_file_path
         ) as f:
             read_configuration_dump = json.loads(await f.read())
         assert read_configuration_dump == betty_qtbot.app.configuration.dump()

--- a/betty/tests/gui/test_app.py
+++ b/betty/tests/gui/test_app.py
@@ -83,13 +83,11 @@ class TestWelcomeWindow:
         betty_qtbot.assert_exception_error(contained_error_type=SerdeError)
 
     async def test_open_project_with_valid_file_should_show_project_window(
-        self,
-        mocker: MockerFixture,
-        betty_qtbot: BettyQtBot,
+        self, mocker: MockerFixture, betty_qtbot: BettyQtBot, tmp_path: Path
     ) -> None:
         title = "My First Ancestry Site"
         configuration = ProjectConfiguration(
-            title=title
+            title=title, configuration_file_path=tmp_path / "betty.json"
         )
         await configuration.write()
         await betty_qtbot.app.project.configuration.write()
@@ -138,10 +136,8 @@ class TestApplicationConfiguration:
         locale = "nl-NL"
         betty_qtbot.app.configuration.locale = locale
 
-        configuration_file_path = betty_qtbot.app.configuration.configuration_file_path
-        assert configuration_file_path is not None
         async with aiofiles.open(
-            configuration_file_path
+            betty_qtbot.app.configuration.configuration_file_path
         ) as f:
             read_configuration_dump = json.loads(await f.read())
         assert read_configuration_dump == betty_qtbot.app.configuration.dump()

--- a/betty/tests/gui/test_project.py
+++ b/betty/tests/gui/test_project.py
@@ -70,10 +70,8 @@ class TestProjectWindow:
         title = "My First Ancestry Site"
         betty_qtbot.app.project.configuration.title = title
 
-        configuration_file_path = betty_qtbot.app.project.configuration.configuration_file_path
-        assert configuration_file_path
         async with aiofiles.open(
-            configuration_file_path
+            betty_qtbot.app.project.configuration.configuration_file_path
         ) as f:
             read_configuration_dump = json.loads(await f.read())
         assert read_configuration_dump == betty_qtbot.app.project.configuration.dump()

--- a/betty/tests/gui/test_project.py
+++ b/betty/tests/gui/test_project.py
@@ -70,8 +70,10 @@ class TestProjectWindow:
         title = "My First Ancestry Site"
         betty_qtbot.app.project.configuration.title = title
 
+        configuration_file_path = betty_qtbot.app.project.configuration.configuration_file_path
+        assert configuration_file_path
         async with aiofiles.open(
-            betty_qtbot.app.project.configuration.configuration_file_path
+            configuration_file_path
         ) as f:
             read_configuration_dump = json.loads(await f.read())
         assert read_configuration_dump == betty_qtbot.app.project.configuration.dump()

--- a/betty/tests/json/test_schema.py
+++ b/betty/tests/json/test_schema.py
@@ -17,13 +17,12 @@ class TestSchema:
             False,
         ],
     )
-    async def test_build(self, clean_urls: bool) -> None:
+    async def test_build(self, clean_urls: bool, new_temporary_app: App) -> None:
         async with aiofiles.open(
             Path(__file__).parent / "test_schema_assets" / "json-schema-schema.json"
         ) as f:
             json_schema_schema = stdjson.loads(await f.read())
 
-        async with App.new_temporary() as app, app:
-            sut = Schema(app)
-            schema = await sut.build()
+        sut = Schema(new_temporary_app)
+        schema = await sut.build()
         jsonschema.validate(json_schema_schema, schema)

--- a/betty/tests/test_cli.py
+++ b/betty/tests/test_cli.py
@@ -71,7 +71,7 @@ async def new_temporary_app(
     mocker: MockerFixture, tmp_path: Path
 ) -> AsyncIterator[App]:
     async with App.new_temporary(
-        project=Project(
+        Project(
             configuration=ProjectConfiguration(
                 configuration_file_path=tmp_path / "betty.json"
             )

--- a/betty/tests/test_cli.py
+++ b/betty/tests/test_cli.py
@@ -70,10 +70,11 @@ Stderr:
 async def new_temporary_app(
     mocker: MockerFixture, tmp_path: Path
 ) -> AsyncIterator[App]:
-    # @todo can we get rid of tmp_path entirely here?
     async with App.new_temporary(
         project=Project(
-            configuration=ProjectConfiguration()
+            configuration=ProjectConfiguration(
+                configuration_file_path=tmp_path / "betty.json"
+            )
         )
     ) as app:
         m_new_from_environment = mocker.AsyncMock()

--- a/betty/tests/test_cli.py
+++ b/betty/tests/test_cli.py
@@ -24,7 +24,7 @@ from betty.cli import main, CommandProvider, global_command, catch_exceptions
 from betty.error import UserFacingError
 from betty.gui.app import BettyPrimaryWindow
 from betty.locale import Str, DEFAULT_LOCALIZER
-from betty.project import ExtensionConfiguration
+from betty.project import ExtensionConfiguration, Project, ProjectConfiguration
 from betty.serde.dump import Dump
 from betty.serve import Server, AppServer
 from betty.tests.conftest import BettyQtBot
@@ -67,8 +67,15 @@ Stderr:
 
 
 @pytest.fixture
-async def new_temporary_app(mocker: MockerFixture) -> AsyncIterator[App]:
-    async with App.new_temporary() as app:
+async def new_temporary_app(
+    mocker: MockerFixture, tmp_path: Path
+) -> AsyncIterator[App]:
+    # @todo can we get rid of tmp_path entirely here?
+    async with App.new_temporary(
+        project=Project(
+            configuration=ProjectConfiguration()
+        )
+    ) as app:
         m_new_from_environment = mocker.AsyncMock()
         m_new_from_environment.__aenter__.return_value = app
         mocker.patch(

--- a/betty/tests/test_config.py
+++ b/betty/tests/test_config.py
@@ -20,8 +20,10 @@ from betty.serde.load import FormatError, Asserter
 
 
 class TestFileBasedConfiguration:
-    async def test_configuration_file_path_should_error_unknown_format(self) -> None:
-        configuration = FileBasedConfiguration()
+    async def test_configuration_file_path_should_error_unknown_format(
+        self, tmp_path: Path
+    ) -> None:
+        configuration = FileBasedConfiguration(tmp_path / "file")
         with NamedTemporaryFile(mode="r+", suffix=".abc") as f:
             with pytest.raises(FormatError):
                 configuration.configuration_file_path = Path(f.name)

--- a/betty/tests/test_documentation.py
+++ b/betty/tests/test_documentation.py
@@ -73,7 +73,7 @@ class TestDocumentation:
         ],
     )
     async def test_should_contain_valid_configuration(
-        self, language: str, format: Format
+        self, language: str, format: Format, tmp_path: Path
     ) -> None:
         async with aiofiles.open(
             ROOT_DIRECTORY_PATH
@@ -91,5 +91,7 @@ class TestDocumentation:
         assert match is not None
         dump = match[1]
         assert dump is not None
-        configuration = ProjectConfiguration()
+        configuration = ProjectConfiguration(
+            configuration_file_path=tmp_path / "betty.json"
+        )
         configuration.load(format.load(dump))

--- a/betty/tests/test_generate.py
+++ b/betty/tests/test_generate.py
@@ -42,312 +42,318 @@ class _ThirdPartyExtension(Extension, EntityTypeProvider):
 
 
 class TestGenerate:
-    async def test_html_lang(self) -> None:
-        async with App.new_temporary() as app, app:
-            app.project.configuration.locales["en-US"].alias = "en"
-            app.project.configuration.locales.append(
-                LocaleConfiguration(
-                    "nl-NL",
-                    alias="nl",
-                )
+    async def test_html_lang(self, new_temporary_app: App) -> None:
+        new_temporary_app.project.configuration.locales["en-US"].alias = "en"
+        new_temporary_app.project.configuration.locales.append(
+            LocaleConfiguration(
+                "nl-NL",
+                alias="nl",
             )
-            await generate(app)
-            async with aiofiles.open(
-                await assert_betty_html(app, "/nl/index.html", check_links=True)
-            ) as f:
-                html = await f.read()
-                assert '<html lang="nl-NL"' in html
+        )
+        await generate(new_temporary_app)
+        async with aiofiles.open(
+            await assert_betty_html(
+                new_temporary_app, "/nl/index.html", check_links=True
+            )
+        ) as f:
+            html = await f.read()
+            assert '<html lang="nl-NL"' in html
 
-    async def test_root_redirect(self) -> None:
-        async with App.new_temporary() as app, app:
-            app.project.configuration.locales.replace(
-                LocaleConfiguration(
-                    "nl-NL",
-                    alias="nl",
-                ),
-                LocaleConfiguration(
-                    "en-US",
-                    alias="en",
-                ),
+    async def test_root_redirect(self, new_temporary_app: App) -> None:
+        new_temporary_app.project.configuration.locales.replace(
+            LocaleConfiguration(
+                "nl-NL",
+                alias="nl",
+            ),
+            LocaleConfiguration(
+                "en-US",
+                alias="en",
+            ),
+        )
+        await generate(new_temporary_app)
+        async with aiofiles.open(
+            await assert_betty_html(new_temporary_app, "/index.html", check_links=True)
+        ) as f:
+            meta_redirect = (
+                '<meta http-equiv="refresh" content="0; url=/nl/index.html">'
             )
-            await generate(app)
-            async with aiofiles.open(
-                await assert_betty_html(app, "/index.html", check_links=True)
-            ) as f:
-                meta_redirect = (
-                    '<meta http-equiv="refresh" content="0; url=/nl/index.html">'
-                )
-                assert meta_redirect in await f.read()
+            assert meta_redirect in await f.read()
 
-    async def test_links(self) -> None:
-        async with App.new_temporary() as app, app:
-            app.project.configuration.locales.replace(
-                LocaleConfiguration(
-                    "nl-NL",
-                    alias="nl",
-                ),
-                LocaleConfiguration(
-                    "en-US",
-                    alias="en",
-                ),
+    async def test_links(self, new_temporary_app: App) -> None:
+        new_temporary_app.project.configuration.locales.replace(
+            LocaleConfiguration(
+                "nl-NL",
+                alias="nl",
+            ),
+            LocaleConfiguration(
+                "en-US",
+                alias="en",
+            ),
+        )
+        await generate(new_temporary_app)
+        async with aiofiles.open(
+            await assert_betty_html(
+                new_temporary_app, "/nl/index.html", check_links=True
             )
-            await generate(app)
-            async with aiofiles.open(
-                await assert_betty_html(app, "/nl/index.html", check_links=True)
-            ) as f:
-                html = await f.read()
-                assert (
-                    '<link rel="canonical" href="https://example.com/nl/index.html" hreflang="nl-NL" type="text/html">'
-                    in html
-                )
-                assert (
-                    '<link rel="alternate" href="/en/index.html" hreflang="en-US" type="text/html">'
-                    in html
-                )
-            async with aiofiles.open(
-                await assert_betty_html(app, "/en/index.html", check_links=True)
-            ) as f:
-                html = await f.read()
-                assert (
-                    '<link rel="canonical" href="https://example.com/en/index.html" hreflang="en-US" type="text/html">'
-                    in html
-                )
-                assert (
-                    '<link rel="alternate" href="/nl/index.html" hreflang="nl-NL" type="text/html">'
-                    in html
-                )
-
-    async def test_links_for_entity_pages(self) -> None:
-        async with App.new_temporary() as app, app:
-            app.project.configuration.locales.replace(
-                LocaleConfiguration(
-                    "nl-NL",
-                    alias="nl",
-                ),
-                LocaleConfiguration(
-                    "en-US",
-                    alias="en",
-                ),
-            )
-            person = Person(id="PERSON1")
-            app.project.ancestry.add(person)
-            await generate(app)
-            async with aiofiles.open(
-                await assert_betty_html(
-                    app, f"/nl/person/{person.id}/index.html", check_links=True
-                )
-            ) as f:
-                html = await f.read()
+        ) as f:
+            html = await f.read()
             assert (
-                f'<link rel="canonical" href="https://example.com/nl/person/{person.id}/index.html" hreflang="nl-NL" type="text/html">'
+                '<link rel="canonical" href="https://example.com/nl/index.html" hreflang="nl-NL" type="text/html">'
                 in html
             )
             assert (
-                f'<link rel="alternate" href="/en/person/{person.id}/index.html" hreflang="en-US" type="text/html">'
+                '<link rel="alternate" href="/en/index.html" hreflang="en-US" type="text/html">'
+                in html
+            )
+        async with aiofiles.open(
+            await assert_betty_html(
+                new_temporary_app, "/en/index.html", check_links=True
+            )
+        ) as f:
+            html = await f.read()
+            assert (
+                '<link rel="canonical" href="https://example.com/en/index.html" hreflang="en-US" type="text/html">'
                 in html
             )
             assert (
-                f'<link rel="alternate" href="/person/{person.id}/index.json" hreflang="und" type="application/json">'
-                in html
-            )
-            async with aiofiles.open(
-                await assert_betty_html(
-                    app, f"/en/person/{person.id}/index.html", check_links=True
-                )
-            ) as f:
-                html = await f.read()
-            assert (
-                f'<link rel="canonical" href="https://example.com/en/person/{person.id}/index.html" hreflang="en-US" type="text/html">'
-                in html
-            )
-            assert (
-                f'<link rel="alternate" href="/nl/person/{person.id}/index.html" hreflang="nl-NL" type="text/html">'
-                in html
-            )
-            assert (
-                f'<link rel="alternate" href="/person/{person.id}/index.json" hreflang="und" type="application/json">'
+                '<link rel="alternate" href="/nl/index.html" hreflang="nl-NL" type="text/html">'
                 in html
             )
 
-    async def test_third_party_entities(self) -> None:
+    async def test_links_for_entity_pages(self, new_temporary_app: App) -> None:
+        new_temporary_app.project.configuration.locales.replace(
+            LocaleConfiguration(
+                "nl-NL",
+                alias="nl",
+            ),
+            LocaleConfiguration(
+                "en-US",
+                alias="en",
+            ),
+        )
+        person = Person(id="PERSON1")
+        new_temporary_app.project.ancestry.add(person)
+        await generate(new_temporary_app)
+        async with aiofiles.open(
+            await assert_betty_html(
+                new_temporary_app,
+                f"/nl/person/{person.id}/index.html",
+                check_links=True,
+            )
+        ) as f:
+            html = await f.read()
+        assert (
+            f'<link rel="canonical" href="https://example.com/nl/person/{person.id}/index.html" hreflang="nl-NL" type="text/html">'
+            in html
+        )
+        assert (
+            f'<link rel="alternate" href="/en/person/{person.id}/index.html" hreflang="en-US" type="text/html">'
+            in html
+        )
+        assert (
+            f'<link rel="alternate" href="/person/{person.id}/index.json" hreflang="und" type="application/json">'
+            in html
+        )
+        async with aiofiles.open(
+            await assert_betty_html(
+                new_temporary_app,
+                f"/en/person/{person.id}/index.html",
+                check_links=True,
+            )
+        ) as f:
+            html = await f.read()
+        assert (
+            f'<link rel="canonical" href="https://example.com/en/person/{person.id}/index.html" hreflang="en-US" type="text/html">'
+            in html
+        )
+        assert (
+            f'<link rel="alternate" href="/nl/person/{person.id}/index.html" hreflang="nl-NL" type="text/html">'
+            in html
+        )
+        assert (
+            f'<link rel="alternate" href="/person/{person.id}/index.json" hreflang="und" type="application/json">'
+            in html
+        )
+
+    async def test_third_party_entities(self, new_temporary_app: App) -> None:
         entity_type = _ThirdPartyEntity
-        async with App.new_temporary() as app, app:
-            app.project.configuration.extensions.append(
-                ExtensionConfiguration(_ThirdPartyExtension)
+        new_temporary_app.project.configuration.extensions.append(
+            ExtensionConfiguration(_ThirdPartyExtension)
+        )
+        new_temporary_app.project.configuration.entity_types.append(
+            EntityTypeConfiguration(
+                entity_type=entity_type,
+                generate_html_list=True,
             )
-            app.project.configuration.entity_types.append(
-                EntityTypeConfiguration(
-                    entity_type=entity_type,
-                    generate_html_list=True,
-                )
-            )
-            await generate(app)
+        )
+        await generate(new_temporary_app)
         await assert_betty_html(
-            app,
+            new_temporary_app,
             f"/{camel_case_to_kebab_case(get_entity_type_name(entity_type))}/index.html",
             check_links=True,
         )
         await assert_betty_json(
-            app,
+            new_temporary_app,
             f"/{camel_case_to_kebab_case(get_entity_type_name(entity_type))}/index.json",
         )
 
-    async def test_third_party_entity(self) -> None:
+    async def test_third_party_entity(self, new_temporary_app: App) -> None:
         entity_type = _ThirdPartyEntity
-        async with App.new_temporary() as app, app:
-            app.project.configuration.extensions.append(
-                ExtensionConfiguration(_ThirdPartyExtension)
-            )
-            entity = _ThirdPartyEntity(
-                id="ENTITY1",
-            )
-            app.project.ancestry.add(entity)
-            await generate(app)
-            await assert_betty_html(
-                app,
-                f"/{camel_case_to_kebab_case(get_entity_type_name(entity_type))}/{entity.id}/index.html",
-                check_links=True,
-            )
-            await assert_betty_json(
-                app,
-                f"/{camel_case_to_kebab_case(get_entity_type_name(entity_type))}/{entity.id}/index.json",
-            )
-
-    async def test_files(self) -> None:
-        async with App.new_temporary() as app, app:
-            app.project.configuration.entity_types.append(
-                EntityTypeConfiguration(
-                    entity_type=File,
-                    generate_html_list=True,
-                )
-            )
-            await generate(app)
-        await assert_betty_html(app, "/file/index.html", check_links=True)
-        await assert_betty_json(app, "/file/index.json", "fileCollection")
-
-    async def test_file(self) -> None:
-        async with App.new_temporary() as app, app:
-            with NamedTemporaryFile() as f:
-                file = File(
-                    id="FILE1",
-                    path=Path(f.name),
-                )
-                app.project.ancestry.add(file)
-                await generate(app)
-            await assert_betty_html(
-                app, "/file/%s/index.html" % file.id, check_links=True
-            )
-            await assert_betty_json(app, "/file/%s/index.json" % file.id)
-
-    async def test_places(self) -> None:
-        async with App.new_temporary() as app, app:
-            await generate(app)
-        await assert_betty_html(app, "/place/index.html", check_links=True)
-        await assert_betty_json(app, "/place/index.json")
-
-    async def test_place(self) -> None:
-        async with App.new_temporary() as app, app:
-            place = Place(
-                id="PLACE1",
-                names=[PlaceName(name="one")],
-            )
-            app.project.ancestry.add(place)
-            await generate(app)
-        await assert_betty_html(
-            app, "/place/%s/index.html" % place.id, check_links=True
+        new_temporary_app.project.configuration.extensions.append(
+            ExtensionConfiguration(_ThirdPartyExtension)
         )
-        await assert_betty_json(app, "/place/%s/index.json" % place.id)
+        entity = _ThirdPartyEntity(
+            id="ENTITY1",
+        )
+        new_temporary_app.project.ancestry.add(entity)
+        await generate(new_temporary_app)
+        await assert_betty_html(
+            new_temporary_app,
+            f"/{camel_case_to_kebab_case(get_entity_type_name(entity_type))}/{entity.id}/index.html",
+            check_links=True,
+        )
+        await assert_betty_json(
+            new_temporary_app,
+            f"/{camel_case_to_kebab_case(get_entity_type_name(entity_type))}/{entity.id}/index.json",
+        )
 
-    async def test_people(self) -> None:
-        async with App.new_temporary() as app, app:
-            await generate(app)
-        await assert_betty_html(app, "/person/index.html", check_links=True)
-        await assert_betty_json(app, "/person/index.json")
+    async def test_files(self, new_temporary_app: App) -> None:
+        new_temporary_app.project.configuration.entity_types.append(
+            EntityTypeConfiguration(
+                entity_type=File,
+                generate_html_list=True,
+            )
+        )
+        await generate(new_temporary_app)
+        await assert_betty_html(new_temporary_app, "/file/index.html", check_links=True)
+        await assert_betty_json(new_temporary_app, "/file/index.json", "fileCollection")
 
-    async def test_person(self) -> None:
+    async def test_file(self, new_temporary_app: App) -> None:
+        with NamedTemporaryFile() as f:
+            file = File(
+                id="FILE1",
+                path=Path(f.name),
+            )
+            new_temporary_app.project.ancestry.add(file)
+            await generate(new_temporary_app)
+            await assert_betty_html(
+                new_temporary_app, "/file/%s/index.html" % file.id, check_links=True
+            )
+            await assert_betty_json(new_temporary_app, "/file/%s/index.json" % file.id)
+
+    async def test_places(self, new_temporary_app: App) -> None:
+        await generate(new_temporary_app)
+        await assert_betty_html(
+            new_temporary_app, "/place/index.html", check_links=True
+        )
+        await assert_betty_json(new_temporary_app, "/place/index.json")
+
+    async def test_place(self, new_temporary_app: App) -> None:
+        place = Place(
+            id="PLACE1",
+            names=[PlaceName(name="one")],
+        )
+        new_temporary_app.project.ancestry.add(place)
+        await generate(new_temporary_app)
+        await assert_betty_html(
+            new_temporary_app, "/place/%s/index.html" % place.id, check_links=True
+        )
+        await assert_betty_json(new_temporary_app, "/place/%s/index.json" % place.id)
+
+    async def test_people(self, new_temporary_app: App) -> None:
+        await generate(new_temporary_app)
+        await assert_betty_html(
+            new_temporary_app, "/person/index.html", check_links=True
+        )
+        await assert_betty_json(new_temporary_app, "/person/index.json")
+
+    async def test_person(self, new_temporary_app: App) -> None:
         person = Person(id="PERSON1")
-        async with App.new_temporary() as app, app:
-            app.project.ancestry.add(person)
-            await generate(app)
-            await assert_betty_html(
-                app,
-                f"/person/{person.id}/index.html",
-                check_links=True,
-            )
-            await assert_betty_json(
-                app,
-                f"/person/{person.id}/index.json",
-            )
-
-    async def test_events(self) -> None:
-        async with App.new_temporary() as app, app:
-            await generate(app)
-        await assert_betty_html(app, "/event/index.html", check_links=True)
-        await assert_betty_json(app, "/event/index.json", "eventCollection")
-
-    async def test_event(self) -> None:
-        async with App.new_temporary() as app, app:
-            event = Event(
-                id="EVENT1",
-                event_type=Birth,
-            )
-            app.project.ancestry.add(event)
-            await generate(app)
+        new_temporary_app.project.ancestry.add(person)
+        await generate(new_temporary_app)
         await assert_betty_html(
-            app, "/event/%s/index.html" % event.id, check_links=True
+            new_temporary_app,
+            f"/person/{person.id}/index.html",
+            check_links=True,
         )
-        await assert_betty_json(app, "/event/%s/index.json" % event.id, "event")
+        await assert_betty_json(
+            new_temporary_app,
+            f"/person/{person.id}/index.json",
+        )
 
-    async def test_citation(self) -> None:
-        async with App.new_temporary() as app, app:
-            source = Source("A Little Birdie")
-            citation = Citation(
-                id="CITATION1",
-                source=source,
-            )
-            app.project.ancestry.add(citation, source)
-            await generate(app)
+    async def test_events(self, new_temporary_app: App) -> None:
+        await generate(new_temporary_app)
         await assert_betty_html(
-            app, "/citation/%s/index.html" % citation.id, check_links=True
+            new_temporary_app, "/event/index.html", check_links=True
         )
-        await assert_betty_json(app, "/citation/%s/index.json" % citation.id)
+        await assert_betty_json(
+            new_temporary_app, "/event/index.json", "eventCollection"
+        )
 
-    async def test_sources(self) -> None:
-        async with App.new_temporary() as app, app:
-            await generate(app)
-        await assert_betty_html(app, "/source/index.html", check_links=True)
-        await assert_betty_json(app, "/source/index.json")
-
-    async def test_source(self) -> None:
-        async with App.new_temporary() as app, app:
-            source = Source(
-                id="SOURCE1",
-                name="A Little Birdie",
-            )
-            app.project.ancestry.add(source)
-            await generate(app)
+    async def test_event(self, new_temporary_app: App) -> None:
+        event = Event(
+            id="EVENT1",
+            event_type=Birth,
+        )
+        new_temporary_app.project.ancestry.add(event)
+        await generate(new_temporary_app)
         await assert_betty_html(
-            app, "/source/%s/index.html" % source.id, check_links=True
+            new_temporary_app, "/event/%s/index.html" % event.id, check_links=True
         )
-        await assert_betty_json(app, "/source/%s/index.json" % source.id)
+        await assert_betty_json(
+            new_temporary_app, "/event/%s/index.json" % event.id, "event"
+        )
+
+    async def test_citation(self, new_temporary_app: App) -> None:
+        source = Source("A Little Birdie")
+        citation = Citation(
+            id="CITATION1",
+            source=source,
+        )
+        new_temporary_app.project.ancestry.add(citation, source)
+        await generate(new_temporary_app)
+        await assert_betty_html(
+            new_temporary_app, "/citation/%s/index.html" % citation.id, check_links=True
+        )
+        await assert_betty_json(
+            new_temporary_app, "/citation/%s/index.json" % citation.id
+        )
+
+    async def test_sources(self, new_temporary_app: App) -> None:
+        await generate(new_temporary_app)
+        await assert_betty_html(
+            new_temporary_app, "/source/index.html", check_links=True
+        )
+        await assert_betty_json(new_temporary_app, "/source/index.json")
+
+    async def test_source(self, new_temporary_app: App) -> None:
+        source = Source(
+            id="SOURCE1",
+            name="A Little Birdie",
+        )
+        new_temporary_app.project.ancestry.add(source)
+        await generate(new_temporary_app)
+        await assert_betty_html(
+            new_temporary_app, "/source/%s/index.html" % source.id, check_links=True
+        )
+        await assert_betty_json(new_temporary_app, "/source/%s/index.json" % source.id)
 
 
 class TestResourceOverride:
-    async def test(self) -> None:
-        async with App.new_temporary() as app, app:
-            localized_assets_directory_path = (
-                Path(app.project.configuration.assets_directory_path)
-                / "public"
-                / "localized"
-            )
-            localized_assets_directory_path.mkdir(parents=True)
-            async with aiofiles.open(
-                str(localized_assets_directory_path / "index.html.j2"), "w"
-            ) as f:
-                await f.write("{% block page_content %}Betty was here{% endblock %}")
-            await generate(app)
+    async def test(self, new_temporary_app: App) -> None:
+        localized_assets_directory_path = (
+            Path(new_temporary_app.project.configuration.assets_directory_path)
+            / "public"
+            / "localized"
+        )
+        localized_assets_directory_path.mkdir(parents=True)
         async with aiofiles.open(
-            app.project.configuration.www_directory_path / "index.html"
+            str(localized_assets_directory_path / "index.html.j2"), "w"
+        ) as f:
+            await f.write("{% block page_content %}Betty was here{% endblock %}")
+        await generate(new_temporary_app)
+        async with aiofiles.open(
+            new_temporary_app.project.configuration.www_directory_path / "index.html"
         ) as f:
             assert "Betty was here" in await f.read()
 
@@ -357,16 +363,15 @@ class TestResourceOverride:
     reason="lxml cannot be installed directly onto vanilla Windows.",
 )
 class TestSitemapGenerate:
-    async def test_validate(self) -> None:
+    async def test_validate(self, new_temporary_app: App) -> None:
         from lxml import etree
 
-        async with App.new_temporary() as app, app:
-            await generate(app)
+        await generate(new_temporary_app)
         schema_doc = etree.parse(
             Path(__file__).parent / "test_generate_assets" / "sitemap.xsd"
         )
         schema = etree.XMLSchema(schema_doc)
         sitemap_doc = etree.parse(
-            app.project.configuration.www_directory_path / "sitemap.xml"
+            new_temporary_app.project.configuration.www_directory_path / "sitemap.xml"
         )
         schema.validate(sitemap_doc)

--- a/betty/tests/test_openapi.py
+++ b/betty/tests/test_openapi.py
@@ -17,13 +17,12 @@ class TestSpecification:
             False,
         ],
     )
-    async def test_build(self, clean_urls: bool) -> None:
+    async def test_build(self, clean_urls: bool, new_temporary_app: App) -> None:
         async with aiofiles.open(
             Path(__file__).parent / "test_openapi_assets" / "openapi-schema.json"
         ) as f:
             schema = stdjson.loads(await f.read())
-        async with App.new_temporary() as app, app:
-            app.project.configuration.clean_urls = clean_urls
-            sut = Specification(app)
-            specification = await sut.build()
-            jsonschema.validate(specification, schema)
+        new_temporary_app.project.configuration.clean_urls = clean_urls
+        sut = Specification(new_temporary_app)
+        specification = await sut.build()
+        jsonschema.validate(specification, schema)

--- a/betty/tests/test_project.py
+++ b/betty/tests/test_project.py
@@ -640,7 +640,7 @@ class TestEntityTypeConfigurationMapping(
 class TestProjectConfiguration:
     @pytest.fixture
     def sut(self, tmp_path: Path) -> ProjectConfiguration:
-        return ProjectConfiguration(configuration_file_path=tmp_path)
+        return ProjectConfiguration(configuration_file_path=tmp_path / "betty.json")
 
     async def test_name(self, sut: ProjectConfiguration) -> None:
         name = "MyFirstBettySite"

--- a/betty/tests/test_project.py
+++ b/betty/tests/test_project.py
@@ -840,7 +840,9 @@ class TestProjectConfiguration:
         with raises_error(error_type=AssertionFailed):
             ProjectConfiguration.load(dump, sut)
 
-    async def test_load_should_error_if_invalid_config(self, sut: ProjectConfiguration) -> None:
+    async def test_load_should_error_if_invalid_config(
+        self, sut: ProjectConfiguration
+    ) -> None:
         dump: Dump = {}
         with raises_error(error_type=AssertionFailed):
             ProjectConfiguration.load(dump, sut)

--- a/betty/tests/test_serve.py
+++ b/betty/tests/test_serve.py
@@ -10,20 +10,20 @@ from betty.serve import BuiltinAppServer
 
 
 class TestBuiltinServer:
-    async def test(self, mocker: MockerFixture) -> None:
+    async def test(self, mocker: MockerFixture, new_temporary_app: App) -> None:
         mocker.patch("webbrowser.open_new_tab")
         content = "Hello, and welcome to my site!"
-        async with App.new_temporary() as app, app:
-            await makedirs(app.project.configuration.www_directory_path)
-            async with aiofiles.open(
-                app.project.configuration.www_directory_path / "index.html", "w"
-            ) as f:
-                await f.write(content)
-            async with BuiltinAppServer(app) as server:
+        await makedirs(new_temporary_app.project.configuration.www_directory_path)
+        async with aiofiles.open(
+            new_temporary_app.project.configuration.www_directory_path / "index.html",
+            "w",
+        ) as f:
+            await f.write(content)
+        async with BuiltinAppServer(new_temporary_app) as server:
 
-                def _assert_response(response: Response) -> None:
-                    assert response.status_code == 200
-                    assert content == response.content.decode("utf-8")
-                    assert "no-cache" == response.headers["Cache-Control"]
+            def _assert_response(response: Response) -> None:
+                assert response.status_code == 200
+                assert content == response.content.decode("utf-8")
+                assert "no-cache" == response.headers["Cache-Control"]
 
-                await Do(requests.get, server.public_url).until(_assert_response)
+            await Do(requests.get, server.public_url).until(_assert_response)

--- a/betty/tests/test_url.py
+++ b/betty/tests/test_url.py
@@ -28,10 +28,11 @@ class TestLocalizedPathUrlGenerator:
             ("/example/index.html", "/example/index.html"),
         ],
     )
-    async def test_generate(self, expected: str, resource: str) -> None:
-        async with App.new_temporary() as app, app:
-            sut = LocalizedPathUrlGenerator(app)
-            assert expected == sut.generate(resource, "text/html")
+    async def test_generate(
+        self, expected: str, resource: str, new_temporary_app: App
+    ) -> None:
+        sut = LocalizedPathUrlGenerator(new_temporary_app)
+        assert expected == sut.generate(resource, "text/html")
 
     @pytest.mark.parametrize(
         "expected, resource",
@@ -42,11 +43,12 @@ class TestLocalizedPathUrlGenerator:
             ("/example", "/example/index.html"),
         ],
     )
-    async def test_generate_with_clean_urls(self, expected: str, resource: str) -> None:
-        async with App.new_temporary() as app, app:
-            app.project.configuration.clean_urls = True
-            sut = LocalizedPathUrlGenerator(app)
-            assert expected == sut.generate(resource, "text/html")
+    async def test_generate_with_clean_urls(
+        self, expected: str, resource: str, new_temporary_app: App
+    ) -> None:
+        new_temporary_app.project.configuration.clean_urls = True
+        sut = LocalizedPathUrlGenerator(new_temporary_app)
+        assert expected == sut.generate(resource, "text/html")
 
     @pytest.mark.parametrize(
         "expected, resource",
@@ -55,10 +57,11 @@ class TestLocalizedPathUrlGenerator:
             ("https://example.com/example", "example"),
         ],
     )
-    async def test_generate_absolute(self, expected: str, resource: str) -> None:
-        async with App.new_temporary() as app, app:
-            sut = LocalizedPathUrlGenerator(app)
-            assert expected == sut.generate(resource, "text/html", absolute=True)
+    async def test_generate_absolute(
+        self, expected: str, resource: str, new_temporary_app: App
+    ) -> None:
+        sut = LocalizedPathUrlGenerator(new_temporary_app)
+        assert expected == sut.generate(resource, "text/html", absolute=True)
 
     @pytest.mark.parametrize(
         "expected, url_generator_locale",
@@ -72,22 +75,22 @@ class TestLocalizedPathUrlGenerator:
         self,
         expected: str,
         url_generator_locale: Localey | None,
+        new_temporary_app: App,
     ) -> None:
-        async with App.new_temporary() as app, app:
-            app.project.configuration.locales.replace(
-                LocaleConfiguration(
-                    "nl-NL",
-                    alias="nl",
-                ),
-                LocaleConfiguration(
-                    "en-US",
-                    alias="en",
-                ),
-            )
-            sut = LocalizedPathUrlGenerator(app)
-            assert expected == sut.generate(
-                "/index.html", "text/html", locale=url_generator_locale
-            )
+        new_temporary_app.project.configuration.locales.replace(
+            LocaleConfiguration(
+                "nl-NL",
+                alias="nl",
+            ),
+            LocaleConfiguration(
+                "en-US",
+                alias="en",
+            ),
+        )
+        sut = LocalizedPathUrlGenerator(new_temporary_app)
+        assert expected == sut.generate(
+            "/index.html", "text/html", locale=url_generator_locale
+        )
 
 
 class EntityUrlGeneratorTestUrlyEntity(UserFacingEntity, Entity):
@@ -99,19 +102,17 @@ class EntityUrlGeneratorTestNonUrlyEntity(UserFacingEntity, Entity):
 
 
 class TestEntityUrlGenerator:
-    async def test_generate(self) -> None:
-        async with App.new_temporary() as app, app:
-            sut = _EntityUrlGenerator(app, EntityUrlGeneratorTestUrlyEntity)
-            assert (
-                "/betty.tests.test_url.-entity-url-generator-test-urly-entity/I1/index.html"
-                == sut.generate(EntityUrlGeneratorTestUrlyEntity("I1"), "text/html")
-            )
+    async def test_generate(self, new_temporary_app: App) -> None:
+        sut = _EntityUrlGenerator(new_temporary_app, EntityUrlGeneratorTestUrlyEntity)
+        assert (
+            "/betty.tests.test_url.-entity-url-generator-test-urly-entity/I1/index.html"
+            == sut.generate(EntityUrlGeneratorTestUrlyEntity("I1"), "text/html")
+        )
 
-    async def test_generate_with_invalid_value(self) -> None:
-        async with App.new_temporary() as app, app:
-            sut = _EntityUrlGenerator(app, EntityUrlGeneratorTestUrlyEntity)
-            with pytest.raises(ValueError):
-                sut.generate(EntityUrlGeneratorTestNonUrlyEntity(), "text/html")
+    async def test_generate_with_invalid_value(self, new_temporary_app: App) -> None:
+        sut = _EntityUrlGenerator(new_temporary_app, EntityUrlGeneratorTestUrlyEntity)
+        with pytest.raises(ValueError):
+            sut.generate(EntityUrlGeneratorTestNonUrlyEntity(), "text/html")
 
 
 class TestAppUrlGenerator:
@@ -157,7 +158,8 @@ class TestAppUrlGenerator:
             ),
         ],
     )
-    async def test_generate(self, expected: str, resource: Any) -> None:
-        async with App.new_temporary() as app, app:
-            sut = AppUrlGenerator(app)
-            assert expected == sut.generate(resource, "text/html")
+    async def test_generate(
+        self, expected: str, resource: Any, new_temporary_app: App
+    ) -> None:
+        sut = AppUrlGenerator(new_temporary_app)
+        assert expected == sut.generate(resource, "text/html")

--- a/betty/tests/test_wikipedia.py
+++ b/betty/tests/test_wikipedia.py
@@ -810,14 +810,13 @@ class TestRetriever:
 
 class TestPopulator:
     async def test_populate_link_should_convert_http_to_https(
-        self, mocker: MockerFixture
+        self, mocker: MockerFixture, new_temporary_app: App
     ) -> None:
         m_retriever = mocker.patch("betty.wikipedia._Retriever")
         link = Link("http://en.wikipedia.org/wiki/Amsterdam")
         page_language = "nl"
-        async with App.new_temporary() as app, app:
-            sut = _Populator(app, m_retriever)
-            await sut.populate_link(link, page_language)
+        sut = _Populator(new_temporary_app, m_retriever)
+        await sut.populate_link(link, page_language)
         assert "https://en.wikipedia.org/wiki/Amsterdam" == link.url
 
     @pytest.mark.parametrize(
@@ -833,15 +832,15 @@ class TestPopulator:
         expected: MediaType,
         media_type: MediaType | None,
         mocker: MockerFixture,
+        new_temporary_app: App,
     ) -> None:
         m_retriever = mocker.patch("betty.wikipedia._Retriever")
         link = Link(
             "http://en.wikipedia.org/wiki/Amsterdam",
             media_type=media_type,
         )
-        async with App.new_temporary() as app, app:
-            sut = _Populator(app, m_retriever)
-            await sut.populate_link(link, "en")
+        sut = _Populator(new_temporary_app, m_retriever)
+        await sut.populate_link(link, "en")
         assert expected == link.media_type
 
     @pytest.mark.parametrize(
@@ -857,13 +856,13 @@ class TestPopulator:
         expected: str,
         relationship: str | None,
         mocker: MockerFixture,
+        new_temporary_app: App,
     ) -> None:
         m_retriever = mocker.patch("betty.wikipedia._Retriever")
         link = Link("http://en.wikipedia.org/wiki/Amsterdam")
         link.relationship = relationship
-        async with App.new_temporary() as app, app:
-            sut = _Populator(app, m_retriever)
-            await sut.populate_link(link, "en")
+        sut = _Populator(new_temporary_app, m_retriever)
+        await sut.populate_link(link, "en")
         assert expected == link.relationship
 
     @pytest.mark.parametrize(
@@ -880,13 +879,13 @@ class TestPopulator:
         page_language: str,
         locale: str | None,
         mocker: MockerFixture,
+        new_temporary_app: App,
     ) -> None:
         m_retriever = mocker.patch("betty.wikipedia._Retriever")
         link = Link("http://%s.wikipedia.org/wiki/Amsterdam" % page_language)
         link.locale = locale
-        async with App.new_temporary() as app, app:
-            sut = _Populator(app, m_retriever)
-            await sut.populate_link(link, page_language)
+        sut = _Populator(new_temporary_app, m_retriever)
+        await sut.populate_link(link, page_language)
         assert expected == link.locale
 
     @pytest.mark.parametrize(
@@ -901,6 +900,7 @@ class TestPopulator:
         expected: str,
         description: str,
         mocker: MockerFixture,
+        new_temporary_app: App,
     ) -> None:
         m_retriever = mocker.patch("betty.wikipedia._Retriever")
         link = Link(
@@ -908,9 +908,8 @@ class TestPopulator:
             description=description,
         )
         page_language = "en"
-        async with App.new_temporary() as app, app:
-            sut = _Populator(app, m_retriever)
-            await sut.populate_link(link, page_language)
+        sut = _Populator(new_temporary_app, m_retriever)
+        await sut.populate_link(link, page_language)
         assert expected == link.description
 
     @pytest.mark.parametrize(
@@ -925,6 +924,7 @@ class TestPopulator:
         expected: str,
         label: str | None,
         mocker: MockerFixture,
+        new_temporary_app: App,
     ) -> None:
         m_retriever = mocker.patch("betty.wikipedia._Retriever")
         link = Link("http://en.wikipedia.org/wiki/Amsterdam")
@@ -935,13 +935,12 @@ class TestPopulator:
             "The city of Amsterdam",
             "Amsterdam, such a lovely place!",
         )
-        async with App.new_temporary() as app, app:
-            sut = _Populator(app, m_retriever)
-            await sut.populate_link(link, "en", summary)
+        sut = _Populator(new_temporary_app, m_retriever)
+        await sut.populate_link(link, "en", summary)
         assert expected == link.label
 
     async def test_populate_should_ignore_resource_without_link_support(
-        self, mocker: MockerFixture
+        self, mocker: MockerFixture, new_temporary_app: App
     ) -> None:
         m_retriever = mocker.patch("betty.wikipedia._Retriever")
         source = Source("The Source")
@@ -949,27 +948,25 @@ class TestPopulator:
             id="the_citation",
             source=source,
         )
-        async with App.new_temporary() as app, app:
-            app.project.ancestry.add(resource)
-            sut = _Populator(app, m_retriever)
-            await sut.populate()
+        new_temporary_app.project.ancestry.add(resource)
+        sut = _Populator(new_temporary_app, m_retriever)
+        await sut.populate()
 
     async def test_populate_should_ignore_resource_without_links(
-        self, mocker: MockerFixture
+        self, mocker: MockerFixture, new_temporary_app: App
     ) -> None:
         m_retriever = mocker.patch("betty.wikipedia._Retriever")
         resource = Source(
             id="the_source",
             name="The Source",
         )
-        async with App.new_temporary() as app, app:
-            app.project.ancestry.add(resource)
-            sut = _Populator(app, m_retriever)
-            await sut.populate()
+        new_temporary_app.project.ancestry.add(resource)
+        sut = _Populator(new_temporary_app, m_retriever)
+        await sut.populate()
         assert [] == resource.links
 
     async def test_populate_should_ignore_non_wikipedia_links(
-        self, mocker: MockerFixture
+        self, mocker: MockerFixture, new_temporary_app: App
     ) -> None:
         m_retriever = mocker.patch("betty.wikipedia._Retriever")
         link = Link("https://example.com")
@@ -978,14 +975,13 @@ class TestPopulator:
             name="The Source",
             links=[link],
         )
-        async with App.new_temporary() as app, app:
-            app.project.ancestry.add(resource)
-            sut = _Populator(app, m_retriever)
-            await sut.populate()
+        new_temporary_app.project.ancestry.add(resource)
+        sut = _Populator(new_temporary_app, m_retriever)
+        await sut.populate()
         assert [link] == resource.links
 
     async def test_populate_should_populate_existing_link(
-        self, mocker: MockerFixture
+        self, mocker: MockerFixture, new_temporary_app: App
     ) -> None:
         m_retriever = mocker.patch(
             "betty.wikipedia._Retriever", spec=_Retriever, new_callable=AsyncMock
@@ -1004,10 +1000,9 @@ class TestPopulator:
             name="The Source",
             links=[link],
         )
-        async with App.new_temporary() as app, app:
-            app.project.ancestry.add(resource)
-            sut = _Populator(app, m_retriever)
-            await sut.populate()
+        new_temporary_app.project.ancestry.add(resource)
+        sut = _Populator(new_temporary_app, m_retriever)
+        await sut.populate()
         m_retriever.get_summary.assert_called_once_with(page_language, page_name)
         assert 1 == len(resource.links)
         assert "Amsterdam" == link.label
@@ -1017,7 +1012,7 @@ class TestPopulator:
         assert "external" == link.relationship
 
     async def test_populate_should_add_translation_links(
-        self, mocker: MockerFixture
+        self, mocker: MockerFixture, new_temporary_app: App
     ) -> None:
         m_retriever = mocker.patch(
             "betty.wikipedia._Retriever", spec=_Retriever, new_callable=AsyncMock
@@ -1050,17 +1045,16 @@ class TestPopulator:
             name="The Source",
             links=[link_en],
         )
-        async with App.new_temporary() as app, app:
-            app.project.configuration.locales["en-US"].alias = "en"
-            app.project.configuration.locales.append(
-                LocaleConfiguration(
-                    "nl-NL",
-                    alias="nl",
-                )
+        new_temporary_app.project.configuration.locales["en-US"].alias = "en"
+        new_temporary_app.project.configuration.locales.append(
+            LocaleConfiguration(
+                "nl-NL",
+                alias="nl",
             )
-            app.project.ancestry.add(resource)
-            sut = _Populator(app, m_retriever)
-            await sut.populate()
+        )
+        new_temporary_app.project.ancestry.add(resource)
+        sut = _Populator(new_temporary_app, m_retriever)
+        await sut.populate()
 
         m_retriever.get_summary.assert_has_calls(
             [
@@ -1078,7 +1072,7 @@ class TestPopulator:
         assert "external" == link_nl.relationship
 
     async def test_populate_place_should_add_coordinates(
-        self, mocker: MockerFixture
+        self, mocker: MockerFixture, new_temporary_app: App
     ) -> None:
         m_retriever = mocker.patch(
             "betty.wikipedia._Retriever", spec=_Retriever, new_callable=AsyncMock
@@ -1092,14 +1086,15 @@ class TestPopulator:
         wikipedia_link = Link(f"https://{page_language}.wikipedia.org/wiki/{page_name}")
         other_link = Link("https://example.com")
         place = Place(links=[wikipedia_link, other_link])
-        async with App.new_temporary() as app, app:
-            app.project.ancestry.add(place)
-            sut = _Populator(app, m_retriever)
-            await sut.populate()
+        new_temporary_app.project.ancestry.add(place)
+        sut = _Populator(new_temporary_app, m_retriever)
+        await sut.populate()
 
         assert coordinates is place.coordinates
 
-    async def test_populate_has_links(self, mocker: MockerFixture) -> None:
+    async def test_populate_has_links(
+        self, mocker: MockerFixture, new_temporary_app: App
+    ) -> None:
         m_retriever = mocker.patch(
             "betty.wikipedia._Retriever", spec=_Retriever, new_callable=AsyncMock
         )
@@ -1115,9 +1110,8 @@ class TestPopulator:
 
         link = Link(f"https://{page_language}.wikipedia.org/wiki/{page_name}")
         place = Place(links=[link])
-        async with App.new_temporary() as app, app:
-            app.project.ancestry.add(place)
-            sut = _Populator(app, m_retriever)
-            await sut.populate()
+        new_temporary_app.project.ancestry.add(place)
+        sut = _Populator(new_temporary_app, m_retriever)
+        await sut.populate()
 
         assert place.files[0].path == image.path


### PR DESCRIPTION
Remove usage of `FileBasedConfiguration`'s automatic temporary configuration directory creation (and problematic clean-up)

Add a `new_temporary_project` fixture like `new_temporary_app`

## Goals
- Temporary directories must be cleaned up, but `FileBasedConfiguration` does not provide an API for that. As a consequence, this clean-up often fails, most notably manifested in frequent random CI test failures. The goal is to prevent these random failures.
- As configuration files are, in production, on disk, and do not need cleaning up, and temporary files are only used for testing, `FileBasedConfiguration` should not explicitly facilitate temporary files. This complexity should be handled by the caller, who can then also take care of clean-up.

## Blocked by
- https://github.com/bartfeenstra/betty/issues/1372 (or at least, this PR already does for `ProjectConfiguration` what 1372 does for all `Configuration`)

## Obsoletes
- https://github.com/bartfeenstra/betty/pull/1534