### PR TITLE
Allow `assert_mapping()` and `assert_sequence()` to be used with and without item assertions

### DIFF
--- a/betty/assets/locale/betty.pot
+++ b/betty/assets/locale/betty.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-08-04 18:34+0100\n"
+"POT-Creation-Date: 2024-08-04 19:38+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -629,9 +629,6 @@ msgid "This must be a decimal number."
 msgstr ""
 
 msgid "This must be a key-value mapping."
-msgstr ""
-
-msgid "This must be a list."
 msgstr ""
 
 msgid "This must be a positive number."

--- a/betty/assets/locale/de-DE/betty.po
+++ b/betty/assets/locale/de-DE/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-08-04 18:34+0100\n"
+"POT-Creation-Date: 2024-08-04 19:38+0100\n"
 "PO-Revision-Date: 2024-02-08 13:24+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: de\n"
@@ -796,15 +796,11 @@ msgstr "Es muss eine Dezimalzahl sein."
 msgid "This must be a key-value mapping."
 msgstr "Es muss ein Key-Value Paar sein."
 
-msgid "This must be a list."
-msgstr "Es muss eine Liste sein."
-
 msgid "This must be a positive number."
 msgstr "Es muss einen positive Zahl sein."
 
-#, fuzzy
 msgid "This must be a sequence."
-msgstr "Es muss ein Text-String sein."
+msgstr ""
 
 msgid "This must be a string."
 msgstr "Es muss ein Text-String sein."

--- a/betty/assets/locale/fr-FR/betty.po
+++ b/betty/assets/locale/fr-FR/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-08-04 18:34+0100\n"
+"POT-Creation-Date: 2024-08-04 19:38+0100\n"
 "PO-Revision-Date: 2024-02-08 13:24+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: fr\n"
@@ -718,9 +718,6 @@ msgid "This must be a decimal number."
 msgstr ""
 
 msgid "This must be a key-value mapping."
-msgstr ""
-
-msgid "This must be a list."
 msgstr ""
 
 msgid "This must be a positive number."

--- a/betty/assets/locale/nl-NL/betty.po
+++ b/betty/assets/locale/nl-NL/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-08-04 18:34+0100\n"
+"POT-Creation-Date: 2024-08-04 19:38+0100\n"
 "PO-Revision-Date: 2024-02-11 15:31+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: nl\n"
@@ -191,10 +191,14 @@ msgid "Appearances"
 msgstr "Verschijningen"
 
 msgid "At least {expected} items are required, but found {actual}."
-msgstr "Minimaal {expected} items zijn vereist, maar er waren er {actual} gevonden."
+msgstr ""
+"Minimaal {expected} items zijn vereist, maar er waren er {actual} "
+"gevonden."
 
 msgid "At most {expected} items are allowed, but found {actual}."
-msgstr "Maximaal {expected} items zijn toegestaan, maar er waren er {actual} gevonden."
+msgstr ""
+"Maximaal {expected} items zijn toegestaan, maar er waren er {actual} "
+"gevonden."
 
 msgid "At which URL will your site be published?"
 msgstr "Op welke URL wordt je site gepubliceerd?"
@@ -806,15 +810,11 @@ msgstr "Dit moet een decimaal getal zijn."
 msgid "This must be a key-value mapping."
 msgstr "Dit moet een sleutel-waardetoewijzing zijn."
 
-msgid "This must be a list."
-msgstr "Dit moet een lijst zijn."
-
 msgid "This must be a positive number."
 msgstr "Dit moet een positief getal zijn."
 
-#, fuzzy
 msgid "This must be a sequence."
-msgstr "Dit moet een tekenreeks zijn."
+msgstr "Dit moet een reeks zijn."
 
 msgid "This must be a string."
 msgstr "Dit moet een tekenreeks zijn."

--- a/betty/assets/locale/uk/betty.po
+++ b/betty/assets/locale/uk/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-08-04 18:34+0100\n"
+"POT-Creation-Date: 2024-08-04 19:38+0100\n"
 "PO-Revision-Date: 2024-02-08 13:08+0000\n"
 "Last-Translator: Rainer Thieringer <rainerthi@gmail.com>\n"
 "Language: uk\n"
@@ -720,9 +720,6 @@ msgid "This must be a decimal number."
 msgstr ""
 
 msgid "This must be a key-value mapping."
-msgstr ""
-
-msgid "This must be a list."
 msgstr ""
 
 msgid "This must be a positive number."

--- a/betty/config/collections/mapping.py
+++ b/betty/config/collections/mapping.py
@@ -17,7 +17,7 @@ from typing import (
 
 from typing_extensions import override
 
-from betty.assertion import assert_sequence, assert_dict
+from betty.assertion import assert_sequence, assert_mapping
 from betty.config import Configuration
 from betty.config.collections import ConfigurationCollection, ConfigurationKey
 from betty.serde.dump import Dump, VoidableDump, minimize
@@ -97,7 +97,7 @@ class ConfigurationMapping(
             *assert_sequence(self.load_item)(
                 [
                     self._load_key(item_value_dump, item_key_dump)
-                    for item_key_dump, item_value_dump in assert_dict()(dump).items()
+                    for item_key_dump, item_value_dump in assert_mapping()(dump).items()
                 ]
             )
         )

--- a/betty/project/__init__.py
+++ b/betty/project/__init__.py
@@ -30,6 +30,7 @@ from typing_extensions import override
 
 from betty import fs, event_dispatcher
 from betty import model
+from betty.ancestry import Ancestry, Person, Event, Place, Source
 from betty.assertion import (
     Assertion,
     RequiredField,
@@ -38,11 +39,11 @@ from betty.assertion import (
     assert_setattr,
     assert_str,
     assert_bool,
-    assert_dict,
     assert_locale,
     assert_int,
     assert_positive_number,
     assert_fields,
+    assert_mapping,
 )
 from betty.assertion.error import AssertionFailed
 from betty.assets import AssetRepository
@@ -64,7 +65,6 @@ from betty.locale.localizable.config import (
 )
 from betty.locale.localizer import LocalizerRepository
 from betty.model import Entity, UserFacingEntity
-from betty.ancestry import Ancestry, Person, Event, Place, Source
 from betty.plugin.assertion import assert_plugin
 from betty.project import extension
 from betty.project.extension import (
@@ -416,10 +416,10 @@ class ExtensionConfigurationMapping(
 
     @override
     def load_item(self, dump: Dump) -> ExtensionConfiguration:
-        dict_dump = assert_fields(
+        fields_dump = assert_fields(
             RequiredField("extension", assert_plugin(extension.EXTENSION_REPOSITORY))
         )(dump)
-        configuration = ExtensionConfiguration(dict_dump["extension"])
+        configuration = ExtensionConfiguration(fields_dump["extension"])
         configuration.load(dump)
         return configuration
 
@@ -433,14 +433,14 @@ class ExtensionConfigurationMapping(
         item_dump: Dump,
         key_dump: str,
     ) -> Dump:
-        dict_dump = assert_dict()(item_dump)
-        dict_dump["extension"] = key_dump
-        return dict_dump
+        mapping_dump = dict(assert_mapping()(item_dump))
+        mapping_dump["extension"] = key_dump
+        return mapping_dump
 
     @override
     def _dump_key(self, item_dump: VoidableDump) -> tuple[VoidableDump, str]:
-        dict_dump = assert_dict()(item_dump)
-        return dict_dump, dict_dump.pop("extension")
+        mapping_dump = dict(assert_mapping()(item_dump))
+        return mapping_dump, mapping_dump.pop("extension")
 
     def enable(self, *extension_types: type[Extension]) -> None:
         """
@@ -565,15 +565,15 @@ class EntityTypeConfigurationMapping(
         item_dump: Dump,
         key_dump: str,
     ) -> Dump:
-        dict_dump = assert_dict()(item_dump)
+        mapping_dump = dict(assert_mapping()(item_dump))
         assert_plugin(model.ENTITY_TYPE_REPOSITORY)(key_dump)
-        dict_dump["entity_type"] = key_dump
-        return dict_dump
+        mapping_dump["entity_type"] = key_dump
+        return mapping_dump
 
     @override
     def _dump_key(self, item_dump: VoidableDump) -> tuple[VoidableDump, str]:
-        dict_dump = assert_dict()(item_dump)
-        return dict_dump, dict_dump.pop("entity_type")
+        mapping_dump = dict(assert_mapping()(item_dump))
+        return mapping_dump, mapping_dump.pop("entity_type")
 
     @override
     def load_item(self, dump: Dump) -> EntityTypeConfiguration:

--- a/betty/tests/assertion/test___init__.py
+++ b/betty/tests/assertion/test___init__.py
@@ -23,10 +23,8 @@ from betty.assertion import (
     assert_float,
     assert_positive_number,
     assert_number,
-    assert_list,
     assert_mapping,
     assert_sequence,
-    assert_dict,
     assert_fields,
     assert_field,
     assert_file_path,
@@ -170,15 +168,6 @@ class TestAssertStr:
             assert_str()(False)
 
 
-class TestAssertList:
-    async def test_with_list(self) -> None:
-        assert_list()([])
-
-    async def test_without_list(self) -> None:
-        with raises_error(error_type=AssertionFailed):
-            assert_list()(False)
-
-
 class TestAssertSequence:
     async def test_without_list(self) -> None:
         with raises_error(error_type=AssertionFailed):
@@ -193,15 +182,6 @@ class TestAssertSequence:
 
     async def test_with_valid_sequence(self) -> None:
         assert_sequence(assert_str())(["Hello!"])
-
-
-class TestAssertDict:
-    async def test_with_dict(self) -> None:
-        assert_dict()({})
-
-    async def test_without_dict(self) -> None:
-        with raises_error(error_type=AssertionFailed):
-            assert_dict()(False)
 
 
 class TestAssertFields:

--- a/betty/tests/config/collections/test_mapping.py
+++ b/betty/tests/config/collections/test_mapping.py
@@ -9,12 +9,12 @@ from typing import (
 from typing_extensions import override
 
 from betty.assertion import (
-    assert_dict,
     assert_record,
     RequiredField,
     assert_str,
     assert_setattr,
     assert_int,
+    assert_mapping,
 )
 from betty.config import Configuration
 from betty.config.collections.mapping import ConfigurationMapping
@@ -113,10 +113,10 @@ class ConfigurationMappingTestConfigurationMapping(
         item_dump: Dump,
         key_dump: str,
     ) -> Dump:
-        dict_item_dump = assert_dict()(item_dump)
-        dict_item_dump["key"] = key_dump
-        return dict_item_dump
+        mapping_item_dump = dict(assert_mapping()(item_dump))
+        mapping_item_dump["key"] = key_dump
+        return mapping_item_dump
 
     def _dump_key(self, item_dump: VoidableDump) -> tuple[VoidableDump, str]:
-        dict_item_dump = assert_dict()(item_dump)
-        return dict_item_dump, dict_item_dump.pop("key")
+        mapping_item_dump = dict(assert_mapping()(item_dump))
+        return mapping_item_dump, mapping_item_dump.pop("key")


### PR DESCRIPTION
Allow `assert_mapping()` and `assert_sequence()` to be used with and without item assertions, and remove `assert_dict()` and `assert_list()`