### PR TITLE
Automatically localize Localizables in Jinja2 templates

### DIFF
--- a/betty/assets/public/localized/index.html.j2
+++ b/betty/assets/public/localized/index.html.j2
@@ -1,6 +1,6 @@
 {% extends 'base.html.j2' %}
 {% set page_title %}
-    {% trans project_title=project.configuration.title | localize %}
+    {% trans project_title=project.configuration.title %}
         Welcome to {{ project_title }}
     {% endtrans %}
 {% endset %}

--- a/betty/assets/public/static/index.html.j2
+++ b/betty/assets/public/static/index.html.j2
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-    <title>{{ project.configuration.title | localize }}</title>
+    <title>{{ project.configuration.title }}</title>
     <meta http-equiv="refresh" content="0; url={{ '/index.html' | url(locale=project.configuration.locales.default.locale) }}">
 </head>
 <body>

--- a/betty/assets/templates/entity/page.html.j2
+++ b/betty/assets/templates/entity/page.html.j2
@@ -2,7 +2,7 @@
 {% set page_title = entity.label | localize %}
 {% set entity_contexts = entity_contexts(entity) %}
 {% do breadcrumbs.append(
-    entity_type.plugin_label_plural() | localize,
+    entity_type.plugin_label_plural(),
     entity_type.plugin_id() | url(absolute=true)
 ) %}
 {% do breadcrumbs.append(

--- a/betty/assets/templates/head.html.j2
+++ b/betty/assets/templates/head.html.j2
@@ -1,12 +1,12 @@
-<title>{% if page_title is defined %}{{ page_title | striptags }} - {% endif %}{{ project.configuration.title | localize }}</title>
+<title>{{ project.configuration.title }}</title>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="generator" content="Betty (https://betty.readthedocs.io)">
 {% if project.configuration.author %}
-    <meta name="author" content="{{ project.configuration.author | localize }}">
+    <meta name="author" content="{{ project.configuration.author }}">
 {% endif %}
 <meta name="og:title" content="{{ page_title | default(project.configuration.title | localize) | striptags }}">
-<meta name="og:site_name" content="{{ project.configuration.title | localize }}">
+<meta name="og:site_name" content="{{ project.configuration.title }}">
 <meta name="twitter:title" content="{{ page_title | default(project.configuration.title | localize) | striptags }}">
 <meta name="twitter:card" content="summary_large_image">
 {% if page_resource is defined %}

--- a/betty/extension/cotton_candy/assets/public/localized/index.html.j2
+++ b/betty/extension/cotton_candy/assets/public/localized/index.html.j2
@@ -1,6 +1,6 @@
 {% extends 'base.html.j2' %}
 {% set page_title %}
-    {% trans project_title=project.configuration.title | localize %}
+    {% trans project_title=project.configuration.title %}
         Welcome to {{ project_title }}
     {% endtrans %}
 {% endset %}

--- a/betty/extension/cotton_candy/assets/templates/base.html.j2
+++ b/betty/extension/cotton_candy/assets/templates/base.html.j2
@@ -11,7 +11,7 @@
 </script>
 <div id="page">
     <nav id="nav-primary">
-        <a id="site-title" href="{{ '/index.html' | url }}" title="{{ project.configuration.title | localize }}">{{ project.configuration.title | localize }}</a>
+        <a id="site-title" href="{{ '/index.html' | url }}" title="{{ project.configuration.title }}">{{ project.configuration.title }}</a>
         <div id="search"
              data-betty-search-index="{{ '/search-index.json' | url }}">
             <div class="overlay-controls">
@@ -22,7 +22,7 @@
                 {% if search_keywords_example_person_name %}
                     {% set search_keywords_example -%}
                         {% filter forceescape %}
-                            {% trans example = search_keywords_example_person_name.label | localize -%}
+                            {% trans example = search_keywords_example_person_name.label -%}
                                 E.g. "{{ example }}"
                             {%- endtrans %}
                         {% endfilter %}
@@ -53,7 +53,7 @@
                                 {% if entity_type_configuration.entity_type.plugin_id() == 'event' %}
                                     {% trans %}Timeline{% endtrans %}
                                 {% else %}
-                                    {{ entity_type_configuration.entity_type.plugin_label_plural() | localize }}
+                                    {{ entity_type_configuration.entity_type.plugin_label_plural() }}
                                 {% endif %}
                             </a>
                         </li>

--- a/betty/extension/cotton_candy/assets/templates/entity/label--citation.html.j2
+++ b/betty/extension/cotton_candy/assets/templates/entity/label--citation.html.j2
@@ -17,7 +17,7 @@
     {% endif %}
     {%- if citation.public -%}
         {%- if citation.location -%}
-                {% set location = citation.location | localize %}
+                {% set location = citation.location %}
                 <span class="citation-location">
                     {% if citation_context == citation %}
                         {{ location }}

--- a/betty/extension/cotton_candy/assets/templates/entity/label--event.html.j2
+++ b/betty/extension/cotton_candy/assets/templates/entity/label--event.html.j2
@@ -4,7 +4,7 @@
 {%- macro person_label(person) -%}
     {% include 'entity/label--person.html.j2' %}
 {%- endmacro -%}
-{%- set formatted_event = event.event_type.plugin_label() | localize -%}
+{%- set formatted_event = event.event_type.plugin_label() -%}
 {%- if event is not has_generated_entity_id and not embedded -%}
     {% set formatted_event = ('<a href="' + event | url + '">' + formatted_event + '</a>') | safe %}
 {%- endif -%}

--- a/betty/extension/cotton_candy/assets/templates/entity/label.html.j2
+++ b/betty/extension/cotton_candy/assets/templates/entity/label.html.j2
@@ -2,7 +2,7 @@
 {%- if not embedded and entity is public and entity is not has_generated_entity_id -%}
     <a href="{{ entity | url }}">
 {%- endif -%}
-{{ entity.label | localize }}
+{{ entity.label }}
 {%- if not embedded and entity is public and entity is not has_generated_entity_id -%}
     </a>
 {%- endif -%}

--- a/betty/extension/cotton_candy/assets/templates/entity/meta--person.html.j2
+++ b/betty/extension/cotton_candy/assets/templates/entity/meta--person.html.j2
@@ -40,10 +40,10 @@
         {%- if formatted_start is defined or formatted_end is defined -%}
             <dl>
                 {%- if formatted_start is defined -%}
-                    <div><dt>{{ start_of_life_event.event_type.plugin_label() | localize }}</dt><dd>{{ formatted_start }}</dd></div>
+                    <div><dt>{{ start_of_life_event.event_type.plugin_label() }}</dt><dd>{{ formatted_start }}</dd></div>
                 {%- endif -%}
                 {%- if formatted_end is defined -%}
-                    <div><dt>{{ end_of_life_event.event_type.plugin_label() | localize }}</dt><dd>{{ formatted_end }}</dd></div>
+                    <div><dt>{{ end_of_life_event.event_type.plugin_label() }}</dt><dd>{{ formatted_end }}</dd></div>
                 {%- endif -%}
             </dl>
         {%- endif -%}

--- a/betty/extension/cotton_candy/assets/templates/entity/page--citation.html.j2
+++ b/betty/extension/cotton_candy/assets/templates/entity/page--citation.html.j2
@@ -1,6 +1,6 @@
 {% extends 'entity/page.html.j2' %}
 {% set citation = citation | default(entity) %}
-{% set page_title = citation.location %}
+{% set page_title = citation.label | localize %}
 {% block page_content %}
     <div class="meta">
     {% include 'entity/meta--citation.html.j2' %}

--- a/betty/extension/cotton_candy/assets/templates/footer.html.j2
+++ b/betty/extension/cotton_candy/assets/templates/footer.html.j2
@@ -1,6 +1,6 @@
 {% if project.configuration.author %}
     <p>
-        {% trans author = project.configuration.author | localize %}© Copyright {{ author }}, unless otherwise credited{% endtrans %}
+        {% trans author = project.configuration.author %}© Copyright {{ author }}, unless otherwise credited{% endtrans %}
     </p>
 {% endif %}
 <p>{% trans %}A family history as told by <a href="https://github.com/bartfeenstra/betty">Betty👵</a>{% endtrans %}</p>

--- a/betty/extension/http_api_doc/assets/public/static/api/index.html.j2
+++ b/betty/extension/http_api_doc/assets/public/static/api/index.html.j2
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>{% trans %}API documentation{% endtrans %} - {{ project.configuration.title | localize }}</title>
+    <title>{% trans %}API documentation{% endtrans %} - {{ project.configuration.title }}</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">

--- a/betty/extension/trees/assets/public/localized/people.json.j2
+++ b/betty/extension/trees/assets/public/localized/people.json.j2
@@ -1,7 +1,7 @@
 {% set ns = namespace(people={}) %}
 {% for person in project.ancestry['person'] %}
     {% if person.public %}
-        {% set person_label = person.label | localize %}
+        {% set person_label = person.label %}
     {% else %}
         {% set person_label = _('private') %}
     {% endif %}

--- a/betty/locale/localizable/__init__.py
+++ b/betty/locale/localizable/__init__.py
@@ -30,6 +30,10 @@ class Localizable(ABC):
     @override
     def __str__(self) -> str:
         localized = self.localize(DEFAULT_LOCALIZER)
+        # @todo
+        print("remove this")
+        print([type(self), localized])
+        raise RuntimeError(self)
         warn(
             f'{type(self)} ("{localized}") SHOULD NOT be cast to a string. Instead, call {type(self)}.localize() to ensure it is always formatted in the desired locale.',
             stacklevel=2,


### PR DESCRIPTION
## Drawbacks
This is when printing values only. When passing them on as arguments to filters or tests, they remain unlocalized and **must** be used with the `localize` filter. These two types of behaviors are inconsistent and confusing.