### PR TITLE
Revert back to using `AsyncExecutor` when loading ancestries

### DIFF
--- a/betty/project/load/__init__.py
+++ b/betty/project/load/__init__.py
@@ -4,12 +4,10 @@ Provide the Ancestry loading API.
 
 from abc import ABC, abstractmethod
 from asyncio import gather
-from math import ceil
-from os import cpu_count
 
 from betty.ancestry.link import Link
 from betty.concurrent import MAX_STRANDS
-from betty.job.executor.threading import ThreadPoolExecutor
+from betty.job.executor.asyncio import AsyncExecutor
 from betty.job.scheduler import Scheduler
 from betty.job.scheduler.default import DefaultScheduler
 from betty.project import Project, ProjectContext
@@ -48,16 +46,10 @@ async def load(project: Project, *, job_context: ProjectContext | None = None) -
         job_context = ProjectContext(project)
 
     extensions = await project.extensions
-    threading_concurrency = cpu_count() or 2
-    async_concurrency = ceil(MAX_STRANDS / threading_concurrency)
     load_scheduler = DefaultScheduler(
         job_context, progress=job_context.progress, user=project.app.user
     )
-    async with ThreadPoolExecutor(
-        load_scheduler,
-        async_concurrency=async_concurrency,
-        threading_concurrency=threading_concurrency,
-    ):
+    async with AsyncExecutor(load_scheduler, concurrency=MAX_STRANDS):
         await gather(
             *(
                 extension.load(load_scheduler)
@@ -71,11 +63,7 @@ async def load(project: Project, *, job_context: ProjectContext | None = None) -
     post_load_scheduler = DefaultScheduler(
         job_context, progress=job_context.progress, user=project.app.user
     )
-    async with ThreadPoolExecutor(
-        post_load_scheduler,
-        async_concurrency=async_concurrency,
-        threading_concurrency=threading_concurrency,
-    ):
+    async with AsyncExecutor(post_load_scheduler, concurrency=MAX_STRANDS):
         await gather(
             *(
                 extension.post_load(post_load_scheduler)


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/2967