### PR TITLE
Fix missing template files for entity list pages

### DIFF
--- a/betty/project/extension/cotton_candy/assets/templates/entity/label--place.html.j2
+++ b/betty/project/extension/cotton_candy/assets/templates/entity/label--place.html.j2
@@ -5,12 +5,16 @@
     {%- if names | length == 0 -%}
         {%- set names = place.names -%}
     {%- endif -%}
-    {%- set name = (names | first).name | localize -%}
+    {%- if names -%}
+        {%- set name = (names | first).name -%}
+    {%- else -%}
+        {%- set name = place.label -%}
+    {%- endif -%}
 
     {%- if not embedded -%}
         <a href="{{ place | localized_url }}">
     {%- endif -%}
-    {{ name | html_lang }}
+    {{ name | localize | html_lang }}
     {%- if not embedded -%}
         </a>
     {%- endif -%}

--- a/betty/project/extension/cotton_candy/assets/templates/entity/list.html.j2
+++ b/betty/project/extension/cotton_candy/assets/templates/entity/list.html.j2
@@ -1,0 +1,11 @@
+{% set entities = entities | select('public') | list %}
+{% if entities | length > 0 %}
+    <ul class="entities">
+        {% for entity in entities %}
+            <li class="{{ loop.cycle('odd', 'even') }}">
+                {% include ['entity/label--' + entity.plugin_id() + '.html.j2', 'entity/label.html.j2'] %}
+                {% include ['entity/meta--' + entity.plugin_id() + '.html.j2', 'entity/meta.html.j2'] %}
+            </li>
+        {% endfor %}
+    </ul>
+{% endif %}

--- a/betty/project/extension/cotton_candy/assets/templates/entity/page-list--event.html.j2
+++ b/betty/project/extension/cotton_candy/assets/templates/entity/page-list--event.html.j2
@@ -2,7 +2,7 @@
 {% set events = events | default(entities) | list %}
 {% set page_title = _('Events') %}
 {% block page_content %}
-    {% if events | length > 0 %}
+    {% if events | select('public') | list | length > 0 %}
         {% include 'entity/list--event.html.j2' %}
     {% else %}
         <p>{% trans %}I'm sorry, dear, but it seems there are no events.{% endtrans %}</p>

--- a/betty/project/extension/cotton_candy/assets/templates/entity/page-list--file.html.j2
+++ b/betty/project/extension/cotton_candy/assets/templates/entity/page-list--file.html.j2
@@ -2,8 +2,8 @@
 {% set files = files | default(entities) %}
 {% set page_title = _('Media') %}
 {% block page_content %}
-    {% if files | length > 0 %}
-        {% include 'entity/list--file.html.j2' %}
+    {% if files | select('public') | list | length > 0 %}
+        {% include ['entity/list--file.html.j2', 'entity/list.html.j2'] %}
     {% else %}
         <p>{% trans %}I'm sorry, dear, but it seems there are no media.{% endtrans %}</p>
     {% endif %}

--- a/betty/project/extension/cotton_candy/assets/templates/entity/page-list--person.html.j2
+++ b/betty/project/extension/cotton_candy/assets/templates/entity/page-list--person.html.j2
@@ -2,7 +2,7 @@
 {% set people = people | default(entities) %}
 {% set page_title = _('People') %}
 {% block page_content %}
-    {% if people | length > 0 %}
+    {% if people | select('public') | list | length > 0 %}
         {% include 'entity/list--person.html.j2' %}
     {% else %}
         <p>{% trans %}I'm sorry, dear, but it seems there are no people.{% endtrans %}</p>

--- a/betty/project/extension/cotton_candy/assets/templates/entity/page-list--place.html.j2
+++ b/betty/project/extension/cotton_candy/assets/templates/entity/page-list--place.html.j2
@@ -2,7 +2,7 @@
 {% set places = places | default(entities) %}
 {% set page_title = _('Places') %}
 {% block page_content %}
-    {% if places | length > 0 %}
+    {% if places | select('public') | list | length > 0 %}
         {% with canonical=True %}
             {% include 'entity/list--place.html.j2' %}
         {% endwith %}

--- a/betty/project/extension/cotton_candy/assets/templates/entity/page-list--source.html.j2
+++ b/betty/project/extension/cotton_candy/assets/templates/entity/page-list--source.html.j2
@@ -2,7 +2,7 @@
 {% set sources = sources | default(entities) %}
 {% set page_title = _('Sources') %}
 {% block page_content %}
-    {% if sources | length > 0 %}
+    {% if sources | select('public') | list | length > 0 %}
         {% include 'entity/list--source.html.j2' %}
     {% else %}
         <p>{% trans %}I'm sorry, dear, but it seems there are no sources.{% endtrans %}</p>

--- a/betty/tests/project/extension/cotton_candy/assets/templates/entity/test_page_list__event_html_j2.py
+++ b/betty/tests/project/extension/cotton_candy/assets/templates/entity/test_page_list__event_html_j2.py
@@ -1,0 +1,43 @@
+from betty.ancestry.event import Event
+from betty.date import Date
+from betty.project.extension.cotton_candy import CottonCandy
+from betty.test_utils.jinja2 import TemplateFileTestBase
+
+
+class TestTemplate(TemplateFileTestBase):
+    extensions = {CottonCandy}
+    template = "entity/page-list--event.html.j2"
+
+    async def test_without_entities(self) -> None:
+        async with self.assert_template_file(
+            data={
+                "page_resource": f"/{Event.plugin_id()}/index.html",
+                "entity_type": Event,
+                "entities": [],
+            },
+        ) as (actual, _):
+            assert "I'm sorry" in actual
+
+    async def test_with_public_entity(self) -> None:
+        event = Event(id="E1", date=Date(1970, 1, 1))
+
+        async with self.assert_template_file(
+            data={
+                "page_resource": f"/{Event.plugin_id()}/index.html",
+                "entity_type": Event,
+                "entities": [event],
+            },
+        ) as (actual, _):
+            assert event.id in actual
+
+    async def test_with_private_entity(self) -> None:
+        event = Event(id="E1", date=Date(1970, 1, 1), private=True)
+
+        async with self.assert_template_file(
+            data={
+                "page_resource": f"/{Event.plugin_id()}/index.html",
+                "entity_type": Event,
+                "entities": [event],
+            },
+        ) as (actual, _):
+            assert event.id not in actual

--- a/betty/tests/project/extension/cotton_candy/assets/templates/entity/test_page_list__file_html_j2.py
+++ b/betty/tests/project/extension/cotton_candy/assets/templates/entity/test_page_list__file_html_j2.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+from betty.ancestry.file import File
+from betty.project.extension.cotton_candy import CottonCandy
+from betty.test_utils.jinja2 import TemplateFileTestBase
+
+
+class TestTemplate(TemplateFileTestBase):
+    extensions = {CottonCandy}
+    template = "entity/page-list--file.html.j2"
+
+    async def test_without_entities(self) -> None:
+        async with self.assert_template_file(
+            data={
+                "page_resource": f"/{File.plugin_id()}/index.html",
+                "entity_type": File,
+                "entities": [],
+            },
+        ) as (actual, _):
+            assert "I'm sorry" in actual
+
+    async def test_with_public_entity(self) -> None:
+        file = File(path=Path())
+
+        async with self.assert_template_file(
+            data={
+                "page_resource": f"/{File.plugin_id()}/index.html",
+                "entity_type": File,
+                "entities": [file],
+            },
+        ) as (actual, _):
+            assert file.id in actual
+
+    async def test_with_private_entity(self) -> None:
+        file = File(path=Path(), private=True)
+
+        async with self.assert_template_file(
+            data={
+                "page_resource": f"/{File.plugin_id()}/index.html",
+                "entity_type": File,
+                "entities": [file],
+            },
+        ) as (actual, _):
+            assert file.id not in actual

--- a/betty/tests/project/extension/cotton_candy/assets/templates/entity/test_page_list__person_html_j2.py
+++ b/betty/tests/project/extension/cotton_candy/assets/templates/entity/test_page_list__person_html_j2.py
@@ -1,0 +1,42 @@
+from betty.ancestry.person import Person
+from betty.project.extension.cotton_candy import CottonCandy
+from betty.test_utils.jinja2 import TemplateFileTestBase
+
+
+class TestTemplate(TemplateFileTestBase):
+    extensions = {CottonCandy}
+    template = "entity/page-list--person.html.j2"
+
+    async def test_without_entities(self) -> None:
+        async with self.assert_template_file(
+            data={
+                "page_resource": f"/{Person.plugin_id()}/index.html",
+                "entity_type": Person,
+                "entities": [],
+            },
+        ) as (actual, _):
+            assert "I'm sorry" in actual
+
+    async def test_with_public_entity(self) -> None:
+        person = Person(id="P1")
+
+        async with self.assert_template_file(
+            data={
+                "page_resource": f"/{Person.plugin_id()}/index.html",
+                "entity_type": Person,
+                "entities": [person],
+            },
+        ) as (actual, _):
+            assert person.id in actual
+
+    async def test_with_private_entity(self) -> None:
+        person = Person(id="P1", private=True)
+
+        async with self.assert_template_file(
+            data={
+                "page_resource": f"/{Person.plugin_id()}/index.html",
+                "entity_type": Person,
+                "entities": [person],
+            },
+        ) as (actual, _):
+            assert person.id not in actual

--- a/betty/tests/project/extension/cotton_candy/assets/templates/entity/test_page_list__place_html_j2.py
+++ b/betty/tests/project/extension/cotton_candy/assets/templates/entity/test_page_list__place_html_j2.py
@@ -1,0 +1,42 @@
+from betty.ancestry.place import Place
+from betty.project.extension.cotton_candy import CottonCandy
+from betty.test_utils.jinja2 import TemplateFileTestBase
+
+
+class TestTemplate(TemplateFileTestBase):
+    extensions = {CottonCandy}
+    template = "entity/page-list--place.html.j2"
+
+    async def test_without_entities(self) -> None:
+        async with self.assert_template_file(
+            data={
+                "page_resource": f"/{Place.plugin_id()}/index.html",
+                "entity_type": Place,
+                "entities": [],
+            },
+        ) as (actual, _):
+            assert "I'm sorry" in actual
+
+    async def test_with_public_entity(self) -> None:
+        place = Place()
+
+        async with self.assert_template_file(
+            data={
+                "page_resource": f"/{Place.plugin_id()}/index.html",
+                "entity_type": Place,
+                "entities": [place],
+            },
+        ) as (actual, _):
+            assert place.id in actual
+
+    async def test_with_private_entity(self) -> None:
+        place = Place(private=True)
+
+        async with self.assert_template_file(
+            data={
+                "page_resource": f"/{Place.plugin_id()}/index.html",
+                "entity_type": Place,
+                "entities": [place],
+            },
+        ) as (actual, _):
+            assert place.id not in actual

--- a/betty/tests/project/extension/cotton_candy/assets/templates/entity/test_page_list__source_html_j2.py
+++ b/betty/tests/project/extension/cotton_candy/assets/templates/entity/test_page_list__source_html_j2.py
@@ -1,0 +1,42 @@
+from betty.ancestry.source import Source
+from betty.project.extension.cotton_candy import CottonCandy
+from betty.test_utils.jinja2 import TemplateFileTestBase
+
+
+class TestTemplate(TemplateFileTestBase):
+    extensions = {CottonCandy}
+    template = "entity/page-list--source.html.j2"
+
+    async def test_without_entities(self) -> None:
+        async with self.assert_template_file(
+            data={
+                "page_resource": f"/{Source.plugin_id()}/index.html",
+                "entity_type": Source,
+                "entities": [],
+            },
+        ) as (actual, _):
+            assert "I'm sorry" in actual
+
+    async def test_with_public_entity(self) -> None:
+        source = Source()
+
+        async with self.assert_template_file(
+            data={
+                "page_resource": f"/{Source.plugin_id()}/index.html",
+                "entity_type": Source,
+                "entities": [source],
+            },
+        ) as (actual, _):
+            assert source.id in actual
+
+    async def test_with_private_entity(self) -> None:
+        source = Source(private=True)
+
+        async with self.assert_template_file(
+            data={
+                "page_resource": f"/{Source.plugin_id()}/index.html",
+                "entity_type": Source,
+                "entities": [source],
+            },
+        ) as (actual, _):
+            assert source.id not in actual


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/2187

## Changes
- Provide a fallback entity list page for any entity type
- Add tests to assert that all Cotton Candy entity list page templates function correctly 
- Fix the bug where the file list page errored