### PR TITLE
Temporarily avoid Webpack 5.100.0 and newer

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.29.1"
   },
+  "overrides": {
+    "webpack": "^5.96.1 <5.100.0"
+  },
   "type": "module"
 }


### PR DESCRIPTION
This temporarily prevents https://github.com/webpack/webpack/issues/19680 from being an issue