### PR TITLE
`FileBasedConfiguration` must no longer create its own project directories

### DIFF
--- a/betty/app/__init__.py
+++ b/betty/app/__init__.py
@@ -97,31 +97,20 @@ class AppConfiguration(FileBasedConfiguration):
 
     def __init__(
         self,
-        configuration_directory_path: Path | None = None,
+        configuration_file_path: Path,
         *,
         locale: str | None = None,
     ):
-        if configuration_directory_path is None:
-            deprecate(
-                f"Initializing {type(self)} without a configuration directory path is deprecated as of Betty 0.3.3, and will be removed in Betty 0.4.x.",
-                stacklevel=2,
-            )
-            configuration_directory_path = CONFIGURATION_DIRECTORY_PATH
-        super().__init__()
-        self._configuration_directory_path = configuration_directory_path
+        super().__init__(configuration_file_path)
         self._locale: str | None = locale
 
     @override
     @property
     def configuration_file_path(self) -> Path:
-        return self._configuration_directory_path / "app.json"
+        return self._configuration_file_path
 
     @configuration_file_path.setter
     def configuration_file_path(self, __: Path) -> None:
-        pass
-
-    @configuration_file_path.deleter
-    def configuration_file_path(self) -> None:
         pass
 
     @property
@@ -171,7 +160,7 @@ class App(Configurable[AppConfiguration]):
         self,
         configuration: AppConfiguration,
         cache_directory_path: Path,
-        project: Project | None = None,
+        project: Project,
     ):
         super().__init__()
         self._started = False
@@ -185,7 +174,7 @@ class App(Configurable[AppConfiguration]):
         self._localizers: LocalizerRepository | None = None
         with suppress(FileNotFoundError):
             wait_to_thread(self.configuration.read())
-        self._project = project or Project()
+        self._project = project
         self.project.configuration.extensions.on_change(self._update_extensions)
 
         self._dispatcher: ExtensionDispatcher | None = None
@@ -230,7 +219,7 @@ class App(Configurable[AppConfiguration]):
         Create a new application from an existing application.
         """
         yield cls(
-            AppConfiguration(app.configuration._configuration_directory_path),
+            AppConfiguration(app.configuration.configuration_file_path),
             app._cache_directory_path,
             app.project if project is None else project,
         )

--- a/betty/config.py
+++ b/betty/config.py
@@ -111,7 +111,8 @@ class FileBasedConfiguration(Configuration):
 
     def __init__(self, configuration_file_path: Path):
         super().__init__()
-        self._configuration_file_path = configuration_file_path
+        self._autowrite = False
+        self.configuration_file_path = configuration_file_path
 
     @property
     def autowrite(self) -> bool:
@@ -194,13 +195,6 @@ class FileBasedConfiguration(Configuration):
                     )
                 )
 
-    def __del__(self) -> None:
-        if (
-            hasattr(self, "_configuration_directory")
-            and self._configuration_directory is not None
-        ):
-            self._configuration_directory.cleanup()
-
     @property
     def configuration_file_path(self) -> Path:
         """
@@ -215,14 +209,6 @@ class FileBasedConfiguration(Configuration):
         formats = FormatRepository()
         formats.format_for(configuration_file_path.suffix[1:])
         self._configuration_file_path = configuration_file_path
-
-    @configuration_file_path.deleter
-    def configuration_file_path(self) -> None:
-        if self._autowrite:
-            raise RuntimeError(
-                "Cannot remove the configuration file path while autowrite is enabled."
-            )
-        self._configuration_file_path = None
 
 
 ConfigurationKey: TypeAlias = SupportsIndex | Hashable | type[Any]

--- a/betty/config.py
+++ b/betty/config.py
@@ -11,7 +11,6 @@ from collections.abc import Callable
 from contextlib import chdir
 from pathlib import Path
 from reprlib import recursive_repr
-from tempfile import TemporaryDirectory
 from typing import (
     Generic,
     Iterable,
@@ -24,7 +23,6 @@ from typing import (
     Any,
     Sequence,
     overload,
-    cast,
     Self,
     TypeAlias,
     TYPE_CHECKING,
@@ -111,11 +109,9 @@ class FileBasedConfiguration(Configuration):
     Any configuration that is stored in a file on disk.
     """
 
-    def __init__(self):
+    def __init__(self, configuration_file_path: Path):
         super().__init__()
-        self._configuration_directory: TemporaryDirectory | None = None  # type: ignore[type-arg]
-        self._configuration_file_path: Path | None = None
-        self._autowrite = False
+        self._configuration_file_path = configuration_file_path
 
     @property
     def autowrite(self) -> bool:
@@ -210,16 +206,7 @@ class FileBasedConfiguration(Configuration):
         """
         The path to the configuration's file.
         """
-        if self._configuration_file_path is None:
-            if self._configuration_directory is None:
-                self._configuration_directory = TemporaryDirectory()
-            wait_to_thread(
-                self._write(
-                    Path(self._configuration_directory.name)
-                    / f"{type(self).__name__}.json"
-                )
-            )
-        return cast(Path, self._configuration_file_path)
+        return self._configuration_file_path
 
     @configuration_file_path.setter
     def configuration_file_path(self, configuration_file_path: Path) -> None:

--- a/betty/project.py
+++ b/betty/project.py
@@ -736,7 +736,7 @@ class ProjectConfiguration(FileBasedConfiguration):
         lifetime_threshold: int = DEFAULT_LIFETIME_THRESHOLD,
         name: str | None = None,
     ):
-        super().__init__()
+        super().__init__(configuration_file_path)
         self._name = name
         self._computed_name: str | None = None
         self._base_url = "https://example.com" if base_url is None else base_url

--- a/betty/tests/conftest.py
+++ b/betty/tests/conftest.py
@@ -25,6 +25,7 @@ from betty.cache.file import BinaryFileCache
 from betty.gui import BettyApplication
 from betty.gui.error import ExceptionError
 from betty.locale import DEFAULT_LOCALIZER
+from betty.project import Project
 from betty.warnings import BettyDeprecationWarning
 
 if TYPE_CHECKING:
@@ -61,12 +62,21 @@ def qapp_cls() -> type[BettyApplication]:
 
 
 @pytest.fixture()
-async def new_temporary_app() -> AsyncIterator[App]:
+async def new_temporary_app(new_temporary_project: Project) -> AsyncIterator[App]:
     """
     Create a new, temporary :py:class:`betty.app.App`.
     """
-    async with App.new_temporary() as app, app:
+    async with App.new_temporary(project=new_temporary_project) as app, app:
         yield app
+
+
+@pytest.fixture()
+async def new_temporary_project() -> AsyncIterator[Project]:
+    """
+    Create a new, temporary :py:class:`betty.project.Project`.
+    """
+    async with Project.new_temporary() as project, project:
+        yield project
 
 
 _QObjectT = TypeVar("_QObjectT", bound=QObject)


### PR DESCRIPTION
## Proposals
- ProjectConfiguration should receive a project directory path OR a configuration file path. `project_path`?