### PR TITLE
docs: replace "CLI" with "Console" in docs and comments

### DIFF
--- a/betty/locale/babel.py
+++ b/betty/locale/babel.py
@@ -18,6 +18,6 @@ def _run_babel(*args: str) -> None:
 
 async def run_babel(*args: str) -> None:
     """
-    Run a Babel Command Line Interface (CLI) command.
+    Run a Babel Command Line Interface (Console) command.
     """
     await to_thread(_run_babel, *args)

--- a/betty/test_utils/console/__init__.py
+++ b/betty/test_utils/console/__init__.py
@@ -31,7 +31,7 @@ async def run(
     app: App, *args: str, expected_exit_code: SystemExitCode = SystemExitCode.OK
 ) -> Result:
     """
-    Run a Betty CLI command.
+    Run a Betty console command.
     """
     stderr_f = StringIO()
     stdout_f = StringIO()

--- a/documentation/development/plugin.rst
+++ b/documentation/development/plugin.rst
@@ -47,7 +47,7 @@ Built-in plugin types
 ^^^^^^^^^^^^^^^^^^^^^
 The following plugin types are provided by Betty itself:
 
-- :doc:`CLI commands </development/plugin/command>`
+- :doc:`Console commands </development/plugin/command>`
 - :doc:`Copyright notices </development/plugin/copyright-notice>`
 - :doc:`Entity types </development/plugin/entity-type>`
 - :doc:`Event types </development/plugin/event-type>`

--- a/documentation/development/plugin/command.rst
+++ b/documentation/development/plugin/command.rst
@@ -1,4 +1,4 @@
-CLI command plugins
+Console command plugins
 ===================
 
 .. list-table::


### PR DESCRIPTION
Closes #2785 