### PR TITLE
Allow ledgers to acquire shared (read-only) locks

### DIFF
--- a/betty/cache/__init__.py
+++ b/betty/cache/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Generic, Literal, Self, TypeAlias, overload
+from typing import TYPE_CHECKING, Generic, Self, TypeAlias
 
 from typing_extensions import TypeVar
 
@@ -40,6 +40,11 @@ class CacheItem(Generic[_CacheItemValueCoT], ABC):
 
 
 CacheItemValueSetter: TypeAlias = Callable[[_CacheItemValueT], Awaitable[None]]
+GetSet: TypeAlias = (
+    tuple[CacheItem[_CacheItemValueContraT], None]
+    | tuple[None, CacheItemValueSetter[_CacheItemValueContraT]]
+    | tuple[None, None]
+)
 
 
 @threadsafe
@@ -76,37 +81,10 @@ class Cache(Generic[_CacheItemValueContraT], ABC):
         Add or update a cache item.
         """
 
-    @overload
-    def getset(
-        self, cache_item_id: str
-    ) -> AbstractAsyncContextManager[
-        tuple[
-            CacheItem[_CacheItemValueContraT] | None,
-            CacheItemValueSetter[_CacheItemValueContraT],
-        ]
-    ]:
-        pass
-
-    @overload
-    def getset(
-        self, cache_item_id: str, *, wait: Literal[False] = False
-    ) -> AbstractAsyncContextManager[
-        tuple[
-            CacheItem[_CacheItemValueContraT] | None,
-            CacheItemValueSetter[_CacheItemValueContraT] | None,
-        ]
-    ]:
-        pass
-
     @abstractmethod
     def getset(
         self, cache_item_id: str, *, wait: bool = True
-    ) -> AbstractAsyncContextManager[
-        tuple[
-            CacheItem[_CacheItemValueContraT] | None,
-            CacheItemValueSetter[_CacheItemValueContraT] | None,
-        ]
-    ]:
+    ) -> AbstractAsyncContextManager[GetSet[_CacheItemValueContraT]]:
         """
         Get the cache item with the given ID, and provide a setter to add or update it within the same atomic operation.
 

--- a/betty/cache/_base.py
+++ b/betty/cache/_base.py
@@ -2,19 +2,18 @@ from abc import abstractmethod
 from collections.abc import AsyncIterator, Sequence
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from datetime import datetime
+from functools import partial
 from typing import (
     Any,
     Generic,
-    Literal,
     Protocol,
     Self,
     TypeVar,
-    overload,
 )
 
 from typing_extensions import override
 
-from betty.cache import Cache, CacheItem, CacheItemValueSetter
+from betty.cache import Cache, CacheItem, GetSet
 from betty.concurrent import AsynchronizedLock, Ledger
 from betty.typing import threadsafe
 
@@ -123,37 +122,11 @@ class _CommonCacheBase(Cache[_CacheItemValueContraT], Generic[_CacheItemValueCon
     ) -> None:
         pass
 
-    @overload
-    def getset(
-        self, cache_item_id: str
-    ) -> AbstractAsyncContextManager[
-        tuple[
-            CacheItem[_CacheItemValueContraT] | None,
-            CacheItemValueSetter[_CacheItemValueContraT],
-        ]
-    ]:
-        pass
-
-    @overload
-    def getset(
-        self, cache_item_id: str, *, wait: Literal[False] = False
-    ) -> AbstractAsyncContextManager[
-        tuple[
-            CacheItem[_CacheItemValueContraT] | None,
-            CacheItemValueSetter[_CacheItemValueContraT] | None,
-        ]
-    ]:
-        pass
-
     @override
     def getset(
         self, cache_item_id: str, *, wait: bool = True
-    ) -> AbstractAsyncContextManager[
-        tuple[
-            CacheItem[_CacheItemValueContraT] | None,
-            CacheItemValueSetter[_CacheItemValueContraT] | None,
-        ]
-    ]:
+    ) -> AbstractAsyncContextManager[GetSet[_CacheItemValueContraT]]:
+        # @todo merge _getset() into this method?
         return self._getset(cache_item_id, self._get, self._set, wait=wait)
 
     @asynccontextmanager
@@ -164,12 +137,7 @@ class _CommonCacheBase(Cache[_CacheItemValueContraT], Generic[_CacheItemValueCon
         setter: _CommonCacheBaseSetter[_CacheItemValueContraT],
         *,
         wait: bool = True,
-    ) -> AsyncIterator[
-        tuple[
-            CacheItem[_CacheItemValueContraT] | None,
-            CacheItemValueSetter[_CacheItemValueContraT] | None,
-        ]
-    ]:
+    ) -> AsyncIterator[GetSet[_CacheItemValueContraT]]:
         # @todo We probably want to use an exclusive lock here but then downgrade to a non-exclusive lock if a value is found
         # @todo and the setter is not needed?
         # @todo
@@ -177,11 +145,12 @@ class _CommonCacheBase(Cache[_CacheItemValueContraT], Generic[_CacheItemValueCon
         lock = self._cache_item_lock_ledger.ledger(cache_item_id)
         if await lock.acquire(wait=wait):
             try:
-
-                async def _setter(value: _CacheItemValueContraT) -> None:
-                    await setter(cache_item_id, value)
-
-                yield await getter(cache_item_id), _setter
+                cache_item = await getter(cache_item_id)
+                if cache_item is not None:
+                    await lock.share()
+                    yield cache_item, None
+                else:
+                    yield None, partial(setter, cache_item_id)
                 return
             finally:
                 await lock.release()

--- a/betty/cache/_base.py
+++ b/betty/cache/_base.py
@@ -93,7 +93,7 @@ class _CommonCacheBase(Cache[_CacheItemValueContraT], Generic[_CacheItemValueCon
     async def get(
         self, cache_item_id: str
     ) -> AsyncIterator[CacheItem[_CacheItemValueContraT] | None]:
-        async with self._cache_item_lock_ledger.ledger(cache_item_id):
+        async with self._cache_item_lock_ledger.ledger(cache_item_id, exclusive=False):
             yield await self._get(cache_item_id)
 
     @abstractmethod
@@ -170,6 +170,10 @@ class _CommonCacheBase(Cache[_CacheItemValueContraT], Generic[_CacheItemValueCon
             CacheItemValueSetter[_CacheItemValueContraT] | None,
         ]
     ]:
+        # @todo We probably want to use an exclusive lock here but then downgrade to a non-exclusive lock if a value is found
+        # @todo and the setter is not needed?
+        # @todo
+        # @todo
         lock = self._cache_item_lock_ledger.ledger(cache_item_id)
         if await lock.acquire(wait=wait):
             try:

--- a/betty/cache/file.py
+++ b/betty/cache/file.py
@@ -14,18 +14,16 @@ from pickle import dumps, loads
 from typing import (
     TYPE_CHECKING,
     Generic,
-    Literal,
     Self,
     TypeVar,
     final,
-    overload,
 )
 
 import aiofiles
 from aiofiles.ospath import getmtime
 from typing_extensions import override
 
-from betty.cache import CacheItem, CacheItemValueSetter
+from betty.cache import CacheItem, GetSet
 from betty.cache._base import _CommonCacheBase, _CommonCacheBaseState
 from betty.hashid import hashid
 from betty.typing import threadsafe
@@ -178,41 +176,10 @@ class _FileCache(
     def _path(self) -> Path:
         return self._root_path.joinpath(*self._scopes)
 
-    @overload
-    def getset(
-        self, cache_item_id: str, *, suffix: str | None = None
-    ) -> AbstractAsyncContextManager[
-        tuple[
-            CacheItem[_CacheItemValueContraT] | None,
-            CacheItemValueSetter[_CacheItemValueContraT],
-        ]
-    ]:
-        pass
-
-    @overload
-    def getset(
-        self,
-        cache_item_id: str,
-        *,
-        suffix: str | None = None,
-        wait: Literal[False] = False,
-    ) -> AbstractAsyncContextManager[
-        tuple[
-            CacheItem[_CacheItemValueContraT] | None,
-            CacheItemValueSetter[_CacheItemValueContraT] | None,
-        ]
-    ]:
-        pass
-
     @override
     def getset(
         self, cache_item_id: str, *, suffix: str | None = None, wait: bool = True
-    ) -> AbstractAsyncContextManager[
-        tuple[
-            CacheItem[_CacheItemValueContraT] | None,
-            CacheItemValueSetter[_CacheItemValueContraT] | None,
-        ]
-    ]:
+    ) -> AbstractAsyncContextManager[GetSet[_CacheItemValueContraT]]:
         return self._getset(
             cache_item_id,
             partial(self._get, suffix=suffix),

--- a/betty/cache/no_op.py
+++ b/betty/cache/no_op.py
@@ -4,49 +4,16 @@ Provide no-op caching.
 
 from __future__ import annotations
 
-from contextlib import AbstractAsyncContextManager, asynccontextmanager
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Literal,
-    Self,
-    TypeAlias,
-    final,
-    overload,
-)
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any, Self, final
 
 from typing_extensions import override
 
-from betty.cache import Cache, CacheItem, CacheItemValueSetter
+from betty.cache import Cache, CacheItem, GetSet
 from betty.typing import threadsafe
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
-    from types import TracebackType
-
-_GetSet: TypeAlias = tuple[
-    CacheItem[Any] | None,
-    CacheItemValueSetter[Any] | None,
-]
-
-
-class _NoOpGetSet:
-    def __init__(self, has_setter: bool):
-        self._has_setter = has_setter
-
-    async def __aenter__(self) -> _GetSet:
-        return None, self._set if self._has_setter else None
-
-    async def _set(self, value: Any) -> None:
-        return
-
-    async def __aexit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> None:
-        return
 
 
 @final
@@ -75,33 +42,12 @@ class NoOpCache(Cache[Any]):
     ) -> None:
         return
 
-    @overload
-    def getset(
-        self, cache_item_id: str
-    ) -> AbstractAsyncContextManager[
-        tuple[
-            CacheItem[Any] | None,
-            CacheItemValueSetter[Any],
-        ]
-    ]:
-        pass
-
-    @overload
-    def getset(
-        self, cache_item_id: str, *, wait: Literal[False] = False
-    ) -> AbstractAsyncContextManager[
-        tuple[
-            CacheItem[Any] | None,
-            CacheItemValueSetter[Any] | None,
-        ]
-    ]:
-        pass
-
     @override
-    def getset(
+    @asynccontextmanager
+    async def getset(
         self, cache_item_id: str, *, wait: bool = True
-    ) -> AbstractAsyncContextManager[_GetSet]:
-        return _NoOpGetSet(wait)
+    ) -> AsyncIterator[GetSet[Any]]:
+        yield None, None
 
     @override
     async def delete(self, cache_item_id: str) -> None:

--- a/betty/concurrent.py
+++ b/betty/concurrent.py
@@ -14,7 +14,7 @@ from typing import Literal, Self, TypeAlias, TypeVar, Union, final
 
 from typing_extensions import override
 
-from betty.typing import threadsafe
+from betty.typing import internal, threadsafe
 
 _KeyT = TypeVar("_KeyT")
 _ValueT = TypeVar("_ValueT")
@@ -227,11 +227,16 @@ class RateLimiter:
             self._available -= 1
 
 
-# @todo The ledger would have to keep track of read access (a counter) and write access (a boolean)
 _Ledger: TypeAlias = MutableMapping[Hashable, int | Literal[True]]
 
 
-class _LedgerTransaction(Lock):
+@final
+@internal
+class LedgerTransaction(Lock):
+    """
+    A lock for a single ledger transaction.
+    """
+
     def __init__(
         self,
         transaction_id: Hashable,
@@ -250,36 +255,47 @@ class _LedgerTransaction(Lock):
             while True:
                 async with self._ledger_lock:
                     if self._can_acquire():
-                        return self._acquire()
+                        self._acquire()
+                        return True
                 await sleep(0)
         else:
             async with self._ledger_lock:
                 if self._can_acquire():
-                    return self._acquire()
+                    self._acquire()
+                    return True
                 return False
 
     def _can_acquire(self) -> bool:
         try:
-            lock = self._ledger[self._transaction_id]
-            if isinstance(lock, int):
-                self._ledger[self._transaction_id] += 1
-                return True
-            return False
+            return isinstance(self._ledger[self._transaction_id], int)
         except KeyError:
-            self._ledger[self._transaction_id] = True if self._exclusive else 1
             return True
 
-    def _acquire(self) -> bool:
-        self._ledger[self._transaction_id] = True
-        return True
+    def _acquire(self) -> None:
+        self._ledger[self._transaction_id] = True if self._exclusive else 1
+
+    def _release(self) -> None:
+        if self._exclusive:
+            self._ledger[self._transaction_id] = 0
+        else:
+            self._ledger[self._transaction_id] -= 1
 
     @override
     async def release(self) -> None:
         async with self._ledger_lock:
-            if self._exclusive:
-                self._ledger[self._transaction_id] = 0
-            else:
-                self._ledger[self._transaction_id] -= 1
+            self._release()
+
+    async def share(self) -> None:
+        """
+        Relinquish any exclusive acquisition and 'downgrade' to a shared acquisition of this lock.
+
+        This MUST only ever be called by the code who successfully acquired this lock.
+        """
+        if not self._exclusive:
+            return
+        self._release()
+        self._exclusive = False
+        self._acquire()
 
 
 @threadsafe
@@ -294,10 +310,12 @@ class Ledger:
         self._ledger_lock = ledger_lock
         self._ledger: _Ledger = {}
 
-    def ledger(self, transaction_id: Hashable, *, exclusive: bool = True) -> Lock:
+    def ledger(
+        self, transaction_id: Hashable, *, exclusive: bool = True
+    ) -> LedgerTransaction:
         """
         Ledger a new lock for the given transaction ID.
         """
-        return _LedgerTransaction(
+        return LedgerTransaction(
             transaction_id, self._ledger_lock, self._ledger, exclusive
         )

--- a/betty/concurrent.py
+++ b/betty/concurrent.py
@@ -10,7 +10,7 @@ from asyncio import sleep
 from collections.abc import Hashable, MutableMapping
 from math import floor
 from types import TracebackType
-from typing import Self, TypeAlias, TypeVar, Union, final
+from typing import Literal, Self, TypeAlias, TypeVar, Union, final
 
 from typing_extensions import override
 
@@ -227,16 +227,22 @@ class RateLimiter:
             self._available -= 1
 
 
-class _Transaction(Lock):
+# @todo The ledger would have to keep track of read access (a counter) and write access (a boolean)
+_Ledger: TypeAlias = MutableMapping[Hashable, int | Literal[True]]
+
+
+class _LedgerTransaction(Lock):
     def __init__(
         self,
         transaction_id: Hashable,
         ledger_lock: Lock,
-        ledger: MutableMapping[Hashable, bool],
+        ledger: _Ledger,
+        exclusive: bool,
     ):
         self._transaction_id = transaction_id
         self._ledger_lock = ledger_lock
         self._ledger = ledger
+        self._exclusive = exclusive
 
     @override
     async def acquire(self, *, wait: bool = True) -> bool:
@@ -254,9 +260,13 @@ class _Transaction(Lock):
 
     def _can_acquire(self) -> bool:
         try:
-            return not self._ledger[self._transaction_id]
+            lock = self._ledger[self._transaction_id]
+            if isinstance(lock, int):
+                self._ledger[self._transaction_id] += 1
+                return True
+            return False
         except KeyError:
-            self._ledger[self._transaction_id] = False
+            self._ledger[self._transaction_id] = True if self._exclusive else 1
             return True
 
     def _acquire(self) -> bool:
@@ -265,7 +275,11 @@ class _Transaction(Lock):
 
     @override
     async def release(self) -> None:
-        self._ledger[self._transaction_id] = False
+        async with self._ledger_lock:
+            if self._exclusive:
+                self._ledger[self._transaction_id] = 0
+            else:
+                self._ledger[self._transaction_id] -= 1
 
 
 @threadsafe
@@ -278,10 +292,12 @@ class Ledger:
 
     def __init__(self, ledger_lock: Lock):
         self._ledger_lock = ledger_lock
-        self._ledger: MutableMapping[Hashable, bool] = {}
+        self._ledger: _Ledger = {}
 
-    def ledger(self, transaction_id: Hashable) -> Lock:
+    def ledger(self, transaction_id: Hashable, *, exclusive: bool = True) -> Lock:
         """
         Ledger a new lock for the given transaction ID.
         """
-        return _Transaction(transaction_id, self._ledger_lock, self._ledger)
+        return _LedgerTransaction(
+            transaction_id, self._ledger_lock, self._ledger, exclusive
+        )

--- a/betty/test_utils/cache.py
+++ b/betty/test_utils/cache.py
@@ -111,6 +111,7 @@ class CacheTestBase(Generic[_CacheItemValueT]):
             async with self._new_sut(scopes=scopes) as sut:
                 async with sut.getset("id") as (cache_item, setter):
                     assert cache_item is None
+                    assert setter is not None
                     await setter(value)
                 async with sut.get("id") as cache_item:
                     assert cache_item is not None

--- a/betty/tests/cache/test_no_op.py
+++ b/betty/tests/cache/test_no_op.py
@@ -23,7 +23,7 @@ class TestNoOpCache:
         sut = NoOpCache()
         async with sut.getset("id") as (cache_item, setter):
             assert cache_item is None
-            await setter(123)
+            assert setter is None
 
     async def test_getset_without_wait(self) -> None:
         sut = NoOpCache()


### PR DESCRIPTION
This fixes(or replaces) https://github.com/bartfeenstra/betty/issues/2991

## To do
- part of the reason out locks and caches are so complex is that we keep locks to ensure cache items are not removed or overwritten while being read. What if we make that an assumption, and document it? Can we make the code simpler and reduce the amount and duration of lock acquisitions? 