### PR TITLE
Remove `wait_to_thread()`

### DIFF
--- a/betty/app/__init__.py
+++ b/betty/app/__init__.py
@@ -72,7 +72,7 @@ class App(Configurable[AppConfiguration], TargetFactory[Any], CoreComponent):
         """
         configuration = AppConfiguration()
         if config.CONFIGURATION_FILE_PATH.exists():
-            (await assert_configuration_file(configuration))(
+            await assert_configuration_file(configuration)(
                 config.CONFIGURATION_FILE_PATH
             )
         yield cls(

--- a/betty/app/config.py
+++ b/betty/app/config.py
@@ -9,13 +9,7 @@ from typing import final, Self
 from typing_extensions import override
 
 from betty import fs
-from betty.assertion import (
-    assert_record,
-    OptionalField,
-    assert_str,
-    assert_setattr,
-    assert_locale,
-)
+from betty.assertion import assert_record, OptionalField, assert_str, assert_locale
 from betty.config import Configuration
 from betty.serde.dump import Dump, minimize, DumpMapping
 from betty.typing import void_none
@@ -44,19 +38,22 @@ class AppConfiguration(Configuration):
         """
         return self._locale
 
-    @locale.setter
-    def locale(self, locale: str) -> None:
-        self._locale = assert_locale()(locale)
+    async def set_locale(self, locale: str) -> str | None:
+        """
+        Set :py:attr:`betty.app.config.AppConfiguration.locale`.
+        """
+        self._locale = await assert_locale()(locale)
+        return self.locale
 
     @override
     def update(self, other: Self) -> None:
         self._locale = other._locale
 
     @override
-    def load(self, dump: Dump) -> None:
-        assert_record(
-            OptionalField("locale", assert_str() | assert_setattr(self, "locale"))
-        )(dump)
+    async def load(self, dump: Dump) -> None:
+        await assert_record(OptionalField("locale", assert_str() | self.set_locale))(
+            dump
+        )
 
     @override
     def dump(self) -> DumpMapping[Dump]:

--- a/betty/asyncio.py
+++ b/betty/asyncio.py
@@ -4,47 +4,10 @@ Provide asynchronous programming utilities.
 
 from __future__ import annotations
 
-from asyncio import run
 from inspect import isawaitable
-from threading import Thread
-from typing import Awaitable, TypeVar, Generic, cast
+from typing import Awaitable, TypeVar
 
 _T = TypeVar("_T")
-
-
-def wait_to_thread(f: Awaitable[_T]) -> _T:
-    """
-    Wait for an awaitable in another thread.
-    """
-    synced = _WaiterThread(f)
-    synced.start()
-    synced.join()
-    return synced.return_value
-
-
-class _WaiterThread(Thread, Generic[_T]):
-    def __init__(self, awaitable: Awaitable[_T]):
-        super().__init__()
-        self._awaitable = awaitable
-        self._return_value: _T | None = None
-        self._e: BaseException | None = None
-
-    @property
-    def return_value(self) -> _T:
-        if self._e:
-            raise self._e
-        return cast(_T, self._return_value)
-
-    def run(self) -> None:
-        run(self._run())
-
-    async def _run(self) -> None:
-        try:
-            self._return_value = await self._awaitable
-        except BaseException as e:  # noqa: B036
-            # Store the exception, so it can be reraised when the calling thread
-            # gets self.return_value.
-            self._e = e
 
 
 async def ensure_await(value: Awaitable[_T] | _T) -> _T:

--- a/betty/cli/commands/__init__.py
+++ b/betty/cli/commands/__init__.py
@@ -245,9 +245,9 @@ async def _read_project_configuration_file(
 ) -> None:
     localizer = await project.app.localizer
     logger = logging.getLogger(__name__)
-    assert_configuration = await assert_configuration_file(project.configuration)
+    assert_configuration = assert_configuration_file(project.configuration)
     try:
-        assert_configuration(configuration_file_path)
+        await assert_configuration(configuration_file_path)
     except UserFacingError as error:
         logger.debug(error.localize(localizer))
         raise

--- a/betty/cli/commands/config.py
+++ b/betty/cli/commands/config.py
@@ -55,7 +55,7 @@ class Config(ShorthandPluginBase, AppDependentFactory, Command):
         )
         async def config(*, locale: str) -> None:
             logger = getLogger(__name__)
-            self._app.configuration.locale = locale
+            await self._app.configuration.set_locale(locale)
             new_localizer = await self._app.localizers.get(locale)
             logger.info(
                 new_localizer._("Betty will talk to you in {locale}").format(

--- a/betty/cli/commands/new.py
+++ b/betty/cli/commands/new.py
@@ -125,18 +125,20 @@ class New(ShorthandPluginBase, AppDependentFactory, Command):
                 localizer._("What is your project called in {locale}?"),
             )
 
-            configuration.name = click.prompt(
-                localizer._("What is your project's machine name?"),
-                default=machinify(
-                    configuration.title.localize(
-                        await self._app.localizers.get(
-                            configuration.locales.default.locale
+            await configuration.set_name(
+                click.prompt(
+                    localizer._("What is your project's machine name?"),
+                    default=machinify(
+                        configuration.title.localize(
+                            await self._app.localizers.get(
+                                configuration.locales.default.locale
+                            )
                         )
-                    )
-                ),
-                value_proc=user_facing_error_to_bad_parameter(localizer)(
-                    assert_machine_name()
-                ),
+                    ),
+                    value_proc=user_facing_error_to_bad_parameter(localizer)(
+                        assert_machine_name()
+                    ),
+                )
             )
 
             configuration.author = _prompt_static_translations(
@@ -184,15 +186,15 @@ class New(ShorthandPluginBase, AppDependentFactory, Command):
         return new
 
 
-def _assert_project_configuration_file_path(value: Any) -> Path:
-    configuration_file_path = assert_path()(value)
+async def _assert_project_configuration_file_path(value: Any) -> Path:
+    configuration_file_path = await assert_path()(value)
     if not configuration_file_path.suffix:
         configuration_file_path /= "betty.yaml"
     return configuration_file_path
 
 
-def _assert_url(value: Any) -> str:
-    url = assert_str()(value)
+async def _assert_url(value: Any) -> str:
+    url = await assert_str()(value)
     parsed_url = urlparse(url)
     scheme = parsed_url.scheme or "http"
     return f"{scheme}://{parsed_url.netloc}{parsed_url.path}"

--- a/betty/config/collections/__init__.py
+++ b/betty/config/collections/__init__.py
@@ -111,7 +111,7 @@ class ConfigurationCollection(
         pass
 
     @abstractmethod
-    def load_item(self, dump: Dump) -> _ConfigurationT:
+    async def load_item(self, dump: Dump) -> _ConfigurationT:
         """
         Create and load a new item from the given dump, or raise an assertion error.
 

--- a/betty/config/collections/mapping.py
+++ b/betty/config/collections/mapping.py
@@ -116,27 +116,29 @@ class ConfigurationMapping(
     """
 
     @abstractmethod
-    def _load_key(self, item_dump: DumpMapping[Dump], key_dump: str) -> None:
+    async def _load_key(self, item_dump: DumpMapping[Dump], key_dump: str) -> None:
         pass
 
     @abstractmethod
     def _dump_key(self, item_dump: DumpMapping[Dump]) -> str:
         pass
 
-    def __load_item_key(self, value_dump: DumpMapping[Dump], key_dump: str) -> Dump:
-        self._load_key(value_dump, key_dump)
+    async def __load_item_key(
+        self, value_dump: DumpMapping[Dump], key_dump: str
+    ) -> Dump:
+        await self._load_key(value_dump, key_dump)
         return value_dump
 
     @override
-    def load(self, dump: Dump) -> None:
+    async def load(self, dump: Dump) -> None:
         self.clear()
         self.replace(
-            *assert_mapping(self.load_item)(
+            *await assert_mapping(self.load_item)(
                 {
                     item_key_dump: self.__load_item_key(item_value_dump, item_key_dump)
-                    for item_key_dump, item_value_dump in assert_mapping(
-                        assert_mapping()
-                    )(dump).items()
+                    for item_key_dump, item_value_dump in (
+                        await assert_mapping(assert_mapping())(dump)
+                    ).items()
                 }
             ).values()
         )
@@ -165,8 +167,8 @@ class OrderedConfigurationMapping(
     """
 
     @override
-    def load(self, dump: Dump) -> None:
-        self.replace(*assert_sequence(self.load_item)(dump))
+    async def load(self, dump: Dump) -> None:
+        self.replace(*await assert_sequence(self.load_item)(dump))
 
     @override
     def dump(self) -> Voidable[DumpSequence[Dump]]:

--- a/betty/config/collections/mapping.py
+++ b/betty/config/collections/mapping.py
@@ -133,13 +133,17 @@ class ConfigurationMapping(
     async def load(self, dump: Dump) -> None:
         self.clear()
         self.replace(
-            *await assert_mapping(self.load_item)(
-                {
-                    item_key_dump: self.__load_item_key(item_value_dump, item_key_dump)
-                    for item_key_dump, item_value_dump in (
-                        await assert_mapping(assert_mapping())(dump)
-                    ).items()
-                }
+            *(
+                await assert_mapping(self.load_item)(
+                    {
+                        item_key_dump: self.__load_item_key(
+                            item_value_dump, item_key_dump
+                        )
+                        for item_key_dump, item_value_dump in (
+                            await assert_mapping(assert_mapping())(dump)
+                        ).items()
+                    }
+                )
             ).values()
         )
 

--- a/betty/config/collections/sequence.py
+++ b/betty/config/collections/sequence.py
@@ -84,8 +84,8 @@ class ConfigurationSequence(
         self.append(*configurations)
 
     @override
-    def load(self, dump: Dump) -> None:
-        self.replace(*assert_sequence(self.load_item)(dump))
+    async def load(self, dump: Dump) -> None:
+        self.replace(*await assert_sequence(self.load_item)(dump))
 
     @override
     def dump(self) -> Voidable[DumpSequence[Dump]]:

--- a/betty/locale/localizable/__init__.py
+++ b/betty/locale/localizable/__init__.py
@@ -348,8 +348,8 @@ class StaticTranslationsLocalizable(
         if isinstance(translations, StaticTranslationsLocalizable):
             self._translations = translations._translations
         else:
-            translations = assert_static_translations()(translations)
-            assert_len(minimum=1 if self._required else 0)(translations)
+            translations = await assert_static_translations()(translations)
+            await assert_len(minimum=1 if self._required else 0)(translations)
             self._translations = dict(translations)
 
     @property

--- a/betty/locale/localizable/config.py
+++ b/betty/locale/localizable/config.py
@@ -36,11 +36,11 @@ class StaticTranslationsLocalizableConfiguration(
         self._translations = other._translations
 
     @override
-    def load(self, dump: Dump) -> None:
+    async def load(self, dump: Dump) -> None:
         self._translations.clear()
 
-        translations = assert_static_translations()(dump)
-        assert_len(minimum=1 if self._required else 0)(translations)
+        translations = await assert_static_translations()(dump)
+        await assert_len(minimum=1 if self._required else 0)(translations)
         for locale, translation in translations.items():
             self[locale] = translation
 

--- a/betty/plugin/__init__.py
+++ b/betty/plugin/__init__.py
@@ -22,7 +22,7 @@ from betty.typing import internal
 
 if TYPE_CHECKING:
     from betty.locale.localizable import Localizable
-    from collections.abc import AsyncIterator, Sequence, Mapping
+    from collections.abc import AsyncIterator, Sequence, Mapping, Iterator
 
 
 class PluginError(UserFacingError):
@@ -163,6 +163,13 @@ class PluginIdToTypeMap(Generic[_PluginT]):
         self, plugin_identifier: MachineName | type[_PluginT]
     ) -> type[_PluginT]:
         return self.get(plugin_identifier)
+
+    @property
+    def types(self) -> Iterator[type[_PluginT]]:
+        """
+        Get the available plugin types.
+        """
+        yield from self._id_to_type_map.values()
 
 
 class PluginRepository(Generic[_PluginT], TargetFactory[_PluginT], ABC):

--- a/betty/plugin/config.py
+++ b/betty/plugin/config.py
@@ -43,7 +43,7 @@ class PluginConfiguration(Configuration):
         description: ShorthandStaticTranslations | None = None,
     ):
         super().__init__()
-        self._id = assert_machine_name()(plugin_id)
+        self._id = plugin_id
         self.label = label
         if description is not None:
             self.description = description
@@ -62,8 +62,8 @@ class PluginConfiguration(Configuration):
         self.description.update(other.description)
 
     @override
-    def load(self, dump: Dump) -> None:
-        assert_record(
+    async def load(self, dump: Dump) -> None:
+        await assert_record(
             RequiredField("id", assert_machine_name() | assert_setattr(self, "_id")),
             RequiredField("label", self.label.load),
             OptionalField("description", self.description.load),
@@ -119,7 +119,7 @@ class PluginConfigurationMapping(
         return configuration.id
 
     @override
-    def _load_key(self, item_dump: DumpMapping[Dump], key_dump: str) -> None:
+    async def _load_key(self, item_dump: DumpMapping[Dump], key_dump: str) -> None:
         item_dump["id"] = key_dump
 
     @override
@@ -135,9 +135,9 @@ class PluginConfigurationPluginConfigurationMapping(
     """
 
     @override
-    def load_item(self, dump: Dump) -> PluginConfiguration:
+    async def load_item(self, dump: Dump) -> PluginConfiguration:
         item = PluginConfiguration("-", "")
-        item.load(dump)
+        await item.load(dump)
         return item
 
     @classmethod

--- a/betty/project/extension/cotton_candy/config.py
+++ b/betty/project/extension/cotton_candy/config.py
@@ -9,11 +9,7 @@ from typing import Self, Sequence, TYPE_CHECKING
 
 from typing_extensions import override
 
-from betty.assertion import (
-    assert_str,
-    assert_record,
-    OptionalField,
-)
+from betty.assertion import assert_str, assert_record, OptionalField
 from betty.assertion.error import AssertionFailed
 from betty.config import Configuration
 from betty.locale.localizable import _
@@ -65,8 +61,8 @@ class ColorConfiguration(Configuration):
         self.hex = other.hex
 
     @override
-    def load(self, dump: Dump) -> None:
-        self._hex = (assert_str() | self._assert_hex)(dump)
+    async def load(self, dump: Dump) -> None:
+        self._hex = await assert_str().chain(self._assert_hex)(dump)
 
     @override
     def dump(self) -> Voidable[Dump]:
@@ -147,8 +143,8 @@ class CottonCandyConfiguration(Configuration):
         self.link_active_color.update(other.link_active_color)
 
     @override
-    def load(self, dump: Dump) -> None:
-        assert_record(
+    async def load(self, dump: Dump) -> None:
+        await assert_record(
             OptionalField("featured_entities", self.featured_entities.load),
             OptionalField("primary_inactive_color", self.primary_inactive_color.load),
             OptionalField("primary_active_color", self.primary_active_color.load),

--- a/betty/project/extension/demo/__init__.py
+++ b/betty/project/extension/demo/__init__.py
@@ -494,7 +494,7 @@ async def demo_project(app: App) -> AsyncIterator[Project]:
     Create a new demonstration project.
     """
     async with Project.new_temporary(app) as project:
-        project.configuration.name = Demo.plugin_id()
+        await project.configuration.set_name(Demo.plugin_id())
         project.configuration.title = {
             "en-US": "A Betty demonstration",
             "nl-NL": "Een demonstratie van Betty",

--- a/betty/project/extension/gramps/config.py
+++ b/betty/project/extension/gramps/config.py
@@ -147,9 +147,9 @@ DEFAULT_GENDER_MAP: Mapping[str, MachineName] = {
 }
 
 
-def _assert_gramps_type(value: Any) -> str:
-    event_type = assert_str()(value)
-    assert_len(minimum=1)(event_type)
+async def _assert_gramps_type(value: Any) -> str:
+    event_type = await assert_str()(value)
+    await assert_len(minimum=1)(event_type)
     return event_type
 
 
@@ -179,8 +179,10 @@ class PluginMapping(Configuration):
         }
 
     @override
-    def load(self, dump: Dump) -> None:
-        self._mapping = assert_mapping(assert_machine_name(), _assert_gramps_type)(dump)
+    async def load(self, dump: Dump) -> None:
+        self._mapping = await assert_mapping(
+            assert_machine_name(), _assert_gramps_type
+        )(dump)
 
     @override
     def dump(self) -> Voidable[Dump]:
@@ -279,8 +281,8 @@ class FamilyTreeConfiguration(Configuration):
         return self._presence_roles
 
     @override
-    def load(self, dump: Dump) -> None:
-        assert_record(
+    async def load(self, dump: Dump) -> None:
+        await assert_record(
             RequiredField("file", assert_path() | assert_setattr(self, "file_path")),
             OptionalField("event_types", self.event_types.load),
             OptionalField("genders", self.genders.load),
@@ -315,11 +317,11 @@ class FamilyTreeConfigurationSequence(ConfigurationSequence[FamilyTreeConfigurat
     """
 
     @override
-    def load_item(self, dump: Dump) -> FamilyTreeConfiguration:
+    async def load_item(self, dump: Dump) -> FamilyTreeConfiguration:
         # Use a dummy path to satisfy initializer arguments.
         # It will be overridden when loading the fump.
         item = FamilyTreeConfiguration(Path())
-        item.load(dump)
+        await item.load(dump)
         return item
 
 
@@ -346,8 +348,8 @@ class GrampsConfiguration(Configuration):
         self._family_trees.update(other._family_trees)
 
     @override
-    def load(self, dump: Dump) -> None:
-        assert_record(OptionalField("family_trees", self.family_trees.load))(dump)
+    async def load(self, dump: Dump) -> None:
+        await assert_record(OptionalField("family_trees", self.family_trees.load))(dump)
 
     @override
     def dump(self) -> Voidable[DumpMapping[Dump]]:

--- a/betty/project/extension/wikipedia/config.py
+++ b/betty/project/extension/wikipedia/config.py
@@ -6,12 +6,7 @@ from typing import Self
 
 from typing_extensions import override
 
-from betty.assertion import (
-    OptionalField,
-    assert_record,
-    assert_bool,
-    assert_setattr,
-)
+from betty.assertion import OptionalField, assert_record, assert_bool, assert_setattr
 from betty.config import Configuration
 from betty.serde.dump import Dump, DumpMapping
 
@@ -41,8 +36,8 @@ class WikipediaConfiguration(Configuration):
         self._populate_images = other._populate_images
 
     @override
-    def load(self, dump: Dump) -> None:
-        assert_record(
+    async def load(self, dump: Dump) -> None:
+        await assert_record(
             OptionalField(
                 "populate_images",
                 assert_bool() | assert_setattr(self, "populate_images"),

--- a/betty/serde/load.py
+++ b/betty/serde/load.py
@@ -5,7 +5,6 @@ An API to load serializable data dumps.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -18,7 +17,7 @@ class Loadable(ABC):
     """
 
     @abstractmethod
-    def load(self, dump: Dump) -> None:
+    async def load(self, dump: Dump) -> None:
         """
         Load a serialized data dump into ``self``.
 

--- a/betty/test_utils/ancestry/event_type.py
+++ b/betty/test_utils/ancestry/event_type.py
@@ -22,7 +22,7 @@ class EventTypeTestBase(PluginTestBase[EventType]):
         Tests :py:meth:`betty.ancestry.event_type.EventType.comes_after` implementations.
         """
         for event_type_id in self.get_sut_class().comes_after():
-            assert_plugin_identifier(
+            await assert_plugin_identifier(
                 event_type_id,
                 EventType,  # type: ignore[type-abstract]
             )
@@ -32,7 +32,7 @@ class EventTypeTestBase(PluginTestBase[EventType]):
         Tests :py:meth:`betty.ancestry.event_type.EventType.comes_before` implementations.
         """
         for event_type_id in self.get_sut_class().comes_before():
-            assert_plugin_identifier(
+            await assert_plugin_identifier(
                 event_type_id,
                 EventType,  # type: ignore[type-abstract]
             )

--- a/betty/test_utils/config/collections/__init__.py
+++ b/betty/test_utils/config/collections/__init__.py
@@ -63,7 +63,7 @@ class ConfigurationCollectionTestBase(Generic[_ConfigurationKeyT, _Configuration
         ]
         assert non_void_dumps, "At least one configuration object must return a configuration dump that is not Void"
         for dump in non_void_dumps:
-            sut.load_item(dump)
+            await sut.load_item(dump)
 
     async def test_replace_without_items(self) -> None:
         """

--- a/betty/test_utils/plugin/__init__.py
+++ b/betty/test_utils/plugin/__init__.py
@@ -16,12 +16,12 @@ from betty.string import camel_case_to_kebab_case
 _PluginT = TypeVar("_PluginT", bound=Plugin)
 
 
-def assert_plugin_identifier(value: Any, plugin_type: type[_PluginT]) -> None:
+async def assert_plugin_identifier(value: Any, plugin_type: type[_PluginT]) -> None:
     """
     Assert that something is a plugin identifier.
     """
     if isinstance(value, str):
-        assert_machine_name()(value)
+        await assert_machine_name()(value)
     else:
         assert issubclass(value, plugin_type)
 
@@ -49,7 +49,7 @@ class PluginTestBase(Generic[_PluginT]):
         """
         Tests :py:meth:`betty.plugin.Plugin.plugin_id` implementations.
         """
-        assert_machine_name()(self.get_sut_class().plugin_id())
+        await assert_machine_name()(self.get_sut_class().plugin_id())
 
     async def test_plugin_label(self) -> None:
         """

--- a/betty/test_utils/project/extension/__init__.py
+++ b/betty/test_utils/project/extension/__init__.py
@@ -47,7 +47,7 @@ class ExtensionTestBase(PluginTestBase[Extension]):
         Tests :py:meth:`betty.project.extension.Extension.depends_on` implementations.
         """
         for extension_id in self.get_sut_class().depends_on():
-            assert_plugin_identifier(
+            await assert_plugin_identifier(
                 extension_id,
                 Extension,  # type: ignore[type-abstract]
             )
@@ -57,7 +57,7 @@ class ExtensionTestBase(PluginTestBase[Extension]):
         Tests :py:meth:`betty.project.extension.Extension.comes_after` implementations.
         """
         for extension_id in self.get_sut_class().comes_after():
-            assert_plugin_identifier(
+            await assert_plugin_identifier(
                 extension_id,
                 Extension,  # type: ignore[type-abstract]
             )
@@ -67,7 +67,7 @@ class ExtensionTestBase(PluginTestBase[Extension]):
         Tests :py:meth:`betty.project.extension.Extension.comes_before` implementations.
         """
         for extension_id in self.get_sut_class().comes_before():
-            assert_plugin_identifier(
+            await assert_plugin_identifier(
                 extension_id,
                 Extension,  # type: ignore[type-abstract]
             )
@@ -104,8 +104,8 @@ class DummyConfigurableExtensionConfiguration(Configuration):
         self.check = other.check
 
     @override
-    def load(self, dump: Dump) -> None:
-        assert_record(
+    async def load(self, dump: Dump) -> None:
+        await assert_record(
             RequiredField("check", assert_bool() | assert_setattr(self, "check"))
         )(dump)
 

--- a/betty/tests/assertion/test___init__.py
+++ b/betty/tests/assertion/test___init__.py
@@ -46,28 +46,28 @@ _T = TypeVar("_T")
 class TestAssertionChain:
     async def test___call__(self) -> None:
         sut = AssertionChain[int, int](lambda value: value)
-        assert sut(123) == 123
+        assert await sut(123) == 123
 
     async def test___or__(self) -> None:
         sut = AssertionChain[int, int](lambda value: value)
         sut |= lambda value: 2 * value
-        assert sut(123) == 246
+        assert await sut(123) == 246
 
     async def test_assertion(self) -> None:
         sut = AssertionChain[int, int](lambda value: value)
-        assert sut(123) == 123
+        assert await sut(123) == 123
 
     async def test_chain(self) -> None:
         sut = AssertionChain[int, int](lambda value: value)
         sut = sut.chain(lambda value: 2 * value)
-        assert sut(123) == 246
+        assert await sut(123) == 246
 
 
-def _always_valid(value: int) -> int:
+async def _always_valid(value: int) -> int:
     return value
 
 
-def _always_invalid(value: int) -> int:
+async def _always_invalid(value: int) -> int:
     raise AssertionFailed(static(""))
 
 
@@ -86,38 +86,38 @@ class TestAssertOr:
         else_assertion: Assertion[Any, bool],
         value: int,
     ) -> None:
-        assert assert_or(if_assertion, else_assertion)(value) == value
+        assert await assert_or(if_assertion, else_assertion)(value) == value
 
     async def test_with_invalid_assertion(self) -> None:
         with raises_error(error_type=AssertionFailed):
-            assert_or(_always_invalid, _always_invalid)(123)
+            await assert_or(_always_invalid, _always_invalid)(123)
 
 
 class TestAssertBool:
     async def test_with_valid_value(self) -> None:
-        assert_bool()(True)
+        await assert_bool()(True)
 
     async def test_with_invalid_value(self) -> None:
         with raises_error(error_type=AssertionFailed):
-            assert_bool()(123)
+            await assert_bool()(123)
 
 
 class TestAssertInt:
     async def test_with_valid_value(self) -> None:
-        assert_int()(123)
+        await assert_int()(123)
 
     async def test_with_invalid_value(self) -> None:
         with raises_error(error_type=AssertionFailed):
-            assert_int()(False)
+            await assert_int()(False)
 
 
 class TestAssertFloat:
     async def test_with_valid_value(self) -> None:
-        assert_float()(1.23)
+        await assert_float()(1.23)
 
     async def test_with_invalid_value(self) -> None:
         with raises_error(error_type=AssertionFailed):
-            assert_float()(False)
+            await assert_float()(False)
 
 
 class TestAssertNumber:
@@ -129,11 +129,11 @@ class TestAssertNumber:
         ],
     )
     async def test_with_valid_value(self, value: Number) -> None:
-        assert_number()(value)
+        await assert_number()(value)
 
     async def test_with_invalid_value(self) -> None:
         with raises_error(error_type=AssertionFailed):
-            assert_number()(False)
+            await assert_number()(False)
 
 
 class TestAssertPositiveNumber:
@@ -147,7 +147,7 @@ class TestAssertPositiveNumber:
         ],
     )
     async def test_with_valid_value(self, value: int | float) -> None:
-        assert_positive_number()(1.23)
+        await assert_positive_number()(1.23)
 
     @pytest.mark.parametrize(
         "value",
@@ -159,53 +159,53 @@ class TestAssertPositiveNumber:
     )
     async def test_with_invalid_value(self, value: int | float) -> None:
         with raises_error(error_type=AssertionFailed):
-            assert_positive_number()(value)
+            await assert_positive_number()(value)
 
 
 class TestAssertStr:
     async def test_with_valid_value(self) -> None:
-        assert_str()("Hello, world!")
+        await assert_str()("Hello, world!")
 
     async def test_with_invalid_value(self) -> None:
         with raises_error(error_type=AssertionFailed):
-            assert_str()(False)
+            await assert_str()(False)
 
 
 class TestAssertSequence:
     async def test_without_list(self) -> None:
         with raises_error(error_type=AssertionFailed):
-            assert_sequence(assert_str())(False)
+            await assert_sequence(assert_str())(False)
 
     async def test_with_invalid_item(self) -> None:
         with raises_error(error_type=AssertionFailed, error_contexts=[Index(0)]):
-            assert_sequence(assert_str())([123])
+            await assert_sequence(assert_str())([123])
 
     async def test_with_empty_list(self) -> None:
-        assert_sequence(assert_str())([])
+        await assert_sequence(assert_str())([])
 
     async def test_with_valid_sequence(self) -> None:
-        assert_sequence(assert_str())(["Hello!"])
+        await assert_sequence(assert_str())(["Hello!"])
 
 
 class TestAssertFields:
     async def test_with_invalid_value(self) -> None:
         with raises_error(error_type=AssertionFailed):
-            assert_fields(OptionalField("hello", assert_str()))(None)
+            await assert_fields(OptionalField("hello", assert_str()))(None)
 
     async def test_required_without_key(self) -> None:
         with raises_error(error_type=AssertionFailed, error_contexts=[Key("hello")]):
-            assert_fields(RequiredField("hello", assert_str()))({})
+            await assert_fields(RequiredField("hello", assert_str()))({})
 
     async def test_optional_without_key(self) -> None:
         expected: Mapping[str, Any] = {}
-        actual = assert_fields(OptionalField("hello", assert_str()))({})
+        actual = await assert_fields(OptionalField("hello", assert_str()))({})
         assert actual == expected
 
     async def test_required_key_with_key(self) -> None:
         expected = {
             "hello": "World!",
         }
-        actual = assert_fields(RequiredField("hello", assert_str()))(
+        actual = await assert_fields(RequiredField("hello", assert_str()))(
             {"hello": "World!"}
         )
         assert actual == expected
@@ -214,7 +214,7 @@ class TestAssertFields:
         expected = {
             "hello": "World!",
         }
-        actual = assert_fields(OptionalField("hello", assert_str()))(
+        actual = await assert_fields(OptionalField("hello", assert_str()))(
             {"hello": "World!"}
         )
         assert actual == expected
@@ -223,68 +223,72 @@ class TestAssertFields:
 class TestAssertField:
     async def test_with_invalid_value(self) -> None:
         with raises_error(error_type=AssertionFailed):
-            assert_field(OptionalField("hello", assert_str()))(None)
+            await assert_field(OptionalField("hello", assert_str()))(None)
 
     async def test_required_without_key(self) -> None:
         with raises_error(error_type=AssertionFailed, error_contexts=[Key("hello")]):
-            assert_field(RequiredField("hello", assert_str()))({})
+            await assert_field(RequiredField("hello", assert_str()))({})
 
     async def test_optional_without_key(self) -> None:
         expected = Void
-        actual = assert_field(OptionalField("hello", assert_str()))({})
+        actual = await assert_field(OptionalField("hello", assert_str()))({})
         assert actual == expected
 
     async def test_required_key_with_key(self) -> None:
         expected = "World!"
-        actual = assert_field(RequiredField("hello", assert_str()))({"hello": "World!"})
+        actual = await assert_field(RequiredField("hello", assert_str()))(
+            {"hello": "World!"}
+        )
         assert actual == expected
 
     async def test_optional_key_with_key(self) -> None:
         expected = "World!"
-        actual = assert_field(OptionalField("hello", assert_str()))({"hello": "World!"})
+        actual = await assert_field(OptionalField("hello", assert_str()))(
+            {"hello": "World!"}
+        )
         assert actual == expected
 
 
 class TestAssertMapping:
     async def test_without_mapping(self) -> None:
         with raises_error(error_type=AssertionFailed):
-            assert_mapping(assert_str())(None)
+            await assert_mapping(assert_str())(None)
 
     async def test_with_invalid_item(self) -> None:
         with raises_error(error_type=AssertionFailed, error_contexts=[Key("hello")]):
-            assert_mapping(assert_str())({"hello": False})
+            await assert_mapping(assert_str())({"hello": False})
 
     async def test_with_empty_dict(self) -> None:
-        assert_mapping(assert_str())({})
+        await assert_mapping(assert_str())({})
 
     async def test_with_valid_mapping(self) -> None:
-        assert_mapping(assert_str())({"hello": "World!"})
+        await assert_mapping(assert_str())({"hello": "World!"})
 
 
 class TestAssertRecord:
     async def test_with_optional_fields_without_items(self) -> None:
         expected: Mapping[str, Any] = {}
-        actual = assert_record(OptionalField("hello", assert_str()))({})
+        actual = await assert_record(OptionalField("hello", assert_str()))({})
         assert actual == expected
 
     async def test_with_optional_fields_with_items(self) -> None:
         expected = {
             "hello": "WORLD!",
         }
-        actual = assert_record(
+        actual = await assert_record(
             OptionalField("hello", assert_str().chain(lambda x: x.upper()))
         )({"hello": "World!"})
         assert actual == expected
 
     async def test_with_required_fields_without_items(self) -> None:
         with raises_error(error_type=AssertionFailed):
-            assert_record(RequiredField("hello", assert_str()))({})
+            await assert_record(RequiredField("hello", assert_str()))({})
 
     async def test_with_required_fields_with_items(self) -> None:
         expected = {
             "hello": "WORLD!",
         }
-        actual = assert_record(
+        actual = await assert_record(
             RequiredField("hello", assert_str().chain(lambda x: x.upper()))
         )(
             {
@@ -296,42 +300,42 @@ class TestAssertRecord:
 
 class TestAssertPath:
     async def test_with_valid_str_path(self) -> None:
-        assert_path()("~/../foo/bar")
+        await assert_path()("~/../foo/bar")
 
     async def test_with_valid_path_path(self) -> None:
-        assert_path()(Path("~/../foo/bar"))
+        await assert_path()(Path("~/../foo/bar"))
 
 
 class TestAssertDirectoryPath:
     async def test_without_existing_path(self) -> None:
         with raises_error(error_type=AssertionFailed):
-            assert_directory_path()("~/../foo/bar")
+            await assert_directory_path()("~/../foo/bar")
 
     async def test_without_directory_path(self) -> None:
         with NamedTemporaryFile() as f, raises_error(error_type=AssertionFailed):
-            assert_directory_path()(f.name)
+            await assert_directory_path()(f.name)
 
     async def test_with_valid_path_str(self) -> None:
         async with TemporaryDirectory() as directory_path_str:
-            assert_directory_path()(directory_path_str)
+            await assert_directory_path()(directory_path_str)
 
     async def test_with_valid_path_path(self) -> None:
         async with TemporaryDirectory() as directory_path_str:
-            assert_directory_path()(Path(directory_path_str))
+            await assert_directory_path()(Path(directory_path_str))
 
 
 class TestAssertFilePath:
     async def test_without_existing_path(self) -> None:
         with pytest.raises(UserFacingError):
-            assert_file_path()("~/../foo/bar")
+            await assert_file_path()("~/../foo/bar")
 
     async def test_with_valid_path_str(self) -> None:
         with NamedTemporaryFile() as f:
-            assert_file_path()(f.name)
+            await assert_file_path()(f.name)
 
     async def test_with_valid_path_path(self) -> None:
         with NamedTemporaryFile() as f:
-            assert_file_path()(Path(f.name))
+            await assert_file_path()(Path(f.name))
 
 
 class TestAssertIsinstance:
@@ -340,14 +344,14 @@ class TestAssertIsinstance:
             pass
 
         instance = MyClass()
-        assert assert_isinstance(MyClass)(instance) == instance
+        assert await assert_isinstance(MyClass)(instance) is instance
 
     async def test_without_instance(self) -> None:
         class MyClass:
             pass
 
         with pytest.raises(AssertionFailed):
-            assert assert_isinstance(MyClass)(object())  # type: ignore[truthy-bool]
+            assert await assert_isinstance(MyClass)(object())  # type: ignore[truthy-bool]
 
 
 class TestAssertLen:
@@ -363,7 +367,7 @@ class TestAssertLen:
         ],
     )
     async def test_exact_with_valid_value(self, exact: int, value: Sized) -> None:
-        assert_len(exact)(value)
+        await assert_len(exact)(value)
 
     @pytest.mark.parametrize(
         ("exact", "value"),
@@ -381,7 +385,7 @@ class TestAssertLen:
     )
     async def test_exact_with_invalid_value(self, exact: int, value: Sized) -> None:
         with pytest.raises(AssertionFailed):
-            assert_len(exact)(value)
+            await assert_len(exact)(value)
 
     @pytest.mark.parametrize(
         ("minimum", "maximum", "value"),
@@ -413,7 +417,7 @@ class TestAssertLen:
     async def test_bound_with_valid_value(
         self, minimum: int | None, maximum: int | None, value: Sized
     ) -> None:
-        assert_len(minimum=minimum, maximum=maximum)(value)
+        await assert_len(minimum=minimum, maximum=maximum)(value)
 
     @pytest.mark.parametrize(
         ("minimum", "maximum", "value"),
@@ -435,4 +439,4 @@ class TestAssertLen:
         self, minimum: int | None, maximum: int | None, value: Sized
     ) -> None:
         with pytest.raises(AssertionFailed):
-            assert_len(minimum=minimum, maximum=maximum)(value)
+            await assert_len(minimum=minimum, maximum=maximum)(value)

--- a/betty/tests/cli/commands/test_config.py
+++ b/betty/tests/cli/commands/test_config.py
@@ -26,5 +26,5 @@ class TestConfig:
             locale,
         )
         configuration = AppConfiguration()
-        (await assert_configuration_file(configuration))(configuration_file_path)
+        await assert_configuration_file(configuration)(configuration_file_path)
         assert configuration.locale == locale

--- a/betty/tests/cli/commands/test_new.py
+++ b/betty/tests/cli/commands/test_new.py
@@ -18,7 +18,7 @@ class TestNew:
         configuration_file_path = project_directory_path / "betty.yaml"
         await run(app, "new", input="\n".join(inputs))
         configuration = await ProjectConfiguration.new(configuration_file_path)
-        return (await assert_configuration_file(configuration))(configuration_file_path)
+        return await assert_configuration_file(configuration)(configuration_file_path)
 
     async def test_click_command_minimal(
         self, new_temporary_app: App, tmp_path: Path

--- a/betty/tests/config/collections/test_mapping.py
+++ b/betty/tests/config/collections/test_mapping.py
@@ -40,8 +40,8 @@ class ConfigurationMappingTestConfiguration(Configuration):
         pass  # pragma: no cover
 
     @override
-    def load(self, dump: Dump) -> None:
-        assert_record(
+    async def load(self, dump: Dump) -> None:
+        await assert_record(
             RequiredField("key", assert_str() | assert_setattr(self, "key")),
             RequiredField("value", assert_int() | assert_setattr(self, "value")),
         )(dump)
@@ -91,13 +91,13 @@ class TestConfigurationMapping(
 
     async def test_load_without_items(self) -> None:
         sut = self.get_sut()
-        sut.load({})
+        await sut.load({})
         assert len(sut) == 0
 
     async def test_load_with_items(self) -> None:
         sut = self.get_sut()
         configurations = self.get_configurations()
-        sut.load({item.key: item.dump() for item in configurations})
+        await sut.load({item.key: item.dump() for item in configurations})
         assert len(sut) == len(configurations)
 
     async def test_dump_without_items(self) -> None:
@@ -120,15 +120,15 @@ class ConfigurationMappingTestConfigurationMapping(
     ConfigurationMapping[str, ConfigurationMappingTestConfiguration]
 ):
     @override
-    def load_item(self, dump: Dump) -> ConfigurationMappingTestConfiguration:
+    async def load_item(self, dump: Dump) -> ConfigurationMappingTestConfiguration:
         configuration = ConfigurationMappingTestConfiguration("", 0)
-        configuration.load(dump)
+        await configuration.load(dump)
         return configuration
 
     def _get_key(self, configuration: ConfigurationMappingTestConfiguration) -> str:
         return configuration.key
 
-    def _load_key(self, item_dump: DumpMapping[Dump], key_dump: str) -> None:
+    async def _load_key(self, item_dump: DumpMapping[Dump], key_dump: str) -> None:
         item_dump["key"] = key_dump
 
     def _dump_key(self, item_dump: DumpMapping[Dump]) -> str:
@@ -174,13 +174,13 @@ class TestOrderedConfigurationMapping(
 
     async def test_load_without_items(self) -> None:
         sut = self.get_sut()
-        sut.load([])
+        await sut.load([])
         assert len(sut) == 0
 
     async def test_load_with_items(self) -> None:
         sut = self.get_sut()
         configurations = self.get_configurations()
-        sut.load([item.dump() for item in configurations])
+        await sut.load([item.dump() for item in configurations])
         assert len(sut) == len(configurations)
 
     async def test_dump_without_items(self) -> None:
@@ -201,9 +201,9 @@ class OrderedConfigurationMappingTestOrderedConfigurationMapping(
     OrderedConfigurationMapping[str, ConfigurationMappingTestConfiguration]
 ):
     @override
-    def load_item(self, dump: Dump) -> ConfigurationMappingTestConfiguration:
+    async def load_item(self, dump: Dump) -> ConfigurationMappingTestConfiguration:
         configuration = ConfigurationMappingTestConfiguration("", 0)
-        configuration.load(dump)
+        await configuration.load(dump)
         return configuration
 
     @override

--- a/betty/tests/config/collections/test_sequence.py
+++ b/betty/tests/config/collections/test_sequence.py
@@ -23,8 +23,8 @@ class ConfigurationSequenceTestConfiguration(Configuration):
         pass  # pragma: no cover
 
     @override
-    def load(self, dump: Dump) -> None:
-        assert_record(
+    async def load(self, dump: Dump) -> None:
+        await assert_record(
             RequiredField("value", assert_int() | assert_setattr(self, "value")),
         )(dump)
 
@@ -61,13 +61,13 @@ class TestConfigurationSequence(
 
     async def test_load_without_items(self) -> None:
         sut = self.get_sut()
-        sut.load([])
+        await sut.load([])
         assert len(sut) == 0
 
     async def test_load_with_items(self) -> None:
         sut = self.get_sut()
         configurations = self.get_configurations()
-        sut.load([item.dump() for item in configurations])
+        await sut.load([item.dump() for item in configurations])
         assert len(sut) == len(configurations)
 
 
@@ -75,7 +75,7 @@ class ConfigurationSequenceTestConfigurationSequence(
     ConfigurationSequence[ConfigurationSequenceTestConfiguration]
 ):
     @override
-    def load_item(self, dump: Dump) -> ConfigurationSequenceTestConfiguration:
+    async def load_item(self, dump: Dump) -> ConfigurationSequenceTestConfiguration:
         configuration = ConfigurationSequenceTestConfiguration(0)
-        configuration.load(dump)
+        await configuration.load(dump)
         return configuration

--- a/betty/tests/gramps/test_loader.py
+++ b/betty/tests/gramps/test_loader.py
@@ -169,7 +169,7 @@ class TestGrampsLoader:
             app,
             Project.new_temporary(app) as project,
         ):
-            project.configuration.name = self.PROJECT_NAME
+            await project.configuration.set_name(self.PROJECT_NAME)
             async with project:
                 loader = GrampsLoader(
                     project.ancestry,

--- a/betty/tests/locale/localizable/test_assertion.py
+++ b/betty/tests/locale/localizable/test_assertion.py
@@ -17,7 +17,7 @@ class TestAssertStaticTranslations:
         ],
     )
     async def test_with_valid_value(self, value: ShorthandStaticTranslations) -> None:
-        assert_static_translations()(value)
+        await assert_static_translations()(value)
 
     @pytest.mark.parametrize(
         "value",
@@ -39,4 +39,4 @@ class TestAssertStaticTranslations:
     )
     async def test_with_invalid_value(self, value: ShorthandStaticTranslations) -> None:
         with pytest.raises(UserFacingError):
-            assert_static_translations()(value)
+            await assert_static_translations()(value)

--- a/betty/tests/locale/localizable/test_config.py
+++ b/betty/tests/locale/localizable/test_config.py
@@ -85,12 +85,12 @@ class TestStaticTranslationsLocalizableConfiguration:
     async def test_load_without_translations_should_error(self) -> None:
         sut = StaticTranslationsLocalizableConfiguration()
         with pytest.raises(AssertionFailed):
-            sut.load({})
+            await sut.load({})
 
     async def test_load_with_single_undetermined_translation(self) -> None:
         dump = "Hello, world!"
         sut = StaticTranslationsLocalizableConfiguration()
-        sut.load(dump)
+        await sut.load(dump)
         assert sut[UNDETERMINED_LOCALE] == "Hello, world!"
 
     async def test_load_with_multiple_translations(self) -> None:
@@ -99,7 +99,7 @@ class TestStaticTranslationsLocalizableConfiguration:
             "nl-NL": "Hallo, wereld!",
         }
         sut = StaticTranslationsLocalizableConfiguration()
-        sut.load(dump)
+        await sut.load(dump)
         assert sut[DEFAULT_LOCALIZER.locale] == "Hello, world!"
         assert sut["nl-NL"] == "Hallo, wereld!"
 

--- a/betty/tests/plugin/test_config.py
+++ b/betty/tests/plugin/test_config.py
@@ -38,7 +38,7 @@ class TestPluginConfiguration:
             "label": "",
         }
         sut = PluginConfiguration("-", "")
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.id == plugin_id
 
     async def test_load_with_undetermined_label(self) -> None:
@@ -48,7 +48,7 @@ class TestPluginConfiguration:
             "label": label,
         }
         sut = PluginConfiguration("-", "")
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.label[UNDETERMINED_LOCALE] == label
 
     async def test_load_with_expanded_label(self) -> None:
@@ -60,7 +60,7 @@ class TestPluginConfiguration:
             },
         }
         sut = PluginConfiguration("-", "")
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.label[DEFAULT_LOCALIZER.locale] == label
 
     async def test_load_with_undetermined_description(self) -> None:
@@ -71,7 +71,7 @@ class TestPluginConfiguration:
             "description": description,
         }
         sut = PluginConfiguration("-", "")
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.description[UNDETERMINED_LOCALE] == description
 
     async def test_load_with_expanded_description(self) -> None:
@@ -84,7 +84,7 @@ class TestPluginConfiguration:
             },
         }
         sut = PluginConfiguration("-", "")
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.description[DEFAULT_LOCALIZER.locale] == description
 
     async def test_dump(self) -> None:

--- a/betty/tests/project/extension/cotton_candy/test_config.py
+++ b/betty/tests/project/extension/cotton_candy/test_config.py
@@ -5,13 +5,13 @@ from typing import Any, TYPE_CHECKING
 import pytest
 
 from betty.assertion.error import AssertionFailed
+from betty.model import UserFacingEntity
+from betty.plugin.static import StaticPluginRepository
+from betty.project.config import EntityReference
 from betty.project.extension.cotton_candy.config import (
     ColorConfiguration,
     CottonCandyConfiguration,
 )
-from betty.model import UserFacingEntity
-from betty.plugin.static import StaticPluginRepository
-from betty.project.config import EntityReference
 from betty.test_utils.assertion.error import raises_error
 from betty.test_utils.model import DummyEntity
 
@@ -44,7 +44,7 @@ class TestColorConfiguration:
         hex_value = "#000000"
         dump = hex_value
         sut = ColorConfiguration("#ffffff")
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.hex == hex_value
 
     @pytest.mark.parametrize(
@@ -59,7 +59,7 @@ class TestColorConfiguration:
     async def test_load_with_invalid_value(self, dump: Dump) -> None:
         sut = ColorConfiguration("#ffffff")
         with pytest.raises(AssertionFailed):
-            sut.load(dump)
+            await sut.load(dump)
 
     async def test_dump_with_value(self) -> None:
         hex_value = "#000000"
@@ -84,12 +84,12 @@ class CottonCandyConfigurationTestEntitytest_load_with_featured_entities:
 class TestCottonCandyConfiguration:
     async def test_load_with_minimal_configuration(self) -> None:
         dump: Mapping[str, Any] = {}
-        CottonCandyConfiguration().load(dump)
+        await CottonCandyConfiguration().load(dump)
 
     async def test_load_without_dict_should_error(self) -> None:
         dump = None
         with raises_error(error_type=AssertionFailed):
-            CottonCandyConfiguration().load(dump)
+            await CottonCandyConfiguration().load(dump)
 
     async def test_load_with_featured_entities(self, mocker: MockerFixture) -> None:
         mocker.patch(
@@ -107,7 +107,7 @@ class TestCottonCandyConfiguration:
             ],
         }
         sut = CottonCandyConfiguration()
-        sut.load(dump)
+        await sut.load(dump)
         assert entity_type is sut.featured_entities[0].entity_type
         assert sut.featured_entities[0].entity_id == entity_id
 
@@ -117,7 +117,7 @@ class TestCottonCandyConfiguration:
             "primary_inactive_color": hex_value,
         }
         sut = CottonCandyConfiguration()
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.primary_inactive_color.hex == hex_value
 
     async def test_load_with_primary_active_color(self) -> None:
@@ -126,7 +126,7 @@ class TestCottonCandyConfiguration:
             "primary_active_color": hex_value,
         }
         sut = CottonCandyConfiguration()
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.primary_active_color.hex == hex_value
 
     async def test_load_with_link_inactive_color(self) -> None:
@@ -135,7 +135,7 @@ class TestCottonCandyConfiguration:
             "link_inactive_color": hex_value,
         }
         sut = CottonCandyConfiguration()
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.link_inactive_color.hex == hex_value
 
     async def test_load_with_link_active_color(self) -> None:
@@ -144,7 +144,7 @@ class TestCottonCandyConfiguration:
             "link_active_color": hex_value,
         }
         sut = CottonCandyConfiguration()
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.link_active_color.hex == hex_value
 
     async def test_dump_with_minimal_configuration(self) -> None:

--- a/betty/tests/project/extension/gramps/test_config.py
+++ b/betty/tests/project/extension/gramps/test_config.py
@@ -65,7 +65,7 @@ class TestFamilyTreeConfiguration:
     async def test_load_with_minimal_configuration(self, tmp_path: Path) -> None:
         file_path = tmp_path / "ancestry.gramps"
         dump: Dump = {"file": str(file_path)}
-        FamilyTreeConfiguration(tmp_path).load(dump)
+        await FamilyTreeConfiguration(tmp_path).load(dump)
 
     async def test_load_with_event_types(self, tmp_path: Path) -> None:
         file_path = tmp_path / "ancestry.gramps"
@@ -74,7 +74,7 @@ class TestFamilyTreeConfiguration:
             "event_types": {"my-first-gramps-type": "my-first-betty-plugin-id"},
         }
         sut = FamilyTreeConfiguration(tmp_path)
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.event_types["my-first-gramps-type"] == "my-first-betty-plugin-id"
 
     async def test_load_with_genders(self, tmp_path: Path) -> None:
@@ -84,7 +84,7 @@ class TestFamilyTreeConfiguration:
             "genders": {"my-first-gramps-type": "my-first-betty-plugin-id"},
         }
         sut = FamilyTreeConfiguration(tmp_path)
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.genders["my-first-gramps-type"] == "my-first-betty-plugin-id"
 
     async def test_load_with_place_types(self, tmp_path: Path) -> None:
@@ -94,7 +94,7 @@ class TestFamilyTreeConfiguration:
             "place_types": {"my-first-gramps-type": "my-first-betty-plugin-id"},
         }
         sut = FamilyTreeConfiguration(tmp_path)
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.place_types["my-first-gramps-type"] == "my-first-betty-plugin-id"
 
     async def test_load_with_presence_roles(self, tmp_path: Path) -> None:
@@ -104,13 +104,13 @@ class TestFamilyTreeConfiguration:
             "presence_roles": {"my-first-gramps-type": "my-first-betty-plugin-id"},
         }
         sut = FamilyTreeConfiguration(tmp_path)
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.presence_roles["my-first-gramps-type"] == "my-first-betty-plugin-id"
 
     async def test_load_without_dict_should_error(self, tmp_path: Path) -> None:
         dump = None
         with raises_error(error_type=AssertionFailed):
-            FamilyTreeConfiguration(tmp_path).load(dump)
+            await FamilyTreeConfiguration(tmp_path).load(dump)
 
     async def test_dump_with_minimal_configuration(self, tmp_path: Path) -> None:
         sut = FamilyTreeConfiguration(tmp_path)
@@ -208,15 +208,15 @@ class TestFamilyTreeConfiguration:
 
 
 class TestPluginMapping:
-    def test_load_without_values(self) -> None:
+    async def test_load_without_values(self) -> None:
         sut = PluginMapping()
-        sut.load({})
+        await sut.load({})
         assert sut.dump() is Void
 
-    def test_load_with_values(self) -> None:
+    async def test_load_with_values(self) -> None:
         dump: Dump = {"my-first-gramps-type": "my-first-betty-plugin-id"}
         sut = PluginMapping()
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.dump() == dump
         assert sut["my-first-gramps-type"] == "my-first-betty-plugin-id"
 
@@ -231,10 +231,10 @@ class TestPluginMapping:
             [],
         ],
     )
-    def test_load_should_error(self, dump: Dump) -> None:
+    async def test_load_should_error(self, dump: Dump) -> None:
         sut = PluginMapping()
         with pytest.raises(AssertionFailed):
-            sut.load(dump)
+            await sut.load(dump)
 
     @pytest.mark.parametrize(
         ("expected", "sut"),
@@ -295,12 +295,12 @@ class TestPluginMapping:
 class TestGrampsConfiguration:
     async def test_load_with_minimal_configuration(self) -> None:
         dump: Dump = {}
-        GrampsConfiguration().load(dump)
+        await GrampsConfiguration().load(dump)
 
     async def test_load_without_dict_should_error(self) -> None:
         dump = None
         with raises_error(error_type=AssertionFailed):
-            GrampsConfiguration().load(dump)
+            await GrampsConfiguration().load(dump)
 
     async def test_load_with_family_tree(self, tmp_path: Path) -> None:
         file_path = tmp_path / "ancestry.gramps"
@@ -312,7 +312,7 @@ class TestGrampsConfiguration:
             ],
         }
         sut = GrampsConfiguration()
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.family_trees[0].file_path == file_path
 
     async def test_dump_with_minimal_configuration(self) -> None:

--- a/betty/tests/project/extension/wikipedia/test_config.py
+++ b/betty/tests/project/extension/wikipedia/test_config.py
@@ -15,12 +15,12 @@ if TYPE_CHECKING:
 class TestWikipediaConfiguration:
     async def test_load_with_minimal_configuration(self) -> None:
         dump: Mapping[str, Any] = {}
-        WikipediaConfiguration().load(dump)
+        await WikipediaConfiguration().load(dump)
 
     async def test_load_without_dict_should_error(self) -> None:
         dump = None
         with raises_error(error_type=AssertionFailed):
-            WikipediaConfiguration().load(dump)
+            await WikipediaConfiguration().load(dump)
 
     @pytest.mark.parametrize(
         "populate_images",
@@ -36,7 +36,7 @@ class TestWikipediaConfiguration:
             "populate_images": populate_images,
         }
         sut = WikipediaConfiguration()
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.populate_images == populate_images
 
     async def test_dump_with_minimal_configuration(self) -> None:

--- a/betty/tests/project/test___init__.py
+++ b/betty/tests/project/test___init__.py
@@ -334,7 +334,7 @@ class TestProject:
     async def test_name_with_configuration_name(self, new_temporary_app: App) -> None:
         name = "hello-world"
         async with Project.new_temporary(new_temporary_app) as sut:
-            sut.configuration.name = name
+            await sut.configuration.set_name(name)
             async with sut:
                 assert sut.name == name
 

--- a/betty/tests/project/test_config.py
+++ b/betty/tests/project/test_config.py
@@ -107,7 +107,7 @@ class TestEntityReference:
         )
         entity_id = "123"
         dump = entity_id
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.entity_id == entity_id
 
     @pytest.mark.parametrize(
@@ -132,7 +132,7 @@ class TestEntityReference:
             EntityReferenceTestEntityOne, entity_type_is_constrained=True
         )
         with raises_error(error_type=AssertionFailed):
-            sut.load(dump)
+            await sut.load(dump)
 
     async def test_load_without_constraint(self, mocker: MockerFixture) -> None:
         mocker.patch(
@@ -146,7 +146,7 @@ class TestEntityReference:
             "entity": entity_id,
         }
         sut = EntityReference[EntityReferenceTestEntityOne]()
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.entity_type == entity_type
         assert sut.entity_id == entity_id
 
@@ -159,7 +159,7 @@ class TestEntityReference:
         }
         sut = EntityReference[EntityReferenceTestEntityOne]()
         with raises_error(error_type=AssertionFailed):
-            sut.load(dump)
+            await sut.load(dump)
 
     async def test_load_without_constraint_without_string_entity_type_should_error(
         self,
@@ -171,7 +171,7 @@ class TestEntityReference:
         }
         sut = EntityReference[EntityReferenceTestEntityOne]()
         with raises_error(error_type=AssertionFailed):
-            sut.load(dump)
+            await sut.load(dump)
 
     async def test_load_without_constraint_without_importable_entity_type_should_error(
         self,
@@ -183,7 +183,7 @@ class TestEntityReference:
         }
         sut = EntityReference[EntityReferenceTestEntityOne]()
         with raises_error(error_type=AssertionFailed):
-            sut.load(dump)
+            await sut.load(dump)
 
     async def test_load_without_constraint_without_string_entity_id_should_error(
         self,
@@ -195,7 +195,7 @@ class TestEntityReference:
         }
         sut = EntityReference[EntityReferenceTestEntityOne]()
         with raises_error(error_type=AssertionFailed):
-            sut.load(dump)
+            await sut.load(dump)
 
     async def test_dump_with_constraint(self) -> None:
         sut = EntityReference[Entity](Entity, None, entity_type_is_constrained=True)
@@ -325,14 +325,14 @@ class TestLocaleConfiguration:
         dump: Dump = {}
         sut = LocaleConfiguration(DEFAULT_LOCALE)
         with raises_error(error_type=AssertionFailed):
-            sut.load(dump)
+            await sut.load(dump)
 
     async def test_load_with_locale(self) -> None:
         dump: Dump = {
             "locale": UNDETERMINED_LOCALE,
         }
         sut = LocaleConfiguration(DEFAULT_LOCALE)
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.locale == UNDETERMINED_LOCALE
 
     async def test_load_with_alias(self) -> None:
@@ -341,7 +341,7 @@ class TestLocaleConfiguration:
             "alias": "UNDETERMINED_LOCALE",
         }
         sut = LocaleConfiguration(DEFAULT_LOCALE)
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.alias == "UNDETERMINED_LOCALE"
 
     async def test_dump_should_dump_minimal(self) -> None:
@@ -476,7 +476,7 @@ class _DummyConfiguration(Configuration):
         pass  # pragma: no cover
 
     @override
-    def load(self, dump: Dump) -> None:
+    async def load(self, dump: Dump) -> None:
         pass  # pragma: no cover
 
     @override
@@ -516,24 +516,24 @@ class TestExtensionConfiguration:
 
     async def test_load_without_extension(self) -> None:
         with raises_error(error_type=AssertionFailed):
-            ExtensionConfiguration(DummyExtension).load({})
+            await ExtensionConfiguration(DummyExtension).load({})
 
     async def test_load_with_extension(self) -> None:
         sut = ExtensionConfiguration(DummyExtension)
-        sut.load({"extension": DummyConfigurableExtension.plugin_id()})
+        await sut.load({"extension": DummyConfigurableExtension.plugin_id()})
         assert sut.extension_type == DummyConfigurableExtension
         assert sut.enabled
 
     async def test_load_with_enabled(self) -> None:
         sut = ExtensionConfiguration(DummyExtension)
-        sut.load(
+        await sut.load(
             {"extension": DummyConfigurableExtension.plugin_id(), "enabled": False}
         )
         assert not sut.enabled
 
     async def test_load_with_configuration(self) -> None:
         sut = ExtensionConfiguration(DummyConfigurableExtension)
-        sut.load(
+        await sut.load(
             {
                 "extension": DummyConfigurableExtension.plugin_id(),
                 "configuration": {
@@ -552,7 +552,7 @@ class TestExtensionConfiguration:
     ) -> None:
         sut = ExtensionConfiguration(DummyExtension)
         with pytest.raises(AssertionFailed):
-            sut.load(
+            await sut.load(
                 {
                     "extension": DummyExtension.plugin_id(),
                     "configuration": {
@@ -706,7 +706,7 @@ class TestEntityTypeConfiguration:
         dump: Dump = {}
         sut = EntityTypeConfiguration(EntityTypeConfigurationTestEntityOne)
         with raises_error(error_type=AssertionFailed):
-            sut.load(dump)
+            await sut.load(dump)
 
     async def test_load_with_minimal_configuration(self, mocker: MockerFixture) -> None:
         mocker.patch(
@@ -717,7 +717,7 @@ class TestEntityTypeConfiguration:
             "entity_type": EntityTypeConfigurationTestEntityOne.plugin_id(),
         }
         sut = EntityTypeConfiguration(EntityTypeConfigurationTestEntityOne)
-        sut.load(dump)
+        await sut.load(dump)
 
     @pytest.mark.parametrize(
         "generate_html_list,",
@@ -738,7 +738,7 @@ class TestEntityTypeConfiguration:
             "generate_html_list": generate_html_list,
         }
         sut = EntityTypeConfiguration(EntityTypeConfigurationTestEntityOne)
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.generate_html_list == generate_html_list
 
     async def test_dump_with_minimal_configuration(self) -> None:
@@ -878,7 +878,7 @@ class TestCopyrightNoticeConfiguration:
             "text": text,
         }
         sut = CopyrightNoticeConfiguration("-", "", summary="", text="")
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.summary[UNDETERMINED_LOCALE] == summary
         assert sut.text[UNDETERMINED_LOCALE] == text
 
@@ -890,7 +890,7 @@ class TestCopyrightNoticeConfiguration:
         }
         sut = CopyrightNoticeConfiguration("-", "", summary="", text="")
         with pytest.raises(AssertionFailed):
-            sut.load(dump)
+            await sut.load(dump)
 
     async def test_load_with_missing_text(self) -> None:
         dump: Dump = {
@@ -900,7 +900,7 @@ class TestCopyrightNoticeConfiguration:
         }
         sut = CopyrightNoticeConfiguration("-", "", summary="", text="")
         with pytest.raises(AssertionFailed):
-            sut.load(dump)
+            await sut.load(dump)
 
     async def test_dump(self) -> None:
         summary = "My First Copyright Summary"
@@ -985,7 +985,7 @@ class TestLicenseConfiguration:
             "text": text,
         }
         sut = LicenseConfiguration("-", "", summary="", text="")
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.summary[UNDETERMINED_LOCALE] == summary
         assert sut.text[UNDETERMINED_LOCALE] == text
 
@@ -997,7 +997,7 @@ class TestLicenseConfiguration:
         }
         sut = LicenseConfiguration("-", "", summary="", text="")
         with pytest.raises(AssertionFailed):
-            sut.load(dump)
+            await sut.load(dump)
 
     async def test_load_with_missing_text(self) -> None:
         dump: Dump = {
@@ -1007,7 +1007,7 @@ class TestLicenseConfiguration:
         }
         sut = LicenseConfiguration("-", "", summary="", text="")
         with pytest.raises(AssertionFailed):
-            sut.load(dump)
+            await sut.load(dump)
 
     async def test_dump(self) -> None:
         summary = "My First License Summary"
@@ -1215,7 +1215,7 @@ class TestProjectConfiguration:
 
     async def test_lifetime_threshold(self, tmp_path: Path) -> None:
         sut = await ProjectConfiguration.new(tmp_path / "betty.json")
-        sut.lifetime_threshold = 999
+        await sut.set_lifetime_threshold(999)
         assert sut.lifetime_threshold == 999
 
     async def test_locales(self, tmp_path: Path) -> None:
@@ -1251,7 +1251,7 @@ class TestProjectConfiguration:
     async def test_name(self, tmp_path: Path) -> None:
         sut = await ProjectConfiguration.new(tmp_path / "betty.json")
         name = "my-first-betty-site"
-        sut.name = name
+        await sut.set_name(name)
         assert sut.name == name
 
     async def test_url(self, tmp_path: Path) -> None:
@@ -1351,7 +1351,7 @@ class TestProjectConfiguration:
     async def test_load_should_load_minimal(self, tmp_path: Path) -> None:
         sut = await ProjectConfiguration.new(tmp_path / "betty.json")
         dump = sut.dump()
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.url == dump["url"]
         assert sut.title.localize(DEFAULT_LOCALIZER) == "Betty"
         assert not sut.author
@@ -1363,7 +1363,7 @@ class TestProjectConfiguration:
         sut = await ProjectConfiguration.new(tmp_path / "betty.json")
         dump = sut.dump()
         dump["name"] = name
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.name == name
 
     async def test_load_should_load_title(self, tmp_path: Path) -> None:
@@ -1371,7 +1371,7 @@ class TestProjectConfiguration:
         sut = await ProjectConfiguration.new(tmp_path / "betty.json")
         dump = sut.dump()
         dump["title"] = title
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.title.localize(DEFAULT_LOCALIZER) == title
 
     async def test_load_should_load_author(self, tmp_path: Path) -> None:
@@ -1379,7 +1379,7 @@ class TestProjectConfiguration:
         sut = await ProjectConfiguration.new(tmp_path / "betty.json")
         dump = sut.dump()
         dump["author"] = author
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.author.localize(DEFAULT_LOCALIZER) == author
 
     async def test_load_should_load_logo(self, tmp_path: Path) -> None:
@@ -1387,7 +1387,7 @@ class TestProjectConfiguration:
         sut = await ProjectConfiguration.new(tmp_path / "betty.json")
         dump = sut.dump()
         dump["logo"] = str(logo)
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.logo == logo
 
     async def test_load_should_load_locale_locale(self, tmp_path: Path) -> None:
@@ -1395,7 +1395,7 @@ class TestProjectConfiguration:
         sut = await ProjectConfiguration.new(tmp_path / "betty.json")
         dump = sut.dump()
         dump["locales"] = [{"locale": locale}]
-        sut.load(dump)
+        await sut.load(dump)
         assert len(sut.locales) == 1
         assert locale in sut.locales
 
@@ -1405,7 +1405,7 @@ class TestProjectConfiguration:
         sut = await ProjectConfiguration.new(tmp_path / "betty.json")
         dump = sut.dump()
         dump["locales"] = [{"locale": locale, "alias": alias}]
-        sut.load(dump)
+        await sut.load(dump)
         assert len(sut.locales) == 1
         assert locale in sut.locales
         actual = sut.locales[locale]
@@ -1416,7 +1416,7 @@ class TestProjectConfiguration:
         sut = await ProjectConfiguration.new(tmp_path / "betty.json")
         dump = sut.dump()
         dump["clean_urls"] = clean_urls
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.clean_urls == clean_urls
 
     @pytest.mark.parametrize(
@@ -1430,7 +1430,7 @@ class TestProjectConfiguration:
         sut = await ProjectConfiguration.new(tmp_path / "betty.json")
         dump = sut.dump()
         dump["debug"] = debug
-        sut.load(dump)
+        await sut.load(dump)
         assert sut.debug == debug
 
     async def test_load_should_load_one_extension_with_configuration(
@@ -1450,7 +1450,7 @@ class TestProjectConfiguration:
                 "configuration": extension_configuration,
             },
         }
-        sut.load(dump)
+        await sut.load(dump)
         actual = sut.extensions[DummyConfigurableExtension]
         assert actual.enabled
         assert isinstance(
@@ -1469,7 +1469,7 @@ class TestProjectConfiguration:
         dump["extensions"] = {
             _DummyNonConfigurableExtension.plugin_id(): {},
         }
-        sut.load(dump)
+        await sut.load(dump)
         actual = sut.extensions[_DummyNonConfigurableExtension]
         assert actual.enabled
         assert actual.extension_configuration is None
@@ -1483,7 +1483,7 @@ class TestProjectConfiguration:
             DummyConfigurableExtension.plugin_id(): 1337,
         }
         with raises_error(error_type=AssertionFailed):
-            sut.load(dump)
+            await sut.load(dump)
 
     async def test_load_unknown_extension_type_name_should_error(
         self, tmp_path: Path
@@ -1494,7 +1494,7 @@ class TestProjectConfiguration:
             "non.existent.type": {},
         }
         with raises_error(error_type=AssertionFailed):
-            sut.load(dump)
+            await sut.load(dump)
 
     async def test_load_not_an_extension_type_name_should_error(
         self, tmp_path: Path
@@ -1505,7 +1505,7 @@ class TestProjectConfiguration:
             f"{self.__class__.__module__}.{self.__class__.__name__}": {}
         }
         with raises_error(error_type=AssertionFailed):
-            sut.load(dump)
+            await sut.load(dump)
 
     @pytest.mark.parametrize(
         "event_types_configuration",
@@ -1520,7 +1520,7 @@ class TestProjectConfiguration:
         sut = await ProjectConfiguration.new(tmp_path / "betty.json")
         dump = sut.dump()
         dump["event_types"] = event_types_configuration
-        sut.load(dump)
+        await sut.load(dump)
         if event_types_configuration:
             assert sut.dump()["event_types"] == event_types_configuration
 
@@ -1537,7 +1537,7 @@ class TestProjectConfiguration:
         sut = await ProjectConfiguration.new(tmp_path / "betty.json")
         dump = sut.dump()
         dump["place_types"] = place_types_configuration
-        sut.load(dump)
+        await sut.load(dump)
         if place_types_configuration:
             assert sut.dump()["place_types"] == place_types_configuration
 
@@ -1554,7 +1554,7 @@ class TestProjectConfiguration:
         sut = await ProjectConfiguration.new(tmp_path / "betty.json")
         dump = sut.dump()
         dump["presence_roles"] = presence_roles_configuration
-        sut.load(dump)
+        await sut.load(dump)
         if presence_roles_configuration:
             assert sut.dump()["presence_roles"] == presence_roles_configuration
 
@@ -1571,7 +1571,7 @@ class TestProjectConfiguration:
         sut = await ProjectConfiguration.new(tmp_path / "betty.json")
         dump = sut.dump()
         dump["genders"] = genders_configuration
-        sut.load(dump)
+        await sut.load(dump)
         if genders_configuration:
             assert sut.dump()["genders"] == genders_configuration
 
@@ -1579,7 +1579,7 @@ class TestProjectConfiguration:
         dump: Dump = {}
         sut = await ProjectConfiguration.new(tmp_path / "betty.json")
         with raises_error(error_type=AssertionFailed):
-            sut.load(dump)
+            await sut.load(dump)
 
     async def test_dump_should_dump_minimal(self, tmp_path: Path) -> None:
         sut = await ProjectConfiguration.new(tmp_path / "betty.json")
@@ -1601,7 +1601,7 @@ class TestProjectConfiguration:
     async def test_dump_should_dump_name(self, tmp_path: Path) -> None:
         name = "my-first-betty-site"
         sut = await ProjectConfiguration.new(tmp_path / "betty.json")
-        sut.name = name
+        await sut.set_name(name)
         dump = sut.dump()
         assert dump["name"] == name
 
@@ -1726,7 +1726,7 @@ class TestProjectConfiguration:
         dump: Dump = {}
         sut = await ProjectConfiguration.new(tmp_path / "betty.json")
         with raises_error(error_type=AssertionFailed):
-            sut.load(dump)
+            await sut.load(dump)
 
     async def test_update(self, tmp_path: Path) -> None:
         url = "https://betty.example.com"

--- a/betty/tests/test_asyncio.py
+++ b/betty/tests/test_asyncio.py
@@ -1,15 +1,4 @@
-from betty.asyncio import wait_to_thread, ensure_await
-
-
-class TestWaitToThread:
-    async def test(self) -> None:
-        expected = "Hello, oh asynchronous, world!"
-
-        async def _async() -> str:
-            return expected
-
-        actual = wait_to_thread(_async())
-        assert actual == expected
+from betty.asyncio import ensure_await
 
 
 class TestEnsureAwait:

--- a/betty/tests/test_documentation.py
+++ b/betty/tests/test_documentation.py
@@ -95,7 +95,7 @@ class TestDocumentation:
         dump = match[1]
         assert dump is not None
         configuration = await ProjectConfiguration.new(tmp_path / "betty.json")
-        configuration.load(serde_format.load(dump))
+        await configuration.load(serde_format.load(dump))
 
 
 class TestDocstringSphinxReferences:

--- a/betty/tests/test_machine_name.py
+++ b/betty/tests/test_machine_name.py
@@ -50,7 +50,7 @@ class TestAssertMachineName:
         ],
     )
     async def test_with_valid_value(self, alleged_machine_name: str) -> None:
-        assert_machine_name()(alleged_machine_name)
+        await assert_machine_name()(alleged_machine_name)
 
     @pytest.mark.parametrize(
         "alleged_machine_name",
@@ -65,7 +65,7 @@ class TestAssertMachineName:
     )
     async def test_with_invalid_value(self, alleged_machine_name: str) -> None:
         with pytest.raises(InvalidMachineName):
-            assert_machine_name()(alleged_machine_name)
+            await assert_machine_name()(alleged_machine_name)
 
 
 class TestInvalidMachineName:
@@ -109,5 +109,5 @@ class TestMachinify:
     async def test(self, expected: str | None, source: str) -> None:
         actual = machinify(source)
         if expected is not None:
-            assert_machine_name()(expected)
+            await assert_machine_name()(expected)
         assert actual == expected


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/2057

## Ideas
- Allow assertions (and chains) to be synchronous and/or asynchronous? Chains must be typed so that synchronous chains cannot be extended by asynchronous assertions. The other way around is type-safe, and we don't have to worry about that.
- The problem is that some sync APIs (__getitem__ et al) use assertions for input validation. These cannot be made async like regular setters.