### PR TITLE
Remove `wait_to_thread()`

### DIFF
--- a/betty/app/__init__.py
+++ b/betty/app/__init__.py
@@ -55,8 +55,7 @@ class App(Configurable[AppConfiguration], TargetFactory[Any], CoreComponent):
         cache_factory: Callable[[Self], Cache[Any]],
         fetcher: Fetcher | None = None,
     ):
-        super().__init__()
-        self._configuration = configuration
+        super().__init__(configuration=configuration)
         self._assets: AssetRepository | None = None
         self._localization_initialized = False
         self._localizer: Localizer | None = None

--- a/betty/asyncio.py
+++ b/betty/asyncio.py
@@ -4,52 +4,10 @@ Provide asynchronous programming utilities.
 
 from __future__ import annotations
 
-from asyncio import run
 from inspect import isawaitable
-from threading import Thread
-from typing import Awaitable, TypeVar, Generic, cast
-from typing_extensions import deprecated
-
-from betty.typing import internal
+from typing import Awaitable, TypeVar
 
 _T = TypeVar("_T")
-
-
-@internal
-@deprecated("This function is deprecated and will be removed without an alternative.")
-def wait_to_thread(f: Awaitable[_T]) -> _T:
-    """
-    Wait for an awaitable in another thread.
-    """
-    synced = _WaiterThread(f)
-    synced.start()
-    synced.join()
-    return synced.return_value
-
-
-class _WaiterThread(Thread, Generic[_T]):
-    def __init__(self, awaitable: Awaitable[_T]):
-        super().__init__()
-        self._awaitable = awaitable
-        self._return_value: _T | None = None
-        self._e: BaseException | None = None
-
-    @property
-    def return_value(self) -> _T:
-        if self._e:
-            raise self._e
-        return cast(_T, self._return_value)
-
-    def run(self) -> None:
-        run(self._run())
-
-    async def _run(self) -> None:
-        try:
-            self._return_value = await self._awaitable
-        except BaseException as e:  # noqa: B036
-            # Store the exception, so it can be reraised when the calling thread
-            # gets self.return_value.
-            self._e = e
 
 
 async def ensure_await(value: Awaitable[_T] | _T) -> _T:

--- a/betty/config/__init__.py
+++ b/betty/config/__init__.py
@@ -49,6 +49,8 @@ class Configurable(Generic[_ConfigurationT]):
         """
         The object's configuration.
         """
+        # @todo Add an __init__ so we won't have to use hasattr()
+        # @todo This would also work nicely with the removal of ConfigurableExtension.default_configuration()
         if not hasattr(self, "_configuration"):
             raise RuntimeError(
                 f"{self} has no configuration. {type(self)}.__init__() must ensure it is set."

--- a/betty/config/__init__.py
+++ b/betty/config/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from contextlib import chdir
-from typing import Generic, TypeVar, TypeAlias, TYPE_CHECKING
+from typing import Generic, TypeVar, TypeAlias, TYPE_CHECKING, Any
 
 import aiofiles
 from aiofiles.os import makedirs
@@ -42,19 +42,15 @@ class Configurable(Generic[_ConfigurationT]):
     Any configurable object.
     """
 
-    _configuration: _ConfigurationT
+    def __init__(self, *args: Any, configuration: _ConfigurationT, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self._configuration = configuration
 
     @property
     def configuration(self) -> _ConfigurationT:
         """
         The object's configuration.
         """
-        # @todo Add an __init__ so we won't have to use hasattr()
-        # @todo This would also work nicely with the removal of ConfigurableExtension.default_configuration()
-        if not hasattr(self, "_configuration"):
-            raise RuntimeError(
-                f"{self} has no configuration. {type(self)}.__init__() must ensure it is set."
-            )
         return self._configuration
 
 

--- a/betty/plugin/__init__.py
+++ b/betty/plugin/__init__.py
@@ -30,7 +30,7 @@ from betty.machine_name import MachineName
 if TYPE_CHECKING:
     from graphlib import TopologicalSorter
     from betty.locale.localizable import Localizable
-    from collections.abc import AsyncIterator, Sequence, Mapping, Iterable
+    from collections.abc import AsyncIterator, Sequence, Mapping, Iterable, Iterator
 
 
 class PluginError(Exception):
@@ -207,6 +207,12 @@ class PluginIdToTypeMap(Generic[_PluginT]):
         self, plugin_identifier: MachineName | type[_PluginT]
     ) -> type[_PluginT]:
         return self.get(plugin_identifier)
+
+    def __iter__(self) -> Iterator[MachineName]:
+        yield from self._id_to_type_map
+
+    def values(self) -> Iterator[type[_PluginT]]:
+        return self._id_to_type_map.values()
 
 
 class PluginRepository(Generic[_PluginT], TargetFactory[_PluginT], ABC):

--- a/betty/project/__init__.py
+++ b/betty/project/__init__.py
@@ -98,9 +98,8 @@ class Project(Configurable[ProjectConfiguration], TargetFactory[Any], CoreCompon
         *,
         ancestry: Ancestry,
     ):
-        super().__init__()
+        super().__init__(configuration=configuration)
         self._app = app
-        self._configuration = configuration
         self._ancestry = ancestry
 
         self._assets: AssetRepository | None = None

--- a/betty/project/extension/__init__.py
+++ b/betty/project/extension/__init__.py
@@ -123,13 +123,21 @@ class ConfigurableExtension(
         super().__init__(project)
         self._configuration = self.default_configuration()
 
-    @classmethod
-    @abstractmethod
-    def default_configuration(cls) -> _ConfigurationT:
-        """
-        Get this extension's default configuration.
-        """
-        pass
+
+    # @todo For some extensions, config can only be created asynchrnously.
+    # @todo However, default_configuration() is called from __init__() and unussable.
+    # @todo Now that extensions all have an async factory method, they can instantiate their default config there.
+    # @todo
+    # @todo
+    # @todo
+
+    # @classmethod
+    # @abstractmethod
+    # def default_configuration(cls) -> _ConfigurationT:
+    #     """
+    #     Get this extension's default configuration.
+    #     """
+    #     pass
 
 
 async def sort_extension_type_graph(

--- a/betty/project/extension/__init__.py
+++ b/betty/project/extension/__init__.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from abc import abstractmethod
 from typing import TypeVar, TYPE_CHECKING, Generic, Self, Sequence
 
 from typing_extensions import override
@@ -119,25 +118,8 @@ class ConfigurableExtension(
     A configurable extension.
     """
 
-    def __init__(self, project: Project):
-        super().__init__(project)
-        self._configuration = self.default_configuration()
-
-
-    # @todo For some extensions, config can only be created asynchrnously.
-    # @todo However, default_configuration() is called from __init__() and unussable.
-    # @todo Now that extensions all have an async factory method, they can instantiate their default config there.
-    # @todo
-    # @todo
-    # @todo
-
-    # @classmethod
-    # @abstractmethod
-    # def default_configuration(cls) -> _ConfigurationT:
-    #     """
-    #     Get this extension's default configuration.
-    #     """
-    #     pass
+    def __init__(self, project: Project,*,configuration:_ConfigurationT):
+        super().__init__(project,configuration=configuration)
 
 
 async def sort_extension_type_graph(

--- a/betty/project/extension/cotton_candy/__init__.py
+++ b/betty/project/extension/cotton_candy/__init__.py
@@ -183,7 +183,9 @@ class CottonCandy(
     @override
     @classmethod
     def default_configuration(cls) -> CottonCandyConfiguration:
-        return CottonCandyConfiguration(entity_type_id_to_type_map=await ENTITY_TYPE_REPOSITORY.map())
+        return CottonCandyConfiguration(
+            entity_type_id_to_type_map=await ENTITY_TYPE_REPOSITORY.map()
+        )
 
     @override
     @property

--- a/betty/project/extension/cotton_candy/__init__.py
+++ b/betty/project/extension/cotton_candy/__init__.py
@@ -29,7 +29,7 @@ from betty.jinja2 import (
     Filters,
 )
 from betty.locale.localizable import _, static
-from betty.model import has_generated_entity_id
+from betty.model import has_generated_entity_id, ENTITY_TYPE_REPOSITORY
 from betty.os import link_or_copy
 from betty.plugin import ShorthandPluginBase
 from betty.privacy import is_public
@@ -183,7 +183,7 @@ class CottonCandy(
     @override
     @classmethod
     def default_configuration(cls) -> CottonCandyConfiguration:
-        return CottonCandyConfiguration()
+        return CottonCandyConfiguration(entity_type_id_to_type_map=await ENTITY_TYPE_REPOSITORY.map())
 
     @override
     @property

--- a/betty/project/extension/cotton_candy/config.py
+++ b/betty/project/extension/cotton_candy/config.py
@@ -17,6 +17,7 @@ from betty.assertion import (
 from betty.assertion.error import AssertionFailed
 from betty.config import Configuration
 from betty.locale.localizable import _
+from betty.plugin import PluginIdToTypeMap
 from betty.project.config import EntityReference, EntityReferenceSequence
 
 if TYPE_CHECKING:
@@ -81,6 +82,7 @@ class CottonCandyConfiguration(Configuration):
     def __init__(
         self,
         *,
+            entity_type_id_to_type_map: PluginIdToTypeMap[Entity],
         featured_entities: (
             Sequence[EntityReference[UserFacingEntity & Entity]] | None
         ) = None,
@@ -90,8 +92,9 @@ class CottonCandyConfiguration(Configuration):
         link_active_color: str = DEFAULT_LINK_ACTIVE_COLOR,
     ):
         super().__init__()
+        self._entity_type_id_to_type_map=entity_type_id_to_type_map
         self._featured_entities = EntityReferenceSequence["UserFacingEntity & Entity"](
-            featured_entities or ()
+            featured_entities or (), entity_type_id_to_type_map=self._entity_type_id_to_type_map
         )
         self._primary_inactive_color = ColorConfiguration(primary_inactive_color)
         self._primary_active_color = ColorConfiguration(primary_active_color)

--- a/betty/project/extension/cotton_candy/config.py
+++ b/betty/project/extension/cotton_candy/config.py
@@ -82,7 +82,7 @@ class CottonCandyConfiguration(Configuration):
     def __init__(
         self,
         *,
-            entity_type_id_to_type_map: PluginIdToTypeMap[Entity],
+        entity_type_id_to_type_map: PluginIdToTypeMap[Entity],
         featured_entities: (
             Sequence[EntityReference[UserFacingEntity & Entity]] | None
         ) = None,
@@ -92,9 +92,10 @@ class CottonCandyConfiguration(Configuration):
         link_active_color: str = DEFAULT_LINK_ACTIVE_COLOR,
     ):
         super().__init__()
-        self._entity_type_id_to_type_map=entity_type_id_to_type_map
+        self._entity_type_id_to_type_map = entity_type_id_to_type_map
         self._featured_entities = EntityReferenceSequence["UserFacingEntity & Entity"](
-            featured_entities or (), entity_type_id_to_type_map=self._entity_type_id_to_type_map
+            featured_entities or (),
+            entity_type_id_to_type_map=self._entity_type_id_to_type_map,
         )
         self._primary_inactive_color = ColorConfiguration(primary_inactive_color)
         self._primary_active_color = ColorConfiguration(primary_active_color)

--- a/betty/project/extension/demo/project.py
+++ b/betty/project/extension/demo/project.py
@@ -27,6 +27,7 @@ from betty.date import Date, DateRange
 from betty.fs import DATA_DIRECTORY_PATH
 from betty.license.licenses import spdx_license_id_to_license_id
 from betty.media_type.media_types import SVG
+from betty.model import ENTITY_TYPE_REPOSITORY
 from betty.project import Project
 from betty.project.config import (
     ExtensionConfiguration,
@@ -52,6 +53,8 @@ async def create_project(app: App, project_directory_path: Path) -> Project:
     """
     from betty.project.extension.demo import Demo
 
+    entity_type_id_to_type_map = await ENTITY_TYPE_REPOSITORY.map()
+
     configuration = await ProjectConfiguration.new(
         project_directory_path / "betty.json",
         name=Demo.plugin_id(),
@@ -70,9 +73,21 @@ async def create_project(app: App, project_directory_path: Path) -> Project:
                 CottonCandy,
                 extension_configuration=CottonCandyConfiguration(
                     featured_entities=[
-                        EntityReference(Place, "betty-demo-amsterdam"),
-                        EntityReference(Person, "betty-demo-liberta-lankester"),
-                        EntityReference(Place, "betty-demo-netherlands"),
+                        EntityReference(
+                            Place,
+                            "betty-demo-amsterdam",
+                            entity_type_id_to_type_map=entity_type_id_to_type_map,
+                        ),
+                        EntityReference(
+                            Person,
+                            "betty-demo-liberta-lankester",
+                            entity_type_id_to_type_map=entity_type_id_to_type_map,
+                        ),
+                        EntityReference(
+                            Place,
+                            "betty-demo-netherlands",
+                            entity_type_id_to_type_map=entity_type_id_to_type_map,
+                        ),
                     ],
                 ),
             ),

--- a/betty/tests/project/extension/demo/test___init__.py
+++ b/betty/tests/project/extension/demo/test___init__.py
@@ -11,7 +11,6 @@ from betty.ancestry.place import Place
 from betty.ancestry.source import Source
 from betty.app import App
 from betty.project import Project
-from betty.project.config import ExtensionConfiguration
 from betty.project.extension.demo import Demo
 from betty.project.load import load
 from betty.test_utils.project.extension import ExtensionTestBase
@@ -38,7 +37,7 @@ class TestDemo(ExtensionTestBase[Demo]):
             app,
             Project.new_temporary(app) as project,
         ):
-            project.configuration.extensions.append(ExtensionConfiguration(Demo))
+            project.configuration.extensions.enable(Demo)
             async with project:
                 await load(project)
             assert len(project.ancestry[Person]) != 0

--- a/betty/tests/project/extension/deriver/test___init__.py
+++ b/betty/tests/project/extension/deriver/test___init__.py
@@ -18,7 +18,6 @@ from betty.ancestry.presence_role.presence_roles import Subject
 from betty.date import DateRange, Date
 from betty.model.collections import record_added
 from betty.project import Project
-from betty.project.config import ExtensionConfiguration
 from betty.project.extension.deriver import Deriver
 from betty.project.load import load
 from betty.test_utils.ancestry.event_type import DummyEventType
@@ -92,7 +91,7 @@ class TestDeriver(ExtensionTestBase[Deriver]):
         Presence(person, Subject(), event)
 
         async with Project.new_temporary(new_temporary_app) as project:
-            project.configuration.extensions.append(ExtensionConfiguration(Deriver))
+            project.configuration.extensions.enable(Deriver)
             project.ancestry.add(person)
             async with project:
                 async with record_added(project.ancestry) as added:

--- a/betty/tests/test_asyncio.py
+++ b/betty/tests/test_asyncio.py
@@ -1,15 +1,4 @@
-from betty.asyncio import wait_to_thread, ensure_await
-
-
-class TestWaitToThread:
-    async def test(self) -> None:
-        expected = "Hello, oh asynchronous, world!"
-
-        async def _async() -> str:
-            return expected
-
-        actual = wait_to_thread(_async())
-        assert actual == expected
+from betty.asyncio import ensure_await
 
 
 class TestEnsureAwait:


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/2057

This obsoletes https://github.com/bartfeenstra/betty/pull/2074

This aims to resolve the issue by limiting changes to public 'runtime' APIs as much as possible, and focusing on making the necessary changes during object initialization instead.

## Proposals 
- Do not use plugin repositories when validating config. Do it after the necessary components have been bootstrapped.