### PR TITLE
Allow projects to use locales not necessarily supported by the operating system

### DIFF
--- a/betty/assertion/__init__.py
+++ b/betty/assertion/__init__.py
@@ -540,7 +540,14 @@ def assert_locale() -> AssertionChain[Any, str]:
             raise AssertionFailed(error) from error
         return value
 
-    return assert_str() | _assert_locale
+    return assert_locale_identifier() | _assert_locale
+
+
+def assert_locale_identifier() -> AssertionChain[Any, str]:
+    """
+    Assert that a value could be a valid `IETF BCP 47 language tag <https://en.wikipedia.org/wiki/IETF_language_tag>`_.
+    """
+    return assert_str() | assert_len(minimum=1) | str
 
 
 def assert_setattr(

--- a/betty/cli/commands/dev_new_translation.py
+++ b/betty/cli/commands/dev_new_translation.py
@@ -6,7 +6,7 @@ import asyncclick as click
 from typing_extensions import override
 
 from betty.app.factory import AppDependentFactory
-from betty.assertion import assert_locale
+from betty.assertion import assert_locale_identifier
 from betty.cli.commands import command, Command, parameter_callback
 from betty.locale import translation
 from betty.locale.localizable import _
@@ -46,7 +46,9 @@ class DevNewTranslation(ShorthandPluginBase, AppDependentFactory, Command):
             else self.plugin_label().localize(localizer),
         )
         @click.argument(
-            "locale", required=True, callback=parameter_callback(assert_locale())
+            "locale",
+            required=True,
+            callback=parameter_callback(assert_locale_identifier()),
         )
         async def dev_new_translation(locale: str) -> None:
             await translation.new_dev_translation(locale)

--- a/betty/cli/commands/extension_new_translation.py
+++ b/betty/cli/commands/extension_new_translation.py
@@ -6,7 +6,7 @@ import asyncclick as click
 from typing_extensions import override
 
 from betty.app.factory import AppDependentFactory
-from betty.assertion import assert_locale
+from betty.assertion import assert_locale_identifier
 from betty.cli.commands import command, parameter_callback, Command
 from betty.locale import translation
 from betty.locale.localizable import _
@@ -59,7 +59,9 @@ class ExtensionNewTranslation(ShorthandPluginBase, AppDependentFactory, Command)
             ),
         )
         @click.argument(
-            "locale", required=True, callback=parameter_callback(assert_locale())
+            "locale",
+            required=True,
+            callback=parameter_callback(assert_locale_identifier()),
         )
         async def extension_new_translation(  # noqa D103
             extension: type[Extension], locale: str

--- a/betty/cli/commands/new_translation.py
+++ b/betty/cli/commands/new_translation.py
@@ -6,7 +6,7 @@ import asyncclick as click
 from typing_extensions import override
 
 from betty.app.factory import AppDependentFactory
-from betty.assertion import assert_locale
+from betty.assertion import assert_locale_identifier
 from betty.cli.commands import command, Command, parameter_callback, project_option
 from betty.locale import translation
 from betty.locale.localizable import _
@@ -47,7 +47,9 @@ class NewTranslation(ShorthandPluginBase, AppDependentFactory, Command):
             else self.plugin_label().localize(localizer),
         )
         @click.argument(
-            "locale", required=True, callback=parameter_callback(assert_locale())
+            "locale",
+            required=True,
+            callback=parameter_callback(assert_locale_identifier()),
         )
         @project_option
         async def new_translation(project: Project, locale: str) -> None:

--- a/betty/locale/localizable/assertion.py
+++ b/betty/locale/localizable/assertion.py
@@ -11,7 +11,7 @@ from betty.assertion import (
     assert_or,
     assert_str,
     assert_mapping,
-    assert_locale,
+    assert_locale_identifier,
 )
 from betty.locale import UNDETERMINED_LOCALE
 
@@ -25,5 +25,5 @@ def assert_static_translations() -> AssertionChain[Any, StaticTranslations]:
     """
     return assert_or(
         assert_str().chain(lambda translation: {UNDETERMINED_LOCALE: translation}),
-        assert_mapping(assert_str(), assert_locale()),
+        assert_mapping(assert_str(), assert_locale_identifier()),
     )

--- a/betty/tests/assertion/test___init__.py
+++ b/betty/tests/assertion/test___init__.py
@@ -33,6 +33,7 @@ from betty.assertion import (
     assert_none,
     assert_locale,
     assert_setattr,
+    assert_locale_identifier,
 )
 from betty.assertion.error import AssertionFailed, Index, Key
 from betty.error import UserFacingError
@@ -539,6 +540,7 @@ class TestAssertLocale:
             True,
             False,
             123,
+            "",
             "non-existent-locale",
             object(),
             [],
@@ -548,6 +550,37 @@ class TestAssertLocale:
     def test_with_invalid_value(self, value: Any) -> None:
         with pytest.raises(AssertionFailed):
             assert_locale()(value)
+
+
+class TestAssertLocaleIdentifier:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            UNDETERMINED_LOCALE,
+            DEFAULT_LOCALE,
+            "nl-NL",
+            "uk",
+            "non-existent-locale",
+        ],
+    )
+    def test_with_valid_value(self, value: str) -> None:
+        assert assert_locale_identifier()(value) == value
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            True,
+            False,
+            123,
+            "",
+            object(),
+            [],
+            {},
+        ],
+    )
+    def test_with_invalid_value(self, value: Any) -> None:
+        with pytest.raises(AssertionFailed):
+            assert_locale_identifier()(value)
 
 
 class TestAssertSetattr:

--- a/betty/tests/cli/commands/test_dev_new_translation.py
+++ b/betty/tests/cli/commands/test_dev_new_translation.py
@@ -19,6 +19,6 @@ class TestDevNewTranslation:
         await run(
             new_temporary_app,
             "dev-new-translation",
-            "123",
+            "",
             expected_exit_code=2,
         )

--- a/betty/tests/cli/commands/test_extension_new_translation.py
+++ b/betty/tests/cli/commands/test_extension_new_translation.py
@@ -47,6 +47,6 @@ class TestExtensionNewTranslation(ExtensionTranslationTestBase):
             new_temporary_app,
             "extension-new-translation",
             "with-assets",
-            "123",
+            "",
             expected_exit_code=2,
         )

--- a/betty/tests/cli/commands/test_new_translation.py
+++ b/betty/tests/cli/commands/test_new_translation.py
@@ -35,6 +35,6 @@ class TestNewTranslation:
         await run(
             new_temporary_app,
             "new-translation",
-            "123",
+            "",
             expected_exit_code=2,
         )

--- a/betty/tests/locale/localizable/test_assertion.py
+++ b/betty/tests/locale/localizable/test_assertion.py
@@ -1,4 +1,5 @@
 import pytest
+
 from betty.error import UserFacingError
 from betty.locale import DEFAULT_LOCALE
 from betty.locale.localizable import ShorthandStaticTranslations
@@ -13,6 +14,7 @@ class TestAssertStaticTranslations:
             {
                 "en-US": "Hello, world!",
                 "nl-NL": "Hallo, wereld!",
+                "unknown-locale": "H3ll0, w0rld!",
             },
         ],
     )
@@ -33,7 +35,7 @@ class TestAssertStaticTranslations:
                 123: "a valid translation",
             },
             {
-                "notalocale": "a valid translation",
+                "": "a valid translation",
             },
         ],
     )


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/2184

## Changes
- `betty new-translation`, `betty extension-new-translation`, and `betty dev-new-translation` now allow any locale, even if it does not exist on the current system.
- Static translations, such as used for configuration (project name, author, etc) and entities (labels, descriptions, etc) now allow any locale, even if it does not exist on the current system.