### PR TITLE
Make URL generators accept `MediaType` instead or raw media type strings

### DIFF
--- a/betty/jinja2/filter.py
+++ b/betty/jinja2/filter.py
@@ -46,6 +46,7 @@ from betty.locale import (
     SPECIAL_LOCALES,
 )
 from betty.locale.localized import Localized, negotiate_localizeds, LocalizedStr
+from betty.media_type.media_types import HTML
 from betty.os import link_or_copy
 from betty.serde.dump import minimize
 from betty.string import (
@@ -54,13 +55,13 @@ from betty.string import (
     upper_camel_case_to_lower_camel_case,
 )
 from betty.typing import void_none, none_void
+from betty.media_type import MediaType
 
 if TYPE_CHECKING:
     from betty.ancestry.date import HasDate
     from betty.date import Datey
     from betty.locale.localizable import Localizable
     from jinja2.nodes import EvalContext
-    from betty.media_type import MediaType
     from pathlib import Path
     from collections.abc import Awaitable
 
@@ -83,7 +84,7 @@ async def filter_localized_url(
     localized_url_generator = await context_project(context).localized_url_generator
     return localized_url_generator.generate(
         resource,
-        media_type or "text/html",
+        MediaType(media_type) if media_type else HTML,
         locale=locale or context_localizer(context).locale,
         **kwargs,
     )

--- a/betty/media_type/media_types.py
+++ b/betty/media_type/media_types.py
@@ -10,6 +10,10 @@ from betty.media_type import MediaType
 HTML = MediaType("text/html")
 
 
+#: The media type for JSON content.
+JSON = MediaType("application/json")
+
+
 #: The media type for JSON-LD content.
 JSON_LD = MediaType("application/ld+json")
 

--- a/betty/project/extension/trees/__init__.py
+++ b/betty/project/extension/trees/__init__.py
@@ -12,6 +12,7 @@ from typing_extensions import override
 
 from betty.ancestry.person import Person
 from betty.locale.localizable import _
+from betty.media_type.media_types import HTML
 from betty.plugin import ShorthandPluginBase
 from betty.project.extension import Extension
 from betty.project.extension.webpack import Webpack, WebpackEntryPointProvider
@@ -46,7 +47,7 @@ async def _generate_people_json_for_locale(
             "label": person.label.localize(localizer)
             if person.public
             else private_label,
-            "url": localized_url_generator.generate(person, "text/html"),
+            "url": localized_url_generator.generate(person, HTML),
             "parentIds": [parent.id for parent in person.parents],
             "childIds": [child.id for child in person.children],
             "private": person.private,

--- a/betty/project/generate/__init__.py
+++ b/betty/project/generate/__init__.py
@@ -21,7 +21,6 @@ from asyncio import (
 )
 from collections.abc import MutableSequence
 from contextlib import suppress
-from math import floor
 from pathlib import Path
 from typing import (
     cast,
@@ -34,11 +33,13 @@ from typing import (
 
 import aiofiles
 from aiofiles.os import makedirs
+from math import floor
 
 from betty import model
 from betty.locale import get_display_name
 from betty.locale.localizable import _
 from betty.locale.localizer import DEFAULT_LOCALIZER
+from betty.media_type.media_types import JSON, HTML
 from betty.model import UserFacingEntity, Entity, has_generated_entity_id
 from betty.openapi import Specification
 from betty.privacy import is_public
@@ -356,7 +357,7 @@ async def _generate_entity_type_list_json(
         cast(MutableSequence[str], data["collection"]).append(
             localized_url_generator.generate(
                 entity,
-                "application/json",
+                JSON,
                 absolute=True,
             )
         )
@@ -483,7 +484,7 @@ async def _generate_sitemap(
                     entity,
                     absolute=True,
                     locale=locale,
-                    media_type="text/html",
+                    media_type=HTML,
                 )
             )
             sitemap_batch_urls_length += 1

--- a/betty/project/url.py
+++ b/betty/project/url.py
@@ -10,6 +10,7 @@ from urllib.parse import quote
 from typing_extensions import override
 
 from betty import model
+from betty.media_type.media_types import HTML, JSON, JSON_LD
 from betty.project.factory import ProjectDependentFactory
 from betty.string import camel_case_to_kebab_case
 from betty.typing import internal
@@ -21,6 +22,7 @@ from betty.url import (
 from betty.url.proxy import ProxyLocalizedUrlGenerator
 
 if TYPE_CHECKING:
+    from betty.media_type import MediaType
     from betty.project import Project
     from betty.model import Entity
     from betty.locale import Localey
@@ -70,7 +72,7 @@ class _LocalizedPathUrlGenerator(_ProjectUrlGenerator, StdLocalizedUrlGenerator)
     def generate(
         self,
         resource: Any,
-        media_type: str,
+        media_type: MediaType,
         *,
         absolute: bool = False,
         locale: Localey | None = None,
@@ -137,11 +139,11 @@ class _EntityTypeDependentUrlGenerator(_ProjectUrlGenerator, StdLocalizedUrlGene
         )
 
     def _get_extension_and_locale(
-        self, media_type: str, *, locale: Localey | None
+        self, media_type: MediaType, *, locale: Localey | None
     ) -> tuple[str, Localey | None]:
-        if media_type == "text/html":
+        if media_type == HTML:
             return "html", locale or self._default_locale
-        elif media_type == "application/json":
+        elif media_type in (JSON, JSON_LD):
             return "json", None
         else:
             raise ValueError(f'Unknown entity media type "{media_type}".')
@@ -159,7 +161,7 @@ class _EntityTypeUrlGenerator(_EntityTypeDependentUrlGenerator):
     def generate(
         self,
         resource: Entity,
-        media_type: str,
+        media_type: MediaType,
         *,
         absolute: bool = False,
         locale: Localey | None = None,
@@ -187,7 +189,7 @@ class _EntityUrlGenerator(_EntityTypeDependentUrlGenerator):
     def generate(
         self,
         resource: Entity,
-        media_type: str,
+        media_type: MediaType,
         *,
         absolute: bool = False,
         locale: Localey | None = None,
@@ -249,7 +251,7 @@ class LocalizedUrlGenerator(StdLocalizedUrlGenerator, ProjectDependentFactory):
     def generate(
         self,
         resource: Any,
-        media_type: str,
+        media_type: MediaType,
         *,
         absolute: bool = False,
         locale: Localey | None = None,

--- a/betty/tests/project/test_url.py
+++ b/betty/tests/project/test_url.py
@@ -6,6 +6,8 @@ from pytest_mock import MockerFixture
 
 from betty.app import App
 from betty.locale import Localey, DEFAULT_LOCALE
+from betty.media_type import MediaType
+from betty.media_type.media_types import HTML
 from betty.plugin.static import StaticPluginRepository
 from betty.project import Project
 from betty.project.config import LocaleConfiguration
@@ -66,7 +68,7 @@ class TestLocalizedUrlGenerator:
                     {DEFAULT_LOCALE: DEFAULT_LOCALE},
                     False,
                     path,
-                    "text/html",
+                    HTML,
                     False,
                     None,
                 )
@@ -90,7 +92,7 @@ class TestLocalizedUrlGenerator:
                     {DEFAULT_LOCALE: DEFAULT_LOCALE},
                     False,
                     path,
-                    "text/html",
+                    HTML,
                     True,
                     None,
                 )
@@ -114,7 +116,7 @@ class TestLocalizedUrlGenerator:
                     {DEFAULT_LOCALE: DEFAULT_LOCALE},
                     True,
                     path,
-                    "text/html",
+                    HTML,
                     False,
                     None,
                 )
@@ -139,7 +141,7 @@ class TestLocalizedUrlGenerator:
         locales: Mapping[str, str],
         clean_urls: bool,
         resource: str,
-        media_type: str,
+        media_type: MediaType,
         absolute: bool,
         locale: Localey | None,
         new_temporary_app: App,

--- a/betty/tests/url/test_proxy.py
+++ b/betty/tests/url/test_proxy.py
@@ -1,10 +1,12 @@
 from collections.abc import Sequence
 from typing import Any
-from typing_extensions import override
 
 import pytest
+from typing_extensions import override
 
 from betty.locale import Localey
+from betty.media_type import MediaType
+from betty.media_type.media_types import HTML, JSON
 from betty.url import LocalizedUrlGenerator, UnsupportedResource
 from betty.url.proxy import ProxyLocalizedUrlGenerator
 
@@ -19,7 +21,7 @@ class TestProxyLocalizedUrlGenerator:
         def generate(
             self,
             resource: Any,
-            media_type: str,
+            media_type: MediaType,
             *,
             absolute: bool = False,
             locale: Localey | None = None,
@@ -35,7 +37,7 @@ class TestProxyLocalizedUrlGenerator:
         def generate(
             self,
             resource: Any,
-            media_type: str,
+            media_type: MediaType,
             *,
             absolute: bool = False,
             locale: Localey | None = None,
@@ -70,28 +72,28 @@ class TestProxyLocalizedUrlGenerator:
             (
                 "/\ntext/html\nFalse\nNone",
                 "/",
-                "text/html",
+                HTML,
                 False,
                 None,
             ),
             (
                 "/\napplication/json\nFalse\nNone",
                 "/",
-                "application/json",
+                JSON,
                 False,
                 None,
             ),
             (
                 "/\ntext/html\nTrue\nNone",
                 "/",
-                "text/html",
+                HTML,
                 True,
                 None,
             ),
             (
                 "/\ntext/html\nFalse\nnl-NL",
                 "/",
-                "text/html",
+                HTML,
                 False,
                 "nl-NL",
             ),
@@ -101,7 +103,7 @@ class TestProxyLocalizedUrlGenerator:
         self,
         expected: str,
         resource: Any,
-        media_type: str,
+        media_type: MediaType,
         absolute: bool,
         locale: Localey | None,
     ) -> None:

--- a/betty/url/__init__.py
+++ b/betty/url/__init__.py
@@ -10,6 +10,7 @@ from typing import Any, TYPE_CHECKING, Self
 from betty.locale import negotiate_locale, Localey, to_locale
 
 if TYPE_CHECKING:
+    from betty.media_type import MediaType
     from collections.abc import Mapping
 
 
@@ -51,7 +52,7 @@ class LocalizedUrlGenerator(_UrlGenerator):
     def generate(
         self,
         resource: Any,
-        media_type: str,
+        media_type: MediaType,
         *,
         absolute: bool = False,
         locale: Localey | None = None,

--- a/betty/url/proxy.py
+++ b/betty/url/proxy.py
@@ -3,9 +3,11 @@ Provide proxy URL generators.
 """
 
 from typing import final, Any
+
 from typing_extensions import override
 
 from betty.locale import Localey
+from betty.media_type import MediaType
 from betty.url import LocalizedUrlGenerator, UnsupportedResource
 
 
@@ -26,7 +28,7 @@ class ProxyLocalizedUrlGenerator(LocalizedUrlGenerator):
     def generate(
         self,
         resource: Any,
-        media_type: str,
+        media_type: MediaType,
         *,
         absolute: bool = False,
         locale: Localey | None = None,


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/2075