### PR TITLE
Refactor how the Gramps extension maps data

### DIFF
--- a/betty/assets/locale/ar/betty.po
+++ b/betty/assets/locale/ar/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-16 17:10+0000\n"
+"POT-Creation-Date: 2025-03-22 20:24+0000\n"
 "PO-Revision-Date: 2024-11-30 19:00+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: ar\n"
@@ -176,13 +176,6 @@ msgstr ""
 msgid ""
 "Betty is unfamiliar with Gramps file \"{file_id}\"'s license ID of "
 "\"{license_id}\" and ignored it."
-msgstr ""
-
-#, python-brace-format
-msgid ""
-"Betty is unfamiliar with Gramps person \"{person_id}\"'s gender of "
-"\"{gramps_gender}\". The person was imported, but their gender was set to"
-" \"{betty_gender}\"."
 msgstr ""
 
 #, python-brace-format

--- a/betty/assets/locale/betty.pot
+++ b/betty/assets/locale/betty.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-16 17:10+0000\n"
+"POT-Creation-Date: 2025-03-22 20:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,13 +164,6 @@ msgstr ""
 msgid ""
 "Betty is unfamiliar with Gramps file \"{file_id}\"'s license ID of "
 "\"{license_id}\" and ignored it."
-msgstr ""
-
-#, python-brace-format
-msgid ""
-"Betty is unfamiliar with Gramps person \"{person_id}\"'s gender of "
-"\"{gramps_gender}\". The person was imported, but their gender was set to "
-"\"{betty_gender}\"."
 msgstr ""
 
 #, python-brace-format

--- a/betty/assets/locale/de-DE/betty.po
+++ b/betty/assets/locale/de-DE/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-16 17:10+0000\n"
+"POT-Creation-Date: 2025-03-22 20:24+0000\n"
 "PO-Revision-Date: 2025-03-16 07:01+0000\n"
 "Last-Translator: Ettore Atalan <atalanttore@googlemail.com>\n"
 "Language: de_DE\n"
@@ -179,13 +179,6 @@ msgstr ""
 msgid ""
 "Betty is unfamiliar with Gramps file \"{file_id}\"'s license ID of "
 "\"{license_id}\" and ignored it."
-msgstr ""
-
-#, python-brace-format
-msgid ""
-"Betty is unfamiliar with Gramps person \"{person_id}\"'s gender of "
-"\"{gramps_gender}\". The person was imported, but their gender was set to"
-" \"{betty_gender}\"."
 msgstr ""
 
 #, python-brace-format

--- a/betty/assets/locale/fr-FR/betty.po
+++ b/betty/assets/locale/fr-FR/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-16 17:10+0000\n"
+"POT-Creation-Date: 2025-03-22 20:24+0000\n"
 "PO-Revision-Date: 2024-11-29 18:58+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: fr_FR\n"
@@ -171,13 +171,6 @@ msgstr ""
 msgid ""
 "Betty is unfamiliar with Gramps file \"{file_id}\"'s license ID of "
 "\"{license_id}\" and ignored it."
-msgstr ""
-
-#, python-brace-format
-msgid ""
-"Betty is unfamiliar with Gramps person \"{person_id}\"'s gender of "
-"\"{gramps_gender}\". The person was imported, but their gender was set to"
-" \"{betty_gender}\"."
 msgstr ""
 
 #, python-brace-format

--- a/betty/assets/locale/he/betty.po
+++ b/betty/assets/locale/he/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-16 17:10+0000\n"
+"POT-Creation-Date: 2025-03-22 20:24+0000\n"
 "PO-Revision-Date: 2025-02-19 16:48+0000\n"
 "Last-Translator: Yaron Shahrabani <sh.yaron@gmail.com>\n"
 "Language: he\n"
@@ -167,13 +167,6 @@ msgstr ""
 msgid ""
 "Betty is unfamiliar with Gramps file \"{file_id}\"'s license ID of "
 "\"{license_id}\" and ignored it."
-msgstr ""
-
-#, python-brace-format
-msgid ""
-"Betty is unfamiliar with Gramps person \"{person_id}\"'s gender of "
-"\"{gramps_gender}\". The person was imported, but their gender was set to"
-" \"{betty_gender}\"."
 msgstr ""
 
 #, python-brace-format

--- a/betty/assets/locale/nl-NL/betty.po
+++ b/betty/assets/locale/nl-NL/betty.po
@@ -7,16 +7,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-16 17:10+0000\n"
+"POT-Creation-Date: 2025-03-22 20:24+0000\n"
 "PO-Revision-Date: 2025-03-16 21:34+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
-"Language-Team: Dutch <https://hosted.weblate.org/projects/betty/betty/nl/>\n"
-"Language: nl-NL\n"
+"Language: nl_NL\n"
+"Language-Team: Dutch "
+"<https://hosted.weblate.org/projects/betty/betty/nl/>\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.11-dev\n"
 "Generated-By: Babel 2.17.0\n"
 
 #, python-brace-format
@@ -191,16 +191,6 @@ msgid ""
 msgstr ""
 "Betty kent licentie-ID \"{license_id}\" van Gramps-bestand \"{file_id}\" "
 "niet en heeft het genegeerd."
-
-#, python-brace-format
-msgid ""
-"Betty is unfamiliar with Gramps person \"{person_id}\"'s gender of "
-"\"{gramps_gender}\". The person was imported, but their gender was set to"
-" \"{betty_gender}\"."
-msgstr ""
-"Betty kent het Gramps-geslacht \"{gramps_gender}\" van persoon "
-"\"{person_id}\" niet. De persoon is geladen, maar hun geslacht is nu "
-"\"{betty_gender}\"."
 
 #, python-brace-format
 msgid ""
@@ -1401,3 +1391,4 @@ msgstr "© Copyright de auteur, tenzij anders vermeld"
 #, python-brace-format
 msgid "© Copyright {author}, unless otherwise credited"
 msgstr "© Copyright {author}, tenzij anders vermeld"
+

--- a/betty/assets/locale/uk/betty.po
+++ b/betty/assets/locale/uk/betty.po
@@ -7,18 +7,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty 0.4\n"
 "Report-Msgid-Bugs-To: illia@maier.page\n"
-"POT-Creation-Date: 2025-03-16 17:10+0000\n"
+"POT-Creation-Date: 2025-03-22 20:24+0000\n"
 "PO-Revision-Date: 2025-03-16 21:34+0000\n"
 "Last-Translator: Максим Горпиніч <maksimgorpinic2005a@gmail.com>\n"
-"Language-Team: Ukrainian <https://hosted.weblate.org/projects/betty/betty/uk/"
-">\n"
 "Language: uk\n"
+"Language-Team: Ukrainian "
+"<https://hosted.weblate.org/projects/betty/betty/uk/>\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
-"X-Generator: Weblate 5.11-dev\n"
 "Generated-By: Babel 2.17.0\n"
 
 #, python-brace-format
@@ -192,16 +191,6 @@ msgid ""
 msgstr ""
 "Betty не знайома з ID ліцензії файлу Gramps \"{file_id}\" як "
 "\"{license_id}\" і проігнорувала його."
-
-#, python-brace-format
-msgid ""
-"Betty is unfamiliar with Gramps person \"{person_id}\"'s gender of "
-"\"{gramps_gender}\". The person was imported, but their gender was set to"
-" \"{betty_gender}\"."
-msgstr ""
-"Betty не знайома зі статтю особи Gramps \"{person_id}\" як "
-"\"{gramps_gender}\". Особа була імпортована, але її стать змінена на "
-"\"{betty_gender}\"."
 
 #, python-brace-format
 msgid ""
@@ -1403,3 +1392,4 @@ msgstr "© Авторське право належить автору, якщо
 #, python-brace-format
 msgid "© Copyright {author}, unless otherwise credited"
 msgstr "© Авторське право {author}, якщо не зазначено інше"
+

--- a/betty/gramps/loader.py
+++ b/betty/gramps/loader.py
@@ -17,21 +17,81 @@ from typing import Iterable, cast, TYPE_CHECKING, TypeVar, Generic, final
 
 import aiofiles
 from aiofiles.tempfile import TemporaryDirectory
+from geopy import Point
+from lxml import etree
+from typing_extensions import override
+
 from betty.ancestry.citation import Citation
 from betty.ancestry.enclosure import Enclosure
 from betty.ancestry.event import Event
+from betty.ancestry.event_type.event_types import (
+    Adoption,
+    Baptism,
+    Birth,
+    Burial,
+    Confirmation,
+    Cremation,
+    Death,
+    Divorce,
+    DivorceAnnouncement,
+    Emigration,
+    Engagement,
+    Immigration,
+    Marriage,
+    MarriageAnnouncement,
+    Occupation,
+    Residence,
+    Retirement,
+    Will,
+    BarMitzvah,
+    BatMitzvah,
+)
 from betty.ancestry.event_type.event_types import Unknown as UnknownEventType
 from betty.ancestry.file import File
 from betty.ancestry.file_reference import FileReference
-from betty.ancestry.gender.genders import Unknown as UnknownGender
+from betty.ancestry.gender.genders import (
+    Unknown as UnknownGender,
+    Female,
+    Male,
+    NonBinary,
+)
 from betty.ancestry.link import HasLinks, Link
 from betty.ancestry.name import Name
 from betty.ancestry.note import Note
 from betty.ancestry.person import Person
 from betty.ancestry.person_name import PersonName
 from betty.ancestry.place import Place
+from betty.ancestry.place_type.place_types import (
+    Borough,
+    Building,
+    City,
+    Country,
+    County,
+    Department,
+    District,
+    Farm,
+    Hamlet,
+    Locality,
+    Municipality,
+    Neighborhood,
+    Number,
+    Parish,
+    Province,
+    Region,
+    State,
+    Street,
+    Town,
+    Village,
+)
 from betty.ancestry.place_type.place_types import Unknown as UnknownPlaceType
 from betty.ancestry.presence import Presence
+from betty.ancestry.presence_role.presence_roles import (
+    Celebrant,
+    Subject,
+    Witness,
+    Attendee,
+    Informant,
+)
 from betty.ancestry.presence_role.presence_roles import Unknown as UnknownPresenceRole
 from betty.ancestry.source import Source
 from betty.asyncio import ensure_await
@@ -46,9 +106,6 @@ from betty.model.association import ToManyResolver, ToOneResolver, resolve
 from betty.plugin import PluginNotFound
 from betty.privacy import HasPrivacy
 from betty.typing import internal
-from geopy import Point
-from lxml import etree
-from typing_extensions import override
 
 if TYPE_CHECKING:
     from xml.etree import ElementTree
@@ -63,7 +120,6 @@ if TYPE_CHECKING:
     from betty.ancestry.place_type import PlaceType
     from betty.ancestry.presence_role import PresenceRole
     from betty.ancestry.gender import Gender
-    from betty.factory import Factory
     from betty.locale.localizer import Localizer
     from collections.abc import MutableMapping, Mapping, Sequence, Awaitable, Callable
 
@@ -142,6 +198,78 @@ class _ToManyResolver(Generic[_EntityT], ToManyResolver[_EntityT]):
             yield cast("_EntityT", self._handles_to_entities[handle])
 
 
+_GENDER_MAPPING = {
+    "F": Female,
+    "M": Male,
+    "U": UnknownGender,
+    "X": NonBinary,
+}
+
+DEFAULT_EVENT_TYPES_MAPPING = {
+    "Adopted": Adoption,
+    "Adult Christening": Baptism,
+    "Baptism": Baptism,
+    "Bar Mitzvah": BarMitzvah,
+    "Bat Mitzvah": BatMitzvah,
+    "Birth": Birth,
+    "Burial": Burial,
+    "Christening": Baptism,
+    "Confirmation": Confirmation,
+    "Cremation": Cremation,
+    "Death": Death,
+    "Divorce": Divorce,
+    "Divorce Filing": DivorceAnnouncement,
+    "Emigration": Emigration,
+    "Engagement": Engagement,
+    "Immigration": Immigration,
+    "Marriage": Marriage,
+    "Marriage Banns": MarriageAnnouncement,
+    "Occupation": Occupation,
+    "Residence": Residence,
+    "Retirement": Retirement,
+    "Will": Will,
+}
+
+
+DEFAULT_PLACE_TYPES_MAPPING = {
+    "Borough": Borough,
+    "Building": Building,
+    "City": City,
+    "Country": Country,
+    "County": County,
+    "Department": Department,
+    "District": District,
+    "Farm": Farm,
+    "Hamlet": Hamlet,
+    "Locality": Locality,
+    "Municipality": Municipality,
+    "Neighborhood": Neighborhood,
+    "Number": Number,
+    "Parish": Parish,
+    "Province": Province,
+    "Region": Region,
+    "State": State,
+    "Street": Street,
+    "Town": Town,
+    "Unknown": UnknownPlaceType,
+    "Village": Village,
+}
+
+
+DEFAULT_PRESENCE_ROLES_MAPPING = {
+    "Aide": Attendee,
+    "Bride": Subject,
+    "Celebrant": Celebrant,
+    "Clergy": Celebrant,
+    "Family": Subject,
+    "Groom": Subject,
+    "Informant": Informant,
+    "Primary": Subject,
+    "Unknown": UnknownPresenceRole,
+    "Witness": Witness,
+}
+
+
 @internal
 class GrampsLoader:
     """
@@ -152,15 +280,13 @@ class GrampsLoader:
         self,
         ancestry: Ancestry,
         *,
-        factory: Factory,
         localizer: Localizer,
         copyright_notices: PluginRepository[CopyrightNotice],
         licenses: PluginRepository[License],
         attribute_prefix_key: str | None = None,
         event_type_mapping: Mapping[str, Callable[[], EventType | Awaitable[EventType]]]
         | None = None,
-        gender_mapping: Mapping[str, Callable[[], Gender | Awaitable[Gender]]]
-        | None = None,
+        genders: PluginRepository[Gender],
         place_type_mapping: Mapping[str, Callable[[], PlaceType | Awaitable[PlaceType]]]
         | None = None,
         presence_role_mapping: Mapping[
@@ -171,7 +297,6 @@ class GrampsLoader:
         super().__init__()
         self._ancestry = ancestry
         self._handles_to_entities: MutableMapping[str, Entity] = {}
-        self._factory = factory
         self._attribute_prefix_key = attribute_prefix_key
         self._added_entity_counts: MutableMapping[type[Entity], int] = defaultdict(
             lambda: 0
@@ -182,7 +307,7 @@ class GrampsLoader:
         self._copyright_notices = copyright_notices
         self._licenses = licenses
         self._event_type_mapping = event_type_mapping or {}
-        self._gender_mapping = gender_mapping or {}
+        self._genders = genders
         self._place_type_mapping = place_type_mapping or {}
         self._presence_role_mapping = presence_role_mapping or {}
 
@@ -579,28 +704,18 @@ class GrampsLoader:
         assert person_handle is not None
         person_id = element.get("id")
         assert person_id is not None
-        gramps_gender = self._load_attribute("gender", element, "attribute")
-        if gramps_gender is None:
+        gender_target: type[Gender] | str | None = self._load_attribute(
+            "gender", element, "attribute"
+        )
+        if gender_target is None:
             gramps_gender = self._xpath1(element, "./ns:gender").text
             assert gramps_gender is not None
+            gender_target = _GENDER_MAPPING[gramps_gender]
 
-        gender: Gender
-        try:
-            gender_factory = self._gender_mapping[gramps_gender]
-        except KeyError:
-            gender = UnknownGender()
-            getLogger(__name__).warning(
-                self._localizer._(
-                    'Betty is unfamiliar with Gramps person "{person_id}"\'s gender of "{gramps_gender}". The person was imported, but their gender was set to "{betty_gender}".',
-                ).format(
-                    person_id=person_id,
-                    gramps_gender=gramps_gender,
-                    betty_gender=gender.plugin_label().localize(self._localizer),
-                )
-            )
-        else:
-            gender = await ensure_await(gender_factory())
-        person = Person(id=element.get("id"), gender=gender)
+        person = Person(
+            id=element.get("id"),
+            gender=await self._genders.new_target(gender_target),
+        )
 
         name_elements = sorted(
             self._xpath(element, "./ns:name"), key=lambda x: x.get("alt") == "1"

--- a/betty/project/extension/gramps/__init__.py
+++ b/betty/project/extension/gramps/__init__.py
@@ -21,7 +21,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Awaitable
     from betty.event_dispatcher import EventHandlerRegistry
 
-
 _PluginT = TypeVar("_PluginT", bound=Plugin)
 
 
@@ -46,7 +45,6 @@ async def _load_ancestry(event: LoadAncestryEvent) -> None:
         await GrampsLoader(
             project.ancestry,
             attribute_prefix_key=project.configuration.name,
-            factory=project.new_target,
             localizer=await project.app.localizer,
             copyright_notices=project.copyright_notice_repository,
             licenses=await project.license_repository,
@@ -57,13 +55,7 @@ async def _load_ancestry(event: LoadAncestryEvent) -> None:
                 )
                 for gramps_type in family_tree_configuration.event_types
             },
-            gender_mapping={
-                gramps_type: _new_plugin_instance_factory(
-                    family_tree_configuration.genders[gramps_type],
-                    project.gender_repository,
-                )
-                for gramps_type in family_tree_configuration.genders
-            },
+            genders=project.gender_repository,
             place_type_mapping={
                 gramps_type: _new_plugin_instance_factory(
                     family_tree_configuration.place_types[gramps_type],

--- a/betty/project/extension/gramps/config.py
+++ b/betty/project/extension/gramps/config.py
@@ -6,63 +6,10 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, final, TYPE_CHECKING, TypeVar
+from warnings import warn
 
 from typing_extensions import override
 
-from betty.ancestry.event_type.event_types import (
-    Adoption,
-    Baptism,
-    Birth,
-    Burial,
-    Confirmation,
-    Cremation,
-    Death,
-    Divorce,
-    DivorceAnnouncement,
-    Emigration,
-    Engagement,
-    Immigration,
-    Marriage,
-    MarriageAnnouncement,
-    Occupation,
-    Residence,
-    Retirement,
-    Will,
-    BarMitzvah,
-    BatMitzvah,
-)
-from betty.ancestry.gender.genders import Female, Male, Unknown as UnknownGender
-from betty.ancestry.place_type.place_types import (
-    Borough,
-    Building,
-    City,
-    Country,
-    County,
-    Department,
-    District,
-    Farm,
-    Hamlet,
-    Locality,
-    Municipality,
-    Neighborhood,
-    Number,
-    Parish,
-    Province,
-    Region,
-    State,
-    Street,
-    Town,
-    Unknown as UnknownPlaceType,
-    Village,
-)
-from betty.ancestry.presence_role.presence_roles import (
-    Celebrant,
-    Subject,
-    Unknown as UnknownPresenceRole,
-    Witness,
-    Attendee,
-    Informant,
-)
 from betty.assertion import (
     RequiredField,
     OptionalField,
@@ -75,6 +22,11 @@ from betty.assertion import (
 )
 from betty.config import Configuration
 from betty.config.collections.sequence import ConfigurationSequence
+from betty.gramps.loader import (
+    DEFAULT_EVENT_TYPES_MAPPING,
+    DEFAULT_PLACE_TYPES_MAPPING,
+    DEFAULT_PRESENCE_ROLES_MAPPING,
+)
 from betty.plugin import Plugin
 from betty.plugin.config import PluginInstanceConfiguration
 from betty.typing import internal
@@ -85,74 +37,6 @@ if TYPE_CHECKING:
     from collections.abc import Mapping, MutableMapping, Iterable, Iterator
 
 _PluginT = TypeVar("_PluginT", bound=Plugin)
-
-DEFAULT_EVENT_TYPE_MAP: Mapping[str, PluginInstanceConfiguration] = {
-    "Adopted": PluginInstanceConfiguration(Adoption),
-    "Adult Christening": PluginInstanceConfiguration(Baptism),
-    "Baptism": PluginInstanceConfiguration(Baptism),
-    "Bar Mitzvah": PluginInstanceConfiguration(BarMitzvah),
-    "Bat Mitzvah": PluginInstanceConfiguration(BatMitzvah),
-    "Birth": PluginInstanceConfiguration(Birth),
-    "Burial": PluginInstanceConfiguration(Burial),
-    "Christening": PluginInstanceConfiguration(Baptism),
-    "Confirmation": PluginInstanceConfiguration(Confirmation),
-    "Cremation": PluginInstanceConfiguration(Cremation),
-    "Death": PluginInstanceConfiguration(Death),
-    "Divorce": PluginInstanceConfiguration(Divorce),
-    "Divorce Filing": PluginInstanceConfiguration(DivorceAnnouncement),
-    "Emigration": PluginInstanceConfiguration(Emigration),
-    "Engagement": PluginInstanceConfiguration(Engagement),
-    "Immigration": PluginInstanceConfiguration(Immigration),
-    "Marriage": PluginInstanceConfiguration(Marriage),
-    "Marriage Banns": PluginInstanceConfiguration(MarriageAnnouncement),
-    "Occupation": PluginInstanceConfiguration(Occupation),
-    "Residence": PluginInstanceConfiguration(Residence),
-    "Retirement": PluginInstanceConfiguration(Retirement),
-    "Will": PluginInstanceConfiguration(Will),
-}
-
-DEFAULT_PLACE_TYPE_MAP: Mapping[str, PluginInstanceConfiguration] = {
-    "Borough": PluginInstanceConfiguration(Borough),
-    "Building": PluginInstanceConfiguration(Building),
-    "City": PluginInstanceConfiguration(City),
-    "Country": PluginInstanceConfiguration(Country),
-    "County": PluginInstanceConfiguration(County),
-    "Department": PluginInstanceConfiguration(Department),
-    "District": PluginInstanceConfiguration(District),
-    "Farm": PluginInstanceConfiguration(Farm),
-    "Hamlet": PluginInstanceConfiguration(Hamlet),
-    "Locality": PluginInstanceConfiguration(Locality),
-    "Municipality": PluginInstanceConfiguration(Municipality),
-    "Neighborhood": PluginInstanceConfiguration(Neighborhood),
-    "Number": PluginInstanceConfiguration(Number),
-    "Parish": PluginInstanceConfiguration(Parish),
-    "Province": PluginInstanceConfiguration(Province),
-    "Region": PluginInstanceConfiguration(Region),
-    "State": PluginInstanceConfiguration(State),
-    "Street": PluginInstanceConfiguration(Street),
-    "Town": PluginInstanceConfiguration(Town),
-    "Unknown": PluginInstanceConfiguration(UnknownPlaceType),
-    "Village": PluginInstanceConfiguration(Village),
-}
-
-DEFAULT_PRESENCE_ROLE_MAP: Mapping[str, PluginInstanceConfiguration] = {
-    "Aide": PluginInstanceConfiguration(Attendee),
-    "Bride": PluginInstanceConfiguration(Subject),
-    "Celebrant": PluginInstanceConfiguration(Celebrant),
-    "Clergy": PluginInstanceConfiguration(Celebrant),
-    "Family": PluginInstanceConfiguration(Subject),
-    "Groom": PluginInstanceConfiguration(Subject),
-    "Informant": PluginInstanceConfiguration(Informant),
-    "Primary": PluginInstanceConfiguration(Subject),
-    "Unknown": PluginInstanceConfiguration(UnknownPresenceRole),
-    "Witness": PluginInstanceConfiguration(Witness),
-}
-
-DEFAULT_GENDER_MAP: Mapping[str, PluginInstanceConfiguration] = {
-    "F": PluginInstanceConfiguration(Female),
-    "M": PluginInstanceConfiguration(Male),
-    "U": PluginInstanceConfiguration(UnknownGender),
-}
 
 
 def _assert_gramps_type(value: Any) -> str:
@@ -220,6 +104,8 @@ class PluginMapping(Configuration):
 class FamilyTreeConfiguration(Configuration):
     """
     Configure a single Gramps family tree.
+
+    The ``genders`` argument has been deprecated since Betty 0.4.13. There is no alternative.
     """
 
     def __init__(
@@ -233,11 +119,33 @@ class FamilyTreeConfiguration(Configuration):
     ):
         super().__init__()
         self.file_path = file_path
-        self._event_types = PluginMapping(DEFAULT_EVENT_TYPE_MAP, event_types or {})
-        self._genders = PluginMapping(DEFAULT_GENDER_MAP, genders or {})
-        self._place_types = PluginMapping(DEFAULT_PLACE_TYPE_MAP, place_types or {})
+        self._event_types = PluginMapping(
+            {
+                gramps_value: PluginInstanceConfiguration(event_type)
+                for gramps_value, event_type in DEFAULT_EVENT_TYPES_MAPPING.items()
+            },
+            event_types or {},
+        )
+        if genders is not None:
+            warn(
+                "The ``genders`` argument has been deprecated since Betty 0.4.13. There is no alternative.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+        self._genders = PluginMapping({}, genders or {})
+        self._place_types = PluginMapping(
+            {
+                gramps_value: PluginInstanceConfiguration(event_type)
+                for gramps_value, event_type in DEFAULT_PLACE_TYPES_MAPPING.items()
+            },
+            place_types or {},
+        )
         self._presence_roles = PluginMapping(
-            DEFAULT_PRESENCE_ROLE_MAP, presence_roles or {}
+            {
+                gramps_value: PluginInstanceConfiguration(event_type)
+                for gramps_value, event_type in DEFAULT_PRESENCE_ROLES_MAPPING.items()
+            },
+            presence_roles or {},
         )
 
     @override

--- a/betty/tests/gramps/test_loader.py
+++ b/betty/tests/gramps/test_loader.py
@@ -38,10 +38,8 @@ from betty.project import Project
 if TYPE_CHECKING:
     from betty.ancestry import Ancestry
     from betty.ancestry.event_type import EventType
-    from betty.ancestry.gender import Gender
     from betty.ancestry.presence_role import PresenceRole
     from collections.abc import Mapping, Awaitable, Callable
-
 
 _MINIMAL_XML = """<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE database PUBLIC "-//Gramps//DTD Gramps XML 1.7.1//EN"
@@ -76,10 +74,10 @@ class TestGrampsLoader:
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
-                factory=project.new_target,
                 localizer=DEFAULT_LOCALIZER,
                 copyright_notices=project.copyright_notice_repository,
                 licenses=await project.license_repository,
+                genders=project.gender_repository,
                 attribute_prefix_key=self.ATTRIBUTE_PREFIX_KEY,
             )
             await sut.load_gramps(gramps_file_path)
@@ -90,10 +88,10 @@ class TestGrampsLoader:
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
-                factory=project.new_target,
                 localizer=DEFAULT_LOCALIZER,
                 copyright_notices=project.copyright_notice_repository,
                 licenses=await project.license_repository,
+                genders=project.gender_repository,
                 attribute_prefix_key=self.ATTRIBUTE_PREFIX_KEY,
             )
             with pytest.raises(GrampsFileNotFound):
@@ -111,10 +109,10 @@ class TestGrampsLoader:
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
-                factory=project.new_target,
                 localizer=DEFAULT_LOCALIZER,
                 copyright_notices=project.copyright_notice_repository,
                 licenses=await project.license_repository,
+                genders=project.gender_repository,
                 attribute_prefix_key=self.ATTRIBUTE_PREFIX_KEY,
             )
             await sut.load_gpkg(gpkg_file_path)
@@ -125,10 +123,10 @@ class TestGrampsLoader:
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
-                factory=project.new_target,
                 localizer=DEFAULT_LOCALIZER,
                 copyright_notices=project.copyright_notice_repository,
                 licenses=await project.license_repository,
+                genders=project.gender_repository,
                 attribute_prefix_key=self.ATTRIBUTE_PREFIX_KEY,
             )
             with pytest.raises(GrampsFileNotFound):
@@ -143,10 +141,10 @@ class TestGrampsLoader:
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
-                factory=project.new_target,
                 localizer=DEFAULT_LOCALIZER,
                 copyright_notices=project.copyright_notice_repository,
                 licenses=await project.license_repository,
+                genders=project.gender_repository,
                 attribute_prefix_key=self.ATTRIBUTE_PREFIX_KEY,
             )
             await sut.load_file(gramps_file_path)
@@ -167,10 +165,10 @@ class TestGrampsLoader:
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
-                factory=project.new_target,
                 localizer=DEFAULT_LOCALIZER,
                 copyright_notices=project.copyright_notice_repository,
                 licenses=await project.license_repository,
+                genders=project.gender_repository,
                 attribute_prefix_key=self.ATTRIBUTE_PREFIX_KEY,
             )
             await sut.load_file(gpkg_file_path)
@@ -186,10 +184,10 @@ class TestGrampsLoader:
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
-                factory=project.new_target,
                 localizer=DEFAULT_LOCALIZER,
                 copyright_notices=project.copyright_notice_repository,
                 licenses=await project.license_repository,
+                genders=project.gender_repository,
                 attribute_prefix_key=self.ATTRIBUTE_PREFIX_KEY,
             )
             await sut.load_file(xml_file_path)
@@ -202,10 +200,10 @@ class TestGrampsLoader:
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
-                factory=project.new_target,
                 localizer=DEFAULT_LOCALIZER,
                 copyright_notices=project.copyright_notice_repository,
                 licenses=await project.license_repository,
+                genders=project.gender_repository,
                 attribute_prefix_key=self.ATTRIBUTE_PREFIX_KEY,
             )
             with pytest.raises(UserFacingGrampsError):
@@ -217,10 +215,10 @@ class TestGrampsLoader:
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
-                factory=project.new_target,
                 localizer=DEFAULT_LOCALIZER,
                 copyright_notices=project.copyright_notice_repository,
                 licenses=await project.license_repository,
+                genders=project.gender_repository,
                 attribute_prefix_key=self.ATTRIBUTE_PREFIX_KEY,
             )
             with pytest.raises(UserFacingGrampsError):
@@ -233,8 +231,6 @@ class TestGrampsLoader:
         xml: str,
         *,
         event_type_mapping: Mapping[str, Callable[[], EventType | Awaitable[EventType]]]
-        | None = None,
-        gender_mapping: Mapping[str, Callable[[], Gender | Awaitable[Gender]]]
         | None = None,
         presence_role_mapping: Mapping[
             str, Callable[[], PresenceRole | Awaitable[PresenceRole]]
@@ -250,13 +246,12 @@ class TestGrampsLoader:
             async with project:
                 loader = GrampsLoader(
                     project.ancestry,
-                    factory=project.new_target,
                     localizer=DEFAULT_LOCALIZER,
                     copyright_notices=project.copyright_notice_repository,
                     licenses=await project.license_repository,
+                    genders=project.gender_repository,
                     attribute_prefix_key=self.ATTRIBUTE_PREFIX_KEY,
                     event_type_mapping=event_type_mapping,
-                    gender_mapping=gender_mapping,
                     presence_role_mapping=presence_role_mapping,
                 )
                 await loader.load_xml(xml.strip())
@@ -268,8 +263,6 @@ class TestGrampsLoader:
         *,
         media_path: Path | None = None,
         event_type_mapping: Mapping[str, Callable[[], EventType | Awaitable[EventType]]]
-        | None = None,
-        gender_mapping: Mapping[str, Callable[[], Gender | Awaitable[Gender]]]
         | None = None,
         presence_role_mapping: Mapping[
             str, Callable[[], PresenceRole | Awaitable[PresenceRole]]
@@ -293,7 +286,6 @@ class TestGrampsLoader:
 </database>
 """,
             event_type_mapping=event_type_mapping,
-            gender_mapping=gender_mapping,
             presence_role_mapping=presence_role_mapping,
         )
 
@@ -301,10 +293,10 @@ class TestGrampsLoader:
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
-                factory=project.new_target,
                 localizer=DEFAULT_LOCALIZER,
                 copyright_notices=project.copyright_notice_repository,
                 licenses=await project.license_repository,
+                genders=project.gender_repository,
                 attribute_prefix_key=self.ATTRIBUTE_PREFIX_KEY,
             )
             await sut.load_xml(_MINIMAL_XML)
@@ -534,11 +526,10 @@ class TestGrampsLoader:
             """
 <people>
     <person handle="_e1dd3bf1f0041d92f586f9d8683" change="1552126972" id="I0000">
-        <gender>U</gender>
+        <gender>X</gender>
     </person>
 </people>
-""",
-            gender_mapping={"U": NonBinary},
+"""
         )
         person = ancestry[Person]["I0000"]
         assert isinstance(person.gender, NonBinary)
@@ -549,14 +540,13 @@ class TestGrampsLoader:
 <people>
     <person handle="_e1dd3bf1f0041d92f586f9d8683" change="1552126972" id="I0000">
         <gender>U</gender>
-        <attribute type="betty:gender" value="unknown"/>
+        <attribute type="betty:gender" value="non-binary"/>
     </person>
 </people>
-""",
-            gender_mapping={"U": NonBinary},
+"""
         )
         person = ancestry[Person]["I0000"]
-        assert isinstance(person.gender, UnknownGender)
+        assert isinstance(person.gender, NonBinary)
 
     async def test_person_should_include_citation(self) -> None:
         ancestry = await self._load_partial(

--- a/betty/tests/project/extension/gramps/test___init__.py
+++ b/betty/tests/project/extension/gramps/test___init__.py
@@ -5,7 +5,6 @@ from aiofiles.tempfile import TemporaryDirectory
 from betty.ancestry.citation import Citation
 from betty.ancestry.event import Event
 from betty.ancestry.event_type.event_types import Birth
-from betty.ancestry.gender.genders import NonBinary
 from betty.ancestry.note import Note
 from betty.ancestry.person import Person
 from betty.ancestry.place import Place
@@ -172,52 +171,6 @@ class TestGramps(ExtensionTestBase[Gramps]):
             assert isinstance(
                 project.ancestry[Person]["I0000"].presences[0].role, Subject
             )
-
-    async def test_load_with_gender_map(
-        self, new_temporary_app: App, tmp_path: Path
-    ) -> None:
-        family_tree_xml = """
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE database PUBLIC "-//Gramps//DTD Gramps XML 1.7.1//EN"
-"http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
-<database xmlns="http://gramps-project.org/xml/1.7.1/">
-    <header>
-        <created date="2019-03-09" version="4.2.8"/>
-        <researcher>
-        </researcher>
-    </header>
-    <people>
-        <person handle="_e1dd3c1caf863ee0081cc2cc16f" change="1552131917" id="I0000">
-            <gender>MyFirstGender</gender>
-        </person>
-    </people>
-</database>
-""".strip()
-        gramps_family_tree_path = tmp_path / "gramps.xml"
-        async with aiofiles.open(gramps_family_tree_path, mode="w") as f:
-            await f.write(family_tree_xml)
-
-        async with Project.new_temporary(new_temporary_app) as project:
-            project.configuration.extensions.append(
-                PluginInstanceConfiguration(
-                    Gramps,
-                    configuration=GrampsConfiguration(
-                        family_trees=[
-                            FamilyTreeConfiguration(
-                                file_path=gramps_family_tree_path,
-                                genders={
-                                    "MyFirstGender": PluginInstanceConfiguration(
-                                        "non-binary"
-                                    )
-                                },
-                            )
-                        ],
-                    ),
-                )
-            )
-            async with project:
-                await load(project)
-            assert isinstance(project.ancestry[Person]["I0000"].gender, NonBinary)
 
     async def test_load_multiple_family_trees(self, new_temporary_app: App) -> None:
         family_tree_one_xml = """

--- a/betty/tests/project/extension/gramps/test_config.py
+++ b/betty/tests/project/extension/gramps/test_config.py
@@ -4,20 +4,20 @@ from pathlib import Path
 import pytest
 
 from betty.ancestry.event_type.event_types import Birth
-from betty.ancestry.gender.genders import Female
 from betty.ancestry.place_type.place_types import Borough
 from betty.ancestry.presence_role.presence_roles import Attendee
 from betty.assertion.error import AssertionFailed
+from betty.gramps.loader import (
+    DEFAULT_EVENT_TYPES_MAPPING,
+    DEFAULT_PLACE_TYPES_MAPPING,
+    DEFAULT_PRESENCE_ROLES_MAPPING,
+)
 from betty.plugin.config import PluginInstanceConfiguration
 from betty.project.extension.gramps.config import (
     FamilyTreeConfiguration,
     GrampsConfiguration,
     FamilyTreeConfigurationSequence,
     PluginMapping,
-    DEFAULT_EVENT_TYPE_MAP,
-    DEFAULT_GENDER_MAP,
-    DEFAULT_PLACE_TYPE_MAP,
-    DEFAULT_PRESENCE_ROLE_MAP,
 )
 from betty.serde.dump import Dump
 from betty.test_utils.assertion.error import raises_error
@@ -65,7 +65,6 @@ class TestFamilyTreeConfiguration:
             tmp_path, genders={gramps_type: PluginInstanceConfiguration(plugin_id)}
         )
         assert sut.genders[gramps_type].id == plugin_id
-        assert sut.genders["F"].id == Female.plugin_id()
 
     def test___init____with_place_types(self, tmp_path: Path) -> None:
         gramps_type = "my-first-gramps-type"
@@ -89,29 +88,26 @@ class TestFamilyTreeConfiguration:
     def test_event_types(self, tmp_path: Path) -> None:
         sut = FamilyTreeConfiguration(tmp_path)
         assert sut.event_types.dump() == {
-            gramps_type: configuration.dump()
-            for gramps_type, configuration in DEFAULT_EVENT_TYPE_MAP.items()
+            gramps_type: plugin.plugin_id()
+            for gramps_type, plugin in DEFAULT_EVENT_TYPES_MAPPING.items()
         }
 
     def test_genders(self, tmp_path: Path) -> None:
         sut = FamilyTreeConfiguration(tmp_path)
-        assert sut.genders.dump() == {
-            gramps_type: configuration.dump()
-            for gramps_type, configuration in DEFAULT_GENDER_MAP.items()
-        }
+        assert sut.genders.dump() == {}
 
     def test_place_types(self, tmp_path: Path) -> None:
         sut = FamilyTreeConfiguration(tmp_path)
         assert sut.place_types.dump() == {
-            gramps_type: configuration.dump()
-            for gramps_type, configuration in DEFAULT_PLACE_TYPE_MAP.items()
+            gramps_type: plugin.plugin_id()
+            for gramps_type, plugin in DEFAULT_PLACE_TYPES_MAPPING.items()
         }
 
     def test_presence_roles(self, tmp_path: Path) -> None:
         sut = FamilyTreeConfiguration(tmp_path)
         assert sut.presence_roles.dump() == {
-            gramps_type: configuration.dump()
-            for gramps_type, configuration in DEFAULT_PRESENCE_ROLE_MAP.items()
+            gramps_type: plugin.plugin_id()
+            for gramps_type, plugin in DEFAULT_PRESENCE_ROLES_MAPPING.items()
         }
 
     async def test_load__with_minimal_configuration(self, tmp_path: Path) -> None:
@@ -139,7 +135,6 @@ class TestFamilyTreeConfiguration:
         sut = FamilyTreeConfiguration(tmp_path)
         sut.load(dump)
         assert sut.genders["my-first-gramps-type"].id == "my-first-betty-plugin-id"
-        assert sut.genders["F"].id == Female.plugin_id()
 
     async def test_load__with_place_types(self, tmp_path: Path) -> None:
         file_path = tmp_path / "ancestry.gramps"
@@ -177,9 +172,6 @@ class TestFamilyTreeConfiguration:
             actual.pop("event_types")  # type: ignore[arg-type]
         )
         assert len(
-            actual.pop("genders")  # type: ignore[arg-type]
-        )
-        assert len(
             actual.pop("place_types")  # type: ignore[arg-type]
         )
         assert len(
@@ -187,6 +179,7 @@ class TestFamilyTreeConfiguration:
         )
         assert actual == {
             "file": str(tmp_path),
+            "genders": {},
         }
 
     async def test_dump__with_event_types(self, tmp_path: Path) -> None:

--- a/documentation/usage/extension/gramps.rst
+++ b/documentation/usage/extension/gramps.rst
@@ -41,11 +41,6 @@ This extension is configurable:
                     event-types:
                       GrampsEventType: betty-event-type
                       AnotherGrampsEventType: another-betty-event-type
-                    genders:
-                      F: female
-                      M: male
-                      U: unknown
-                      NonBinary: non-binary
                     place-types:
                       GrampsPlaceType: betty-place-type
                       AnotherGrampsPlaceType: another-betty-place-type
@@ -67,12 +62,6 @@ This extension is configurable:
                       "event-types": {
                         "GrampsEventType: "betty-event-type",
                         "AnotherGrampsEventType: "another-betty-event-type"
-                      },
-                      "genders": {
-                        "F: "female",
-                        "M: "male",
-                        "U: "unknown",
-                        "NonBinary: "non-binary"
                       },
                       "place-types": {
                         "GrampsPlaceType: "betty-place-type",
@@ -111,28 +100,21 @@ the path to a *Gramps XML* or *Gramps XML Package* file.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 :sup:`optional`
 
-How to map Gramps event types to Betty event types. Each keys is a Gramps event type, and each value is the plugin ID of
+How to map Gramps event types to Betty event types. Each key is a Gramps event type, and each value is the plugin ID of
 the Betty event type to import the Gramps event type as.
-
-``family_trees[].genders``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-:sup:`optional`
-
-How to map Gramps genders to Betty genders. Each keys is a Gramps gender, and each value is the plugin ID of the Betty
-gender to import the Gramps gender as.
 
 ``family_trees[].place_types``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 :sup:`optional`
 
-How to map Gramps place types to Betty place types. Each keys is a Gramps place type, and each value is the plugin ID
+How to map Gramps place types to Betty place types. Each key is a Gramps place type, and each value is the plugin ID
 of the Betty place type to import the Gramps place type as.
 
 ``family_trees[].presence_roles``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 :sup:`optional`
 
-How to map Gramps roles to Betty presence roles. Each keys is a Gramps role, and each value is the plugin ID of the
+How to map Gramps roles to Betty presence roles. Each key is a Gramps role, and each value is the plugin ID of the
 Betty presence role to import the Gramps role as.
 
 
@@ -283,7 +265,7 @@ Betty supports the following Gramps event types without any additional configura
 Genders
 -------
 
-Betty supports the following Gramps genders without any additional configuration:
+Betty maps Gramps genders as follows:
 
 .. list-table:: Genders
    :align: left
@@ -297,6 +279,8 @@ Betty supports the following Gramps genders without any additional configuration
      - ``male``
    * - ``U``
      - ``unknown``
+   * - ``X``
+     - ``non-binary``
 
 Place types
 -----------


### PR DESCRIPTION
This
- No longer maps arbitrary genders after confirming that Gramps only allows 4 hardcoded genders
- Adds support for Gramps' "other"/`X` gender
- No longer shares configuration instances between family trees