### PR TITLE
Run CI tests using Python free threading

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,10 @@ jobs:
             os: windows-latest
             nodejs: 24.x
             python: '3.14'
+          - name: 'Free threading'
+            os: ubuntu-latest
+            nodejs: 22.x
+            python: '3.14t'
     timeout-minutes: 30
     steps:
       - name: Check out the source code


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/2956

## To do
- allow Betty to be installed without Playwright so we avoid greenlet
- in a separate PR: update the test CI matrix to run a dedicated Playwright build. Also add a build command and pyproject.toml group to install Betty without Playwright.
- Add a pyproject.toml classifier
- add a test to ensure that if the current Python build support free threading, free threading is indeed enabled 