### PR TITLE
Revert "Remove APT packages from CI builds that were needed for legacy Python 3.14 support"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,9 @@ jobs:
         if: startsWith(runner.os, 'Linux')
         run: |
           sudo apt-get update
-          sudo apt-get install  poppler-utils
+          # libjpeg-dev is needed because pillow does not (yet) publish wheels for Python 3.14.
+          # libxml2 and libxslt are needed because lxml does not (yet) publish wheels for Python 3.14.
+          sudo apt-get install libjpeg-dev libxml2 libxslt1-dev poppler-utils
 
       - name: Install Brew dependencies
         if: startsWith(runner.os, 'macOS')


### PR DESCRIPTION
Reverts bartfeenstra/betty#2826