### PR TITLE
Make `Localizable.localize()` return `Localized & str`

### DIFF
--- a/betty/error.py
+++ b/betty/error.py
@@ -9,6 +9,7 @@ from typing import TypeVar, Self
 from typing_extensions import override
 
 from betty.locale.localizable import Localizable, _
+from betty.locale.localized import LocalizedStr
 from betty.locale.localizer import Localizer
 
 _BaseExceptionT = TypeVar("_BaseExceptionT", bound=BaseException)
@@ -57,7 +58,7 @@ class UserFacingError(Exception, Localizable):
         return self.localize(DEFAULT_LOCALIZER)
 
     @override
-    def localize(self, localizer: Localizer) -> str:
+    def localize(self, localizer: Localizer) -> LocalizedStr:
         return self._localizable_message.localize(localizer)
 
 

--- a/betty/extension/cotton_candy/assets/templates/entity/label--place.html.j2
+++ b/betty/extension/cotton_candy/assets/templates/entity/label--place.html.j2
@@ -13,7 +13,7 @@
     {%- if not embedded -%}
         <a href="{{ place | url }}">
     {%- endif -%}
-    <span{% if name.locale is not none %} lang="{{ name.locale }}"{% endif %}>{{ name }}</span>
+    {{ name | html_lang }}
     {%- if not embedded -%}
         </a>
     {%- endif -%}

--- a/betty/gramps/loader.py
+++ b/betty/gramps/loader.py
@@ -20,6 +20,7 @@ import aiofiles
 from aiofiles.tempfile import TemporaryDirectory
 from betty.error import FileNotFound
 from betty.gramps.error import GrampsError
+from betty.locale import UNDETERMINED_LOCALE
 from betty.locale.date import DateRange, Datey, Date
 from betty.locale.localizable import _, plain
 from betty.media_type import MediaType, InvalidMediaType
@@ -672,7 +673,7 @@ class GrampsLoader:
             names.append(
                 PlaceName(
                     name=name,
-                    locale=language,
+                    locale=language or UNDETERMINED_LOCALE,
                     date=date,
                 )
             )

--- a/betty/locale/__init__.py
+++ b/betty/locale/__init__.py
@@ -11,10 +11,35 @@ from babel.core import UnknownLocaleError
 from betty import fs
 from langcodes import Language
 
-DEFAULT_LOCALE = "en-US"
-UNDETERMINED_LOCALE = "und"
-
 _LOCALE_DIRECTORY_PATH = fs.ASSETS_DIRECTORY_PATH / "locale"
+
+NO_LINGUISTIC_CONTENT = "zxx"
+UNDETERMINED_LOCALE = "und"
+UNCODED_LOCALE = "mis"
+MULTIPLE_LOCALES = "mul"
+SPECIAL_LOCALES = (
+    NO_LINGUISTIC_CONTENT,
+    UNDETERMINED_LOCALE,
+    UNCODED_LOCALE,
+    MULTIPLE_LOCALES,
+)
+
+DEFAULT_LOCALE = "en-US"
+
+
+def merge_locales(*locales: str) -> str:
+    """
+    Merge locales into a single locale.
+    """
+    unique_locales = set(locales)
+    if len(unique_locales) == 0:
+        return NO_LINGUISTIC_CONTENT
+    elif len(unique_locales) == 1:
+        return next(iter(unique_locales))
+    # Strip locales without linguistic content.
+    if NO_LINGUISTIC_CONTENT in unique_locales:
+        return merge_locales(*(unique_locales - {NO_LINGUISTIC_CONTENT}))
+    return MULTIPLE_LOCALES
 
 
 def to_babel_identifier(locale: Localey) -> str:

--- a/betty/project/__init__.py
+++ b/betty/project/__init__.py
@@ -58,7 +58,7 @@ from betty.config.collections.sequence import ConfigurationSequence
 from betty.core import CoreComponent
 from betty.event_dispatcher import EventDispatcher, EventHandlerRegistry
 from betty.hashid import hashid
-from betty.locale import DEFAULT_LOCALE
+from betty.locale import DEFAULT_LOCALE, UNDETERMINED_LOCALE
 from betty.locale.localizable import _, ShorthandStaticTranslations
 from betty.locale.localizable.config import (
     StaticTranslationsLocalizableConfigurationAttr,
@@ -736,7 +736,7 @@ class LocaleConfigurationSequence(ConfigurationSequence[LocaleConfiguration]):
 
     @override
     def load_item(self, dump: Dump) -> LocaleConfiguration:
-        item = LocaleConfiguration("und")
+        item = LocaleConfiguration(UNDETERMINED_LOCALE)
         item.load(dump)
         return item
 

--- a/betty/requirement.py
+++ b/betty/requirement.py
@@ -11,6 +11,7 @@ from typing import cast, Any, TYPE_CHECKING, final
 from betty.asyncio import wait_to_thread
 from betty.error import UserFacingError
 from betty.locale.localizable import _, Localizable
+from betty.locale.localized import LocalizedStr
 from typing_extensions import override
 
 if TYPE_CHECKING:
@@ -52,13 +53,14 @@ class Requirement(Localizable):
         return None
 
     @override
-    def localize(self, localizer: Localizer) -> str:
-        string = wait_to_thread(self.summary()).localize(localizer)
+    def localize(self, localizer: Localizer) -> LocalizedStr:
+        super_localized = wait_to_thread(self.summary()).localize(localizer)
         details = wait_to_thread(self.details())
+        localized: str = super_localized
         if details is not None:
-            string += f'\n{"-" * len(string)}'
-            string += f"\n{details.localize(localizer)}"
-        return string
+            localized += f'\n{"-" * len(localized)}'
+            localized += f"\n{details.localize(localizer)}"
+        return LocalizedStr(localized, locale=super_localized.locale)
 
     def reduce(self) -> Requirement | None:
         """
@@ -107,11 +109,12 @@ class RequirementCollection(Requirement):
         return self._requirements == other._requirements
 
     @override
-    def localize(self, localizer: Localizer) -> str:
-        localized = super().localize(localizer)
+    def localize(self, localizer: Localizer) -> LocalizedStr:
+        super_localized = super().localize(localizer)
+        localized: str = super_localized
         for requirement in self._requirements:
             localized += f'\n-{indent(requirement.localize(localizer), "  ")[1:]}'
-        return localized
+        return LocalizedStr(localized, locale=super_localized.locale)
 
     @override
     def reduce(self) -> Requirement | None:

--- a/betty/serde/format.py
+++ b/betty/serde/format.py
@@ -13,6 +13,7 @@ from typing_extensions import override
 
 from betty.assertion.error import AssertionFailed
 from betty.locale.localizable import static, Localizable, _
+from betty.locale.localized import LocalizedStr
 from betty.serde.dump import Dump, VoidableDump
 
 if TYPE_CHECKING:
@@ -176,13 +177,15 @@ class FormatStr(Localizable):
         self._serde_formats = serde_formats
 
     @override
-    def localize(self, localizer: Localizer) -> str:
-        return ", ".join(
-            [
-                f"{extension} ({serde_format.label.localize(localizer)})"
-                for serde_format in self._serde_formats
-                for extension in serde_format.extensions
-            ]
+    def localize(self, localizer: Localizer) -> LocalizedStr:
+        return LocalizedStr(
+            ", ".join(
+                [
+                    f"{extension} ({serde_format.label.localize(localizer)})"
+                    for serde_format in self._serde_formats
+                    for extension in serde_format.extensions
+                ]
+            )
         )
 
 

--- a/betty/tests/ancestry/test___init__.py
+++ b/betty/tests/ancestry/test___init__.py
@@ -39,6 +39,7 @@ from betty.ancestry import (
     LinkCollectionSchema,
     LinkSchema,
     PrivacySchema,
+    HasLocale,
 )
 from betty.ancestry.event_type import Birth, UnknownEventType
 from betty.ancestry.presence_role import Subject
@@ -202,6 +203,35 @@ class TestMergePrivacies:
         assert expected == merge_privacies(*privacies)
 
 
+class DummyHasLocale(HasLocale):
+    pass
+
+
+class TestHasLocale:
+    def test_locale_without___init___locale(self) -> None:
+        sut = DummyHasLocale()
+        assert sut.locale == UNDETERMINED_LOCALE
+
+    def test_locale_with___init___locale(self) -> None:
+        locale = "nl"
+        sut = DummyHasLocale(locale=locale)
+        assert sut.locale == locale
+
+    def test_locale(self) -> None:
+        locale = "nl"
+        sut = DummyHasLocale()
+        sut.locale = locale
+        assert sut.locale == locale
+
+    async def test_dump_linked_data(self) -> None:
+        sut = DummyHasLocale()
+        expected: Mapping[str, Any] = {
+            "locale": UNDETERMINED_LOCALE,
+        }
+        actual = await assert_dumps_linked_data(sut)
+        assert expected == actual
+
+
 class TestDated:
     async def test_date(self) -> None:
         class _Dated(Dated):
@@ -248,6 +278,7 @@ class TestNote(EntityTestBase):
                     "url": "/note/the_note/index.json",
                     "relationship": "canonical",
                     "mediaType": "application/ld+json",
+                    "locale": "und",
                 },
                 {
                     "url": "/en/note/the_note/index.html",
@@ -282,6 +313,7 @@ class TestNote(EntityTestBase):
                     "url": "/note/the_note/index.json",
                     "relationship": "canonical",
                     "mediaType": "application/ld+json",
+                    "locale": "und",
                 },
             ],
         }
@@ -331,7 +363,7 @@ class TestLink:
     async def test_locale(self) -> None:
         url = "https://example.com"
         sut = Link(url)
-        assert sut.locale is None
+        assert sut.locale is UNDETERMINED_LOCALE
 
     async def test_description(self) -> None:
         url = "https://example.com"
@@ -352,6 +384,7 @@ class TestLink:
         link = Link("https://example.com")
         expected: Mapping[str, Any] = {
             "url": "https://example.com",
+            "locale": "und",
         }
         actual = await assert_dumps_linked_data(link)
         assert expected == actual
@@ -527,6 +560,7 @@ class TestFile(EntityTestBase):
                         "url": "/file/the_file/index.json",
                         "relationship": "canonical",
                         "mediaType": "application/ld+json",
+                        "locale": "und",
                     },
                     {
                         "url": "/en/file/the_file/index.html",
@@ -587,6 +621,7 @@ class TestFile(EntityTestBase):
                         "url": "/file/the_file/index.json",
                         "relationship": "canonical",
                         "mediaType": "application/ld+json",
+                        "locale": "und",
                     },
                     {
                         "url": "/en/file/the_file/index.html",
@@ -647,6 +682,7 @@ class TestFile(EntityTestBase):
                         "url": "/file/the_file/index.json",
                         "relationship": "canonical",
                         "mediaType": "application/ld+json",
+                        "locale": "und",
                     },
                 ],
             }
@@ -765,6 +801,7 @@ class TestSource(EntityTestBase):
                     "url": "/source/the_source/index.json",
                     "relationship": "canonical",
                     "mediaType": "application/ld+json",
+                    "locale": "und",
                 },
                 {
                     "url": "/en/source/the_source/index.html",
@@ -837,11 +874,13 @@ class TestSource(EntityTestBase):
                 {
                     "url": "https://example.com/the-source",
                     "label": {UNDETERMINED_LOCALE: "The Source Online"},
+                    "locale": "und",
                 },
                 {
                     "url": "/source/the_source/index.json",
                     "relationship": "canonical",
                     "mediaType": "application/ld+json",
+                    "locale": "und",
                 },
                 {
                     "url": "/en/source/the_source/index.html",
@@ -1011,6 +1050,7 @@ class TestCitation(EntityTestBase):
                     "url": "/citation/the_citation/index.json",
                     "relationship": "canonical",
                     "mediaType": "application/ld+json",
+                    "locale": "und",
                 },
                 {
                     "url": "/en/citation/the_citation/index.html",
@@ -1055,6 +1095,7 @@ class TestCitation(EntityTestBase):
                     "url": "/citation/the_citation/index.json",
                     "relationship": "canonical",
                     "mediaType": "application/ld+json",
+                    "locale": "und",
                 },
                 {
                     "url": "/en/citation/the_citation/index.html",
@@ -1100,6 +1141,7 @@ class TestCitation(EntityTestBase):
                     "url": "/citation/the_citation/index.json",
                     "relationship": "canonical",
                     "mediaType": "application/ld+json",
+                    "locale": "und",
                 },
             ],
         }
@@ -1351,6 +1393,7 @@ class TestPlace(EntityTestBase):
             "names": [
                 {
                     "name": name,
+                    "locale": "und",
                 },
             ],
             "enclosedBy": [],
@@ -1362,6 +1405,7 @@ class TestPlace(EntityTestBase):
                     "url": "/place/the_place/index.json",
                     "relationship": "canonical",
                     "mediaType": "application/ld+json",
+                    "locale": "und",
                 },
                 {
                     "url": "/en/place/the_place/index.html",
@@ -1434,11 +1478,13 @@ class TestPlace(EntityTestBase):
                 {
                     "url": "https://example.com/the-place",
                     "label": {UNDETERMINED_LOCALE: "The Place Online"},
+                    "locale": "und",
                 },
                 {
                     "url": "/place/the_place/index.json",
                     "relationship": "canonical",
                     "mediaType": "application/ld+json",
+                    "locale": "und",
                 },
                 {
                     "url": "/en/place/the_place/index.html",
@@ -1606,6 +1652,7 @@ class TestEvent(EntityTestBase):
                     "url": "/event/the_event/index.json",
                     "relationship": "canonical",
                     "mediaType": "application/ld+json",
+                    "locale": "und",
                 },
                 {
                     "url": "/en/event/the_event/index.html",
@@ -1693,6 +1740,7 @@ class TestEvent(EntityTestBase):
                     "url": "/event/the_event/index.json",
                     "relationship": "canonical",
                     "mediaType": "application/ld+json",
+                    "locale": "und",
                 },
                 {
                     "url": "/en/event/the_event/index.html",
@@ -1760,6 +1808,7 @@ class TestEvent(EntityTestBase):
                     "url": "/event/the_event/index.json",
                     "relationship": "canonical",
                     "mediaType": "application/ld+json",
+                    "locale": "und",
                 },
             ],
         }
@@ -1789,7 +1838,7 @@ class TestPersonName(EntityTestBase):
             individual="Janet",
             affiliation="Not a Girl",
         )
-        assert sut.locale is None
+        assert sut.locale is UNDETERMINED_LOCALE
 
     async def test_citations(self) -> None:
         person = Person(id="1")
@@ -1959,6 +2008,7 @@ class TestPerson(EntityTestBase):
                     "url": "/person/the_person/index.json",
                     "relationship": "canonical",
                     "mediaType": "application/ld+json",
+                    "locale": "und",
                 },
                 {
                     "url": "/en/person/the_person/index.html",
@@ -2076,11 +2126,13 @@ class TestPerson(EntityTestBase):
                 {
                     "url": "https://example.com/the-person",
                     "label": {UNDETERMINED_LOCALE: "The Person Online"},
+                    "locale": "und",
                 },
                 {
                     "url": "/person/the_person/index.json",
                     "relationship": "canonical",
                     "mediaType": "application/ld+json",
+                    "locale": "und",
                 },
                 {
                     "url": "/en/person/the_person/index.html",
@@ -2183,6 +2235,7 @@ class TestPerson(EntityTestBase):
                     "url": "/person/the_person/index.json",
                     "relationship": "canonical",
                     "mediaType": "application/ld+json",
+                    "locale": "und",
                 },
             ],
         }

--- a/betty/tests/coverage/test_coverage.py
+++ b/betty/tests/coverage/test_coverage.py
@@ -451,9 +451,6 @@ _BASELINE: Mapping[str, _ModuleIgnore] = {
         # This is an empty class.
         "IncompleteDateError": TestKnownToBeMissing,
     },
-    "betty/locale/localized.py": {
-        "Localized": TestKnownToBeMissing,
-    },
     "betty/locale/localizer.py": {
         "Localizer": TestKnownToBeMissing,
         "LocalizerRepository": {

--- a/betty/tests/extension/cotton_candy/assets/templates/entity/test_label_place_html_j2.py
+++ b/betty/tests/extension/cotton_candy/assets/templates/entity/test_label_place_html_j2.py
@@ -21,7 +21,7 @@ class Test(TemplateTestBase):
         ("expected", "data", "locale"),
         [
             (
-                '<span><a href="/place/P0/index.html"><span>The Place</span></a></span>',
+                '<span><a href="/place/P0/index.html"><span lang="und">The Place</span></a></span>',
                 {
                     "entity": Place(
                         id="P0",
@@ -46,7 +46,7 @@ class Test(TemplateTestBase):
                 None,
             ),
             (
-                '<span><a href="/place/P0/index.html"><span lang="nl">De Plaats</span></a></span>',
+                '<span><a href="/place/P0/index.html">De Plaats</a></span>',
                 {
                     "entity": Place(
                         id="P0",
@@ -65,7 +65,7 @@ class Test(TemplateTestBase):
                 "nl",
             ),
             (
-                "<span><span>The Place</span></span>",
+                '<span><span lang="und">The Place</span></span>',
                 {
                     "entity": Place(
                         id="P0",
@@ -76,7 +76,7 @@ class Test(TemplateTestBase):
                 None,
             ),
             (
-                '<span><a href="/place/P0/index.html"><span lang="nl">De Nieuwe Plaats</span></a></span>',
+                '<span><a href="/place/P0/index.html">De Nieuwe Plaats</a></span>',
                 {
                     "entity": Place(
                         id="P0",

--- a/betty/tests/extension/cotton_candy/assets/templates/entity/test_meta_place_html_j2.py
+++ b/betty/tests/extension/cotton_candy/assets/templates/entity/test_meta_place_html_j2.py
@@ -1,6 +1,6 @@
+from betty.ancestry import PlaceName, Place, Enclosure
 from betty.extension.cotton_candy import CottonCandy
 from betty.jinja2 import EntityContexts
-from betty.ancestry import PlaceName, Place, Enclosure
 from betty.test_utils.assets.templates import TemplateTestBase
 
 
@@ -36,7 +36,7 @@ class Test(TemplateTestBase):
             names=[PlaceName(name="The All-enclosing Place")],
         )
         Enclosure(encloses=enclosing_place, enclosed_by=all_enclosing_place)
-        expected = '<div class="meta">in <span><a href="/place/P1/index.html"><span>The Enclosing Place</span></a></span>, <span><a href="/place/P2/index.html"><span>The All-enclosing Place</span></a></span></div>'
+        expected = '<div class="meta">in <span><a href="/place/P1/index.html"><span lang="und">The Enclosing Place</span></a></span>, <span><a href="/place/P2/index.html"><span lang="und">The All-enclosing Place</span></a></span></div>'
         async with self._render(
             data={
                 "entity": place,
@@ -59,7 +59,7 @@ class Test(TemplateTestBase):
             names=[PlaceName(name="The All-enclosing Place")],
         )
         Enclosure(encloses=enclosing_place, enclosed_by=all_enclosing_place)
-        expected = '<div class="meta">in <span><a href="/place/P1/index.html"><span>The Enclosing Place</span></a></span></div>'
+        expected = '<div class="meta">in <span><a href="/place/P1/index.html"><span lang="und">The Enclosing Place</span></a></span></div>'
         async with self._render(
             data={
                 "entity": place,
@@ -87,7 +87,7 @@ class Test(TemplateTestBase):
             id="P999",
             names=[PlaceName(name="Far Far Away")],
         )
-        expected = '<div class="meta">in <span><a href="/place/P1/index.html"><span>The Enclosing Place</span></a></span>, <span><a href="/place/P2/index.html"><span>The All-enclosing Place</span></a></span></div>'
+        expected = '<div class="meta">in <span><a href="/place/P1/index.html"><span lang="und">The Enclosing Place</span></a></span>, <span><a href="/place/P2/index.html"><span lang="und">The All-enclosing Place</span></a></span></div>'
         async with self._render(
             data={
                 "entity": place,

--- a/betty/tests/extension/cotton_candy/assets/templates/test_event_dimensions_html_j2.py
+++ b/betty/tests/extension/cotton_candy/assets/templates/test_event_dimensions_html_j2.py
@@ -1,8 +1,8 @@
+from betty.ancestry import Event, Place, PlaceName, Citation, Source
+from betty.ancestry.event_type import Birth
 from betty.extension.cotton_candy import CottonCandy
 from betty.jinja2 import EntityContexts
 from betty.locale.date import Date
-from betty.ancestry import Event, Place, PlaceName, Citation, Source
-from betty.ancestry.event_type import Birth
 from betty.test_utils.assets.templates import TemplateTestBase
 
 
@@ -39,9 +39,7 @@ class Test(TemplateTestBase):
             id="P0",
             names=[PlaceName(name="The Place")],
         )
-        expected = (
-            'in <span><a href="/place/P0/index.html"><span>The Place</span></a></span>'
-        )
+        expected = 'in <span><a href="/place/P0/index.html"><span lang="und">The Place</span></a></span>'
         async with self._render(
             data={
                 "event": event,
@@ -74,7 +72,7 @@ class Test(TemplateTestBase):
             id="P0",
             names=[PlaceName(name="The Place")],
         )
-        expected = '1970 in <span><a href="/place/P0/index.html"><span>The Place</span></a></span>'
+        expected = '1970 in <span><a href="/place/P0/index.html"><span lang="und">The Place</span></a></span>'
         async with self._render(
             data={
                 "event": event,
@@ -103,7 +101,7 @@ class Test(TemplateTestBase):
             names=[PlaceName(name="The Place")],
         )
         event.citations.add(Citation(source=Source(name="The Source")))
-        expected = "1970 in <span><span>The Place</span></span>"
+        expected = '1970 in <span><span lang="und">The Place</span></span>'
         async with self._render(
             data={
                 "event": event,

--- a/betty/tests/gramps/test_loader.py
+++ b/betty/tests/gramps/test_loader.py
@@ -7,6 +7,7 @@ import pytest
 from aiofiles.tempfile import TemporaryDirectory
 from betty.app import App
 from betty.gramps.loader import GrampsLoader
+from betty.locale import UNDETERMINED_LOCALE
 from betty.locale.date import Date, DateRange
 from betty.locale.localizer import DEFAULT_LOCALIZER
 from betty.media_type import MediaType
@@ -1024,7 +1025,7 @@ class TestGrampsLoader:
         assert link_minimal.url == link_minimal_url
         assert not link_minimal.description
         assert not link_minimal.label
-        assert link_minimal.locale is None
+        assert link_minimal.locale is UNDETERMINED_LOCALE
         assert link_minimal.media_type is None
         assert link_minimal.relationship is None
         assert link_full.url == link_full_url

--- a/betty/tests/locale/test___init__.py
+++ b/betty/tests/locale/test___init__.py
@@ -4,10 +4,44 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from betty.locale import negotiate_locale, Localey, to_locale
+from betty.locale import (
+    negotiate_locale,
+    Localey,
+    to_locale,
+    merge_locales,
+    NO_LINGUISTIC_CONTENT,
+    SPECIAL_LOCALES,
+    MULTIPLE_LOCALES,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
+
+class TestMergeLocales:
+    @pytest.mark.parametrize(
+        ("expected", "locales"),
+        [
+            # No locales.
+            (NO_LINGUISTIC_CONTENT, []),
+            # A single locale which is passed through.
+            ("nl", ["nl"]),
+            ("de-DE", ["de-DE"]),
+            *((locale, [locale]) for locale in SPECIAL_LOCALES),
+            # Multiple locales.
+            (MULTIPLE_LOCALES, ["nl", "de-DE"]),
+            # Multiple locales, including no linguistic content.
+            ("nl", ["nl", NO_LINGUISTIC_CONTENT]),
+            (MULTIPLE_LOCALES, ["nl", "de-DE", NO_LINGUISTIC_CONTENT]),
+            *(
+                (locale, [locale, NO_LINGUISTIC_CONTENT])
+                for locale in SPECIAL_LOCALES
+                if locale is not NO_LINGUISTIC_CONTENT
+            ),
+        ],
+    )
+    def test(self, expected: str, locales: Sequence[str]) -> None:
+        assert merge_locales(*locales) == expected
 
 
 class TestNegotiateLocale:

--- a/betty/tests/test_wikipedia.py
+++ b/betty/tests/test_wikipedia.py
@@ -12,6 +12,7 @@ from multidict import CIMultiDict
 from betty.ancestry import Source, Link, Citation, Place
 from betty.fetch import FetchResponse
 from betty.fetch.static import StaticFetcher
+from betty.locale import UNDETERMINED_LOCALE
 from betty.locale.localizer import DEFAULT_LOCALIZER
 from betty.media_type import MediaType
 from betty.project import LocaleConfiguration, Project
@@ -701,10 +702,10 @@ class TestPopulator:
         assert expected == link.relationship
 
     @pytest.mark.parametrize(
-        ("expected", "page_language", "locale"),
+        ("expected", "page_language", "original_link_locale"),
         [
             ("nl-NL", "nl", "nl-NL"),
-            ("nl", "nl", None),
+            ("nl", "nl", UNDETERMINED_LOCALE),
             ("nl", "en", "nl"),
         ],
     )
@@ -712,13 +713,13 @@ class TestPopulator:
         self,
         expected: str,
         page_language: str,
-        locale: str | None,
+        original_link_locale: str,
         mocker: MockerFixture,
         new_temporary_app: App,
     ) -> None:
         m_retriever = mocker.patch("betty.wikipedia._Retriever")
         link = Link(f"http://{page_language}.wikipedia.org/wiki/Amsterdam")
-        link.locale = locale
+        link.locale = original_link_locale
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = _Populator(project, m_retriever)
             await sut.populate_link(link, page_language)

--- a/documentation/usage/templating/filters.rst
+++ b/documentation/usage/templating/filters.rst
@@ -13,9 +13,11 @@ In addition to Jinja2's built-in filters, Betty provides the following:
 - :py:func:`format_degrees <betty.jinja2.filter.filter_format_degrees>`
 - :py:func:`hashid <betty.jinja2.filter.filter_hashid>`
 - :py:func:`image_resize_cover <betty.jinja2.filter.filter_image_resize_cover>`
+- :py:func:`html_lang <betty.jinja2.filter.filter_html_lang>`
 - :py:func:`json <betty.jinja2.filter.filter_json>`
 - :py:func:`locale_get_data <betty.locale.get_data>`
 - :py:func:`localize <betty.jinja2.filter.filter_localize>`
+- :py:func:`localize_html_lang <betty.jinja2.filter.filter_localize_html_lang>`
 - :py:func:`map <betty.jinja2.filter.filter_map>`
 - :py:func:`minimize <betty.serde.dump.minimize>`
 - :py:func:`negotiate_dateds <betty.jinja2.filter.filter_negotiate_dateds>`


### PR DESCRIPTION
This allows calling code to know which locale something was localized to. When templating, this means we can add the correct HTML `lang` attributes.