### PR TITLE
Fetch translated Wikipedia image descriptions

### DIFF
--- a/betty/tests/wikipedia/test_client.py
+++ b/betty/tests/wikipedia/test_client.py
@@ -480,6 +480,10 @@ class TestClient:
                     Path(__file__),
                     SVG,
                     "An Example Image",
+                    {
+                        "en": "An Example Image",
+                        "nl": "Een voorbeeldafbeelding",
+                    },
                     "https://example.com/description",
                     "example.svg",
                 ),
@@ -502,6 +506,14 @@ class TestClient:
                                         "mime": "image/svg+xml",
                                         "canonicaltitle": "File:An Example Image",
                                         "descriptionurl": "https://example.com/description",
+                                        "extmetadata": {
+                                            "ImageDescription": {
+                                                "value": {
+                                                    "en": "An Example Image",
+                                                    "nl": "Een voorbeeldafbeelding",
+                                                },
+                                            },
+                                        },
                                     },
                                 ],
                             }
@@ -526,7 +538,7 @@ class TestClient:
         page_language = "en"
         page_name = "Amsterdam & Omstreken"
         page_fetch_url = "https://en.wikipedia.org/w/api.php?action=query&titles=Amsterdam%20%26%20Omstreken&prop=langlinks|pageimages|coordinates&lllimit=500&piprop=name&pilicense=free&pilimit=1&coprimary=primary&format=json&formatversion=2"
-        file_fetch_url = "https://en.wikipedia.org/w/api.php?action=query&prop=imageinfo&titles=File:Amsterdam%20%26%20Omstreken&iiprop=url|mime|canonicaltitle&format=json&formatversion=2"
+        file_fetch_url = "https://en.wikipedia.org/w/api.php?action=query&prop=imageinfo&titles=File:Amsterdam%20%26%20Omstreken&iiprop=url|mime|canonicaltitle|extmetadata&iiextmetadatamultilang=1&format=json&formatversion=2"
 
         fetch_map = {page_fetch_url: _new_json_fetch_response(page_fetch_json)}
         fetch_file_map = {}
@@ -548,3 +560,7 @@ class TestClient:
             assert actual.title == expected.title
             assert actual.wikimedia_commons_url == expected.wikimedia_commons_url
             assert actual.path is image_file_path
+            assert actual.description == {
+                "en": "An Example Image",
+                "nl": "Een voorbeeldafbeelding",
+            }

--- a/betty/tests/wikipedia/test_populator.py
+++ b/betty/tests/wikipedia/test_populator.py
@@ -387,6 +387,7 @@ class TestPopulator:
             Path(__file__),
             MediaType("application/octet-stream"),
             "",
+            {},
             "https://example.com",
             "example",
         )

--- a/betty/wikipedia/client.py
+++ b/betty/wikipedia/client.py
@@ -15,7 +15,10 @@ from urllib.parse import quote, urlparse
 from geopy import Point
 
 from betty.fetch import Fetcher, FetchError
-from betty.locale.localizable import plain
+from betty.locale.localizable import (
+    StaticTranslations,
+    plain,
+)
 from betty.media_type import MediaType
 from betty.typing import internal
 
@@ -25,6 +28,7 @@ if TYPE_CHECKING:
     from betty.concurrent import RateLimiter
 
 
+@internal
 @final
 @dataclass(frozen=True)
 class Summary:
@@ -45,6 +49,7 @@ class Summary:
         return f"https://{self.locale}.wikipedia.org/wiki/{self.name}"
 
 
+@internal
 @final
 @dataclass(frozen=True)
 class Image:
@@ -55,6 +60,7 @@ class Image:
     path: Path
     media_type: MediaType
     title: str
+    description: StaticTranslations
     wikimedia_commons_url: str
     name: str
 
@@ -175,7 +181,7 @@ class Client:
             if page_image_name in self._images:
                 return self._images[page_image_name]
 
-            url = f"https://en.wikipedia.org/w/api.php?action=query&prop=imageinfo&titles=File:{quote(page_image_name)}&iiprop=url|mime|canonicaltitle&format=json&formatversion=2"
+            url = f"https://en.wikipedia.org/w/api.php?action=query&prop=imageinfo&titles=File:{quote(page_image_name)}&iiprop=url|mime|canonicaltitle|extmetadata&iiextmetadatamultilang=1&format=json&formatversion=2"
             image_info_api_data = await self._get_query_api_data(url)
 
             try:
@@ -195,6 +201,13 @@ class Client:
                 image_info["canonicaltitle"][
                     image_info["canonicaltitle"].index(":") + 1 :
                 ],
+                {
+                    language: description
+                    for language, description in image_info["extmetadata"][
+                        "ImageDescription"
+                    ]["value"].items()
+                    if not language.startswith("_")
+                },
                 image_info["descriptionurl"],
                 Path(urlparse(image_info["url"]).path).name,
             )

--- a/betty/wikipedia/populator.py
+++ b/betty/wikipedia/populator.py
@@ -31,6 +31,7 @@ from betty.wikipedia import NotAPageError, parse_page_url
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, MutableMapping, MutableSequence, Sequence
+    from pathlib import Path
 
     from betty.ancestry import Ancestry
     from betty.locale.localizer import LocalizerRepository
@@ -57,8 +58,8 @@ class Populator:
         self._locales = locales
         self._localizers = localizers
         self._client = client
-        self._image_files: MutableMapping[Image, File] = {}
-        self._image_files_locks: Mapping[Image, Lock] = defaultdict(
+        self._image_files: MutableMapping[Path, File] = {}
+        self._image_files_locks: Mapping[Path, Lock] = defaultdict(
             AsynchronizedLock.threading
         )
         self._copyright_notice = copyright_notice
@@ -218,9 +219,9 @@ class Populator:
     async def _image_file_reference(
         self, has_file_references: HasFileReferences, image: Image
     ) -> FileReference:
-        async with self._image_files_locks[image]:
+        async with self._image_files_locks[image.path]:
             try:
-                file = self._image_files[image]
+                file = self._image_files[image.path]
             except KeyError:
                 links = []
                 for locale in self._locales:
@@ -245,8 +246,9 @@ class Populator:
                     media_type=image.media_type,
                     links=links,
                     copyright_notice=self._copyright_notice,
+                    description=image.description,
                 )
-                self._image_files[image] = file
+                self._image_files[image.path] = file
                 self._ancestry.add(file)
             file_reference = FileReference(has_file_references, file)
             self._ancestry.add(file_reference)


### PR DESCRIPTION
## To do
- Use a different Wiki API field, as the description field this PR uses now can be very long, and contain HTML. The field is also not guaranteed to be a mapping. Ideally we use the "caption" field.