### PR TITLE
Revert "Temporarily avoid Webpack 5.100.0 and newer"

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,5 @@
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.29.1"
   },
-  "overrides": {
-    "webpack": "^5.96.1 <5.100.0"
-  },
   "type": "module"
 }


### PR DESCRIPTION
Reverts bartfeenstra/betty#2708 now that https://github.com/webpack/webpack/issues/19680 has been fixed.