### PR TITLE
Fix bugs where translation coverage percentages and a link were not displayed correctly

### DIFF
--- a/betty/sphinx/extension/replacements.py
+++ b/betty/sphinx/extension/replacements.py
@@ -9,9 +9,6 @@ def render_replacements(app: Sphinx, docname: str, source: list[str]) -> None:
     """
     Handle Sphinx's source-read event to perform string replacements.
     """
-    if app.builder.format != "html":
-        return
-
     for token_name, value in app.env.config["html_context"][
         "betty_replacements"
     ].items():

--- a/documentation/usage.rst
+++ b/documentation/usage.rst
@@ -21,4 +21,3 @@ In this section
 - :doc:`/usage/assets`
 - :doc:`/usage/templating`
 - :doc:`/usage/translation`
-- :doc:`/usage/plugin`

--- a/documentation/usage/translation.rst
+++ b/documentation/usage/translation.rst
@@ -14,7 +14,7 @@ German (``de-DE``)
 Ukrainian (``uk``)
     Translations are {{{ translation-coverage-uk }}}% complete.
 
-Extensions and projects can override these translations through :doc:`asset management </usage/assets>`_.
+Extensions and projects can override these translations through :doc:`asset management </usage/assets>`.
 
 Betty uses `gettext <https://www.gnu.org/software/gettext/>`_ to manage its translations. For each language, there must
 be a ``./locale/$locale/LC_MESSAGES/betty.po`` file that contains the translations for that language. These translations


### PR DESCRIPTION
Fix bugs where translation coverage percentages and a link were not displayed correctly on the translations usage documentation page