### PR TITLE
Fix an incorrect instruction for installing Betty from source

### DIFF
--- a/documentation/installation.rst
+++ b/documentation/installation.rst
@@ -91,4 +91,4 @@ Run the following to install the latest unstable version:
 
 #. ``git clone https://github.com/bartfeenstra/betty.git``
 #. ``cd betty``
-#. ``./bin/build``
+#. ``./bin/build-dev``


### PR DESCRIPTION
This fixes a bug reported in https://github.com/bartfeenstra/betty/issues/2822#issuecomment-3356503227