### PR TITLE
Remove `PluginRepository.new_target()`

### DIFF
--- a/betty/app/__init__.py
+++ b/betty/app/__init__.py
@@ -277,7 +277,6 @@ class App(Configurable[AppConfiguration], TargetFactory, ServiceProvider):
                 binary_file_cache=self.binary_file_cache.with_scope("spdx"),
                 fetcher=await self.fetcher,
                 user=self.user,
-                factory=self.new_target,
                 process_pool=self.process_pool,
             ),
         )

--- a/betty/config/file.py
+++ b/betty/config/file.py
@@ -13,6 +13,7 @@ from aiofiles.os import makedirs
 from betty.assertion import AssertionChain, assert_file_path
 from betty.config import Configuration
 from betty.exception import UserFacingExceptionGroup
+from betty.factory import new
 from betty.locale.localizable import Plain
 from betty.serde.format import FORMAT_REPOSITORY, format_for
 
@@ -29,7 +30,7 @@ async def assert_configuration_file(
     Assert that configuration can be loaded from a file.
     """
     available_formats = {
-        available_format: await FORMAT_REPOSITORY.new_target(available_format)
+        available_format: await new(available_format)
         async for available_format in FORMAT_REPOSITORY
     }
 
@@ -61,7 +62,7 @@ async def write_configuration_file(
     serde_format_type = format_for(
         [plugin async for plugin in FORMAT_REPOSITORY], configuration_file_path.suffix
     )
-    serde_format = await FORMAT_REPOSITORY.new_target(serde_format_type)
+    serde_format = await new(serde_format_type)
     dump = serde_format.dump(configuration.dump())
     await makedirs(configuration_file_path.parent, exist_ok=True)
     async with aiofiles.open(configuration_file_path, mode="w") as f:

--- a/betty/gramps/loader.py
+++ b/betty/gramps/loader.py
@@ -51,14 +51,8 @@ from betty.ancestry.event_type.event_types import (
 from betty.ancestry.event_type.event_types import Unknown as UnknownEventType
 from betty.ancestry.file import File
 from betty.ancestry.file_reference import FileReference
-from betty.ancestry.gender.genders import (
-    Female,
-    Male,
-    NonBinary,
-)
-from betty.ancestry.gender.genders import (
-    Unknown as UnknownGender,
-)
+from betty.ancestry.gender.genders import Female, Male, NonBinary
+from betty.ancestry.gender.genders import Unknown as UnknownGender
 from betty.ancestry.has_links import HasLinks
 from betty.ancestry.link import Link
 from betty.ancestry.name import Name
@@ -138,6 +132,7 @@ if TYPE_CHECKING:
     from betty.ancestry.place_type import PlaceType
     from betty.ancestry.presence_role import PresenceRole
     from betty.copyright_notice import CopyrightNotice
+    from betty.factory import Factory
     from betty.license import License
     from betty.plugin import PluginRepository
     from betty.user import User
@@ -320,6 +315,7 @@ class GrampsLoader:
         self,
         ancestry: Ancestry,
         *,
+        factory: Factory,
         user: User,
         copyright_notices: PluginRepository[CopyrightNotice],
         licenses: PluginRepository[License],
@@ -353,6 +349,7 @@ class GrampsLoader:
         self._place_type_mapping = place_type_mapping or {}
         self._presence_role_mapping = presence_role_mapping or {}
         self._gramps_executable = executable or _DEFAULT_GRAMPS_EXECUTABLE
+        self._factory = factory
 
     async def _run_gramps(self, runnee: Sequence[str]) -> Process:
         try:
@@ -770,8 +767,8 @@ class GrampsLoader:
         )
         if copyright_notice_id:
             try:
-                file.copyright_notice = await self._copyright_notices.new_target(
-                    copyright_notice_id
+                file.copyright_notice = await self._factory(
+                    await self._copyright_notices.get(copyright_notice_id)
                 )
             except PluginNotFound:
                 await self._user.message_warning(
@@ -782,7 +779,7 @@ class GrampsLoader:
         license_id = self._load_attribute("license", element, "attribute")
         if license_id:
             try:
-                file.license = await self._licenses.new_target(license_id)
+                file.license = await self._factory(await self._licenses.get(license_id))
             except PluginNotFound:
                 await self._user.message_warning(
                     _(
@@ -815,7 +812,11 @@ class GrampsLoader:
 
         person = Person(
             id=element.get("id"),
-            gender=await self._genders.new_target(gender_target),
+            gender=await self._factory(
+                await self._genders.get(gender_target)
+                if isinstance(gender_target, str)
+                else gender_target
+            ),
         )
 
         name_elements = sorted(

--- a/betty/license/licenses.py
+++ b/betty/license/licenses.py
@@ -17,7 +17,6 @@ from typing_extensions import override
 from betty.cache.file import BinaryFileCache
 from betty.concurrent import AsynchronizedLock, Ledger
 from betty.exception import UserFacingException
-from betty.factory import Factory
 from betty.fetch import Fetcher, FetchError
 from betty.license import License
 from betty.locale.localizable import Localizable, Plain, _
@@ -96,9 +95,8 @@ class SpdxLicenseRepository(PluginRepository[License]):
         user: User,
         binary_file_cache: BinaryFileCache,
         process_pool: Executor,
-        factory: Factory | None = None,
     ):
-        super().__init__(License, factory=factory)
+        super().__init__(License)
         self._fetcher = fetcher
         self._user = user
         self._cache_directory_path = binary_file_cache.with_scope(

--- a/betty/plugin/__init__.py
+++ b/betty/plugin/__init__.py
@@ -18,13 +18,11 @@ from typing import (
     TypeAlias,
     TypeVar,
     final,
-    overload,
 )
 
 from typing_extensions import override
 
 from betty.exception import UserFacingException
-from betty.factory import Factory, TargetFactory, new
 from betty.json.schema import Enum
 from betty.locale.localizable import Join, _, do_you_mean
 from betty.locale.localizer import DEFAULT_LOCALIZER
@@ -252,14 +250,13 @@ class PluginIdToTypeMapping(Generic[_PluginCoT]):
         yield from self._id_to_type_mapping
 
 
-class PluginRepository(Generic[_PluginT], TargetFactory, ABC):
+class PluginRepository(Generic[_PluginT], ABC):
     """
     Discover and manage plugins.
     """
 
-    def __init__(self, plugin: type[_PluginT], *, factory: Factory | None = None):
+    def __init__(self, plugin: type[_PluginT]):
         self._plugin = plugin
-        self._factory = factory or new
         self._plugin_id_schema: Enum | None = None
 
     @final
@@ -308,18 +305,6 @@ class PluginRepository(Generic[_PluginT], TargetFactory, ABC):
     @abstractmethod
     def __aiter__(self) -> AsyncIterator[type[_PluginT]]:
         pass
-
-    @overload
-    async def new_target(self, cls: type[_T]) -> _T:
-        pass
-
-    @overload
-    async def new_target(self, cls: MachineName) -> _PluginT:
-        pass
-
-    @override
-    async def new_target(self, cls: type[_T] | MachineName) -> _T | _PluginT:
-        return await self._factory(await self.get(cls) if isinstance(cls, str) else cls)
 
     @property
     async def plugin_id_schema(self) -> Enum:

--- a/betty/plugin/config.py
+++ b/betty/plugin/config.py
@@ -33,6 +33,7 @@ from betty.typing import Void, Voidable, not_void
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+    from betty.factory import Factory
     from betty.locale.localizable import ShorthandStaticTranslations
     from betty.serde.dump import Dump, DumpMapping
 
@@ -219,12 +220,12 @@ class PluginInstanceConfiguration(Configuration):
         return self._configuration
 
     async def new_plugin_instance(
-        self, repository: PluginRepository[_PluginT]
+        self, repository: PluginRepository[_PluginT], *, factory: Factory
     ) -> _PluginT:
         """
         Create a new plugin instance.
         """
-        plugin = await repository.new_target(self.id)
+        plugin = await factory(await repository.get(self.id))
         if not_void(self.configuration):
             if not isinstance(plugin, DefaultConfigurable):  # type: ignore[redundant-expr]
                 raise UserFacingException(

--- a/betty/plugin/lazy.py
+++ b/betty/plugin/lazy.py
@@ -8,7 +8,6 @@ from typing import Generic, TypeVar
 
 from typing_extensions import override
 
-from betty.factory import Factory
 from betty.machine_name import MachineName
 from betty.plugin import Plugin, PluginNotFound, PluginRepository
 
@@ -20,8 +19,8 @@ class LazyPluginRepositoryBase(PluginRepository[_PluginT], Generic[_PluginT]):
     Lazily load plugins.
     """
 
-    def __init__(self, plugin: type[_PluginT], *, factory: Factory | None = None):
-        super().__init__(plugin, factory=factory)
+    def __init__(self, plugin: type[_PluginT]):
+        super().__init__(plugin)
         self.__plugins: Mapping[str, type[_PluginT]] | None = None
 
     @override

--- a/betty/plugin/proxy.py
+++ b/betty/plugin/proxy.py
@@ -3,12 +3,10 @@ Provide tools for proxying plugin management to other tools.
 """
 
 from collections.abc import AsyncIterator
-from contextlib import suppress
-from typing import Generic, TypeVar, final, overload
+from typing import Generic, TypeVar, final
 
 from typing_extensions import override
 
-from betty.factory import Factory, FactoryError
 from betty.machine_name import MachineName
 from betty.plugin import Plugin, PluginNotFound, PluginRepository
 
@@ -22,37 +20,9 @@ class ProxyPluginRepository(PluginRepository[_PluginT], Generic[_PluginT]):
     Expose multiple other plugin repositories as one unified repository.
     """
 
-    def __init__(
-        self,
-        plugin: type[_PluginT],
-        *upstreams: PluginRepository[_PluginT],
-        factory: Factory | None = None,
-    ):
-        super().__init__(plugin, factory=factory)
+    def __init__(self, plugin: type[_PluginT], *upstreams: PluginRepository[_PluginT]):
+        super().__init__(plugin)
         self._upstreams = upstreams
-
-    @overload
-    async def new_target(self, cls: type[_T]) -> _T:
-        pass
-
-    @overload
-    async def new_target(self, cls: MachineName) -> _PluginT:
-        pass
-
-    @override
-    async def new_target(self, cls: type[_T] | MachineName) -> _T | _PluginT:
-        with suppress(FactoryError):
-            return await super().new_target(cls)
-        resolved_cls = await self.get(cls) if isinstance(cls, str) else cls
-        for upstream in self._upstreams:
-            if issubclass(resolved_cls, Plugin):
-                try:
-                    await upstream.get(resolved_cls.plugin_id())
-                except PluginNotFound:
-                    continue
-            with suppress(PluginNotFound, FactoryError):
-                return await upstream.new_target(resolved_cls)
-        raise FactoryError()
 
     @override
     async def get(self, plugin_id: MachineName) -> type[_PluginT]:

--- a/betty/plugin/static.py
+++ b/betty/plugin/static.py
@@ -7,7 +7,6 @@ from typing import Generic, TypeVar, final
 
 from typing_extensions import override
 
-from betty.factory import Factory
 from betty.machine_name import MachineName
 from betty.plugin import Plugin, PluginNotFound, PluginRepository
 
@@ -20,13 +19,8 @@ class StaticPluginRepository(PluginRepository[_PluginT], Generic[_PluginT]):
     A repository that is given a static collection of plugins, and exposes those.
     """
 
-    def __init__(
-        self,
-        plugin: type[_PluginT],
-        *plugins: type[_PluginT],
-        factory: Factory | None = None,
-    ):
-        super().__init__(plugin, factory=factory)
+    def __init__(self, plugin: type[_PluginT], *plugins: type[_PluginT]):
+        super().__init__(plugin)
         self._plugins = {plugin.plugin_id(): plugin for plugin in plugins}
 
     @override

--- a/betty/project/__init__.py
+++ b/betty/project/__init__.py
@@ -262,11 +262,11 @@ class Project(Configurable[ProjectConfiguration], TargetFactory, ServiceProvider
                 if extension in extensions:
                     extension_instance = await extensions[
                         extension
-                    ].new_plugin_instance(self.extension_repository)
-                else:
-                    extension_instance = await self.extension_repository.new_target(
-                        extension
+                    ].new_plugin_instance(
+                        self.extension_repository, factory=self.new_target
                     )
+                else:
+                    extension_instance = await self.new_target(extension)
                 extension_instances_batch.append(extension_instance)
                 extensions_sorter.done(extension)
             project_extension_instances.append(
@@ -324,7 +324,7 @@ class Project(Configurable[ProjectConfiguration], TargetFactory, ServiceProvider
         The overall project copyright.
         """
         return await self.configuration.copyright_notice.new_plugin_instance(
-            self.copyright_notice_repository
+            self.copyright_notice_repository, factory=self.new_target
         )
 
     @service
@@ -340,7 +340,6 @@ class Project(Configurable[ProjectConfiguration], TargetFactory, ServiceProvider
             StaticPluginRepository(
                 CopyrightNotice, *self.configuration.copyright_notices.new_plugins()
             ),
-            factory=self.new_target,
         )
 
     @service
@@ -349,7 +348,7 @@ class Project(Configurable[ProjectConfiguration], TargetFactory, ServiceProvider
         The overall project license.
         """
         return await self.configuration.license.new_plugin_instance(
-            await self.license_repository
+            await self.license_repository, factory=self.new_target
         )
 
     @service
@@ -363,7 +362,6 @@ class Project(Configurable[ProjectConfiguration], TargetFactory, ServiceProvider
             License,
             await self._app.spdx_license_repository,
             StaticPluginRepository(License, *self.configuration.licenses.new_plugins()),
-            factory=self.new_target,
         )
 
     @service
@@ -377,7 +375,6 @@ class Project(Configurable[ProjectConfiguration], TargetFactory, ServiceProvider
             StaticPluginRepository(
                 EventType, *self.configuration.event_types.new_plugins()
             ),
-            factory=self.new_target,
         )
 
     @service
@@ -391,7 +388,6 @@ class Project(Configurable[ProjectConfiguration], TargetFactory, ServiceProvider
             StaticPluginRepository(
                 PlaceType, *self.configuration.place_types.new_plugins()
             ),
-            factory=self.new_target,
         )
 
     @service
@@ -405,7 +401,6 @@ class Project(Configurable[ProjectConfiguration], TargetFactory, ServiceProvider
             StaticPluginRepository(
                 PresenceRole, *self.configuration.presence_roles.new_plugins()
             ),
-            factory=self.new_target,
         )
 
     @service
@@ -419,7 +414,6 @@ class Project(Configurable[ProjectConfiguration], TargetFactory, ServiceProvider
             Gender,
             GENDER_REPOSITORY,
             StaticPluginRepository(Gender, *self.configuration.genders.new_plugins()),
-            factory=self.new_target,
         )
 
     @service
@@ -429,9 +423,7 @@ class Project(Configurable[ProjectConfiguration], TargetFactory, ServiceProvider
 
         Read more about :doc:`/development/plugin/entity-type`.
         """
-        return ProxyPluginRepository(
-            Entity, model.ENTITY_TYPE_REPOSITORY, factory=self.new_target
-        )
+        return ProxyPluginRepository(Entity, model.ENTITY_TYPE_REPOSITORY)
 
     @service
     def extension_repository(self) -> PluginRepository[Extension]:
@@ -440,9 +432,7 @@ class Project(Configurable[ProjectConfiguration], TargetFactory, ServiceProvider
 
         Read more about :doc:`/development/plugin/extension`.
         """
-        return ProxyPluginRepository(
-            Extension, extension.EXTENSION_REPOSITORY, factory=self.new_target
-        )
+        return ProxyPluginRepository(Extension, extension.EXTENSION_REPOSITORY)
 
 
 _ExtensionT = TypeVar("_ExtensionT", bound=Extension)

--- a/betty/project/extension/demo/jobs.py
+++ b/betty/project/extension/demo/jobs.py
@@ -508,12 +508,10 @@ class LoadAncestry(Job[ProjectContext]):
         project: Project,
     ) -> tuple[Mapping[MachineName, Sequence[File]], Sequence[File]]:
         licenses = await project.license_repository
-        license = await licenses.new_target(  # noqa A001
-            spdx_license_id_to_license_id("AGPL-3.0-or-later")
+        license = await project.new_target(  # noqa A001
+            await licenses.get(spdx_license_id_to_license_id("AGPL-3.0-or-later"))
         )
-        copyright_notice = await project.copyright_notice_repository.new_target(
-            Streetmix
-        )
+        copyright_notice = await project.new_target(Streetmix)
         streetmix_image_directory_path = DATA_DIRECTORY_PATH / "images" / "streetmix"
         masculine: Sequence[File] = []
         feminine: Sequence[File] = []

--- a/betty/project/extension/gramps/jobs.py
+++ b/betty/project/extension/gramps/jobs.py
@@ -16,6 +16,7 @@ from betty.project import ProjectContext
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
+    from betty.factory import Factory
     from betty.job.scheduler import Scheduler
     from betty.plugin.config import PluginInstanceConfiguration
 
@@ -23,10 +24,13 @@ _PluginT = TypeVar("_PluginT", bound=Plugin)
 
 
 def _new_plugin_instance_factory(
-    configuration: PluginInstanceConfiguration, repository: PluginRepository[_PluginT]
+    configuration: PluginInstanceConfiguration,
+    repository: PluginRepository[_PluginT],
+    *,
+    factory: Factory,
 ) -> Callable[[], Awaitable[_PluginT]]:
     async def plugin_instance_factory() -> _PluginT:
-        return await configuration.new_plugin_instance(repository)
+        return await configuration.new_plugin_instance(repository, factory=factory)
 
     return plugin_instance_factory
 
@@ -51,6 +55,7 @@ class LoadAncestry(Job[ProjectContext]):
 
             loader = GrampsLoader(
                 project.ancestry,
+                factory=project.new_target,
                 attribute_prefix_key=project.configuration.name,
                 user=project.app.user,
                 copyright_notices=project.copyright_notice_repository,
@@ -59,6 +64,7 @@ class LoadAncestry(Job[ProjectContext]):
                     gramps_type: _new_plugin_instance_factory(
                         family_tree_configuration.event_types[gramps_type],
                         project.event_type_repository,
+                        factory=project.new_target,
                     )
                     for gramps_type in family_tree_configuration.event_types
                 },
@@ -67,6 +73,7 @@ class LoadAncestry(Job[ProjectContext]):
                     gramps_type: _new_plugin_instance_factory(
                         family_tree_configuration.place_types[gramps_type],
                         project.place_type_repository,
+                        factory=project.new_target,
                     )
                     for gramps_type in family_tree_configuration.place_types
                 },
@@ -74,6 +81,7 @@ class LoadAncestry(Job[ProjectContext]):
                     gramps_type: _new_plugin_instance_factory(
                         family_tree_configuration.presence_roles[gramps_type],
                         project.presence_role_repository,
+                        factory=project.new_target,
                     )
                     for gramps_type in family_tree_configuration.presence_roles
                 },

--- a/betty/project/extension/wiki/__init__.py
+++ b/betty/project/extension/wiki/__init__.py
@@ -22,7 +22,6 @@ from betty.project.load import PostLoader
 from betty.service import service
 from betty.wiki import NotAPageError, parse_page_url, populator
 from betty.wiki.client import RATE_LIMIT, Client, Summary
-from betty.wiki.copyright_notice import WikipediaContributors
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -63,8 +62,8 @@ class Wiki(
     async def new_for_project(cls, project: Project) -> Self:
         return cls(
             project,
-            await project.copyright_notice_repository.new_target(
-                "wikipedia-contributors"
+            await project.new_target(
+                await project.copyright_notice_repository.get("wikipedia-contributors")
             ),
             configuration=cls.new_default_configuration(),
         )
@@ -109,9 +108,7 @@ class Wiki(
             list(self.project.configuration.locales),
             await self.project.localizers,
             await self.client,
-            await self.project.copyright_notice_repository.new_target(
-                WikipediaContributors
-            ),
+            self._wikipedia_contributors_copyright_notice,
         )
 
     @override

--- a/betty/tests/gramps/test_loader.py
+++ b/betty/tests/gramps/test_loader.py
@@ -117,6 +117,7 @@ class TestGrampsLoader:
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
+                factory=project.new_target,
                 user=StaticUser(),
                 copyright_notices=project.copyright_notice_repository,
                 licenses=await project.license_repository,
@@ -131,6 +132,7 @@ class TestGrampsLoader:
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
+                factory=project.new_target,
                 user=StaticUser(),
                 copyright_notices=project.copyright_notice_repository,
                 licenses=await project.license_repository,
@@ -152,6 +154,7 @@ class TestGrampsLoader:
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
+                factory=project.new_target,
                 user=StaticUser(),
                 copyright_notices=project.copyright_notice_repository,
                 licenses=await project.license_repository,
@@ -166,6 +169,7 @@ class TestGrampsLoader:
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
+                factory=project.new_target,
                 user=StaticUser(),
                 copyright_notices=project.copyright_notice_repository,
                 licenses=await project.license_repository,
@@ -184,6 +188,7 @@ class TestGrampsLoader:
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
+                factory=project.new_target,
                 user=StaticUser(),
                 copyright_notices=project.copyright_notice_repository,
                 licenses=await project.license_repository,
@@ -208,6 +213,7 @@ class TestGrampsLoader:
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
+                factory=project.new_target,
                 user=StaticUser(),
                 copyright_notices=project.copyright_notice_repository,
                 licenses=await project.license_repository,
@@ -239,6 +245,7 @@ class TestGrampsLoader:
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
+                factory=project.new_target,
                 user=StaticUser(),
                 copyright_notices=project.copyright_notice_repository,
                 licenses=await project.license_repository,
@@ -255,6 +262,7 @@ class TestGrampsLoader:
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
+                factory=project.new_target,
                 user=StaticUser(),
                 copyright_notices=project.copyright_notice_repository,
                 licenses=await project.license_repository,
@@ -270,6 +278,7 @@ class TestGrampsLoader:
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
+                factory=project.new_target,
                 user=StaticUser(),
                 copyright_notices=project.copyright_notice_repository,
                 licenses=await project.license_repository,
@@ -302,6 +311,7 @@ class TestGrampsLoader:
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
+                factory=project.new_target,
                 user=StaticUser(),
                 copyright_notices=project.copyright_notice_repository,
                 licenses=await project.license_repository,
@@ -334,6 +344,7 @@ class TestGrampsLoader:
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
+                factory=project.new_target,
                 user=StaticUser(),
                 copyright_notices=project.copyright_notice_repository,
                 licenses=await project.license_repository,
@@ -370,6 +381,7 @@ class TestGrampsLoader:
             async with project:
                 loader = GrampsLoader(
                     project.ancestry,
+                    factory=project.new_target,
                     user=StaticUser(),
                     copyright_notices=project.copyright_notice_repository,
                     licenses=await project.license_repository,
@@ -421,6 +433,7 @@ class TestGrampsLoader:
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
+                factory=project.new_target,
                 user=StaticUser(),
                 copyright_notices=project.copyright_notice_repository,
                 licenses=await project.license_repository,
@@ -443,6 +456,7 @@ class TestGrampsLoader:
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
+                factory=project.new_target,
                 user=StaticUser(),
                 copyright_notices=project.copyright_notice_repository,
                 licenses=await project.license_repository,
@@ -469,6 +483,7 @@ class TestGrampsLoader:
         async with Project.new_temporary(new_temporary_app) as project, project:
             sut = GrampsLoader(
                 project.ancestry,
+                factory=project.new_target,
                 user=StaticUser(),
                 copyright_notices=project.copyright_notice_repository,
                 licenses=await project.license_repository,

--- a/betty/tests/license/test_licenses.py
+++ b/betty/tests/license/test_licenses.py
@@ -8,6 +8,7 @@ import pytest
 from typing_extensions import override
 
 from betty.cache.file import BinaryFileCache
+from betty.factory import new
 from betty.fetch.static import StaticFetcher
 from betty.license import License
 from betty.license.licenses import (
@@ -195,7 +196,7 @@ class TestSpdxLicenseRepository:
             zero_bsd_type.plugin_label().localize(DEFAULT_LOCALIZER)
             == "BSD Zero Clause License"
         )
-        zero_bsd = await sut_with_licenses.new_target(zero_bsd_type)
+        zero_bsd = await new(zero_bsd_type)
         assert zero_bsd.summary.localize(DEFAULT_LOCALIZER) == "BSD Zero Clause License"
         assert (
             zero_bsd.text.localize(DEFAULT_LOCALIZER)

--- a/betty/tests/plugin/test___init__.py
+++ b/betty/tests/plugin/test___init__.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 from graphlib import TopologicalSorter
-from typing import TYPE_CHECKING, Literal, Self, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 import pytest
 from typing_extensions import override
 
-from betty.factory import Factory, new
 from betty.plugin import (
     CyclicDependencyError,
     DependentPlugin,
@@ -83,22 +82,9 @@ class _TestPluginRepositoryPluginOneTwoThree(
     pass
 
 
-class _TestPluginRepositoryPluginDefaultFactory(DummyPlugin):
-    pass
-
-
-class _TestPluginRepositoryPluginCustomFactory(DummyPlugin):
-    def __init__(self, must_be_true: Literal[True]):
-        assert must_be_true
-
-    @classmethod
-    def new_custom(cls) -> Self:
-        return cls(True)
-
-
 class _TestPluginRepositoryPluginRepository(PluginRepository[DummyPlugin]):
-    def __init__(self, *plugins: type[DummyPlugin], factory: Factory | None = None):
-        super().__init__(DummyPlugin, factory=factory)
+    def __init__(self, *plugins: type[DummyPlugin]):
+        super().__init__(DummyPlugin)
         self._plugins = {plugin.plugin_id(): plugin for plugin in plugins}
 
     @override
@@ -196,41 +182,6 @@ class TestPluginRepository:
         assert (
             plugin_id_to_type_mapping[_TestPluginRepositoryPluginOne.plugin_id()]
             is _TestPluginRepositoryPluginOne
-        )
-
-    async def test_new_target__with_default_factory(self) -> None:
-        sut = _TestPluginRepositoryPluginRepository(
-            _TestPluginRepositoryPluginDefaultFactory
-        )
-        assert isinstance(
-            await sut.new_target(_TestPluginRepositoryPluginDefaultFactory),
-            _TestPluginRepositoryPluginDefaultFactory,
-        )
-        assert isinstance(
-            await sut.new_target(_TestPluginRepositoryPluginDefaultFactory.plugin_id()),
-            _TestPluginRepositoryPluginDefaultFactory,
-        )
-
-    async def test_new_target__with_custom_factory(self) -> None:
-        async def factory(
-            cls: type[_T],
-        ) -> _T:
-            return (
-                cls.new_custom()  # type: ignore[return-value]
-                if issubclass(cls, _TestPluginRepositoryPluginCustomFactory)
-                else await new(cls)  # type: ignore[arg-type]
-            )
-
-        sut = _TestPluginRepositoryPluginRepository(
-            _TestPluginRepositoryPluginCustomFactory, factory=factory
-        )
-        assert isinstance(
-            await sut.new_target(_TestPluginRepositoryPluginCustomFactory),
-            _TestPluginRepositoryPluginCustomFactory,
-        )
-        assert isinstance(
-            await sut.new_target(_TestPluginRepositoryPluginCustomFactory.plugin_id()),
-            _TestPluginRepositoryPluginCustomFactory,
         )
 
     async def test_plugin_id_schema(self) -> None:

--- a/betty/tests/plugin/test_config.py
+++ b/betty/tests/plugin/test_config.py
@@ -7,6 +7,7 @@ from typing_extensions import override
 from betty.config import DefaultConfigurable
 from betty.config.collections import ConfigurationCollection
 from betty.exception import UserFacingException
+from betty.factory import new
 from betty.locale import UNDETERMINED_LOCALE
 from betty.locale.localizable import ShorthandStaticTranslations
 from betty.locale.localizer import DEFAULT_LOCALIZER
@@ -313,7 +314,7 @@ class TestPluginInstanceConfiguration:
             plugin, configuration=DummyConfiguration(value)
         )
         repository = StaticPluginRepository(DummyPlugin, plugin)
-        instance = await sut.new_plugin_instance(repository)
+        instance = await sut.new_plugin_instance(repository, factory=new)
         assert isinstance(instance, plugin)
         assert instance.configuration.value == value
 
@@ -323,7 +324,7 @@ class TestPluginInstanceConfiguration:
         plugin = _DummyDefaultConfigurablePlugin
         sut = PluginInstanceConfiguration(plugin)
         repository = StaticPluginRepository(DummyPlugin, plugin)
-        instance = await sut.new_plugin_instance(repository)
+        instance = await sut.new_plugin_instance(repository, factory=new)
         assert isinstance(instance, plugin)
 
     async def test_new_plugin_instance__with_non_configurable_plugin_with_configuration(
@@ -336,7 +337,7 @@ class TestPluginInstanceConfiguration:
         )
         repository = StaticPluginRepository(DummyPlugin, plugin)
         with pytest.raises(UserFacingException):
-            await sut.new_plugin_instance(repository)
+            await sut.new_plugin_instance(repository, factory=new)
 
     async def test_new_plugin_instance__with_non_configurable_plugin_without_configuration(
         self,
@@ -344,7 +345,7 @@ class TestPluginInstanceConfiguration:
         plugin = DummyPlugin
         sut = PluginInstanceConfiguration(plugin)
         repository = StaticPluginRepository(DummyPlugin, plugin)
-        instance = await sut.new_plugin_instance(repository)
+        instance = await sut.new_plugin_instance(repository, factory=new)
         assert isinstance(instance, plugin)
 
 

--- a/betty/tests/plugin/test_proxy.py
+++ b/betty/tests/plugin/test_proxy.py
@@ -2,8 +2,7 @@ from typing import TypeVar
 
 import pytest
 
-from betty.factory import FactoryError
-from betty.plugin import Plugin, PluginIdentifier, PluginNotFound
+from betty.plugin import PluginNotFound
 from betty.plugin.proxy import ProxyPluginRepository
 from betty.plugin.static import StaticPluginRepository
 from betty.test_utils.plugin import DummyPlugin
@@ -83,71 +82,3 @@ class TestProxyPluginRepository:
             ProxyPluginRepositoryTestPluginTwo,
             ProxyPluginRepositoryTestPluginThree,
         ]
-
-    @pytest.mark.parametrize(
-        "target",
-        [
-            ProxyPluginRepositoryTestPluginOne,
-            ProxyPluginRepositoryTestPluginOne.plugin_id(),
-        ],
-    )
-    async def test_new_target__with_own_factory(
-        self, target: PluginIdentifier[Plugin]
-    ) -> None:
-        async def _error_raising_factory(cls: type[_T]) -> _T:
-            raise FactoryError(cls)
-
-        sut = ProxyPluginRepository(
-            DummyPlugin,
-            StaticPluginRepository(
-                DummyPlugin,
-                ProxyPluginRepositoryTestPluginOne,
-                factory=_error_raising_factory,
-            ),
-        )
-        await sut.new_target(target)
-
-    @pytest.mark.parametrize(
-        "target",
-        [
-            ProxyPluginRepositoryTestPluginOne,
-            ProxyPluginRepositoryTestPluginOne.plugin_id(),
-        ],
-    )
-    async def test_new_target__with_upstream_factory(
-        self, target: PluginIdentifier[Plugin]
-    ) -> None:
-        async def _error_raising_factory(cls: type[_T]) -> _T:
-            raise FactoryError(cls)
-
-        sut = ProxyPluginRepository(
-            DummyPlugin,
-            StaticPluginRepository(DummyPlugin, ProxyPluginRepositoryTestPluginOne),
-            factory=_error_raising_factory,
-        )
-        await sut.new_target(target)
-
-    @pytest.mark.parametrize(
-        "target",
-        [
-            ProxyPluginRepositoryTestPluginOne,
-            ProxyPluginRepositoryTestPluginOne.plugin_id(),
-        ],
-    )
-    async def test_new_target__without_successful_factories(
-        self, target: PluginIdentifier[Plugin]
-    ) -> None:
-        async def _error_raising_factory(cls: type[_T]) -> _T:
-            raise FactoryError(cls)
-
-        sut = ProxyPluginRepository(
-            DummyPlugin,
-            StaticPluginRepository(
-                DummyPlugin,
-                ProxyPluginRepositoryTestPluginOne,
-                factory=_error_raising_factory,
-            ),
-            factory=_error_raising_factory,
-        )
-        with pytest.raises(FactoryError):
-            await sut.new_target(ProxyPluginRepositoryTestPluginOne)

--- a/betty/tests/project/test_new.py
+++ b/betty/tests/project/test_new.py
@@ -225,7 +225,7 @@ async def test_new__with_gramps(
         assert Gramps in configuration.extensions
         async with Project.new_temporary(app) as project, project:
             gramps = await configuration.extensions[Gramps].new_plugin_instance(
-                project.extension_repository
+                project.extension_repository, factory=project.new_target
             )
             assert isinstance(gramps, Gramps)
             assert (

--- a/betty/wiki/populator.py
+++ b/betty/wiki/populator.py
@@ -27,10 +27,10 @@ if TYPE_CHECKING:
     from collections.abc import Mapping, MutableMapping, Sequence
 
     from betty.ancestry import Ancestry
+    from betty.copyright_notice import CopyrightNotice
     from betty.locale.localizer import LocalizerRepository
     from betty.model import Entity
     from betty.wiki.client import Client, Image
-    from betty.wiki.copyright_notice import WikipediaContributors
 
 
 @threadsafe
@@ -45,7 +45,7 @@ class Populator:
         locales: Sequence[str],
         localizers: LocalizerRepository,
         client: Client,
-        copyright_notice: WikipediaContributors,
+        copyright_notice: CopyrightNotice,
     ):
         self._ancestry = ancestry
         self._locales = locales


### PR DESCRIPTION
Remove `PluginRepository.new_target()` because in the future, not all plugins will be class-based anymore.

The problems these methods aimed to resolve (using the correct factory, e.g. app- or project-based) are more fundamental and widespread than the plugin API, and should eventually be fixed elsewhere.