### PR TITLE
Remove the unused `localize_html_lang` Jinja2 filter

### DIFF
--- a/betty/jinja2/filter.py
+++ b/betty/jinja2/filter.py
@@ -118,24 +118,6 @@ def filter_localize(
 
 
 @pass_context
-def filter_localize_html_lang(
-    context: Context,
-    localizable: Localizable,
-) -> str | Markup:
-    """
-    Localize a value using the context's current localizer.
-
-    This optionally adds the necessary HTML that indicates the localized
-    string is of a different locale than the surrounding HTML.
-    """
-    from betty.jinja2 import context_localizer
-
-    localizer = context_localizer(context)
-    localized = localizable.localize(localizer)
-    return filter_html_lang(context, localized)
-
-
-@pass_context
 def filter_html_lang(
     context: Context,
     localized: LocalizedStr,
@@ -599,7 +581,6 @@ async def filters() -> Mapping[str, Callable[..., Any]]:
         "json": filter_json,
         "locale_get_data": get_data,
         "localize": filter_localize,
-        "localize_html_lang": filter_localize_html_lang,
         "localized_url": filter_localized_url,
         "map": filter_map,
         "negotiate_has_dates": filter_negotiate_has_dates,

--- a/betty/tests/jinja2/test_filter.py
+++ b/betty/tests/jinja2/test_filter.py
@@ -19,7 +19,7 @@ from betty.locale import (
     UNCODED_LOCALE,
     DEFAULT_LOCALE,
 )
-from betty.locale.localizable import StaticTranslationsLocalizable, plain
+from betty.locale.localizable import plain
 from betty.locale.localized import Localized, LocalizedStr
 from betty.media_type import MediaType
 from betty.media_type.media_types import SVG
@@ -611,30 +611,6 @@ class TestFilterHtmlLang(TemplateStringTestBase):
                 "localized": localized,
             },
             autoescape=autoescape,
-        ) as (actual, _):
-            assert actual == expected
-
-
-class TestFilterLocalizeHtmlLang(TemplateStringTestBase):
-    @pytest.mark.parametrize(
-        ("expected", "localized_locale"),
-        [
-            ("Hallo, wereld!", DEFAULT_LOCALE),
-            ('<span lang="nl">Hallo, wereld!</span>', "nl"),
-        ],
-    )
-    async def test(self, expected: str, localized_locale: str) -> None:
-        template = "{{ localizable | localize_html_lang }}"
-        localizable = StaticTranslationsLocalizable(
-            {
-                localized_locale: "Hallo, wereld!",
-            }
-        )
-        async with self.assert_template_string(
-            template=template,
-            data={
-                "localizable": localizable,
-            },
         ) as (actual, _):
             assert actual == expected
 

--- a/documentation/usage/templating/filters.rst
+++ b/documentation/usage/templating/filters.rst
@@ -17,7 +17,6 @@ In addition to Jinja2's built-in filters, Betty provides the following:
 - :py:func:`json <betty.jinja2.filter.filter_json>`
 - :py:func:`locale_get_data <betty.locale.get_data>`
 - :py:func:`localize <betty.jinja2.filter.filter_localize>`
-- :py:func:`localize_html_lang <betty.jinja2.filter.filter_localize_html_lang>`
 - :py:func:`localized_url <betty.jinja2.filter.filter_localized_url>`
 - :py:func:`map <betty.jinja2.filter.filter_map>`
 - :py:func:`negotiate_has_dates <betty.jinja2.filter.filter_negotiate_has_dates>`


### PR DESCRIPTION
Remove `localize_html_lang`, as it does the same as the existing `localize` and `html_lang` filters combined (`localize | html_lang`).