### PR TITLE
Increase the maximum number of simultaneous HTTP client connections per host

### DIFF
--- a/betty/app/__init__.py
+++ b/betty/app/__init__.py
@@ -194,7 +194,7 @@ class App(Configurable[AppConfiguration], TargetFactory, ServiceProvider):
         The HTTP client.
         """
         http_client = aiohttp.ClientSession(
-            connector=aiohttp.TCPConnector(limit_per_host=5),
+            connector=aiohttp.TCPConnector(limit_per_host=99),
             headers={
                 "User-Agent": "Betty (https://betty.readthedocs.io/)",
             },


### PR DESCRIPTION
For more fine-grained control, use a `RateLimiter`.