### PR TITLE
Install a newly missing Qt dependency when building setuptools/PyPI releases

### DIFF
--- a/.github/workflows/release-build-setuptools.yml
+++ b/.github/workflows/release-build-setuptools.yml
@@ -47,6 +47,14 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install APT dependencies
+        run: |
+          sudo apt-get update
+          apt_packages=(
+            libegl1-mesa # For Qt
+          )
+          sudo apt-get install "${apt_packages[@]}"
+
       - name: Build the distributions
         run: ./bin/build-setuptools '${{ github.event.release.tag_name }}'
         shell: bash


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/1550