### PR TITLE
Fix missing error contexts for partial configuration validation

### DIFF
--- a/betty/model/config.py
+++ b/betty/model/config.py
@@ -19,7 +19,8 @@ from betty.assertion import (
 )
 from betty.config import Configuration
 from betty.config.collections.sequence import ConfigurationSequence
-from betty.exception import HumanFacingException
+from betty.data import Index
+from betty.exception import HumanFacingException, HumanFacingExceptionGroup
 from betty.locale.localizable import _
 from betty.machine_name import MachineName, assert_machine_name
 from betty.plugin import PluginIdentifier, PluginRepository, resolve_id
@@ -204,5 +205,7 @@ class EntityReferenceSequence(ConfigurationSequence[EntityReference]):
         """
         Validate the configuration.
         """
-        for reference in self:
-            await reference.validate(entity_type_repository)
+        with HumanFacingExceptionGroup().assert_valid() as errors:
+            for index, reference in enumerate(self):
+                with errors.catch(Index(index)):
+                    await reference.validate(entity_type_repository)

--- a/betty/project/__init__.py
+++ b/betty/project/__init__.py
@@ -24,6 +24,8 @@ from betty.ancestry.presence_role import PresenceRoleDefinition
 from betty.asset import AssetRepository, ProxyAssetRepository, StaticAssetRepository
 from betty.config import Configurable
 from betty.copyright_notice import CopyrightNotice, CopyrightNoticeDefinition
+from betty.data import Key
+from betty.exception import HumanFacingExceptionGroup
 from betty.factory import TargetFactory
 from betty.hashid import hashid
 from betty.job import Context
@@ -144,7 +146,13 @@ class Project(Configurable[ProjectConfiguration], TargetFactory, ServiceProvider
             raise
 
     async def _assert_configuration(self) -> None:
-        await self.configuration.entity_types.validate(self.app.entity_type_repository)
+        with (
+            HumanFacingExceptionGroup().assert_valid() as errors,
+            errors.catch(Key("entity_types")),
+        ):
+            await self.configuration.entity_types.validate(
+                self.app.entity_type_repository
+            )
 
     @property
     def app(self) -> App:

--- a/betty/project/extension/raspberry_mint/__init__.py
+++ b/betty/project/extension/raspberry_mint/__init__.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING, final
 import aiofiles
 from typing_extensions import override
 
+from betty.data import Key
+from betty.exception import HumanFacingExceptionGroup
 from betty.jinja2 import Filters, Jinja2Provider
 from betty.job import Job
 from betty.locale.localizable import Chain, Plain, _
@@ -130,9 +132,15 @@ class RaspberryMint(
             raise
 
     async def _assert_configuration(self) -> None:
-        await self.configuration.featured_entities.validate(
-            self.project.app.entity_type_repository
-        )
+        with (
+            HumanFacingExceptionGroup().assert_valid() as errors,
+            errors.catch(
+                Key("extensions"), Key("raspberry-mint"), Key("featured_entities")
+            ),
+        ):
+            await self.configuration.featured_entities.validate(
+                self.project.app.entity_type_repository
+            )
 
     @override
     async def generate(self, scheduler: Scheduler[ProjectContext]) -> None:

--- a/betty/tests/project/extension/raspberry_mint/test___init__.py
+++ b/betty/tests/project/extension/raspberry_mint/test___init__.py
@@ -41,9 +41,12 @@ class TestRaspberryMint(EntryPointProviderTestBase):
             sut.configuration.featured_entities.replace(
                 EntityReference("non-existent-entity")
             )
-            with pytest.raises(HumanFacingException):
+            with pytest.raises(HumanFacingException) as exc_info:
                 async with sut:
                     pass  # pragma: nocover
+        assert 'data["extensions"]["raspberry-mint"]["featured_entities"][0]' in str(
+            exc_info.value
+        )
 
     @check_skip_webpack_entry_point_provider
     async def test_generate__html_list_for_third_party_entity(

--- a/betty/tests/project/test___init__.py
+++ b/betty/tests/project/test___init__.py
@@ -160,9 +160,12 @@ class TestProject:
                     DummyNonPublicFacingEntityOne.plugin, generate_html_list=True
                 )
             )
-            with pytest.raises(HumanFacingException):
+            with pytest.raises(HumanFacingException) as exc_info:
                 async with sut:
                     pass
+        assert 'data["entity_types"]["dummy-non-public-facing-one"]' in str(
+            exc_info.value
+        )
 
     async def test_extensions__should_enable_betty_extensions(
         self, temporary_app: App


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/2493