### PR TITLE
Remove `Configuration.on_change()`

### DIFF
--- a/betty/app/__init__.py
+++ b/betty/app/__init__.py
@@ -176,6 +176,7 @@ class App(Configurable[AppConfiguration]):
         super().__init__()
         self._started = False
         self._configuration = configuration
+        configuration.mutable = False
         self._assets: AssetRepository | None = None
         self._extensions = _AppExtensions()
         self._extensions_initialized = False

--- a/betty/config.py
+++ b/betty/config.py
@@ -4,8 +4,6 @@ Provide the Configuration API.
 
 from __future__ import annotations
 
-import inspect
-import weakref
 from collections import OrderedDict
 from collections.abc import Callable
 from contextlib import chdir
@@ -27,7 +25,6 @@ from typing import (
     cast,
     Self,
     TypeAlias,
-    TYPE_CHECKING,
 )
 
 import aiofiles
@@ -43,9 +40,6 @@ from betty.serde.error import SerdeErrorCollection
 from betty.serde.format import FormatRepository
 from betty.serde.load import assert_dict, assert_sequence
 
-if TYPE_CHECKING:
-    from _weakref import ReferenceType
-
 
 _ConfigurationListener: TypeAlias = Callable[[], None]
 ConfigurationListener: TypeAlias = "Configuration | _ConfigurationListener"
@@ -55,40 +49,6 @@ class Configuration(Dumpable):
     """
     Any configuration object.
     """
-
-    def __init__(self, *args: Any, **kwargs: Any):
-        super().__init__(*args, **kwargs)
-        self._on_change_listeners: MutableSequence[
-            ReferenceType[_ConfigurationListener]
-        ] = []
-
-    def _dispatch_change(self) -> None:
-        for listener_reference in self._on_change_listeners:
-            listener = listener_reference()
-            if listener is None:
-                continue
-            listener()
-
-    def _prepare_listener(
-        self, listener: ConfigurationListener
-    ) -> ReferenceType[_ConfigurationListener]:
-        if isinstance(listener, Configuration):
-            listener = listener._dispatch_change
-        if inspect.ismethod(listener):  # type: ignore[redundant-expr]
-            return weakref.WeakMethod(listener)  # type: ignore[unreachable]
-        return weakref.ref(listener)
-
-    def on_change(self, listener: ConfigurationListener) -> None:
-        """
-        Add an on-change listener.
-        """
-        self._on_change_listeners.append(self._prepare_listener(listener))
-
-    def remove_on_change(self, listener: ConfigurationListener) -> None:
-        """
-        Remove an on-change listener.
-        """
-        self._on_change_listeners.append(self._prepare_listener(listener))
 
     def update(self, other: Self) -> None:
         """
@@ -115,26 +75,6 @@ class FileBasedConfiguration(Configuration):
         super().__init__()
         self._configuration_directory: TemporaryDirectory | None = None  # type: ignore[type-arg]
         self._configuration_file_path: Path | None = None
-        self._autowrite = False
-
-    @property
-    def autowrite(self) -> bool:
-        """
-        Whether to write this configuration to file whenever it changes.
-        """
-        return self._autowrite
-
-    @autowrite.setter
-    def autowrite(self, autowrite: bool) -> None:
-        if autowrite:
-            if not self._autowrite:
-                self.on_change(self._on_change_write)
-        else:
-            self.remove_on_change(self._on_change_write)
-        self._autowrite = autowrite
-
-    def _on_change_write(self) -> None:
-        wait_to_thread(self.write())
 
     async def write(self, configuration_file_path: Path | None = None) -> None:
         """
@@ -231,10 +171,6 @@ class FileBasedConfiguration(Configuration):
 
     @configuration_file_path.deleter
     def configuration_file_path(self) -> None:
-        if self._autowrite:
-            raise RuntimeError(
-                "Cannot remove the configuration file path while autowrite is enabled."
-            )
         self._configuration_file_path = None
 
 
@@ -282,7 +218,10 @@ class ConfigurationCollection(
     def __repr__(self) -> str:
         return repr_instance(self, configurations=list(self.values()))
 
-    def _remove_without_dispatch(self, *configuration_keys: _ConfigurationKeyT) -> None:
+    def remove(self, *configuration_keys: _ConfigurationKeyT) -> None:
+        """
+        Remove the given keys from the collection.
+        """
         for configuration_key in configuration_keys:
             configuration = self._configurations[configuration_key]  # type: ignore[call-overload]
             del self._configurations[configuration_key]  # type: ignore[call-overload]
@@ -294,28 +233,17 @@ class ConfigurationCollection(
         """
         raise NotImplementedError(repr(self))
 
-    def remove(self, *configuration_keys: _ConfigurationKeyT) -> None:
-        """
-        Remove the given keys from the collection.
-        """
-        self._remove_without_dispatch(*configuration_keys)
-        self._dispatch_change()
-
-    def _clear_without_dispatch(self) -> None:
-        self._remove_without_dispatch(*self.keys())
-
     def clear(self) -> None:
         """
         Clear all items from the collection.
         """
-        self._clear_without_dispatch()
-        self._dispatch_change()
+        self.remove(*self.keys())
 
     def _on_add(self, configuration: _ConfigurationT) -> None:
-        configuration.on_change(self)
+        pass
 
     def _on_remove(self, configuration: _ConfigurationT) -> None:
-        configuration.remove_on_change(self)
+        pass
 
     def to_index(self, configuration_key: _ConfigurationKeyT) -> int:
         """
@@ -471,12 +399,11 @@ class ConfigurationSequence(
 
     @override
     def update(self, other: Self) -> None:
-        self._clear_without_dispatch()
-        self.append(*other)
+        self.replace(*other)
 
     @override
     def replace(self, *values: _ConfigurationT) -> None:
-        self._clear_without_dispatch()
+        self.clear()
         self.append(*values)
 
     @override
@@ -494,21 +421,18 @@ class ConfigurationSequence(
         for configuration in configurations:
             self._on_add(configuration)
             self._configurations.insert(0, configuration)
-        self._dispatch_change()
 
     @override
     def append(self, *configurations: _ConfigurationT) -> None:
         for configuration in configurations:
             self._on_add(configuration)
             self._configurations.append(configuration)
-        self._dispatch_change()
 
     @override
     def insert(self, index: int, *configurations: _ConfigurationT) -> None:
         for configuration in reversed(configurations):
             self._on_add(configuration)
             self._configurations.insert(index, configuration)
-        self._dispatch_change()
 
     @override
     def move_to_beginning(self, *configuration_keys: int) -> None:
@@ -525,7 +449,6 @@ class ConfigurationSequence(
     def move_towards_beginning(self, *configuration_keys: int) -> None:
         for index in configuration_keys:
             self._configurations.insert(index - 1, self._configurations.pop(index))
-        self._dispatch_change()
 
     @override
     def move_to_end(self, *configuration_keys: int) -> None:
@@ -533,13 +456,11 @@ class ConfigurationSequence(
             self._configurations.append(self._configurations[index])
         for index in reversed(configuration_keys):
             self._configurations.pop(index)
-        self._dispatch_change()
 
     @override
     def move_towards_end(self, *configuration_keys: int) -> None:
         for index in reversed(configuration_keys):
             self._configurations.insert(index + 1, self._configurations.pop(index))
-        self._dispatch_change()
 
 
 class ConfigurationMapping(
@@ -623,9 +544,7 @@ class ConfigurationMapping(
         )
 
         # Remove items that should no longer be present.
-        self._remove_without_dispatch(
-            *(key for key in self_keys if key not in other_keys)
-        )
+        self.remove(*(key for key in self_keys if key not in other_keys))
 
         # Ensure everything is in the correct order. This will also trigger reactors.
         self.move_to_beginning(*other_keys)
@@ -659,20 +578,17 @@ class ConfigurationMapping(
         for configuration in configurations:
             configuration_key = self._get_key(configuration)
             self._configurations[configuration_key] = configuration
-            configuration.on_change(self)
         self.move_to_beginning(*map(self._get_key, configurations))
 
     def _append_without_trigger(self, *configurations: _ConfigurationT) -> None:
         for configuration in configurations:
             configuration_key = self._get_key(configuration)
             self._configurations[configuration_key] = configuration
-            configuration.on_change(self)
         self._move_to_end_without_trigger(*map(self._get_key, configurations))
 
     @override
     def append(self, *configurations: _ConfigurationT) -> None:
         self._append_without_trigger(*configurations)
-        self._dispatch_change()
 
     def _insert_without_trigger(
         self, index: int, *configurations: _ConfigurationT
@@ -688,13 +604,11 @@ class ConfigurationMapping(
     @override
     def insert(self, index: int, *configurations: _ConfigurationT) -> None:
         self._insert_without_trigger(index, *configurations)
-        self._dispatch_change()
 
     @override
     def move_to_beginning(self, *configuration_keys: _ConfigurationKeyT) -> None:
         for configuration_key in reversed(configuration_keys):
             self._configurations.move_to_end(configuration_key, False)
-        self._dispatch_change()
 
     @override
     def move_towards_beginning(self, *configuration_keys: _ConfigurationKeyT) -> None:
@@ -709,7 +623,6 @@ class ConfigurationMapping(
     @override
     def move_to_end(self, *configuration_keys: _ConfigurationKeyT) -> None:
         self._move_to_end_without_trigger(*configuration_keys)
-        self._dispatch_change()
 
     @override
     def move_towards_end(self, *configuration_keys: _ConfigurationKeyT) -> None:
@@ -727,7 +640,6 @@ class ConfigurationMapping(
                 index + offset,
                 self._configurations.pop(current_configuration_keys[index]),
             )
-        self._dispatch_change()
 
     def _get_key(self, configuration: _ConfigurationT) -> _ConfigurationKeyT:
         raise NotImplementedError(repr(self))

--- a/betty/extension/cotton_candy/__init__.py
+++ b/betty/extension/cotton_candy/__init__.py
@@ -34,7 +34,7 @@ from betty.model import Entity, UserFacingEntity, GeneratedEntityId
 from betty.model.ancestry import Event, Person, Presence, is_public, Subject
 from betty.model.event_type import StartOfLifeEventType, EndOfLifeEventType
 from betty.os import link_or_copy
-from betty.project import EntityReferenceSequence, EntityReference
+from betty.project import EntityReferenceSequence, EntityReference, ProjectAwareMixin
 from betty.serde.dump import minimize, Dump, VoidableDump, Void
 from betty.serde.load import (
     AssertionFailed,
@@ -77,7 +77,6 @@ class _ColorConfiguration(Configuration):
     def hex(self, hex_value: str) -> None:
         self._assert_hex(hex_value)
         self._hex = hex_value
-        self._dispatch_change()
 
     @override
     def update(self, other: Self) -> None:
@@ -118,15 +117,10 @@ class CottonCandyConfiguration(Configuration):
         self._featured_entities = EntityReferenceSequence["UserFacingEntity & Entity"](
             featured_entities or ()
         )
-        self._featured_entities.on_change(self)
         self._primary_inactive_color = _ColorConfiguration(primary_inactive_color)
-        self._primary_inactive_color.on_change(self)
         self._primary_active_color = _ColorConfiguration(primary_active_color)
-        self._primary_active_color.on_change(self)
         self._link_inactive_color = _ColorConfiguration(link_inactive_color)
-        self._link_inactive_color.on_change(self)
         self._link_active_color = _ColorConfiguration(link_active_color)
-        self._link_active_color.on_change(self)
         self._logo = logo
 
     @property
@@ -174,7 +168,6 @@ class CottonCandyConfiguration(Configuration):
     @logo.setter
     def logo(self, logo: Path | None) -> None:
         self._logo = logo
-        self._dispatch_change()
 
     @override
     def load(self, dump: Dump) -> None:
@@ -292,7 +285,7 @@ class CottonCandy(
         )
 
     @override
-    def gui_build(self) -> QWidget:
+    def gui_build(self) -> QWidget & ProjectAwareMixin:
         from betty.extension.cotton_candy.gui import _CottonCandyGuiWidget
 
         return _CottonCandyGuiWidget(self._app)

--- a/betty/extension/gramps/config.py
+++ b/betty/extension/gramps/config.py
@@ -59,7 +59,6 @@ class FamilyTreeConfiguration(Configuration):
     @override
     def update(self, other: Self) -> None:
         self.file_path = other.file_path
-        self._dispatch_change()
 
 
 class FamilyTreeConfigurationSequence(ConfigurationSequence[FamilyTreeConfiguration]):
@@ -88,7 +87,6 @@ class GrampsConfiguration(Configuration):
     ):
         super().__init__()
         self._family_trees = FamilyTreeConfigurationSequence(family_trees)
-        self._family_trees.on_change(self)
 
     @property
     def family_trees(self) -> FamilyTreeConfigurationSequence:

--- a/betty/extension/nginx/config.py
+++ b/betty/extension/nginx/config.py
@@ -45,7 +45,6 @@ class NginxConfiguration(Configuration):
     @https.setter
     def https(self, https: bool | None) -> None:
         self._https = https
-        self._dispatch_change()
 
     @property
     def www_directory_path(self) -> str | None:
@@ -57,13 +56,11 @@ class NginxConfiguration(Configuration):
     @www_directory_path.setter
     def www_directory_path(self, www_directory_path: str | None) -> None:
         self._www_directory_path = www_directory_path
-        self._dispatch_change()
 
     @override
     def update(self, other: Self) -> None:
         self._https = other._https
         self._www_directory_path = other._www_directory_path
-        self._dispatch_change()
 
     @override
     def load(self, dump: Dump) -> None:

--- a/betty/extension/nginx/serve.py
+++ b/betty/extension/nginx/serve.py
@@ -44,7 +44,6 @@ class DockerizedNginxServer(Server):
         )
 
         isolated_project = Project(ancestry=self._app.project.ancestry)
-        isolated_project.configuration.autowrite = False
         isolated_project.configuration.configuration_file_path = (
             self._app.project.configuration.configuration_file_path
         )

--- a/betty/extension/wikipedia/__init__.py
+++ b/betty/extension/wikipedia/__init__.py
@@ -63,10 +63,6 @@ class Wikipedia(
             self.__retriever = _Retriever(self._app.fetcher)
         return self.__retriever
 
-    @_retriever.deleter
-    def _retriever(self) -> None:
-        self.__retriever = None
-
     @override
     @property
     def filters(self) -> Filters:

--- a/betty/extension/wikipedia/config.py
+++ b/betty/extension/wikipedia/config.py
@@ -39,7 +39,6 @@ class WikipediaConfiguration(Configuration):
     @override
     def update(self, other: Self) -> None:
         self._populate_images = other._populate_images
-        self._dispatch_change()
 
     @override
     def load(self, dump: Dump) -> None:

--- a/betty/extension/wikipedia/gui.py
+++ b/betty/extension/wikipedia/gui.py
@@ -9,19 +9,18 @@ from PyQt6.QtWidgets import (
     QWidget,
     QCheckBox,
 )
-from typing_extensions import override
 
 from betty.app import App
 from betty.extension.wikipedia.config import WikipediaConfiguration
-from betty.gui.locale import LocalizedObject
 from betty.gui.text import Caption
+from betty.project import ProjectAwareMixin
 
 
-class _WikipediaGuiWidget(LocalizedObject, QWidget):
+class _WikipediaGuiWidget(ProjectAwareMixin, QWidget):
     def __init__(
         self, app: App, configuration: WikipediaConfiguration, *args: Any, **kwargs: Any
     ):
-        super().__init__(app, *args, **kwargs)
+        super().__init__(app.project, *args, **kwargs)
         self._app = app
         self._configuration = configuration
         layout = QFormLayout()
@@ -31,19 +30,13 @@ class _WikipediaGuiWidget(LocalizedObject, QWidget):
         def _update_configuration_populate_images(checked: bool) -> None:
             self._configuration.populate_images = checked
 
-        self._populate_images = QCheckBox()
+        self._populate_images = QCheckBox(self._app.localizer._("Populate images"))
         self._populate_images.setChecked(self._configuration.populate_images)
         self._populate_images.toggled.connect(_update_configuration_populate_images)
         layout.addRow(self._populate_images)
-        self._populate_images_caption = Caption()
-        layout.addRow(self._populate_images_caption)
-
-    @override
-    def _set_translatables(self) -> None:
-        super()._set_translatables()
-        self._populate_images.setText(self._app.localizer._("Populate images"))
-        self._populate_images_caption.setText(
+        self._populate_images_caption = Caption(
             self._app.localizer._(
                 "Download images from the Wikipedia links in your ancestry"
             )
         )
+        layout.addRow(self._populate_images_caption)

--- a/betty/gui/__init__.py
+++ b/betty/gui/__init__.py
@@ -17,6 +17,7 @@ from betty.locale import Str, Localizable
 from betty.serde.format import FormatRepository
 
 if TYPE_CHECKING:
+    from betty.project import ProjectAwareMixin
     from collections.abc import AsyncIterator
 
 
@@ -40,7 +41,7 @@ class GuiBuilder:
     Allow extensions to provide their own Graphical User Interface component.
     """
 
-    def gui_build(self) -> QWidget:
+    def gui_build(self) -> QWidget & ProjectAwareMixin:
         """
         Build this extension's Graphical User Interface component.
         """
@@ -151,7 +152,7 @@ class BettyApplication(QApplication):
         self,
         error_type: type[Exception],
         pickled_error_message: bytes,
-        parent: QObject,
+        parent: QWidget,
         close_parent: bool,
     ) -> None:
         error_message = pickle.loads(pickled_error_message)
@@ -176,7 +177,7 @@ class BettyApplication(QApplication):
         error_type: type[Exception],
         error_message: str,
         error_traceback: str,
-        parent: QObject,
+        parent: QWidget,
         close_parent: bool,
     ) -> None:
         window = _UnexpectedExceptionError(

--- a/betty/gui/app.py
+++ b/betty/gui/app.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from pathlib import Path
 from urllib.parse import urlencode
 
-from PyQt6.QtCore import Qt, QCoreApplication, QObject
+from PyQt6.QtCore import Qt, QCoreApplication
 from PyQt6.QtGui import QAction
 from PyQt6.QtWidgets import (
     QFormLayout,
@@ -52,66 +52,74 @@ class BettyPrimaryWindow(BettyMainWindow):
         assert betty_menu is not None
         self.betty_menu = betty_menu
 
-        self.new_project_action = QAction(self)
+        self.new_project_action = QAction(self._app.localizer._("New project..."), self)
         self.new_project_action.setShortcut("Ctrl+N")
         self.new_project_action.triggered.connect(
             lambda _: self.new_project(),
         )
         betty_menu.addAction(self.new_project_action)
 
-        self.open_project_action = QAction(self)
+        self.open_project_action = QAction(
+            self._app.localizer._("Open project..."), self
+        )
         self.open_project_action.setShortcut("Ctrl+O")
         self.open_project_action.triggered.connect(
             lambda _: self.open_project(),
         )
         betty_menu.addAction(self.open_project_action)
 
-        self._demo_action = QAction(self)
+        self._demo_action = QAction(self._app.localizer._("View demo site..."), self)
         self._demo_action.triggered.connect(
             lambda _: self._demo(),
         )
         betty_menu.addAction(self._demo_action)
 
-        self.open_application_configuration_action = QAction(self)
+        self.open_application_configuration_action = QAction(
+            self._app.localizer._("Settings..."), self
+        )
         self.open_application_configuration_action.triggered.connect(
             lambda _: self.open_application_configuration(),
         )
         betty_menu.addAction(self.open_application_configuration_action)
 
-        self.clear_caches_action = QAction(self)
+        self.clear_caches_action = QAction(
+            self._app.localizer._("Clear all caches"), self
+        )
         self.clear_caches_action.triggered.connect(
             lambda _: self.clear_caches(),
         )
         betty_menu.addAction(self.clear_caches_action)
 
-        self.exit_action = QAction(self)
+        self.exit_action = QAction(self._app.localizer._("Exit"), self)
         self.exit_action.setShortcut("Ctrl+Q")
         self.exit_action.triggered.connect(QCoreApplication.quit)
         betty_menu.addAction(self.exit_action)
 
-        help_menu = menu_bar.addMenu("")
+        help_menu = menu_bar.addMenu("&" + self._app.localizer._("Help"))
         assert help_menu is not None
         self.help_menu = help_menu
 
-        self.report_bug_action = QAction(self)
+        self.report_bug_action = QAction(self._app.localizer._("Report a bug"), self)
         self.report_bug_action.triggered.connect(
             lambda _: self.report_bug(),
         )
         help_menu.addAction(self.report_bug_action)
 
-        self.request_feature_action = QAction(self)
+        self.request_feature_action = QAction(
+            self._app.localizer._("Request a new feature"), self
+        )
         self.request_feature_action.triggered.connect(
             lambda _: self.request_feature(),
         )
         help_menu.addAction(self.request_feature_action)
 
-        self._docs_action = QAction(self)
+        self._docs_action = QAction(self._app.localizer._("View documentation"), self)
         self._docs_action.triggered.connect(
             lambda _: self._docs(),
         )
         help_menu.addAction(self._docs_action)
 
-        self.about_action = QAction(self)
+        self.about_action = QAction(self._app.localizer._("About Betty"), self)
         self.about_action.triggered.connect(
             lambda _: self._about_betty(),
         )
@@ -121,25 +129,6 @@ class BettyPrimaryWindow(BettyMainWindow):
     @property
     def window_title(self) -> Localizable:
         return Str.plain("Betty")
-
-    @override
-    def _set_translatables(self) -> None:
-        super()._set_translatables()
-        self.new_project_action.setText(self._app.localizer._("New project..."))
-        self.open_project_action.setText(self._app.localizer._("Open project..."))
-        self._demo_action.setText(self._app.localizer._("View demo site..."))
-        self.open_application_configuration_action.setText(
-            self._app.localizer._("Settings...")
-        )
-        self.clear_caches_action.setText(self._app.localizer._("Clear all caches"))
-        self.exit_action.setText(self._app.localizer._("Exit"))
-        self.help_menu.setTitle("&" + self._app.localizer._("Help"))
-        self.report_bug_action.setText(self._app.localizer._("Report a bug"))
-        self.request_feature_action.setText(
-            self._app.localizer._("Request a new feature")
-        )
-        self._docs_action.setText(self._app.localizer._("View documentation"))
-        self.about_action.setText(self._app.localizer._("About Betty"))
 
     def report_bug(self) -> None:
         """
@@ -305,41 +294,11 @@ class WelcomeWindow(BettyPrimaryWindow):
         central_widget.setLayout(central_layout)
         self.setCentralWidget(central_widget)
 
-        self._welcome = _WelcomeTitle()
+        self._welcome = _WelcomeTitle(self._app.localizer._("Welcome to Betty"))
         self._welcome.setAlignment(Qt.AlignmentFlag.AlignCenter)
         central_layout.addWidget(self._welcome)
 
-        self._welcome_caption = _WelcomeText()
-        central_layout.addWidget(self._welcome_caption)
-
-        self._project_instruction = _WelcomeHeading()
-        self._project_instruction.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        central_layout.addWidget(self._project_instruction)
-
-        project_layout = QHBoxLayout()
-        central_layout.addLayout(project_layout)
-
-        self.open_project_button = _WelcomeAction(self)
-        self.open_project_button.released.connect(self.open_project)
-        project_layout.addWidget(self.open_project_button)
-
-        self.new_project_button = _WelcomeAction(self)
-        self.new_project_button.released.connect(self.new_project)
-        project_layout.addWidget(self.new_project_button)
-
-        self._demo_instruction = _WelcomeHeading()
-        self._demo_instruction.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        central_layout.addWidget(self._demo_instruction)
-
-        self.demo_button = _WelcomeAction(self)
-        self.demo_button.released.connect(self._demo)
-        central_layout.addWidget(self.demo_button)
-
-    @override
-    def _set_translatables(self) -> None:
-        super()._set_translatables()
-        self._welcome.setText(self._app.localizer._("Welcome to Betty"))
-        self._welcome_caption.setText(
+        self._welcome_caption = _WelcomeText(
             self._app.localizer._(
                 'Betty helps you visualize and publish your family history by building interactive genealogy websites out of your <a href="{gramps_url}">Gramps</a> and <a href="{gedcom_url}">GEDCOM</a> family trees.'
             ).format(
@@ -347,19 +306,42 @@ class WelcomeWindow(BettyPrimaryWindow):
                 gedcom_url="https://en.wikipedia.org/wiki/GEDCOM",
             )
         )
-        self._project_instruction.setText(
+        central_layout.addWidget(self._welcome_caption)
+
+        self._project_instruction = _WelcomeHeading(
             self._app.localizer._("Work on a new or existing site of your own")
         )
-        self.open_project_button.setText(
-            self._app.localizer._("Open an existing project")
+        self._project_instruction.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        central_layout.addWidget(self._project_instruction)
+
+        project_layout = QHBoxLayout()
+        central_layout.addLayout(project_layout)
+
+        self.open_project_button = _WelcomeAction(
+            self._app.localizer._("Open an existing project"), self
         )
-        self.new_project_button.setText(self._app.localizer._("Create a new project"))
-        self._demo_instruction.setText(
+        self.open_project_button.released.connect(self.open_project)
+        project_layout.addWidget(self.open_project_button)
+
+        self.new_project_button = _WelcomeAction(
+            self._app.localizer._("Create a new project"), self
+        )
+        self.new_project_button.released.connect(self.new_project)
+        project_layout.addWidget(self.new_project_button)
+
+        self._demo_instruction = _WelcomeHeading(
             self._app.localizer._(
                 "View a demonstration of what a Betty site looks like"
             )
         )
-        self.demo_button.setText(self._app.localizer._("View a demo site"))
+        self._demo_instruction.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        central_layout.addWidget(self._demo_instruction)
+
+        self.demo_button = _WelcomeAction(
+            self._app.localizer._("View a demo site"), self
+        )
+        self.demo_button.released.connect(self._demo)
+        central_layout.addWidget(self.demo_button)
 
 
 class _AboutBettyWindow(BettyMainWindow):
@@ -370,16 +352,10 @@ class _AboutBettyWindow(BettyMainWindow):
         self,
         app: App,
         *,
-        parent: QObject | None = None,
+        parent: QWidget | None = None,
     ):
         super().__init__(app, parent=parent)
-        self._label = Text()
-        self._label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.setCentralWidget(self._label)
-
-    def _set_translatables(self) -> None:
-        super()._set_translatables()
-        self._label.setText(
+        self._label = Text(
             "".join(
                 (
                     "<p>%s</p>" % x
@@ -399,6 +375,8 @@ class _AboutBettyWindow(BettyMainWindow):
                 )
             )
         )
+        self._label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.setCentralWidget(self._label)
 
     @override
     @property
@@ -418,7 +396,7 @@ class ApplicationConfiguration(BettyMainWindow):
         self,
         app: App,
         *,
-        parent: QObject | None = None,
+        parent: QWidget | None = None,
     ):
         super().__init__(app, parent=parent)
 

--- a/betty/gui/locale.py
+++ b/betty/gui/locale.py
@@ -4,10 +4,9 @@ Provide locale management for the Graphical User Interface.
 
 from __future__ import annotations
 
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from PyQt6.QtWidgets import QComboBox, QLabel, QWidget
-from typing_extensions import override
 
 from betty.asyncio import wait_to_thread
 from betty.gui.text import Caption
@@ -15,38 +14,15 @@ from betty.locale import negotiate_locale, get_display_name
 
 if TYPE_CHECKING:
     from betty.app import App
-    from PyQt6 import QtGui
 
 
-class LocalizedObject:
-    """
-    A `PyQt6.QtWidgets.QWidget` mix-in to localize widgets, and re-localize them when the locale changes.
-    """
-
-    def __init__(self, app: App, *args: Any, **kwargs: Any):
-        super().__init__(*args, **kwargs)
-        self._app = app
-
-    @override
-    def showEvent(  # type: ignore[misc]
-        self: LocalizedObject & QWidget,
-        a0: QtGui.QShowEvent | None,
-    ) -> None:
-        super().showEvent(a0)  # type: ignore[misc]
-        self._set_translatables()
-        self._app.configuration.on_change(self._set_translatables)
-
-    def _set_translatables(self) -> None:
-        pass
-
-
-class TranslationsLocaleCollector(LocalizedObject):
+class TranslationsLocaleCollector:
     """
     Helps users select a locale for which translations are available.
     """
 
     def __init__(self, app: App, allowed_locales: set[str]):
-        super().__init__(app)
+        self._app = app
         self._allowed_locales = allowed_locales
 
         allowed_locale_names: list[tuple[str, str]] = []
@@ -62,7 +38,8 @@ class TranslationsLocaleCollector(LocalizedObject):
         allowed_locale_names = sorted(allowed_locale_names, key=lambda x: x[1])
 
         def _update_configuration_locale() -> None:
-            self._app.configuration.locale = self._configuration_locale.currentData()
+            self._app.configuration.locale = self.locale
+            self._set_configuration_locale_caption()
 
         self._configuration_locale = QComboBox()
         for i, (locale, locale_name) in enumerate(allowed_locale_names):
@@ -72,18 +49,60 @@ class TranslationsLocaleCollector(LocalizedObject):
         self._configuration_locale.currentIndexChanged.connect(
             _update_configuration_locale
         )
-        self._configuration_locale_label = QLabel()
+        self._configuration_locale_label = QLabel(self._app.localizer._("Locale"))
         self._configuration_locale_caption = Caption()
 
-        self._set_translatables()
-        self._app.configuration.on_change(self._set_translatables)
+        self._set_configuration_locale_caption()
+
+    def _set_configuration_locale_caption(self) -> None:
+        locale = self.locale
+        localizer = self._app.localizer
+        localizers = self._app.localizers
+        translations_locale = negotiate_locale(
+            locale,
+            list(localizers.locales),
+        )
+        if translations_locale is None:
+            self._configuration_locale_caption.setText(
+                localizer._("There are no translations for {locale_name}.").format(
+                    locale_name=get_display_name(locale, localizer.locale),
+                )
+            )
+        else:
+            negotiated_locale_translations_coverage = wait_to_thread(
+                localizers.coverage(translations_locale)
+            )
+            if negotiated_locale_translations_coverage[1] == 0:
+                negotiated_locale_translations_coverage_percentage = 0
+            else:
+                negotiated_locale_translations_coverage_percentage = round(
+                    100
+                    / (
+                        negotiated_locale_translations_coverage[1]
+                        / negotiated_locale_translations_coverage[0]
+                    )
+                )
+            self._configuration_locale_caption.setText(
+                localizer._(
+                    "The translations for {locale_name} are {coverage_percentage}%% complete."
+                ).format(
+                    locale_name=get_display_name(translations_locale, localizer.locale),
+                    coverage_percentage=round(
+                        negotiated_locale_translations_coverage_percentage
+                    ),
+                )
+            )
 
     @property
-    def locale(self) -> QComboBox:
+    def locale(self) -> str:
         """
         The selected locale.
         """
-        return self._configuration_locale
+        return cast(str, self._configuration_locale.currentData())
+
+    @locale.setter
+    def locale(self, locale: str) -> None:
+        self._configuration_locale.setCurrentText(get_display_name(locale))
 
     @property
     def rows(self) -> list[list[QWidget]]:
@@ -94,48 +113,3 @@ class TranslationsLocaleCollector(LocalizedObject):
             [self._configuration_locale_label, self._configuration_locale],
             [self._configuration_locale_caption],
         ]
-
-    @override
-    def _set_translatables(self) -> None:
-        super()._set_translatables()
-        localizer = self._app.localizer
-        localizers = self._app.localizers
-        self._configuration_locale_label.setText(localizer._("Locale"))
-        locale = self.locale.currentData()
-        if locale:
-            translations_locale = negotiate_locale(
-                locale,
-                list(localizers.locales),
-            )
-            if translations_locale is None:
-                self._configuration_locale_caption.setText(
-                    localizer._("There are no translations for {locale_name}.").format(
-                        locale_name=get_display_name(locale, localizer.locale),
-                    )
-                )
-            else:
-                negotiated_locale_translations_coverage = wait_to_thread(
-                    localizers.coverage(translations_locale)
-                )
-                if negotiated_locale_translations_coverage[1] == 0:
-                    negotiated_locale_translations_coverage_percentage = 0
-                else:
-                    negotiated_locale_translations_coverage_percentage = round(
-                        100
-                        / (
-                            negotiated_locale_translations_coverage[1]
-                            / negotiated_locale_translations_coverage[0]
-                        )
-                    )
-                self._configuration_locale_caption.setText(
-                    localizer._(
-                        "The translations for {locale_name} are {coverage_percentage}%% complete."
-                    ).format(
-                        locale_name=get_display_name(
-                            translations_locale, localizer.locale
-                        ),
-                        coverage_percentage=round(
-                            negotiated_locale_translations_coverage_percentage
-                        ),
-                    )
-                )

--- a/betty/gui/serve.py
+++ b/betty/gui/serve.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import asyncio
 from typing import final, TYPE_CHECKING
 
-from PyQt6.QtCore import Qt, pyqtSignal, QObject, QThread
+from PyQt6.QtCore import Qt, pyqtSignal, QThread
 from PyQt6.QtWidgets import QVBoxLayout, QWidget, QPushButton
 from typing_extensions import override
 
@@ -59,7 +59,7 @@ class _ServeWindow(BettyMainWindow):
         self,
         app: App,
         *,
-        parent: QObject | None = None,
+        parent: QWidget | None = None,
     ):
         super().__init__(app, parent=parent)
         self.server_started.connect(self._server_started)

--- a/betty/gui/window.py
+++ b/betty/gui/window.py
@@ -8,18 +8,15 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from PyQt6.QtGui import QIcon
-from PyQt6.QtWidgets import QApplication, QMainWindow
+from PyQt6.QtWidgets import QApplication, QMainWindow, QWidget
 from typing_extensions import override
-
-from betty.gui.locale import LocalizedObject
 
 if TYPE_CHECKING:
     from betty.locale import Localizable
     from betty.app import App
-    from PyQt6.QtCore import QObject
 
 
-class BettyMainWindow(LocalizedObject, QMainWindow):
+class BettyMainWindow(QMainWindow):
     """
     A generic window.
     """
@@ -34,9 +31,10 @@ class BettyMainWindow(LocalizedObject, QMainWindow):
         self,
         app: App,
         *,
-        parent: QObject | None = None,
+        parent: QWidget | None = None,
     ):
-        super().__init__(app, parent)
+        super().__init__(parent)
+        self._app = app
         self.resize(self.window_width, self.window_height)
         self.setWindowIcon(
             QIcon(
@@ -54,9 +52,6 @@ class BettyMainWindow(LocalizedObject, QMainWindow):
         assert screen is not None
         geometry.moveCenter(screen.availableGeometry().center())
         self.move(geometry.topLeft())
-
-    @override
-    def _set_translatables(self) -> None:
         self.setWindowTitle(
             f"{self.window_title.localize(self._app.localizer)} - Betty"
         )

--- a/betty/jinja2/__init__.py
+++ b/betty/jinja2/__init__.py
@@ -42,7 +42,7 @@ def context_app(context: Context) -> App:
     """
     Get the current app from the Jinja2 context.
     """
-    return cast(Environment, context.environment).app  # type: ignore[has-type, no-any-return]
+    return cast(Environment, context.environment).app
 
 
 def context_job_context(context: Context) -> JobContext | None:

--- a/betty/project.py
+++ b/betty/project.py
@@ -1005,11 +1005,13 @@ class Project(Configurable[ProjectConfiguration]):
 
     def __init__(
         self,
+        configuration: ProjectConfiguration,
         *,
         ancestry: Ancestry | None = None,
     ):
         super().__init__()
-        self._configuration = ProjectConfiguration()
+        self._configuration = configuration
+        configuration.mutable = False
         self._ancestry = Ancestry() if ancestry is None else ancestry
 
     @property

--- a/betty/tests/__init__.py
+++ b/betty/tests/__init__.py
@@ -67,17 +67,18 @@ class TemplateTestCase:
             raise RuntimeError(
                 f"You must define one of `template_string`, `template_file`, `{class_name}.template_string`, or `{class_name}.template_file`."
             )
-        async with App.new_temporary() as app, app:
+        async with App.new_temporary() as app:
             app.project.configuration.debug = True
-            if data is None:
-                data = {}
-            if locale is not None:
-                data["localizer"] = await app.localizers.get(locale)
             app.project.configuration.extensions.enable(*self.extensions)
-            rendered = await template_factory(
-                app.jinja2_environment, template
-            ).render_async(**data)
-            yield rendered, app
+            async with app:
+                if data is None:
+                    data = {}
+                if locale is not None:
+                    data["localizer"] = await app.localizers.get(locale)
+                rendered = await template_factory(
+                    app.jinja2_environment, template
+                ).render_async(**data)
+                yield rendered, app
 
 
 async def assert_betty_html(

--- a/betty/tests/app/test___init__.py
+++ b/betty/tests/app/test___init__.py
@@ -229,26 +229,28 @@ class TestApp:
             assert len(carrier) == 1
             assert isinstance(carrier[0], ComesAfterNonConfigurableExtensionExtension)
 
-    async def test_extensions_addition_to_configuration(self) -> None:
-        async with App.new_temporary() as sut, sut:
-            # Get the extensions before making configuration changes to warm the cache.
-            sut.extensions  # noqa B018
-            sut.project.configuration.extensions.append(
-                ExtensionConfiguration(NonConfigurableExtension)
-            )
-            assert isinstance(
-                sut.extensions[NonConfigurableExtension], NonConfigurableExtension
-            )
+    # @todo Enable this again as part of https://github.com/bartfeenstra/betty/issues/1625
+    # async def test_extensions_addition_to_configuration(self) -> None:
+    #     async with App.new_temporary() as sut, sut:
+    #         # Get the extensions before making configuration changes to warm the cache.
+    #         sut.extensions  # noqa B018
+    #         sut.project.configuration.extensions.append(
+    #             ExtensionConfiguration(NonConfigurableExtension)
+    #         )
+    #         assert isinstance(
+    #             sut.extensions[NonConfigurableExtension], NonConfigurableExtension
+    #         )
 
-    async def test_extensions_removal_from_configuration(self) -> None:
-        async with App.new_temporary() as sut, sut:
-            sut.project.configuration.extensions.append(
-                ExtensionConfiguration(NonConfigurableExtension)
-            )
-            # Get the extensions before making configuration changes to warm the cache.
-            sut.extensions  # noqa B018
-            del sut.project.configuration.extensions[NonConfigurableExtension]
-            assert NonConfigurableExtension not in sut.extensions
+    # @todo Enable this again as part of https://github.com/bartfeenstra/betty/issues/1625
+    # async def test_extensions_removal_from_configuration(self) -> None:
+    #     async with App.new_temporary() as sut, sut:
+    #         sut.project.configuration.extensions.append(
+    #             ExtensionConfiguration(NonConfigurableExtension)
+    #         )
+    #         # Get the extensions before making configuration changes to warm the cache.
+    #         sut.extensions  # noqa B018
+    #         del sut.project.configuration.extensions[NonConfigurableExtension]
+    #         assert NonConfigurableExtension not in sut.extensions
 
     async def test_fetcher(self) -> None:
         async with App.new_temporary() as sut, sut:

--- a/betty/tests/conftest.py
+++ b/betty/tests/conftest.py
@@ -25,6 +25,7 @@ from betty.cache.file import BinaryFileCache
 from betty.gui import BettyApplication
 from betty.gui.error import ExceptionError
 from betty.locale import DEFAULT_LOCALIZER
+from betty.project import Project
 from betty.warnings import BettyDeprecationWarning
 
 if TYPE_CHECKING:
@@ -67,6 +68,14 @@ async def new_temporary_app() -> AsyncIterator[App]:
     """
     async with App.new_temporary() as app, app:
         yield app
+
+
+@pytest.fixture()
+async def new_temporary_project(new_temporary_app: App) -> AsyncIterator[Project]:
+    """
+    Create a new, temporary :py:class:`betty.project.Project`.
+    """
+    yield app.project
 
 
 _QObjectT = TypeVar("_QObjectT", bound=QObject)

--- a/betty/tests/coverage/test_coverage.py
+++ b/betty/tests/coverage/test_coverage.py
@@ -176,7 +176,6 @@ _BASELINE: Mapping[str, _ModuleIgnore] = {
         },
         "FileBasedConfiguration": {
             "__del__": TestKnownToBeMissing,
-            "autowrite": TestKnownToBeMissing,
             "read": TestKnownToBeMissing,
             "write": TestKnownToBeMissing,
         },
@@ -344,9 +343,7 @@ _BASELINE: Mapping[str, _ModuleIgnore] = {
     },
     "betty/gui/__init__.py": TestKnownToBeMissing,
     "betty/gui/app.py": {
-        "ApplicationConfiguration": {
-            "window_title": TestKnownToBeMissing,
-        },
+        "ApplicationConfiguration": TestKnownToBeMissing,
         "BettyPrimaryWindow": {
             "new_project": TestKnownToBeMissing,
             "open_application_configuration": TestKnownToBeMissing,

--- a/betty/tests/gui/test_app.py
+++ b/betty/tests/gui/test_app.py
@@ -1,14 +1,11 @@
-import json
 from pathlib import Path
 
-import aiofiles
 from PyQt6.QtWidgets import QFileDialog
 from pytest_mock import MockerFixture
 
 from betty.gui.app import (
     WelcomeWindow,
     _AboutBettyWindow,
-    ApplicationConfiguration,
     BettyPrimaryWindow,
 )
 from betty.gui.project import ProjectWindow
@@ -123,24 +120,3 @@ class TestWelcomeWindow:
         betty_qtbot.mouse_click(sut.demo_button)
 
         betty_qtbot.assert_window(ServeDemoWindow)
-
-
-class TestApplicationConfiguration:
-    async def test_application_configuration_autowrite(
-        self, betty_qtbot: BettyQtBot
-    ) -> None:
-        betty_qtbot.app.configuration.autowrite = True
-
-        sut = ApplicationConfiguration(betty_qtbot.app)
-        betty_qtbot.qtbot.addWidget(sut)
-        sut.show()
-
-        locale = "nl-NL"
-        betty_qtbot.app.configuration.locale = locale
-
-        async with aiofiles.open(
-            betty_qtbot.app.configuration.configuration_file_path
-        ) as f:
-            read_configuration_dump = json.loads(await f.read())
-        assert read_configuration_dump == betty_qtbot.app.configuration.dump()
-        assert read_configuration_dump["locale"] == locale

--- a/betty/tests/test_project.py
+++ b/betty/tests/test_project.py
@@ -19,6 +19,8 @@ from betty.project import (
     EntityReferenceSequence,
     EntityTypeConfiguration,
     EntityTypeConfigurationMapping,
+    ProjectAwareMixin,
+    Project,
 )
 from betty.serde.error import SerdeError
 from betty.serde.load import (
@@ -1130,3 +1132,13 @@ class DummyConfigurableExtension(
     @classmethod
     def default_configuration(cls) -> DummyConfigurableExtensionConfiguration:
         return DummyConfigurableExtensionConfiguration()
+
+
+class TestProjectAwareMixin:
+    async def test_project(self) -> None:
+        init_project = Project()
+        setter_project = Project()
+        sut = ProjectAwareMixin(init_project)
+        assert sut.project == init_project
+        sut.project = setter_project
+        assert sut.project == setter_project


### PR DESCRIPTION
## To do
- Consider fixing https://github.com/bartfeenstra/betty/issues/1145 here as well
- Add a message to the App configuration GUI window that changes will not take effect until the app is reloaded?
- Add a method to `ProjectWindow` to trigger a project change.
- Ensure configuration widgets receive this event. How to propagate this simply and easily? Given grandparent, parent, and child widgets where only the grandparent and (grand)child are `ProjectAwareMixin`, how to set the new project?
- Add `Configuration.update_transaction()` (name tbd) that is a context manager