### PR TITLE
Upgrade to asyncclick 8.2

### DIFF
--- a/betty/cli/__init__.py
+++ b/betty/cli/__init__.py
@@ -64,7 +64,7 @@ class _ClickHandler(Handler):
         return self.COLOR_LEVELS[NOTSET]
 
 
-class _BettyCommands(click.MultiCommand):
+class _BettyCommands(click.Group):
     terminal_width: ClassVar[int | None] = None
     _bootstrapped = False
     _app: ClassVar[App]

--- a/betty/test_utils/cli.py
+++ b/betty/test_utils/cli.py
@@ -19,7 +19,7 @@ async def run(
     """
     Run a Betty CLI command.
     """
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     result = await runner.invoke(
         await new_main_command(app), args, catch_exceptions=False, input=input
     )

--- a/betty/tests/cli/commands/test_new.py
+++ b/betty/tests/cli/commands/test_new.py
@@ -33,6 +33,8 @@ class TestNew:
             "",
             author,
             url,
+            "",
+            "",
         ]
         configuration = await self._assert_new(new_temporary_app_cli, tmp_path, inputs)
         assert configuration.title.localize(DEFAULT_LOCALIZER) == title
@@ -51,6 +53,8 @@ class TestNew:
             "Mijn Eerste Project",
             "",
             "Mijn Eerste Auteur",
+            "",
+            "",
             "",
         ]
         configuration = await self._assert_new(new_temporary_app_cli, tmp_path, inputs)
@@ -77,6 +81,7 @@ class TestNew:
             "My First Author",
             "",
             "",
+            "",
         ]
         configuration = await self._assert_new(new_temporary_app_cli, tmp_path, inputs)
         assert configuration.name == "mijn-eerste-project"
@@ -96,6 +101,7 @@ class TestNew:
             "My First Project",
             name,
             "My First Author",
+            "",
             "",
             "",
         ]

--- a/betty/tests/cli/test___init__.py
+++ b/betty/tests/cli/test___init__.py
@@ -28,7 +28,7 @@ class _NoOpCommand(Command, DummyPlugin):
 
 
 async def test_main__without_arguments(new_temporary_app_cli: App) -> None:
-    await run(new_temporary_app_cli)
+    await run(new_temporary_app_cli, expected_exit_code=2)
 
 
 async def test_main__help(new_temporary_app_cli: App) -> None:
@@ -96,4 +96,4 @@ class TestClickHandler:
 
 async def test_new_main_command(new_temporary_app_cli: App) -> None:
     main_command = await new_main_command(new_temporary_app_cli)
-    assert await main_command.main("--help", standalone_mode=False) == 0
+    assert await main_command.main(["--help"], standalone_mode=False) == 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ requires-python = '~= 3.11'
 dependencies = [
     'aiofiles ~= 24.1',
     'aiohttp ~= 3.10',
-    'asyncclick ~= 8.1',
+    'asyncclick ~= 8.2',
     'babel ~= 2.16',
     'furo == 2025.7.19',
     'geopy ~= 2.4',


### PR DESCRIPTION
Asyncclick 8.2 introduced several changes that broke backwards compatibility. This PR upgrades our dependency on asyncclick 8.1 to 8.2 and ensures compatibility again.