### PR TITLE
Pickleable ancestry

### DIFF
--- a/betty/tests/ancestry/test_citation.py
+++ b/betty/tests/ancestry/test_citation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Sequence, Mapping, Any, TYPE_CHECKING
+import pickle
+from typing import Sequence, Mapping, Any, TYPE_CHECKING, cast
 
 from typing_extensions import override
 
@@ -9,6 +10,7 @@ from betty.ancestry.event import Event
 from betty.ancestry.event_type.event_types import Birth
 from betty.ancestry.has_citations import HasCitations
 from betty.ancestry.source import Source
+from betty.date import Date
 from betty.locale.localizer import DEFAULT_LOCALIZER
 from betty.privacy import Privacy
 from betty.test_utils.json.linked_data import assert_dumps_linked_data
@@ -156,6 +158,24 @@ class TestCitation(EntityTestBase):
         }
         actual = await assert_dumps_linked_data(citation)
         assert actual == expected
+
+    def test_pickle(self) -> None:
+        date = Date(1970, 1, 1)
+        citation_id = "my-first-citation"
+        location = "My First Location"
+        privacy = Privacy.PRIVATE
+        sut = Citation(
+            date=date,
+            id=citation_id,
+            location=location,
+            privacy=privacy,
+            source=Source(),
+        )
+        unpickled_sut = cast(Citation, pickle.loads(pickle.dumps(sut)))
+        assert unpickled_sut.date == date
+        assert unpickled_sut.id == citation_id
+        assert unpickled_sut.location.localize(DEFAULT_LOCALIZER) == location
+        assert unpickled_sut.privacy == privacy
 
 
 class DummyHasCitations(HasCitations, DummyEntity):

--- a/betty/tests/ancestry/test_enclosure.py
+++ b/betty/tests/ancestry/test_enclosure.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pickle
 from typing import Sequence, TYPE_CHECKING
 
 from typing_extensions import override
@@ -55,3 +56,7 @@ class TestEnclosure(EntityTestBase):
         assert sut.date is None
         sut.citations = [citation]
         assert list(sut.citations) == [citation]
+
+    def test_pickle(self) -> None:
+        sut = Enclosure(Place(), Place())
+        pickle.loads(pickle.dumps(sut))

--- a/betty/tests/ancestry/test_event.py
+++ b/betty/tests/ancestry/test_event.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Sequence, Mapping, Any, TYPE_CHECKING
+import pickle
+from typing import Sequence, Mapping, Any, TYPE_CHECKING, cast
 
 import pytest
 from typing_extensions import override
@@ -19,6 +20,7 @@ from betty.locale import UNDETERMINED_LOCALE
 from betty.locale.localizer import DEFAULT_LOCALIZER
 from betty.model.association import AssociationRequired, TemporaryToOneResolver
 from betty.privacy import Privacy
+from betty.test_utils.ancestry.event_type import DummyEventType
 from betty.test_utils.json.linked_data import assert_dumps_linked_data
 from betty.test_utils.model import EntityTestBase
 
@@ -287,3 +289,26 @@ class TestEvent(EntityTestBase):
         }
         actual = await assert_dumps_linked_data(event)
         assert actual == expected
+
+    def test_pickle(self) -> None:
+        date = Date(1970, 1, 1)
+        description = "My first description"
+        event_id = "my-first-event"
+        event_type = DummyEventType()
+        name = "My First Event"
+        privacy = Privacy.PRIVATE
+        sut = Event(
+            date=date,
+            description=description,
+            event_type=event_type,
+            id=event_id,
+            name=name,
+            privacy=privacy,
+        )
+        unpickled_sut = cast(Event, pickle.loads(pickle.dumps(sut)))
+        assert unpickled_sut.date == date
+        assert unpickled_sut.description.localize(DEFAULT_LOCALIZER) == description
+        assert isinstance(unpickled_sut.event_type, type(event_type))
+        assert unpickled_sut.id == event_id
+        assert unpickled_sut.name.localize(DEFAULT_LOCALIZER) == name
+        assert unpickled_sut.privacy == privacy

--- a/betty/tests/ancestry/test_file.py
+++ b/betty/tests/ancestry/test_file.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
+import pickle
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Sequence, Mapping, Any, TYPE_CHECKING
+from typing import Sequence, Mapping, Any, TYPE_CHECKING, cast
 
 from typing_extensions import override
 
 from betty.ancestry.citation import Citation
 from betty.ancestry.file import File
 from betty.ancestry.file_reference import FileReference
+from betty.ancestry.link import Link
 from betty.ancestry.note import Note
 from betty.ancestry.person import Person
 from betty.ancestry.source import Source
@@ -17,9 +19,12 @@ from betty.copyright_notice.copyright_notices import (
 )
 from betty.license.licenses import PublicDomain as PublicDomainLicense
 from betty.locale.localizer import DEFAULT_LOCALIZER
+from betty.media_type import MediaType
 from betty.media_type.media_types import PLAIN_TEXT
 from betty.privacy import Privacy
+from betty.test_utils.copyright_notice import DummyCopyrightNotice
 from betty.test_utils.json.linked_data import assert_dumps_linked_data
+from betty.test_utils.license import DummyLicense
 from betty.test_utils.model import EntityTestBase
 from betty.tests.ancestry.test___init__ import DummyHasFileReferences
 
@@ -268,3 +273,36 @@ class TestFile(EntityTestBase):
             }
             actual = await assert_dumps_linked_data(file)
             assert actual == expected
+
+    def test_pickle(self) -> None:
+        copyright_notice = DummyCopyrightNotice()
+        description = "My first description"
+        file_id = "my-first-file"
+        license = DummyLicense()  # noqa A001
+        link_url = "https://betty.example.com"
+        links = [Link(link_url)]
+        media_type = MediaType("my-first/media-type")
+        name = "my-first-file.file"
+        path = Path(__file__)
+        privacy = Privacy.PRIVATE
+        sut = File(
+            path,
+            copyright_notice=copyright_notice,
+            description=description,
+            id=file_id,
+            license=license,
+            links=links,
+            media_type=media_type,
+            name=name,
+            privacy=privacy,
+        )
+        unpickled_sut = cast(File, pickle.loads(pickle.dumps(sut)))
+        assert isinstance(unpickled_sut.copyright_notice, type(copyright_notice))
+        assert unpickled_sut.description.localize(DEFAULT_LOCALIZER) == description
+        assert unpickled_sut.id == file_id
+        assert isinstance(unpickled_sut.license, type(license))
+        assert unpickled_sut.links[0].url == link_url
+        assert unpickled_sut.media_type == media_type
+        assert unpickled_sut.name == name
+        assert unpickled_sut.path == path
+        assert unpickled_sut.privacy == privacy

--- a/betty/tests/ancestry/test_file_reference.py
+++ b/betty/tests/ancestry/test_file_reference.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import pickle
 from pathlib import Path
-from typing import Sequence, TYPE_CHECKING
+from typing import Sequence, TYPE_CHECKING, cast
 
 from typing_extensions import override
 
@@ -43,3 +44,14 @@ class TestFileReference(EntityTestBase):
         referee = DummyHasFileReferences()
         sut = FileReference(referee, File(Path()))
         assert sut.referee is referee
+
+    def test_pickle(self) -> None:
+        focus = (1, 2, 3, 4)
+        sut = FileReference(
+            DummyHasFileReferences(),
+            File(Path(__file__)),
+            focus=focus,
+        )
+        unpickled_sut = cast(FileReference, pickle.loads(pickle.dumps(sut)))
+        assert unpickled_sut.focus == focus
+        assert unpickled_sut.id == sut.id

--- a/betty/tests/ancestry/test_note.py
+++ b/betty/tests/ancestry/test_note.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from typing import Sequence, Mapping, Any, TYPE_CHECKING
+import pickle
+from typing import Sequence, Mapping, Any, TYPE_CHECKING, cast
 
 from typing_extensions import override
 
 from betty.ancestry.note import Note
 from betty.locale.localizer import DEFAULT_LOCALIZER
+from betty.privacy import Privacy
 from betty.test_utils.json.linked_data import assert_dumps_linked_data
 from betty.test_utils.model import EntityTestBase
 from betty.tests.ancestry.test_has_notes import DummyHasNotes
@@ -77,3 +79,17 @@ class TestNote(EntityTestBase):
         }
         actual = await assert_dumps_linked_data(note)
         assert actual == expected
+
+    def test_pickle(self) -> None:
+        note_id = "my-first-entity-id"
+        privacy = Privacy.PRIVATE
+        text = "My first note"
+        sut = Note(
+            id=note_id,
+            text=text,
+            privacy=privacy,
+        )
+        unpickled_sut = cast(Note, pickle.loads(pickle.dumps(sut)))
+        assert unpickled_sut.id == note_id
+        assert unpickled_sut.privacy == privacy
+        assert unpickled_sut.text.localize(DEFAULT_LOCALIZER) == text

--- a/betty/tests/ancestry/test_person.py
+++ b/betty/tests/ancestry/test_person.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Sequence, Mapping, Any, TYPE_CHECKING
+import pickle
+from typing import Sequence, Mapping, Any, TYPE_CHECKING, cast
 
 import pytest
 from typing_extensions import override
@@ -416,3 +417,21 @@ class TestPerson(EntityTestBase):
         }
         actual = await assert_dumps_linked_data(person)
         assert actual == expected
+
+    def test_pickle(self) -> None:
+        person_id = "my-first-entity-id"
+        link_url = "https://betty.example.com"
+        links = [Link(link_url)]
+        privacy = Privacy.PRIVATE
+        gender = NonBinary()
+        sut = Person(
+            gender=gender,
+            id=person_id,
+            links=links,
+            privacy=privacy,
+        )
+        unpickled_sut = cast(Person, pickle.loads(pickle.dumps(sut)))
+        assert isinstance(unpickled_sut.gender, type(gender))
+        assert unpickled_sut.id == person_id
+        assert unpickled_sut.links[0].url == link_url
+        assert unpickled_sut.privacy == privacy

--- a/betty/tests/ancestry/test_person_name.py
+++ b/betty/tests/ancestry/test_person_name.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Sequence, TYPE_CHECKING
+import pickle
+from typing import Sequence, TYPE_CHECKING, cast
 
 import pytest
 from typing_extensions import override
@@ -10,6 +11,7 @@ from betty.ancestry.person import Person
 from betty.ancestry.person_name import PersonName
 from betty.ancestry.source import Source
 from betty.locale import UNDETERMINED_LOCALE
+from betty.privacy import Privacy
 from betty.test_utils.json.linked_data import assert_dumps_linked_data
 from betty.test_utils.model import EntityTestBase
 
@@ -164,3 +166,24 @@ class TestPersonName(EntityTestBase):
         self, expected: DumpMapping[Dump], sut: PersonName
     ) -> None:
         assert await assert_dumps_linked_data(sut) == expected
+
+    def test_pickle(self) -> None:
+        affiliation = "Dough"
+        person_name_id = "my-first-person-name"
+        individual = "Jane"
+        locale = "nl-NL"
+        privacy = Privacy.PRIVATE
+        sut = PersonName(
+            affiliation=affiliation,
+            id=person_name_id,
+            individual=individual,
+            locale=locale,
+            person=Person(),
+            privacy=privacy,
+        )
+        unpickled_sut = cast(PersonName, pickle.loads(pickle.dumps(sut)))
+        assert unpickled_sut.affiliation == affiliation
+        assert unpickled_sut.id == person_name_id
+        assert unpickled_sut.individual == individual
+        assert unpickled_sut.locale == locale
+        assert unpickled_sut.privacy == privacy

--- a/betty/tests/ancestry/test_place.py
+++ b/betty/tests/ancestry/test_place.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Sequence, Mapping, Any, TYPE_CHECKING
+import pickle
+from typing import Sequence, Mapping, Any, TYPE_CHECKING, cast
 
 import pytest
 from geopy import Point
@@ -14,7 +15,9 @@ from betty.ancestry.name import Name
 from betty.ancestry.place import Place
 from betty.ancestry.place_type.place_types import Unknown as UnknownPlaceType
 from betty.locale import UNDETERMINED_LOCALE
+from betty.locale.localizer import DEFAULT_LOCALIZER
 from betty.model.association import AssociationRequired, TemporaryToOneResolver
+from betty.privacy import Privacy
 from betty.test_utils.ancestry.place_type import DummyPlaceType
 from betty.test_utils.json.linked_data import assert_dumps_linked_data
 from betty.test_utils.model import EntityTestBase
@@ -235,3 +238,27 @@ class TestPlace(EntityTestBase):
         }
         actual = await assert_dumps_linked_data(place)
         assert actual == expected
+
+    def test_pickle(self) -> None:
+        coordinates = Point(1, 2)
+        place_id = "my-first-place"
+        link_url = "https://betty.example.com"
+        links = [Link(link_url)]
+        name = "My First Place"
+        place_type = UnknownPlaceType()
+        privacy = Privacy.PRIVATE
+        sut = Place(
+            coordinates=coordinates,
+            id=place_id,
+            links=links,
+            names=[Name(name)],
+            place_type=place_type,
+            privacy=privacy,
+        )
+        unpickled_sut = cast(Place, pickle.loads(pickle.dumps(sut)))
+        assert unpickled_sut.coordinates == coordinates
+        assert unpickled_sut.id == place_id
+        assert unpickled_sut.links[0].url == link_url
+        assert unpickled_sut.names[0].name.localize(DEFAULT_LOCALIZER) == name
+        assert isinstance(unpickled_sut.place_type, type(place_type))
+        assert unpickled_sut.privacy == privacy

--- a/betty/tests/ancestry/test_presence.py
+++ b/betty/tests/ancestry/test_presence.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Sequence, TYPE_CHECKING
+import pickle
+from typing import Sequence, TYPE_CHECKING, cast
 
 import pytest
 from typing_extensions import override
@@ -100,3 +101,21 @@ class TestPresence(EntityTestBase):
         }
         actual = await assert_dumps_linked_data(sut)
         assert actual == expected
+
+    def test_pickle(self) -> None:
+        person = Person()
+        role = Subject()
+        event = Event()
+        privacy = Privacy.PRIVATE
+        sut = Presence(
+            person,
+            role,
+            event,
+            privacy=privacy,
+        )
+        unpickled_sut = cast(Presence, pickle.loads(pickle.dumps(sut)))
+        assert unpickled_sut.id == sut.id
+        assert unpickled_sut.person.id == person.id
+        assert isinstance(unpickled_sut.role, type(role))
+        assert unpickled_sut.event.id == event.id
+        assert unpickled_sut.privacy == privacy

--- a/betty/tests/ancestry/test_source.py
+++ b/betty/tests/ancestry/test_source.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Sequence, Mapping, Any, MutableMapping, TYPE_CHECKING
+import pickle
+from typing import Sequence, Mapping, Any, MutableMapping, TYPE_CHECKING, cast
 
 from typing_extensions import override
 
@@ -318,3 +319,27 @@ class TestSource(EntityTestBase):
         assert isinstance(actual, MutableMapping)
         actual.pop("links")
         assert actual == expected
+
+    def test_pickle(self) -> None:
+        source_id = "my-first-entity-id"
+        link_url = "https://betty.example.com"
+        links = [Link(link_url)]
+        privacy = Privacy.PRIVATE
+        author = "My First Author"
+        publisher = "My First Publisher"
+        date = Date(1970, 1, 1)
+        sut = Source(
+            author=author,
+            date=date,
+            id=source_id,
+            links=links,
+            privacy=privacy,
+            publisher=publisher,
+        )
+        unpickled_sut = cast(Source, pickle.loads(pickle.dumps(sut)))
+        assert unpickled_sut.author.localize(DEFAULT_LOCALIZER) == author
+        assert unpickled_sut.date == date
+        assert unpickled_sut.id == source_id
+        assert unpickled_sut.links[0].url == link_url
+        assert unpickled_sut.privacy == privacy
+        assert unpickled_sut.publisher.localize(DEFAULT_LOCALIZER) == publisher


### PR DESCRIPTION
We cannot just pickle an entire large ancestry, for the simply reason that at some point this will run into Python's recursion limit. We should focus on flattening the ancestry graph before pickling.

## To do
- Error when pickling associations.