### PR TITLE
Remove multiprocessing support from .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,12 +1,10 @@
 [run]
 branch = True
 concurrency =
-    multiprocessing
     thread
 omit =
     betty/_bootstrap.py
     betty/_package/**
-parallel = True
 source = betty
 
 [report]


### PR DESCRIPTION
Remove multiprocessing support from .coveragerc because it caused covered code to be omitted