### PR TITLE
Fix a bug where the Gramps loader would error erroneously when parsing newer Gramps XML versions

### DIFF
--- a/betty/assets/locale/ar/betty.po
+++ b/betty/assets/locale/ar/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-25 23:56+0000\n"
+"POT-Creation-Date: 2025-04-23 16:11+0100\n"
 "PO-Revision-Date: 2024-11-30 19:00+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: ar\n"
@@ -524,6 +524,13 @@ msgstr ""
 msgid "Go to the front page"
 msgstr ""
 
+#, python-brace-format
+msgid ""
+"Gramps XML must be compatible with version "
+"{supported_gramps_xml_version}. Gramps XML {loaded_gramps_xml_version} is"
+" not supported."
+msgstr ""
+
 msgid "HTTP API Documentation"
 msgstr ""
 
@@ -954,6 +961,9 @@ msgid "This field is required."
 msgstr ""
 
 msgid "This information is unavailable to protect people's privacy."
+msgstr ""
+
+msgid "This is not valid Gramps XML."
 msgstr ""
 
 msgid "This must be a boolean."

--- a/betty/assets/locale/betty.pot
+++ b/betty/assets/locale/betty.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-25 23:56+0000\n"
+"POT-Creation-Date: 2025-04-23 16:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -512,6 +512,12 @@ msgstr ""
 msgid "Go to the front page"
 msgstr ""
 
+#, python-brace-format
+msgid ""
+"Gramps XML must be compatible with version {supported_gramps_xml_version}."
+" Gramps XML {loaded_gramps_xml_version} is not supported."
+msgstr ""
+
 msgid "HTTP API Documentation"
 msgstr ""
 
@@ -930,6 +936,9 @@ msgid "This field is required."
 msgstr ""
 
 msgid "This information is unavailable to protect people's privacy."
+msgstr ""
+
+msgid "This is not valid Gramps XML."
 msgstr ""
 
 msgid "This must be a boolean."

--- a/betty/assets/locale/de-DE/betty.po
+++ b/betty/assets/locale/de-DE/betty.po
@@ -7,16 +7,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-25 23:56+0000\n"
+"POT-Creation-Date: 2025-04-23 16:11+0100\n"
 "PO-Revision-Date: 2025-03-28 20:02+0000\n"
 "Last-Translator: Ettore Atalan <atalanttore@googlemail.com>\n"
-"Language-Team: German <https://hosted.weblate.org/projects/betty/betty/de/>\n"
-"Language: de-DE\n"
+"Language: de_DE\n"
+"Language-Team: German "
+"<https://hosted.weblate.org/projects/betty/betty/de/>\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.11-dev\n"
 "Generated-By: Babel 2.17.0\n"
 
 #, python-brace-format
@@ -553,6 +553,13 @@ msgstr "Erzeuge deine Site nach {output_directory}."
 msgid "Go to the front page"
 msgstr ""
 
+#, python-brace-format
+msgid ""
+"Gramps XML must be compatible with version "
+"{supported_gramps_xml_version}. Gramps XML {loaded_gramps_xml_version} is"
+" not supported."
+msgstr ""
+
 msgid "HTTP API Documentation"
 msgstr "HTTP API Dokumentation"
 
@@ -987,6 +994,9 @@ msgid "This field is required."
 msgstr "Diese Feld ist erforderlich."
 
 msgid "This information is unavailable to protect people's privacy."
+msgstr ""
+
+msgid "This is not valid Gramps XML."
 msgstr ""
 
 msgid "This must be a boolean."
@@ -1424,3 +1434,4 @@ msgstr ""
 #, python-brace-format
 msgid "© Copyright {author}, unless otherwise credited"
 msgstr "© Copyright {author}, außer anders erwähnt"
+

--- a/betty/assets/locale/fr-FR/betty.po
+++ b/betty/assets/locale/fr-FR/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-25 23:56+0000\n"
+"POT-Creation-Date: 2025-04-23 16:11+0100\n"
 "PO-Revision-Date: 2024-11-29 18:58+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: fr_FR\n"
@@ -519,6 +519,13 @@ msgstr ""
 msgid "Go to the front page"
 msgstr ""
 
+#, python-brace-format
+msgid ""
+"Gramps XML must be compatible with version "
+"{supported_gramps_xml_version}. Gramps XML {loaded_gramps_xml_version} is"
+" not supported."
+msgstr ""
+
 msgid "HTTP API Documentation"
 msgstr ""
 
@@ -937,6 +944,9 @@ msgid "This field is required."
 msgstr ""
 
 msgid "This information is unavailable to protect people's privacy."
+msgstr ""
+
+msgid "This is not valid Gramps XML."
 msgstr ""
 
 msgid "This must be a boolean."

--- a/betty/assets/locale/he/betty.po
+++ b/betty/assets/locale/he/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-25 23:56+0000\n"
+"POT-Creation-Date: 2025-04-23 16:11+0100\n"
 "PO-Revision-Date: 2025-02-19 16:48+0000\n"
 "Last-Translator: Yaron Shahrabani <sh.yaron@gmail.com>\n"
 "Language: he\n"
@@ -515,6 +515,13 @@ msgstr ""
 msgid "Go to the front page"
 msgstr ""
 
+#, python-brace-format
+msgid ""
+"Gramps XML must be compatible with version "
+"{supported_gramps_xml_version}. Gramps XML {loaded_gramps_xml_version} is"
+" not supported."
+msgstr ""
+
 msgid "HTTP API Documentation"
 msgstr ""
 
@@ -933,6 +940,9 @@ msgid "This field is required."
 msgstr ""
 
 msgid "This information is unavailable to protect people's privacy."
+msgstr ""
+
+msgid "This is not valid Gramps XML."
 msgstr ""
 
 msgid "This must be a boolean."

--- a/betty/assets/locale/nl-NL/betty.po
+++ b/betty/assets/locale/nl-NL/betty.po
@@ -7,16 +7,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-25 23:56+0000\n"
+"POT-Creation-Date: 2025-04-23 16:11+0100\n"
 "PO-Revision-Date: 2025-03-31 23:44+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
-"Language-Team: Dutch <https://hosted.weblate.org/projects/betty/betty/nl/>\n"
-"Language: nl-NL\n"
+"Language: nl_NL\n"
+"Language-Team: Dutch "
+"<https://hosted.weblate.org/projects/betty/betty/nl/>\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.11-dev\n"
 "Generated-By: Babel 2.17.0\n"
 
 #, python-brace-format
@@ -577,6 +577,13 @@ msgstr "Bezig je site te genereren naar {output_directory}."
 msgid "Go to the front page"
 msgstr "Ga naar de voorpagina"
 
+#, python-brace-format
+msgid ""
+"Gramps XML must be compatible with version "
+"{supported_gramps_xml_version}. Gramps XML {loaded_gramps_xml_version} is"
+" not supported."
+msgstr ""
+
 msgid "HTTP API Documentation"
 msgstr "HTTP API-documentatie"
 
@@ -1028,6 +1035,9 @@ msgstr "Dit veld is vereist."
 msgid "This information is unavailable to protect people's privacy."
 msgstr "Deze informatie is niet beschikbaar om mensen hun privacy te beschermen."
 
+msgid "This is not valid Gramps XML."
+msgstr ""
+
 msgid "This must be a boolean."
 msgstr "Dit moet een booleaan zijn."
 
@@ -1469,3 +1479,4 @@ msgstr "© Copyright de auteur, tenzij anders vermeld"
 #, python-brace-format
 msgid "© Copyright {author}, unless otherwise credited"
 msgstr "© Copyright {author}, tenzij anders vermeld"
+

--- a/betty/assets/locale/uk/betty.po
+++ b/betty/assets/locale/uk/betty.po
@@ -7,18 +7,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty 0.4\n"
 "Report-Msgid-Bugs-To: illia@maier.page\n"
-"POT-Creation-Date: 2025-03-25 23:56+0000\n"
+"POT-Creation-Date: 2025-04-23 16:11+0100\n"
 "PO-Revision-Date: 2025-04-02 05:02+0000\n"
 "Last-Translator: Максим Горпиніч <maksimgorpinic2005a@gmail.com>\n"
-"Language-Team: Ukrainian <https://hosted.weblate.org/projects/betty/betty/uk/"
-">\n"
 "Language: uk\n"
+"Language-Team: Ukrainian "
+"<https://hosted.weblate.org/projects/betty/betty/uk/>\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
-"X-Generator: Weblate 5.11-dev\n"
 "Generated-By: Babel 2.17.0\n"
 
 #, python-brace-format
@@ -578,6 +577,13 @@ msgstr "Генерація вашого сайту в {output_directory}."
 msgid "Go to the front page"
 msgstr "Перейти на першу сторінку"
 
+#, python-brace-format
+msgid ""
+"Gramps XML must be compatible with version "
+"{supported_gramps_xml_version}. Gramps XML {loaded_gramps_xml_version} is"
+" not supported."
+msgstr ""
+
 msgid "HTTP API Documentation"
 msgstr "документація HTTP API"
 
@@ -1031,6 +1037,9 @@ msgstr "Це поле є обов’язковим."
 msgid "This information is unavailable to protect people's privacy."
 msgstr "Ця інформація недоступна для захисту конфіденційності людей."
 
+msgid "This is not valid Gramps XML."
+msgstr ""
+
 msgid "This must be a boolean."
 msgstr "Це має бути булеве значення."
 
@@ -1483,3 +1492,4 @@ msgstr "© Авторське право належить автору, якщо
 #, python-brace-format
 msgid "© Copyright {author}, unless otherwise credited"
 msgstr "© Авторське право {author}, якщо не зазначено інше"
+

--- a/betty/gramps/loader.py
+++ b/betty/gramps/loader.py
@@ -279,6 +279,8 @@ class GrampsLoader:
     Load Gramps family history data into a project.
     """
 
+    _SUPPORTED_GRAMPS_XML_VERSION = (1, 7, 1)
+
     def __init__(
         self,
         ancestry: Ancestry,
@@ -304,7 +306,8 @@ class GrampsLoader:
         self._added_entity_counts: MutableMapping[type[Entity], int] = defaultdict(
             lambda: 0
         )
-        self._tree: ElementTree.ElementTree | None = None
+        self._tree: ElementTree.ElementTree
+        self._tree_xml_namespace: dict[str, str]
         self._loaded = False
         self._localizer = localizer
         self._copyright_notices = copyright_notices
@@ -423,6 +426,26 @@ class GrampsLoader:
 
         database = self._tree.getroot()
 
+        match = re.fullmatch(
+            r"^{(http:\/\/gramps-project\.org\/xml\/(\d+)\.(\d+)\.(\d+)\/)}database$",
+            database.tag,
+        )
+        if match is None:
+            raise UserFacingGrampsError(_("This is not valid Gramps XML."))
+        version = (int(match.group(2)), int(match.group(3)), int(match.group(4)))
+        if not self._supports_xml_version(version):
+            raise UserFacingGrampsError(
+                _(
+                    "Gramps XML must be compatible with version {supported_gramps_xml_version}. Gramps XML {loaded_gramps_xml_version} is not supported."
+                ).format(
+                    supported_gramps_xml_version=".".join(
+                        map(str, self._SUPPORTED_GRAMPS_XML_VERSION)
+                    ),
+                    loaded_gramps_xml_version=".".join(map(str, version)),
+                )
+            )
+        self._tree_xml_namespace = {"ns": match.group(1)}
+
         media_path: Path | None = None
         try:
             mediapath = self._xpath1(database, "./ns:header/ns:mediapath")
@@ -493,6 +516,15 @@ class GrampsLoader:
 
         resolve(*self._ancestry)
 
+    def _supports_xml_version(self, version: tuple[int, int, int]) -> bool:
+        if version[0] != self._SUPPORTED_GRAMPS_XML_VERSION[0]:
+            return False
+        if version[1] != self._SUPPORTED_GRAMPS_XML_VERSION[1]:
+            return False
+        if version[2] < self._SUPPORTED_GRAMPS_XML_VERSION[2]:
+            return False
+        return True
+
     def _resolve1(
         self, entity_type: type[_EntityT], handle: str
     ) -> _ToOneResolver[_EntityT]:
@@ -509,19 +541,15 @@ class GrampsLoader:
             self._handles_to_entities[handle] = entity
         self._added_entity_counts[entity.type] += 1
 
-    _NS = {
-        "ns": "http://gramps-project.org/xml/1.7.1/",
-    }
-
     def _xpath(
         self, element: ElementTree.Element, selector: str
     ) -> Sequence[ElementTree.Element]:
-        return element.findall(selector, namespaces=self._NS)
+        return element.findall(selector, namespaces=self._tree_xml_namespace)
 
     def _xpath1(
         self, element: ElementTree.Element, selector: str
     ) -> ElementTree.Element:
-        found_element = element.find(selector, namespaces=self._NS)
+        found_element = element.find(selector, namespaces=self._tree_xml_namespace)
         if found_element is None:
             raise XPathError(
                 f'Cannot find an element "{selector}" within {str(element)}.'

--- a/betty/tests/gramps/test_loader.py
+++ b/betty/tests/gramps/test_loader.py
@@ -49,26 +49,21 @@ if TYPE_CHECKING:
     from betty.ancestry.place_type import PlaceType
     from betty.ancestry.presence_role import PresenceRole
 
-_MINIMAL_XML = """<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE database PUBLIC "-//Gramps//DTD Gramps XML 1.7.1//EN"
-"http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
-<database xmlns="http://gramps-project.org/xml/1.7.1/">
+__MINIMAL_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE database PUBLIC "-//Gramps//DTD Gramps XML {version}//EN"
+"http://gramps-project.org/xml/{version}/grampsxml.dtd">
+<database xmlns="http://gramps-project.org/xml/{version}/">
   <header>
     <created date="2019-03-29" version="4.2.8"/>
     <researcher>
     </researcher>
   </header>
-  <people>
-    <person handle="_e21e77455147d79f6b4cc1c76a4" change="1553878037" id="I0000">
-      <gender>U</gender>
-      <name type="Birth Name">
-        <first>Janet</first>
-        <surname>Dough</surname>
-      </name>
-    </person>
-  </people>
 </database>
 """
+
+
+def _minimal_xml(version: str = "1.7.1") -> str:
+    return __MINIMAL_XML.format(version=version)
 
 
 class TestGrampsLoader:
@@ -78,7 +73,7 @@ class TestGrampsLoader:
     async def test_load_gramps(self, new_temporary_app: App, tmp_path: Path) -> None:
         gramps_file_path = tmp_path / "gramps.gramps"
         with gzip.open(gramps_file_path, "w") as f:
-            f.write(_MINIMAL_XML.encode("utf-8"))
+            f.write(_minimal_xml().encode("utf-8"))
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
@@ -108,7 +103,7 @@ class TestGrampsLoader:
     async def test_load_gpkg(self, new_temporary_app: App, tmp_path: Path) -> None:
         gramps_file_path = tmp_path / "gramps.gramps"
         with gzip.open(gramps_file_path, "w") as f:
-            f.write(_MINIMAL_XML.encode("utf-8"))
+            f.write(_minimal_xml().encode("utf-8"))
         gpkg_file_path = tmp_path / "gramps.gpkg"
         with tarfile.open(  # noqa SIM115
             name=gpkg_file_path, mode="w:gz"
@@ -145,7 +140,7 @@ class TestGrampsLoader:
     ) -> None:
         gramps_file_path = tmp_path / "gramps.gramps"
         with gzip.open(gramps_file_path, "w") as f:
-            f.write(_MINIMAL_XML.encode("utf-8"))
+            f.write(_minimal_xml().encode("utf-8"))
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
@@ -164,7 +159,7 @@ class TestGrampsLoader:
     ) -> None:
         gramps_file_path = tmp_path / "gramps.gramps"
         with gzip.open(gramps_file_path, "w") as f:
-            f.write(_MINIMAL_XML.encode("utf-8"))
+            f.write(_minimal_xml().encode("utf-8"))
         gpkg_file_path = tmp_path / "gramps.gpkg"
         with tarfile.open(  # noqa SIM115
             name=gpkg_file_path, mode="w:gz"
@@ -188,7 +183,7 @@ class TestGrampsLoader:
     ) -> None:
         xml_file_path = tmp_path / "gramps.xml"
         async with aiofiles.open(xml_file_path, "w") as f:
-            await f.write(_MINIMAL_XML)
+            await f.write(_minimal_xml())
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
@@ -313,7 +308,56 @@ class TestGrampsLoader:
                 genders=project.gender_repository,
                 attribute_prefix_key=self.ATTRIBUTE_PREFIX_KEY,
             )
-            await sut.load_xml(_MINIMAL_XML)
+            await sut.load_xml(_minimal_xml())
+
+    @pytest.mark.parametrize(
+        "version",
+        [
+            "1.7.0",
+            "1.8.0",
+            "2.0.0",
+        ],
+    )
+    async def test_load_xml_with_unsupported_version_should_error(
+        self, new_temporary_app: App, version: str
+    ) -> None:
+        async with Project.new_temporary(new_temporary_app) as project, project:
+            sut = GrampsLoader(
+                project.ancestry,
+                localizer=DEFAULT_LOCALIZER,
+                copyright_notices=project.copyright_notice_repository,
+                licenses=await project.license_repository,
+                genders=project.gender_repository,
+                attribute_prefix_key=self.ATTRIBUTE_PREFIX_KEY,
+            )
+            with pytest.raises(UserFacingGrampsError):
+                await sut.load_xml(_minimal_xml(version))
+
+    async def test_load_xml_with_invalid_xml_should_error(
+        self, new_temporary_app: App
+    ) -> None:
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE database PUBLIC "-//Gramps//DTD Gramps XML 1.7.1//EN"
+"http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
+<database>
+  <header>
+    <created date="2019-03-29" version="4.2.8"/>
+    <researcher>
+    </researcher>
+  </header>
+</database>
+"""
+        async with Project.new_temporary(new_temporary_app) as project, project:
+            sut = GrampsLoader(
+                project.ancestry,
+                localizer=DEFAULT_LOCALIZER,
+                copyright_notices=project.copyright_notice_repository,
+                licenses=await project.license_repository,
+                genders=project.gender_repository,
+                attribute_prefix_key=self.ATTRIBUTE_PREFIX_KEY,
+            )
+            with pytest.raises(UserFacingGrampsError):
+                await sut.load_xml(xml)
 
     async def test_place_should_include_place_type(self) -> None:
         ancestry = await self._load_partial(


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/2560

This can be installed by running `pip install git+https://github.com/bartfeenstra/betty.git@gramps-xml-compatibility`.