### PR TITLE
Suppress `SIGINT` in `ProcessPoolExecutor` to prevent unhelpful additional `KeyboardInterrupt` being raised

### DIFF
--- a/betty/multiprocessing.py
+++ b/betty/multiprocessing.py
@@ -1,0 +1,29 @@
+"""
+Multiprocessing functionality.
+"""
+
+from concurrent import futures
+from multiprocessing import get_context
+from signal import signal, SIGINT, SIG_IGN
+
+
+class ProcessPoolExecutor(futures.ProcessPoolExecutor):
+    """
+    Like :py:class:`concurrent.futures.ProcessPoolExecutor`, but with error handling and low memory consumption.
+
+    This
+    - uses the ``spawn`` method to create new processes, which is the Python 3.14 default.
+    - ignores SIGINT/:py:class:`KeyboardInterrupt` delivered to it by the parent process to prevent unhelpful
+      additional :py:class:`KeyboardInterrupt` being raised from within the process pool.
+    """
+
+    def __init__(
+        self, max_workers: int | None = None, *, max_tasks_per_child: int | None = None
+    ):
+        super().__init__(
+            initializer=signal,
+            initargs=(SIGINT, SIG_IGN),
+            max_workers=max_workers,
+            max_tasks_per_child=max_tasks_per_child,
+            mp_context=get_context("spawn"),
+        )

--- a/betty/tests/coverage/test_coverage.py
+++ b/betty/tests/coverage/test_coverage.py
@@ -285,6 +285,7 @@ _BASELINE: Mapping[str, _ModuleIgnore] = {
     "betty/copyright_notice/__init__.py": MissingReason.STATIC_CONTENT_ONLY,
     "betty/license/__init__.py": MissingReason.STATIC_CONTENT_ONLY,
     "betty/path.py": MissingReason.SHOULD_BE_COVERED,
+    "betty/multiprocessing.py": MissingReason.STATIC_CONTENT_ONLY,
     "betty/plugin/__init__.py": {
         "DependentPlugin": MissingReason.ABSTRACT,
         "OrderedPlugin": MissingReason.ABSTRACT,


### PR DESCRIPTION
This partly fixes https://github.com/bartfeenstra/betty/issues/2123