### PR TITLE
Add a @service decorator for core components to declare service properties

### DIFF
--- a/betty/app/__init__.py
+++ b/betty/app/__init__.py
@@ -18,9 +18,8 @@ from betty.app.factory import AppDependentFactory
 from betty.assets import AssetRepository
 from betty.cache.file import BinaryFileCache, PickledFileCache
 from betty.cache.no_op import NoOpCache
-from betty.concurrent import AsynchronizedLock
 from betty.config import Configurable, assert_configuration_file
-from betty.core import CoreComponent
+from betty.core import CoreComponent, service
 from betty.factory import new, TargetFactory
 from betty.fetch import Fetcher, http
 from betty.fetch.static import StaticFetcher
@@ -36,7 +35,7 @@ if TYPE_CHECKING:
     from concurrent.futures import Executor
     from betty.plugin import PluginRepository
     from betty.cache import Cache
-    from collections.abc import AsyncIterator, Callable, Awaitable
+    from collections.abc import AsyncIterator, Callable
 
 _T = TypeVar("_T")
 
@@ -56,22 +55,9 @@ class App(Configurable[AppConfiguration], TargetFactory, CoreComponent):
         fetcher: Fetcher | None = None,
     ):
         super().__init__(configuration=configuration)
-        self._assets: AssetRepository | None = None
-        self._localization_initialized = False
-        self._localizer: Localizer | None = None
-        self._localizer_lock = AsynchronizedLock.threading()
-        self._localizers: LocalizerRepository | None = None
-        self._http_client: aiohttp.ClientSession | None = None
-        self._http_client_lock = AsynchronizedLock.threading()
         self._fetcher = fetcher
-        self._fetcher_lock = AsynchronizedLock.threading()
         self._cache_directory_path = cache_directory_path
-        self._cache: Cache[Any] | None = None
         self._cache_factory = cache_factory
-        self._binary_file_cache: BinaryFileCache | None = None
-        self._process_pool: Executor | None = None
-        self._spdx_license_repository: PluginRepository[License] | None = None
-        self._spdx_licenses_lock = AsynchronizedLock.threading()
 
     @classmethod
     @asynccontextmanager
@@ -111,120 +97,86 @@ class App(Configurable[AppConfiguration], TargetFactory, CoreComponent):
                 fetcher=fetcher or StaticFetcher(),
             )
 
-    @property
+    @service
     def assets(self) -> AssetRepository:
         """
         The assets file system.
         """
-        if self._assets is None:
-            self.assert_bootstrapped()
-            self._assets = AssetRepository(fs.ASSETS_DIRECTORY_PATH)
-        return self._assets
+        return AssetRepository(fs.ASSETS_DIRECTORY_PATH)
 
-    @property
-    def localizer(self) -> Awaitable[Localizer]:
+    @service
+    async def localizer(self) -> Localizer:
         """
         Get the application's localizer.
         """
-        return self._get_localizer()
+        return await self.localizers.get_negotiated(
+            self.configuration.locale or DEFAULT_LOCALE
+        )
 
-    async def _get_localizer(self) -> Localizer:
-        async with self._localizer_lock:
-            if self._localizer is None:
-                self.assert_bootstrapped()
-                self._localizer = await self.localizers.get_negotiated(
-                    self.configuration.locale or DEFAULT_LOCALE
-                )
-        return self._localizer
-
-    @property
+    @service
     def localizers(self) -> LocalizerRepository:
         """
         The available localizers.
         """
-        if self._localizers is None:
-            self.assert_bootstrapped()
-            self._localizers = LocalizerRepository(self.assets)
-        return self._localizers
+        return LocalizerRepository(self.assets)
 
-    @property
-    def http_client(self) -> Awaitable[aiohttp.ClientSession]:
+    @service
+    async def http_client(self) -> aiohttp.ClientSession:
         """
         The HTTP client.
         """
-        return self._get_http_client()
+        http_client = aiohttp.ClientSession(
+            connector=aiohttp.TCPConnector(limit_per_host=5),
+            headers={
+                "User-Agent": "Betty (https://betty.readthedocs.io/)",
+            },
+        )
 
-    async def _get_http_client(self) -> aiohttp.ClientSession:
-        async with self._http_client_lock:
-            if self._http_client is None:
-                self.assert_bootstrapped()
-                self._http_client = aiohttp.ClientSession(
-                    connector=aiohttp.TCPConnector(limit_per_host=5),
-                    headers={
-                        "User-Agent": "Betty (https://betty.readthedocs.io/)",
-                    },
-                )
-                self._shutdown_stack.append(self._shutdown_http_client)
-        return self._http_client
+        async def _shutdown(wait: bool) -> None:
+            await http_client.close()
 
-    async def _shutdown_http_client(self, *, wait: bool) -> None:
-        if self._http_client is not None:
-            await self._http_client.close()
+        self._shutdown_stack.append(_shutdown)
+        return http_client
 
-    @property
-    def fetcher(self) -> Awaitable[Fetcher]:
+    @service
+    async def fetcher(self) -> Fetcher:
         """
         The fetcher.
         """
-        return self._get_fetcher()
+        return http.HttpFetcher(
+            await self.http_client,
+            self.cache.with_scope("fetch"),
+            self.binary_file_cache.with_scope("fetch"),
+        )
 
-    async def _get_fetcher(self) -> Fetcher:
-        async with self._fetcher_lock:
-            if self._fetcher is None:
-                self.assert_bootstrapped()
-                self._fetcher = http.HttpFetcher(
-                    await self.http_client,
-                    self.cache.with_scope("fetch"),
-                    self.binary_file_cache.with_scope("fetch"),
-                )
-        return self._fetcher
-
-    @property
+    @service
     def cache(self) -> Cache[Any]:
         """
         The cache.
         """
-        if self._cache is None:
-            self.assert_bootstrapped()
-            self._cache = self._cache_factory(self)
-        return self._cache
+        return self._cache_factory(self)
 
-    @property
+    @service
     def binary_file_cache(self) -> BinaryFileCache:
         """
         The binary file cache.
         """
-        if self._binary_file_cache is None:
-            self.assert_bootstrapped()
-            self._binary_file_cache = BinaryFileCache(self._cache_directory_path)
-        return self._binary_file_cache
+        return BinaryFileCache(self._cache_directory_path)
 
-    @property
+    @service
     def process_pool(self) -> Executor:
         """
         The shared process pool.
 
         Use this to run CPU/computationally-heavy tasks in other processes.
         """
-        if self._process_pool is None:
-            self.assert_bootstrapped()
-            self._process_pool = ProcessPoolExecutor()
-            self._shutdown_stack.append(self._shutdown_process_pool)
-        return self._process_pool
+        process_pool = ProcessPoolExecutor()
 
-    async def _shutdown_process_pool(self, *, wait: bool) -> None:
-        if self._process_pool is not None:
-            self._process_pool.shutdown(wait, cancel_futures=not wait)
+        async def _shutdown(wait: bool) -> None:
+            process_pool.shutdown(wait, cancel_futures=not wait)
+
+        self._shutdown_stack.append(_shutdown)
+        return process_pool
 
     @override
     async def new_target(self, cls: type[_T]) -> _T:
@@ -244,26 +196,18 @@ class App(Configurable[AppConfiguration], TargetFactory, CoreComponent):
             return cast(_T, await cls.new_for_app(self))
         return await new(cls)
 
-    @property
-    def spdx_license_repository(self) -> Awaitable[PluginRepository[License]]:
+    @service
+    async def spdx_license_repository(self) -> PluginRepository[License]:
         """
         The SPDX licenses available to this application.
         """
-        return self._get_spdx_licenses()
-
-    async def _get_spdx_licenses(self) -> PluginRepository[License]:
-        async with self._spdx_licenses_lock:
-            if self._spdx_license_repository is None:
-                self.assert_bootstrapped()
-                self._spdx_license_repository = ProxyPluginRepository(
-                    LICENSE_REPOSITORY,
-                    SpdxLicenseRepository(
-                        binary_file_cache=self.binary_file_cache.with_scope("spdx"),
-                        fetcher=await self.fetcher,
-                        localizer=await self.localizer,
-                        factory=self.new_target,
-                        process_pool=self.process_pool,
-                    ),
-                )
-
-        return self._spdx_license_repository
+        return ProxyPluginRepository(
+            LICENSE_REPOSITORY,
+            SpdxLicenseRepository(
+                binary_file_cache=self.binary_file_cache.with_scope("spdx"),
+                fetcher=await self.fetcher,
+                localizer=await self.localizer,
+                factory=self.new_target,
+                process_pool=self.process_pool,
+            ),
+        )

--- a/betty/core.py
+++ b/betty/core.py
@@ -4,13 +4,18 @@ Provide tools to build core application components.
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable, MutableSequence, Awaitable
+from inspect import iscoroutinefunction
 from types import TracebackType
-from typing import Self, Any, final, TypedDict, Unpack, TypeAlias
+from typing import Self, Any, final, TypedDict, Unpack, TypeAlias, cast, Generic
+from typing import overload, TypeVar
 from warnings import warn
 
 from typing_extensions import override
 
+from betty.concurrent import AsynchronizedLock, Lock
 from betty.typing import internal, public
+
+_T = TypeVar("_T")
 
 
 @internal
@@ -108,7 +113,7 @@ class ShutdownStack(Bootstrapped, Shutdownable):
 
 
 @internal
-class CoreComponent(Bootstrapped, Shutdownable, ABC):  # noqa B024
+class CoreComponent(Bootstrapped, Shutdownable):
     """
     A core component.
 
@@ -150,3 +155,76 @@ class CoreComponent(Bootstrapped, Shutdownable, ABC):  # noqa B024
         exc_tb: TracebackType | None,
     ) -> None:
         await self.shutdown(wait=exc_val is None)
+
+
+_CoreComponentT = TypeVar("_CoreComponentT", bound=CoreComponent)
+
+
+class _Service(Generic[_CoreComponentT, _T]):
+    def __init__(self, f: Callable[[_CoreComponentT], _T]):
+        self._f = f
+        f_name = f.__name__  # type: ignore[attr-defined]
+        self._attr_name = f"_{f_name}"
+
+    @overload
+    def __get__(self, instance: None, owner: type[_CoreComponentT]) -> Self:
+        pass
+
+    @overload
+    def __get__(self, instance: _CoreComponentT, owner: type[_CoreComponentT]) -> _T:
+        pass
+
+    def __get__(
+        self, instance: _CoreComponentT | None, owner: type[_CoreComponentT]
+    ) -> _T | Self:
+        if instance is None:
+            return self  # type: ignore[return-value]
+
+        instance.assert_bootstrapped()
+
+        return self._get(instance)
+
+    @abstractmethod
+    def _get(self, instance: _CoreComponentT) -> _T:
+        pass
+
+
+class _AsynchronousService(_Service[_CoreComponentT, Awaitable[_T]]):
+    async def _get(self, instance: _CoreComponentT) -> _T:
+        service = cast(_T | None, getattr(instance, self._attr_name, None))
+        if service is not None:
+            return service
+
+        lock_attr_name = f"_{self._attr_name}_lock"
+        try:
+            lock = cast(Lock, getattr(instance, lock_attr_name))
+        except AttributeError:
+            lock = AsynchronizedLock.threading()
+            setattr(instance, lock_attr_name, lock)
+        async with lock:
+            service = await self._f(instance)
+            setattr(instance, self._attr_name, service)
+            return service
+
+
+class _SynchronousService(_Service[_CoreComponentT, _T]):
+    def _get(self, instance: _CoreComponentT) -> _T:
+        service = cast(_T | None, getattr(instance, self._attr_name, None))
+        if service is not None:
+            return service
+
+        service = self._f(instance)
+        setattr(instance, self._attr_name, service)
+        return service
+
+
+def service(f: Callable[[_CoreComponentT], _T]) -> _Service[_CoreComponentT, _T]:
+    """
+    Decorate a :py:class:`betty.core.CoreComponent`'s method to be a service property.
+
+    The decorated function should return a new service instance. The decorator will handle caching and concurrency.
+    """
+    if iscoroutinefunction(f):
+        return _AsynchronousService(f)  # type: ignore[return-value]
+    else:
+        return _SynchronousService(f)

--- a/betty/project/__init__.py
+++ b/betty/project/__init__.py
@@ -20,7 +20,6 @@ from typing import (
     Iterator,
     overload,
     cast,
-    Awaitable,
 )
 
 from aiofiles.tempfile import TemporaryDirectory
@@ -33,10 +32,9 @@ from betty.ancestry.gender import GENDER_REPOSITORY, Gender
 from betty.ancestry.place_type import PLACE_TYPE_REPOSITORY, PlaceType
 from betty.ancestry.presence_role import PRESENCE_ROLE_REPOSITORY, PresenceRole
 from betty.assets import AssetRepository
-from betty.concurrent import AsynchronizedLock
 from betty.config import Configurable
 from betty.copyright_notice import CopyrightNotice, COPYRIGHT_NOTICE_REPOSITORY
-from betty.core import CoreComponent
+from betty.core import CoreComponent, service
 from betty.event_dispatcher import EventDispatcher, EventHandlerRegistry
 from betty.factory import TargetFactory
 from betty.hashid import hashid
@@ -98,39 +96,6 @@ class Project(Configurable[ProjectConfiguration], TargetFactory, CoreComponent):
         super().__init__(configuration=configuration)
         self._app = app
         self._ancestry = ancestry
-
-        self._assets: AssetRepository | None = None
-        self._assets_lock = AsynchronizedLock.threading()
-        self._localizers: LocalizerRepository | None = None
-        self._localizers_lock = AsynchronizedLock.threading()
-        self._url_generator: UrlGenerator | None = None
-        self._url_generator_lock = AsynchronizedLock.threading()
-        self._localized_url_generator: LocalizedUrlGenerator | None = None
-        self._localized_url_generator_lock = AsynchronizedLock.threading()
-        self._static_url_generator: StaticUrlGenerator | None = None
-        self._static_url_generator_lock = AsynchronizedLock.threading()
-        self._jinja2_environment: Environment | None = None
-        self._jinja2_environment_lock = AsynchronizedLock.threading()
-        self._renderer: Renderer | None = None
-        self._renderer_lock = AsynchronizedLock.threading()
-        self._extensions: ProjectExtensions | None = None
-        self._extensions_lock = AsynchronizedLock.threading()
-        self._event_dispatcher: EventDispatcher | None = None
-        self._copyright_notice: CopyrightNotice | None = None
-        self._copyright_notice_lock = AsynchronizedLock.threading()
-        self._copyright_notice_repository: PluginRepository[CopyrightNotice] | None = (
-            None
-        )
-        self._license: License | None = None
-        self._license_lock = AsynchronizedLock.threading()
-        self._license_repository: PluginRepository[License] | None = None
-        self._licenses_lock = AsynchronizedLock.threading()
-        self._event_type_repository: PluginRepository[EventType] | None = None
-        self._place_type_repository: PluginRepository[PlaceType] | None = None
-        self._presence_role_repository: PluginRepository[PresenceRole] | None = None
-        self._gender_repository: PluginRepository[Gender] | None = None
-        self._entity_type_repository: PluginRepository[Entity] | None = None
-        self._extension_repository: PluginRepository[Extension] | None = None
 
     @classmethod
     async def new(
@@ -221,145 +186,81 @@ class Project(Configurable[ProjectConfiguration], TargetFactory, CoreComponent):
         """
         return self._ancestry
 
-    @property
-    def assets(self) -> Awaitable[AssetRepository]:
+    @service
+    async def assets(self) -> AssetRepository:
         """
         The assets file system.
         """
-        return self._get_assets()
+        asset_paths = [self.configuration.assets_directory_path]
+        extensions = await self.extensions
+        for project_extension in extensions.flatten():
+            extension_assets_directory_path = project_extension.assets_directory_path()
+            if extension_assets_directory_path is not None:
+                asset_paths.append(extension_assets_directory_path)
+        # Mimic :py:attr:`betty.app.App.assets`.
+        asset_paths.append(fs.ASSETS_DIRECTORY_PATH)
+        return AssetRepository(*asset_paths)
 
-    async def _get_assets(self) -> AssetRepository:
-        async with self._assets_lock:
-            if self._assets is None:
-                self.assert_bootstrapped()
-                asset_paths = [self.configuration.assets_directory_path]
-                extensions = await self.extensions
-                for extension in extensions.flatten():
-                    extension_assets_directory_path = extension.assets_directory_path()
-                    if extension_assets_directory_path is not None:
-                        asset_paths.append(extension_assets_directory_path)
-                # Mimic :py:attr:`betty.app.App.assets`.
-                asset_paths.append(fs.ASSETS_DIRECTORY_PATH)
-                self._assets = AssetRepository(*asset_paths)
-        return self._assets
-
-    @property
-    def localizers(self) -> Awaitable[LocalizerRepository]:
+    @service
+    async def localizers(self) -> LocalizerRepository:
         """
         The available localizers.
         """
-        return self._get_localizers()
+        return LocalizerRepository(await self.assets)
 
-    async def _get_localizers(self) -> LocalizerRepository:
-        async with self._localizers_lock:
-            if self._localizers is None:
-                self.assert_bootstrapped()
-                self._localizers = LocalizerRepository(await self.assets)
-        return self._localizers
-
-    @property
-    def url_generator(self) -> Awaitable[UrlGenerator]:
+    @service
+    async def url_generator(self) -> UrlGenerator:
         """
         The URL generator.
         """
-        return self._get_url_generator()
+        return await new_project_url_generator(self)
 
-    async def _get_url_generator(self) -> UrlGenerator:
-        async with self._url_generator_lock:
-            if self._url_generator is None:
-                self.assert_bootstrapped()
-                self._url_generator = await new_project_url_generator(self)
-        return self._url_generator
-
-    @property
+    @service
     @deprecated(
         "This service has been deprecated since Betty 0.4.8, and will be removed in Betty 0.5. Instead use `Project.url_generator`."
     )
-    def localized_url_generator(self) -> Awaitable[LocalizedUrlGenerator]:
+    async def localized_url_generator(self) -> LocalizedUrlGenerator:
         """
         The URL generator for localizable resources.
         """
-        return self._get_localized_url_generator()
+        return await ProjectLocalizedUrlGenerator.new_for_project(self)
 
-    async def _get_localized_url_generator(self) -> LocalizedUrlGenerator:
-        async with self._localized_url_generator_lock:
-            if self._localized_url_generator is None:
-                self.assert_bootstrapped()
-                self._localized_url_generator = (
-                    await ProjectLocalizedUrlGenerator.new_for_project(self)
-                )
-        return self._localized_url_generator
-
-    @property
+    @service
     @deprecated(
         "This service has been deprecated since Betty 0.4.8, and will be removed in Betty 0.5. Instead use `Project.url_generator`."
     )
-    def static_url_generator(self) -> Awaitable[StaticUrlGenerator]:
+    async def static_url_generator(self) -> StaticUrlGenerator:
         """
         The URL generator for static resources.
         """
-        return self._get_static_url_generator()
+        return await ProjectStaticUrlGenerator.new_for_project(self)
 
-    async def _get_static_url_generator(self) -> StaticUrlGenerator:
-        async with self._static_url_generator_lock:
-            if self._static_url_generator is None:
-                self.assert_bootstrapped()
-                self._static_url_generator = (
-                    await ProjectStaticUrlGenerator.new_for_project(self)
-                )
-        return self._static_url_generator
-
-    @property
-    def jinja2_environment(self) -> Awaitable[Environment]:
+    @service
+    async def jinja2_environment(self) -> Environment:
         """
         The Jinja2 environment.
         """
-        return self._get_jinja2_environment()
+        from betty.jinja2 import Environment
 
-    async def _get_jinja2_environment(self) -> Environment:
-        async with self._jinja2_environment_lock:
-            if not self._jinja2_environment:
-                from betty.jinja2 import Environment
+        return await Environment.new_for_project(self)
 
-                self.assert_bootstrapped()
-                self._jinja2_environment = await Environment.new_for_project(self)
-
-        return self._jinja2_environment
-
-    @property
-    def renderer(self) -> Awaitable[Renderer]:
+    @service
+    async def renderer(self) -> Renderer:
         """
         The (file) content renderer.
         """
-        return self._get_renderer()
+        return SequentialRenderer(
+            [
+                await self.new_target(plugin)
+                for plugin in await RENDERER_REPOSITORY.select()
+            ]
+        )
 
-    async def _get_renderer(self) -> Renderer:
-        async with self._renderer_lock:
-            if not self._renderer:
-                self.assert_bootstrapped()
-                self._renderer = SequentialRenderer(
-                    [
-                        await self.new_target(plugin)
-                        for plugin in await RENDERER_REPOSITORY.select()
-                    ]
-                )
-        return self._renderer
-
-    @property
-    def extensions(self) -> Awaitable[ProjectExtensions]:
+    @service
+    async def extensions(self) -> ProjectExtensions:
         """
         The enabled extensions.
         """
-        return self._get_extensions()
-
-    async def _get_extensions(self) -> ProjectExtensions:
-        async with self._extensions_lock:
-            if self._extensions is None:
-                self._extensions = await self._init_extensions()
-        return self._extensions
-
-    async def _init_extensions(self) -> ProjectExtensions:
-        self.assert_bootstrapped()
         extensions = {}
         for extension_configuration in self.configuration.extensions.values():
             extension = await self.extension_repository.get(extension_configuration.id)
@@ -408,16 +309,12 @@ class Project(Configurable[ProjectConfiguration], TargetFactory, CoreComponent):
 
         return initialized_extensions
 
-    @property
+    @service
     def event_dispatcher(self) -> EventDispatcher:
         """
         The event dispatcher.
         """
-        if self._event_dispatcher is None:
-            self.assert_bootstrapped()
-            self._event_dispatcher = EventDispatcher()
-
-        return self._event_dispatcher
+        return EventDispatcher()
 
     @override
     async def new_target(self, cls: type[_T]) -> _T:
@@ -449,172 +346,117 @@ class Project(Configurable[ProjectConfiguration], TargetFactory, CoreComponent):
             or fs.ASSETS_DIRECTORY_PATH / "public" / "static" / "betty-512x512.png"
         )
 
-    @property
-    def copyright_notice(self) -> Awaitable[CopyrightNotice]:
+    @service
+    async def copyright_notice(self) -> CopyrightNotice:
         """
         The overall project copyright.
         """
-        return self._get_copyright_notice()
+        return await self.configuration.copyright_notice.new_plugin_instance(
+            self.copyright_notice_repository
+        )
 
-    async def _get_copyright_notice(self) -> CopyrightNotice:
-        async with self._copyright_notice_lock:
-            if self._copyright_notice is None:
-                self.assert_bootstrapped()
-                self._copyright_notice = (
-                    await self.configuration.copyright_notice.new_plugin_instance(
-                        self.copyright_notice_repository
-                    )
-                )
-        return self._copyright_notice
-
-    @property
+    @service
     def copyright_notice_repository(self) -> PluginRepository[CopyrightNotice]:
         """
         The copyright notices available to this project.
 
         Read more about :doc:`/development/plugin/copyright-notice`.
         """
-        if self._copyright_notice_repository is None:
-            self.assert_bootstrapped()
-            self._copyright_notice_repository = ProxyPluginRepository(
-                COPYRIGHT_NOTICE_REPOSITORY,
-                StaticPluginRepository(
-                    *self.configuration.copyright_notices.new_plugins()
-                ),
-                factory=self.new_target,
-            )
+        return ProxyPluginRepository(
+            COPYRIGHT_NOTICE_REPOSITORY,
+            StaticPluginRepository(*self.configuration.copyright_notices.new_plugins()),
+            factory=self.new_target,
+        )
 
-        return self._copyright_notice_repository
-
-    @property
-    def license(self) -> Awaitable[License]:
+    @service
+    async def license(self) -> License:
         """
         The overall project license.
         """
-        return self._get_license()
+        return await self.configuration.license.new_plugin_instance(
+            await self.license_repository
+        )
 
-    async def _get_license(self) -> License:
-        async with self._license_lock:
-            if self._license is None:
-                self._license = await self.configuration.license.new_plugin_instance(
-                    await self.license_repository
-                )
-        return self._license
-
-    @property
-    def license_repository(self) -> Awaitable[PluginRepository[License]]:
+    @service
+    async def license_repository(self) -> PluginRepository[License]:
         """
         The licenses available to this project.
 
         Read more about :doc:`/development/plugin/license`.
         """
-        return self._get_licenses()
+        return ProxyPluginRepository(
+            await self._app.spdx_license_repository,
+            StaticPluginRepository(*self.configuration.licenses.new_plugins()),
+            factory=self.new_target,
+        )
 
-    async def _get_licenses(self) -> PluginRepository[License]:
-        async with self._licenses_lock:
-            if self._license_repository is None:
-                self.assert_bootstrapped()
-                self._license_repository = ProxyPluginRepository(
-                    await self._app.spdx_license_repository,
-                    StaticPluginRepository(*self.configuration.licenses.new_plugins()),
-                    factory=self.new_target,
-                )
-
-        return self._license_repository
-
-    @property
+    @service
     def event_type_repository(self) -> PluginRepository[EventType]:
         """
         The event types available to this project.
         """
-        if self._event_type_repository is None:
-            self.assert_bootstrapped()
-            self._event_type_repository = ProxyPluginRepository(
-                EVENT_TYPE_REPOSITORY,
-                StaticPluginRepository(*self.configuration.event_types.new_plugins()),
-                factory=self.new_target,
-            )
+        return ProxyPluginRepository(
+            EVENT_TYPE_REPOSITORY,
+            StaticPluginRepository(*self.configuration.event_types.new_plugins()),
+            factory=self.new_target,
+        )
 
-        return self._event_type_repository
-
-    @property
+    @service
     def place_type_repository(self) -> PluginRepository[PlaceType]:
         """
         The place types available to this project.
         """
-        if self._place_type_repository is None:
-            self.assert_bootstrapped()
-            self._place_type_repository = ProxyPluginRepository(
-                PLACE_TYPE_REPOSITORY,
-                StaticPluginRepository(*self.configuration.place_types.new_plugins()),
-                factory=self.new_target,
-            )
+        return ProxyPluginRepository(
+            PLACE_TYPE_REPOSITORY,
+            StaticPluginRepository(*self.configuration.place_types.new_plugins()),
+            factory=self.new_target,
+        )
 
-        return self._place_type_repository
-
-    @property
+    @service
     def presence_role_repository(self) -> PluginRepository[PresenceRole]:
         """
         The presence roles available to this project.
         """
-        if self._presence_role_repository is None:
-            self.assert_bootstrapped()
-            self._presence_role_repository = ProxyPluginRepository(
-                PRESENCE_ROLE_REPOSITORY,
-                StaticPluginRepository(
-                    *self.configuration.presence_roles.new_plugins()
-                ),
-                factory=self.new_target,
-            )
+        return ProxyPluginRepository(
+            PRESENCE_ROLE_REPOSITORY,
+            StaticPluginRepository(*self.configuration.presence_roles.new_plugins()),
+            factory=self.new_target,
+        )
 
-        return self._presence_role_repository
-
-    @property
+    @service
     def gender_repository(self) -> PluginRepository[Gender]:
         """
         The genders available to this project.
 
         Read more about :doc:`/development/plugin/gender`.
         """
-        if self._gender_repository is None:
-            self.assert_bootstrapped()
-            self._gender_repository = ProxyPluginRepository(
-                GENDER_REPOSITORY,
-                StaticPluginRepository(*self.configuration.genders.new_plugins()),
-                factory=self.new_target,
-            )
+        return ProxyPluginRepository(
+            GENDER_REPOSITORY,
+            StaticPluginRepository(*self.configuration.genders.new_plugins()),
+            factory=self.new_target,
+        )
 
-        return self._gender_repository
-
-    @property
+    @service
     def entity_type_repository(self) -> PluginRepository[Entity]:
         """
         The entity types available to this project.
 
         Read more about :doc:`/development/plugin/entity-type`.
         """
-        if self._entity_type_repository is None:
-            self.assert_bootstrapped()
-            self._entity_type_repository = ProxyPluginRepository(
-                model.ENTITY_TYPE_REPOSITORY, factory=self.new_target
-            )
+        return ProxyPluginRepository(
+            model.ENTITY_TYPE_REPOSITORY, factory=self.new_target
+        )
 
-        return self._entity_type_repository
-
-    @property
+    @service
     def extension_repository(self) -> PluginRepository[Extension]:
         """
         The extensions available to this project.
 
         Read more about :doc:`/development/plugin/extension`.
         """
-        if self._extension_repository is None:
-            self.assert_bootstrapped()
-            self._extension_repository = ProxyPluginRepository(
-                extension.EXTENSION_REPOSITORY, factory=self.new_target
-            )
-
-        return self._extension_repository
+        return ProxyPluginRepository(
+            extension.EXTENSION_REPOSITORY, factory=self.new_target
+        )
 
 
 _ExtensionT = TypeVar("_ExtensionT", bound=Extension)

--- a/betty/project/extension/wikipedia/__init__.py
+++ b/betty/project/extension/wikipedia/__init__.py
@@ -10,6 +10,7 @@ from typing import Iterable, TYPE_CHECKING, final, Self
 from jinja2 import pass_context
 from typing_extensions import override
 
+from betty.core import service
 from betty.fetch import FetchError
 from betty.jinja2 import Jinja2Provider, context_localizer, Filters, Globals
 from betty.locale import negotiate_locale
@@ -23,7 +24,6 @@ from betty.wikipedia.copyright_notice import WikipediaContributors
 
 if TYPE_CHECKING:
     from betty.copyright_notice import CopyrightNotice
-    from collections.abc import Awaitable
     from betty.project import Project
     from betty.event_dispatcher import EventHandlerRegistry
     from jinja2.runtime import Context
@@ -63,7 +63,6 @@ class Wikipedia(
         self._wikipedia_contributors_copyright_notice = (
             wikipedia_contributors_copyright_notice
         )
-        self._retriever: _Retriever | None = None
 
     @override
     @classmethod
@@ -84,18 +83,12 @@ class Wikipedia(
     def register_event_handlers(self, registry: EventHandlerRegistry) -> None:
         registry.add_handler(PostLoadAncestryEvent, _populate_ancestry)
 
-    @property
-    def retriever(self) -> Awaitable[_Retriever]:
+    @service
+    async def retriever(self) -> _Retriever:
         """
         The Wikipedia content retriever.
         """
-        return self._get_retriever()
-
-    async def _get_retriever(self) -> _Retriever:
-        if self._retriever is None:
-            self.assert_bootstrapped()
-            return _Retriever(await self.project.app.fetcher)
-        return self._retriever
+        return _Retriever(await self.project.app.fetcher)
 
     @override
     @property

--- a/betty/tests/test_core.py
+++ b/betty/tests/test_core.py
@@ -1,7 +1,7 @@
 from typing_extensions import override
 
 import pytest
-from betty.core import CoreComponent, Bootstrapped, ShutdownStack, Shutdownable
+from betty.core import CoreComponent, Bootstrapped, ShutdownStack, Shutdownable, service
 
 
 class TestBootstrapped:
@@ -105,3 +105,52 @@ class TestCoreComponent:
         await sut.bootstrap()
         await sut.shutdown()
         assert not sut.bootstrapped
+
+
+class TestService:
+    class _Component(CoreComponent):
+        @service
+        async def my_first_asynchronous_service(self) -> object:
+            return object()
+
+        @service
+        def my_first_synchronous_service(self) -> object:
+            return object()
+
+    async def test_get_class_attr_with_asynchronous_method(self) -> None:
+        self._Component.my_first_asynchronous_service  # noqa: B018
+
+    async def test_get_instance_attr_with_asynchronous_method_with_bootstrapped(
+        self,
+    ) -> None:
+        async with self._Component() as component:
+            assert (
+                await component.my_first_asynchronous_service
+                is await component.my_first_asynchronous_service
+            )
+
+    async def test_get_instance_attr_with_asynchronous_method_without_bootstrapped(
+        self,
+    ) -> None:
+        component = self._Component()
+        with pytest.raises(RuntimeError):
+            await component.my_first_asynchronous_service
+
+    async def test_get_class_attr_with_synchronous_method(self) -> None:
+        self._Component.my_first_synchronous_service  # noqa: B018
+
+    async def test_get_instance_attr_with_synchronous_method_with_bootstrapped(
+        self,
+    ) -> None:
+        async with self._Component() as component:
+            assert (
+                component.my_first_synchronous_service
+                is component.my_first_synchronous_service
+            )
+
+    async def test_get_instance_attr_with_synchronous_method_without_bootstrapped(
+        self,
+    ) -> None:
+        component = self._Component()
+        with pytest.raises(RuntimeError):
+            component.my_first_synchronous_service  # noqa: B018


### PR DESCRIPTION
This makes it easier and quicker for core components (`App`, `Project`, and extensions) to declare services while benefiting from built-in caching and protection against race conditions.