### PR TITLE
Improve core component resource management

### DIFF
--- a/betty/core.py
+++ b/betty/core.py
@@ -2,28 +2,28 @@
 Provide tools to build core application components.
 """
 
-from abc import ABC
-from contextlib import AsyncExitStack
+from abc import ABC, abstractmethod
+from collections.abc import Callable, MutableSequence, Awaitable
 from types import TracebackType
-from typing import Self, Any
+from typing import Self, Any, final, TypedDict, Unpack, TypeAlias
 from warnings import warn
+
+from typing_extensions import override
 
 from betty.typing import internal, public
 
 
 @internal
-class CoreComponent(ABC):  # noqa B024
+class Bootstrapped:
     """
-    A core component.
-
-    Core components can manage their resources by being bootstrapped and shut down.
+    A component that can be in a bootstrapped state.
     """
 
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
         self._bootstrapped = False
-        self._async_exit_stack = AsyncExitStack()
 
+    @final
     @property
     def bootstrapped(self) -> bool:
         """
@@ -31,7 +31,7 @@ class CoreComponent(ABC):  # noqa B024
         """
         return self._bootstrapped
 
-    @public
+    @final
     def assert_bootstrapped(self) -> None:
         """
         Assert that the component has been bootstrapped.
@@ -41,7 +41,7 @@ class CoreComponent(ABC):  # noqa B024
             warn(message, stacklevel=2)
             raise RuntimeError(message)
 
-    @public
+    @final
     def assert_not_bootstrapped(self) -> None:
         """
         Assert that the component was not bootstrapped.
@@ -51,6 +51,74 @@ class CoreComponent(ABC):  # noqa B024
             warn(message, stacklevel=2)
             raise RuntimeError(message)
 
+
+class Shutdownable(ABC):
+    """
+    A component that can be shut down.
+    """
+
+    @abstractmethod
+    async def shutdown(self, *, wait: bool = True) -> None:
+        """
+        Shut the component down.
+        """
+        pass
+
+
+class ShutdownCallbackKwargs(TypedDict):
+    """
+    The keyword arguments to a shutdown callback.
+    """
+
+    #: ``True`` to wait for the component to shut down gracefully, or ``False`` to attempt an immediate forced shutdown.
+    wait: bool
+
+
+ShutdownCallback: TypeAlias = Callable[
+    [Unpack[ShutdownCallbackKwargs]], Awaitable[None]
+]
+
+
+@internal
+@final
+class ShutdownStack(Bootstrapped, Shutdownable):
+    """
+    A stack that invokes callbacks in reverse order upon shutting down.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._bootstrapped = True
+        self._callbacks: MutableSequence[ShutdownCallback] = []
+
+    @override
+    async def shutdown(self, *, wait: bool = True) -> None:
+        self.assert_bootstrapped()
+        self._bootstrapped = False
+        for callback in reversed(self._callbacks):
+            await callback(wait=wait)
+
+    def append(self, callback: ShutdownCallback | Shutdownable) -> None:
+        """
+        Append a callback or another component to the stack.
+        """
+        self._callbacks.append(
+            callback.shutdown if isinstance(callback, Shutdownable) else callback
+        )
+
+
+@internal
+class CoreComponent(Bootstrapped, Shutdownable, ABC):  # noqa B024
+    """
+    A core component.
+
+    Core components can manage their resources by being bootstrapped and shut down.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self._shutdown_stack = ShutdownStack()
+
     @public
     async def bootstrap(self) -> None:
         """
@@ -59,27 +127,26 @@ class CoreComponent(ABC):  # noqa B024
         self.assert_not_bootstrapped()
         self._bootstrapped = True
 
-    @public
-    async def shutdown(self) -> None:
-        """
-        Shut the component down.
-        """
+    @override
+    async def shutdown(self, *, wait: bool = True) -> None:
         self.assert_bootstrapped()
-        await self._async_exit_stack.aclose()
         self._bootstrapped = False
+        await self._shutdown_stack.shutdown(wait=wait)
 
     def __del__(self) -> None:
         if self.bootstrapped:
             warn(f"{self} was bootstrapped, but never shut down.", stacklevel=2)
 
+    @final
     async def __aenter__(self) -> Self:
         await self.bootstrap()
         return self
 
+    @final
     async def __aexit__(
         self,
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
-        await self.shutdown()
+        await self.shutdown(wait=exc_val is None)

--- a/betty/project/__init__.py
+++ b/betty/project/__init__.py
@@ -165,7 +165,8 @@ class Project(Configurable[ProjectConfiguration], TargetFactory[Any], CoreCompon
             for project_extension_batch in await self.extensions:
                 batch_event_handlers = EventHandlerRegistry()
                 for project_extension in project_extension_batch:
-                    await self._async_exit_stack.enter_async_context(project_extension)
+                    await project_extension.bootstrap()
+                    self._shutdown_stack.append(project_extension)
                     project_extension.register_event_handlers(batch_event_handlers)
                 self.event_dispatcher.add_registry(batch_event_handlers)
         except BaseException:

--- a/betty/tests/coverage/test_coverage.py
+++ b/betty/tests/coverage/test_coverage.py
@@ -50,6 +50,7 @@ class MissingReason(Enum):
     COVERED_ELSEWHERE = "This testable is covered by another test"
     DATACLASS = "This testable is inherited from @dataclass"
     ENUM = "This testable is inherited from Enum"
+    TYPED_DICT = "This testable is inherited from TypedDict"
 
 
 _ModuleFunctionExistsIgnore: TypeAlias = None
@@ -121,6 +122,13 @@ _BASELINE: Mapping[str, _ModuleIgnore] = {
         "SynchronizedContextManager": {
             "__enter__": MissingReason.SHOULD_BE_COVERED,
             "__exit__": MissingReason.SHOULD_BE_COVERED,
+        },
+    },
+    "betty/core.py": {
+        "Shutdownable": MissingReason.ABSTRACT,
+        "ShutdownCallbackKwargs": MissingReason.TYPED_DICT,
+        "ShutdownStack": {
+            "append": MissingReason.COVERED_ELSEWHERE,
         },
     },
     "betty/date.py": {

--- a/betty/tests/test_core.py
+++ b/betty/tests/test_core.py
@@ -1,5 +1,79 @@
+from typing_extensions import override
+
 import pytest
-from betty.core import CoreComponent
+from betty.core import CoreComponent, Bootstrapped, ShutdownStack, Shutdownable
+
+
+class TestBootstrapped:
+    class _DummyBootstrapped(Bootstrapped):
+        def set_bootstrapped(self, bootstrapped: bool) -> None:
+            self._bootstrapped = bootstrapped
+
+    async def test_assert_bootstrapped(self) -> None:
+        sut = self._DummyBootstrapped()
+        with pytest.raises(RuntimeError):
+            sut.assert_bootstrapped()
+        sut.set_bootstrapped(True)
+        sut.assert_bootstrapped()
+
+    async def test_assert_bootstrapped_should_error_if_not_bootstrapped(self) -> None:
+        sut = self._DummyBootstrapped()
+        with pytest.raises(RuntimeError), pytest.warns():
+            sut.assert_bootstrapped()
+
+    async def test_assert_not_bootstrapped(self) -> None:
+        sut = self._DummyBootstrapped()
+        sut.assert_not_bootstrapped()
+
+    async def test_assert_not_bootstrapped_should_error_if_bootstrapped(
+        self,
+    ) -> None:
+        sut = self._DummyBootstrapped()
+        sut.set_bootstrapped(True)
+        with pytest.raises(RuntimeError), pytest.warns():
+            sut.assert_not_bootstrapped()
+
+    async def test_bootstrapped(self) -> None:
+        sut = self._DummyBootstrapped()
+        assert not sut.bootstrapped
+        sut.set_bootstrapped(True)
+        assert sut.bootstrapped
+
+
+class TestShutdownStack:
+    @pytest.mark.parametrize(
+        "expected_wait",
+        [
+            True,
+            False,
+        ],
+    )
+    async def test_shutdown(self, expected_wait: bool) -> None:
+        carrier = []
+
+        async def _shutdown(*, wait: bool) -> None:
+            nonlocal carrier
+            carrier.append(wait)
+
+        class _Shutdownable(Shutdownable):
+            @override
+            async def shutdown(self, *, wait: bool = True) -> None:
+                nonlocal carrier
+                carrier.append(wait)
+
+        sut = ShutdownStack()
+        sut.append(_shutdown)
+        sut.append(_Shutdownable())
+        await sut.shutdown(wait=expected_wait)
+        assert carrier == [expected_wait, expected_wait]
+
+    async def test_shutdown_without_callbacks_without_wait(self) -> None:
+        sut = ShutdownStack()
+        await sut.shutdown(wait=False)
+
+    async def test_shutdown_without_callbacks_with_wait(self) -> None:
+        sut = ShutdownStack()
+        await sut.shutdown(wait=True)
 
 
 class TestCoreComponent:
@@ -18,26 +92,6 @@ class TestCoreComponent:
         with pytest.warns():
             del sut
 
-    async def test_assert_bootstrapped(self) -> None:
-        async with CoreComponent() as sut:
-            sut.assert_bootstrapped()
-
-    async def test_assert_bootstrapped_should_error_if_not_bootstrapped(self) -> None:
-        sut = CoreComponent()
-        with pytest.raises(RuntimeError), pytest.warns():
-            sut.assert_bootstrapped()
-
-    async def test_assert_not_bootstrapped(self) -> None:
-        sut = CoreComponent()
-        sut.assert_not_bootstrapped()
-
-    async def test_assert_not_bootstrapped_should_error_if_bootstrapped(
-        self,
-    ) -> None:
-        async with CoreComponent() as sut:
-            with pytest.raises(RuntimeError), pytest.warns():
-                sut.assert_not_bootstrapped()
-
     async def test_bootstrap(self) -> None:
         sut = CoreComponent()
         await sut.bootstrap()
@@ -45,12 +99,6 @@ class TestCoreComponent:
             assert sut.bootstrapped
         finally:
             await sut.shutdown()
-
-    async def test_bootstrapped(self) -> None:
-        sut = CoreComponent()
-        assert not sut.bootstrapped
-        async with sut:
-            assert sut.bootstrapped
 
     async def test_shutdown(self) -> None:
         sut = CoreComponent()


### PR DESCRIPTION
This (partly) fixes https://github.com/bartfeenstra/betty/issues/2123

## Changes
- Introduce signatures and types for shutdown callbacks, so we can propagate a `wait` argument to indicate whether a shutdown must be performed gracefully, allowing work to finish but no new work to start, or whether a shutdown must be as immediate as possible, discarding any possible tasks that may not yet be completed. Concretely, this allows us to shut down the process pool without having to wait for it to complete what may be a long backlog of tasks.
- Make resource clean-up asynchronous