### PR TITLE
Add an HTTP rate limit for the Wikipedia REST API

### DIFF
--- a/betty/http_client/rate_limits.py
+++ b/betty/http_client/rate_limits.py
@@ -33,3 +33,27 @@ class WikipediaActionApi(RateLimit, ClassedPlugin):
         # Foundation-managed Action APIs. We've taken the limit of "200 requests per second" from
         # https://www.mediawiki.org/wiki/Wikimedia_REST_API#Terms_and_conditions instead.
         return 200, 1
+
+
+@RateLimitDefinition(id="wikipedia-rest-api")
+class WikipediaRestApi(RateLimit, ClassedPlugin):
+    """
+    The Wikipedia REST API rate limit.
+
+    See https://www.mediawiki.org/wiki/Wikimedia_REST_API#Terms_and_conditions.
+    """
+
+    @override
+    def match(self, request: ClientRequest) -> bool:
+        return (
+            request.url.scheme in ("http", "https")
+            and request.url.host is not None
+            and request.url.host.endswith(".wikipedia.org")
+            and request.url.path == "/api/rest_v1"
+            or request.url.path.startswith("/api/rest_v1/")
+        )
+
+    @override
+    @property
+    def limit(self) -> tuple[int, int]:
+        return 200, 1

--- a/betty/tests/http_client/test_rate_limits.py
+++ b/betty/tests/http_client/test_rate_limits.py
@@ -3,7 +3,7 @@ from aiohttp.client_reqrep import ClientRequest
 from typing_extensions import override
 from yarl import URL
 
-from betty.http_client.rate_limits import WikipediaActionApi
+from betty.http_client.rate_limits import WikipediaActionApi, WikipediaRestApi
 from betty.plugin import PluginDefinition
 from betty.test_utils.http_client.rate_limit import RateLimitDefinitionTestBase
 
@@ -32,12 +32,47 @@ class TestWikipediaActionApi:
             (False, "GET", "https://example.com"),
         ],
     )
-    def test_match(self, expected: bool, method: str, url: str) -> None:
+    async def test_match(self, expected: bool, method: str, url: str) -> None:
         sut = WikipediaActionApi()
         request = ClientRequest(method, URL(url))
         assert sut.match(request) is expected
 
     def test_limit(self) -> None:
         sut = WikipediaActionApi()
+        assert sut.limit[0]
+        assert sut.limit[1]
+
+
+class TestWikipediaRestApiDefinition(RateLimitDefinitionTestBase):
+    @override
+    @pytest.fixture
+    def sut(self) -> PluginDefinition:
+        return WikipediaRestApi.plugin
+
+
+class TestWikipediaRestApi:
+    @pytest.mark.parametrize(
+        ("expected", "method", "url"),
+        [
+            (True, "GET", "https://en.wikipedia.org/api/rest_v1"),
+            (True, "GET", "https://nl.wikipedia.org/api/rest_v1"),
+            (
+                True,
+                "GET",
+                "https://en.wikipedia.org/api/rest_v1/page/summary/Amsterdam",
+            ),
+            (True, "GET", "http://en.wikipedia.org/api/rest_v1"),
+            (False, "GET", "ftp://en.wikipedia.org/api/rest_v1"),
+            (False, "GET", "https://en.wikipedia.org/api"),
+            (False, "GET", "https://example.com"),
+        ],
+    )
+    async def test_match(self, expected: bool, method: str, url: str) -> None:
+        sut = WikipediaRestApi()
+        request = ClientRequest(method, URL(url))
+        assert sut.match(request) is expected
+
+    def test_limit(self) -> None:
+        sut = WikipediaRestApi()
         assert sut.limit[0]
         assert sut.limit[1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,6 +198,7 @@ betty = 'betty.console:main_standalone'
 
 [project.entry-points.'betty.http_rate_limit']
 'wikipedia-action-api' = 'betty.http_client.rate_limits:WikipediaActionApi.plugin'
+'wikipedia-rest-api' = 'betty.http_client.rate_limits:WikipediaRestApi.plugin'
 
 [project.entry-points.'betty.renderer']
 'jinja2' = 'betty.jinja2:Jinja2Renderer.plugin'


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/2877