### PR TITLE
Add a scroll prevention API

### DIFF
--- a/betty/project/extension/maps/assets/templates/map.html.j2
+++ b/betty/project/extension/maps/assets/templates/map.html.j2
@@ -4,7 +4,16 @@
     {% for place in places %}
         {% do ns.place_urls.append((place | url, place.coordinates.latitude, place.coordinates.longitude, place.label | localize)) %}
     {% endfor %}
-    <div class="map" data-betty-places="{{ ns.place_urls | json }}"></div>
+    <div class="map" data-betty-scroll-prevention-target="todo-scroll-prevention-warning-map" data-betty-places="{{ ns.place_urls | json }}"></div>
+    <div id="todo-scroll-prevention-warning-tree">OOPS NO SCROLLING!!!</div>
+    <style>
+        #todo-scroll-prevention-warning-map {
+            display: none;
+        }
+        #todo-scroll-prevention-warning-map.betty-scroll-prevention-visible {
+            display:block;
+        }
+    </style>
     {% do 'betty-static:///css/maps.css' | public_css %}
     {% do 'maps' | webpack_entry_point_js %}
 {% endif %}

--- a/betty/project/extension/raspberry_mint/webpack/main.ts
+++ b/betty/project/extension/raspberry_mint/webpack/main.ts
@@ -4,5 +4,8 @@ import './css/main.scss'
 import "bootstrap/js/dist/collapse"
 import "bootstrap/js/dist/modal"
 import {Search} from './search.ts'
+import {BETTY} from "@betty.py/betty/main.ts";
+import {initializeScrollPreventions} from "@betty.py/betty/scroll-prevention.ts"
 
 new Search()
+BETTY.addInitializer(initializeScrollPreventions)

--- a/betty/project/extension/trees/assets/templates/tree.html.j2
+++ b/betty/project/extension/trees/assets/templates/tree.html.j2
@@ -1,3 +1,12 @@
-<div class="tree" data-betty-person="{{ person.id }}" data-betty-people="{{ 'betty:///people.json' | url }}"></div>
+<div class="tree" data-betty-scroll-prevention-target="todo-scroll-prevention-warning-tree" data-betty-person="{{ person.id }}" data-betty-people="{{ 'betty:///people.json' | url }}"></div>
+<div id="todo-scroll-prevention-warning-tree">OOPS NO SCROLLING!!!</div>
+<style>
+    #todo-scroll-prevention-warning-tree {
+        display: none;
+    }
+    #todo-scroll-prevention-warning-tree.betty-scroll-prevention-visible {
+        display:block;
+    }
+</style>
 {% do 'betty-static:///css/trees.css' | public_css %}
 {% do 'trees' | webpack_entry_point_js %}

--- a/betty/tests/js/test_main.py
+++ b/betty/tests/js/test_main.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+import aiofiles
+import pytest
+from playwright.async_api import Page
+
+from betty.fs import ROOT_DIRECTORY_PATH
+from betty.locale.localizer import DEFAULT_LOCALIZER
+from betty.serve import BuiltinServer
+from betty.subprocess import run_process
+
+
+async def tsc(file_path: Path, output_directory_path: Path) -> None:
+    await run_process(
+        [
+            "npx",
+            "tsc",
+            "--module",
+            "esnext",
+            "--target",
+            "es2017",
+            "--moduleResolution",
+            "bundler",
+            "--outDir",
+            str(output_directory_path),
+            str(file_path),
+        ],
+        ROOT_DIRECTORY_PATH,
+    )
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test(page: Page, tmp_path: Path) -> None:
+    await tsc(ROOT_DIRECTORY_PATH / "js" / "index.ts", tmp_path)
+    await tsc(ROOT_DIRECTORY_PATH / "js" / "main.ts", tmp_path)
+    async with aiofiles.open(tmp_path / "index.html", "w") as f:
+        await f.write("""
+<!doctype html>
+<html>
+<head>
+    <title>test</title>
+</head>
+<body>
+<script type="module">
+'use strict'
+
+import {BETTY as BETTY_ONE} from "/main.js"
+import {BETTY as BETTY_TWO} from "/main.js"
+document.BETTY_ONE = BETTY_ONE
+document.BETTY_TWO = BETTY_TWO
+</script>
+</body>
+</html>
+
+        """)
+    async with BuiltinServer(tmp_path, localizer=DEFAULT_LOCALIZER) as server:
+        await page.goto(server.public_url)
+        assert await page.evaluate("() => document.BETTY_ON")
+        assert await page.evaluate("() => document.BETTY_ONE && document.BETTY_ONE === document.BETTY_TWO")

--- a/index.html
+++ b/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+<head>
+    <title>test</title>
+</head>
+<body>
+<script type="module">
+'use strict'
+
+import {BETTY as BETTY_ONE} from "/main.js"
+import {BETTY as BETTY_TWO} from "/main.js"
+document.BETTY_ONE = BETTY_ONE
+document.BETTY_TWO = BETTY_TWO
+</script>
+</body>
+</html>
+

--- a/index.js
+++ b/index.js
@@ -1,0 +1,24 @@
+class Betty {
+    constructor() {
+        this.initializers = [];
+        this.finalizers = [];
+    }
+    async addInitializer(initializer) {
+        this.initializers.push(initializer);
+        await initializer(document.body);
+    }
+    async initialize(element) {
+        for (const initializer of this.initializers) {
+            await initializer(element);
+        }
+    }
+    addFinalizer(finalizer) {
+        this.finalizers.push(finalizer);
+    }
+    async finalize(element) {
+        for (const finalizer of this.finalizers) {
+            await finalizer(element);
+        }
+    }
+}
+export { Betty, };

--- a/js/scroll-prevention.ts
+++ b/js/scroll-prevention.ts
@@ -1,0 +1,39 @@
+'use strict'
+
+const attributeName = 'data-betty-scroll-prevention-target'
+
+function initializeScrollPrevention(scrollable: HTMLElement): void {
+    const targetId = scrollable.dataset.bettyScrollPreventionTarget
+    if (targetId === undefined) {
+        throw new Error(`Element does not have the expected "${attributeName}" attribute.`)
+    }
+    const target = document.getElementById(targetId)
+    scrollable.addEventListener('wheel', event => {
+        console.log('WHEEL')
+        console.log(target)
+        // @todo Do not prevent scrolling if the scrollable is fullscreen!!!
+        // @todo Also do not prevent scrolling if CTRL+mouse is used, or two fingers
+        event.stopPropagation()
+        event.preventDefault()
+        target.classList.add('betty-scroll-prevention-visible')
+        // @todo Ensure no race conditions!
+        window.setTimeout(() => {
+            target.classList.remove('betty-scroll-prevention-visible')
+        }, 500)
+    }, {
+        capture: true,
+    })
+}
+
+async function initializeScrollPreventions(element: HTMLElement): Promise<void> { // eslint-disable-line @typescript-eslint/require-await
+    for (const scrollable of element.querySelectorAll(`[${attributeName}]`) as HTMLElement[]) {
+        console.log('INIT SCROLL PREVENTION')
+        console.log(scrollable)
+        initializeScrollPrevention(scrollable)
+    }
+}
+
+export {
+    initializeScrollPrevention,
+    initializeScrollPreventions,
+}

--- a/main.js
+++ b/main.js
@@ -1,0 +1,3 @@
+import { Betty } from "./index.js";
+const BETTY = new Betty();
+export { BETTY };


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/371

## To do
- How to intercept scroll events but only allow propagation UP, and not DOWN?
- When applied to the Cytoscape trees, scrolls are caught by our listener, but not prevented from propagating to Cytoscape itself