### PR TITLE
Refactor the render API

### DIFF
--- a/betty/jinja2/__init__.py
+++ b/betty/jinja2/__init__.py
@@ -414,7 +414,7 @@ class Jinja2Renderer(Renderer, ProjectDependentFactory):
 
     @override
     @property
-    def media_types(self) -> Sequence[MediaType]:
+    def input(self) -> MediaType:
         return [JINJA2]
 
     @override

--- a/betty/render.py
+++ b/betty/render.py
@@ -98,13 +98,13 @@ class RendererDefinition(ClassedPluginDefinition[Renderer]):
 # @todo Type 1 is really the only conversion. Type 2 just resolves templating and leaves the rest intact.
 # @todo Type 3 may cause conflicts but that depends on whether individual renderers act on the same content.
 # @todo
+# @todo Types 1 and 2 are also pretty non-negotiable: given an input and desired output media type, we can either render
+# @todo or reliably error because we do not support that specific conversion.
 # @todo
+# @todo Type 3 is very context-specific. When rendering content from elsewhere, we probably want to run these renderers on it (e.g. Notes or configuration values)
 # @todo
-# @todo
-# @todo
-# @todo
-# @todo
-# @todo
+# @todo Also, we can simplify type 2 by requiring them to work on specific contained media types only, so one
+# @todo Jinja2 renderer for HTML files (*.html.j2), one for JSON files (*.json.j2), etc.
 # @todo
 # @todo
 @final

--- a/betty/render.py
+++ b/betty/render.py
@@ -106,6 +106,17 @@ class RendererDefinition(ClassedPluginDefinition[Renderer]):
 # @todo Also, we can simplify type 2 by requiring them to work on specific contained media types only, so one
 # @todo Jinja2 renderer for HTML files (*.html.j2), one for JSON files (*.json.j2), etc.
 # @todo
+# @todo SHOWER THOUGHTS
+# @todo - Order: type 2 (resolving templates), type 1 (media type conversion), type 3 (post-processing)
+# @todo - As such we can do type 2 in a chain if we want to, no problemo. We keep going until no more type 2s accept the input media type.
+# @todo   This is 'zero or more' so if no type 2 renderers apply, then that is fine
+# @todo - Then we do either no attempt at type 1 (if input and output match already), or exactly one attempt.
+# @todo - Type 3s are still unresolved. Current thoughts are that these should be kept entirely separately.
+# @todo - Also type 1 may need to be done in isolation, or in combination with type 3 but not type 2, e.g. for content
+# @todo   coming from the family tree where we do not want full on templating but need to make sure everything looks
+# @todo   alright on a web page (type 1) and perhaps allow URL resolution for things like notes (type 3).
+# @todo
+# @todo
 # @todo
 @final
 class RendererChain(Renderer):

--- a/betty/render.py
+++ b/betty/render.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
-from contextlib import suppress
 from pathlib import Path
 from shutil import copy2
 from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias, final
@@ -15,12 +14,12 @@ from aiofiles.os import makedirs
 from typing_extensions import override
 
 from betty.locale.localizable import _
-from betty.media_type import UnsupportedMediaType, match_extension, match_media_type
+from betty.media_type import UnsupportedMediaType, match_extension
 from betty.plugin import ClassedPluginDefinition, ClassedPluginTypeDefinition
 from betty.typing import internal
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Mapping
 
     from betty.job import Context
     from betty.locale.localizer import Localizer
@@ -30,19 +29,14 @@ if TYPE_CHECKING:
 CopyFunction: TypeAlias = Callable[[Path, Path], Awaitable[None]]
 
 
+
+
 class Renderer(ABC):
     """
     Render content.
 
     Read more about :doc:`/development/plugin/renderer`.
     """
-
-    @property
-    @abstractmethod
-    def media_types(self) -> Sequence[MediaType]:
-        """
-        The media types this renderer can render from.
-        """
 
     @abstractmethod
     async def render(
@@ -72,33 +66,55 @@ class RendererDefinition(ClassedPluginDefinition[Renderer]):
         label=_("Renderer"),
         cls=Renderer,
     )
-
-
-@final
-class ProxyRenderer(Renderer):
-    """
-    Render using a sequence of other renderers.
-    """
-
-    def __init__(self, upstreams: Sequence[Renderer]):
-        self._upstreams = upstreams
-        self._media_types = [
-            media_type
-            for renderer in self._upstreams
-            for media_type in renderer.media_types
-        ]
-
-    @override
     @property
-    def media_types(self) -> Sequence[MediaType]:
-        return self._media_types
+    @abstractmethod
+    def input(self) -> MediaType:
+        """
+        The media type this renderer can render from.
+        """
 
-    def _get_renderer(self, media_type: MediaType) -> Renderer:
-        for renderer in self._upstreams:
-            with suppress(UnsupportedMediaType):
-                match_media_type(media_type, renderer.media_types)
-                return renderer
-        raise UnsupportedMediaType(media_type)
+    @property
+    @abstractmethod
+    def output(self) -> MediaType:
+        """
+        The media type this renderer can render to.
+        """
+
+
+# @todo We need to thoroughly think through what we want and not conflate two different things:
+# @todo 1. Converting one media type to another (e.g. Markdown to HTML)
+# @todo 2. Templating languages (e.g. Jinja2 where the contained media type is the same as the output media type)
+# @todo 3. Postprocessing, such as URL generation or HTML fixing.
+# @todo
+# @todo We can do 1 easily because we know the source content media type, and input and output media types of any renderers.
+# @todo
+# @todo We can do 2 easily as well, really, and 3 too....
+# @todo
+# @todo The problem lies in how we want to get from input to output.
+# @todo We may not want to chain type 1 renderers (compound problems, graph resolution, ...)
+# @todo We can easily chain type 2 renderers.
+# @todo We can easily chain type 3 renderers.
+# @todo
+# @todo Type 1 is really the only conversion. Type 2 just resolves templating and leaves the rest intact.
+# @todo Type 3 may cause conflicts but that depends on whether individual renderers act on the same content.
+# @todo
+# @todo
+# @todo
+# @todo
+# @todo
+# @todo
+# @todo
+# @todo
+# @todo
+# @todo
+@final
+class RendererChain(Renderer):
+    """
+    A chain of renderers.
+    """
+
+    def __init__(self, *renderers: tuple[Renderer,MediaType,MediaType]):
+        self._renderers = renderers
 
     @override
     async def render(
@@ -110,13 +126,49 @@ class ProxyRenderer(Renderer):
         job_context: Context | None = None,
         localizer: Localizer | None = None,
     ) -> str:
-        return await self._get_renderer(media_type).render(
+        return await self._render(
             content,
+            media_type,
             media_type,
             data=data,
             job_context=job_context,
             localizer=localizer,
         )
+
+    async def _render(
+        self,
+        content: str,
+        root_media_type: MediaType,
+        media_type: MediaType,
+        *,
+        data: Mapping[str, Any] | None = None,
+        job_context: Context | None = None,
+        localizer: Localizer | None = None,
+    ) -> str:
+        # @todo How do we allow recursion but also let the caller know if there were any changes made to the content at all?
+        # @todo Act
+        # @todo
+        # @todo
+        for renderer,renderer_input, renderer_output in self._renderers:
+            if media_type == renderer.input:
+                return await self.render(
+                    await renderer.render(
+                        content,
+                        media_type,
+                        data=data,
+                        job_context=job_context,
+                        localizer=localizer,
+                    ),
+                    renderer.output,
+                    data=data,
+                    job_context=job_context,
+                    localizer=localizer,
+                )
+        if media_type == root_media_type:
+            raise UnsupportedMediaType.new(root_media_type)
+        return content
+
+
 
 
 @internal
@@ -137,7 +189,7 @@ def make_copy_function(
         nonlocal data
         await makedirs(destination_path.parent, exist_ok=True)
         try:
-            media_type, extension = match_extension(source_path, renderer.media_types)
+            media_type, extension = match_extension(source_path, renderer.input)
         except UnsupportedMediaType:
             copy2(source_path, destination_path)
             return

--- a/betty/tests/jinja2/test___init__.py
+++ b/betty/tests/jinja2/test___init__.py
@@ -86,7 +86,7 @@ class TestJinja2Renderer:
 
     async def test_media_types(self) -> None:
         sut = Jinja2Renderer(Jinja2Environment(enable_async=True))
-        sut.media_types  # noqa B018
+        sut.input  # noqa B018
 
 
 class DummyHasFileReferencesEntity(HasFileReferences):

--- a/betty/tests/test_render.py
+++ b/betty/tests/test_render.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -6,13 +6,12 @@ import aiofiles
 import pytest
 from typing_extensions import override
 
-from betty.functools import unique
 from betty.job import Context
 from betty.locale import DEFAULT_LOCALE
 from betty.locale.localizer import Localizer
-from betty.media_type import MediaType, UnsupportedMediaType
+from betty.media_type import MediaType
 from betty.plugin import PluginDefinition
-from betty.render import ProxyRenderer, Renderer, RendererDefinition, make_copy_function
+from betty.render import Renderer, RendererDefinition, make_copy_function
 from betty.test_utils.plugin import PluginDefinitionClassTestBase
 
 
@@ -26,7 +25,7 @@ class TestRendererDefinition(PluginDefinitionClassTestBase):
 class _TestRendererRenderer(Renderer):
     @override
     @property
-    def media_types(self) -> Sequence[MediaType]:
+    def input(self) -> MediaType:
         return [MediaType("text/x.betty.test", extensions=[".test"])]
 
     @override
@@ -51,7 +50,7 @@ class _StaticRenderer(Renderer):
 
     @override
     @property
-    def media_types(self) -> Sequence[MediaType]:
+    def input(self) -> MediaType:
         return [self.MEDIA_TYPE]
 
     @override
@@ -76,36 +75,6 @@ class _StaticRendererTwo(_StaticRenderer):
     MEDIA_TYPE = MediaType("text/x.betty.test.two", extensions=[".two"])
     RENDERED_CONTENT = "TWO"
 
-
-class TestProxyRenderer:
-    def test_media_types__without_upstreams(self) -> None:
-        sut = ProxyRenderer([])
-        assert sut.media_types == []
-
-    def test_media_types__with_upstreams(self) -> None:
-        renderer_one = _StaticRendererOne()
-        renderer_two = _StaticRendererTwo()
-        sut = ProxyRenderer([renderer_one, renderer_two])
-        assert sut.media_types == list(
-            unique(renderer_one.media_types, renderer_two.media_types)
-        )
-
-    async def test_render__without_upstreams(self) -> None:
-        sut = ProxyRenderer([])
-        with pytest.raises(UnsupportedMediaType):
-            await sut.render("", _StaticRendererOne.MEDIA_TYPE)
-
-    async def test_render__without_matching_upstream(self) -> None:
-        sut = ProxyRenderer([_StaticRendererTwo()])
-        with pytest.raises(UnsupportedMediaType):
-            await sut.render("", _StaticRendererOne.MEDIA_TYPE)
-
-    async def test_render__with_upstream(self) -> None:
-        sut = ProxyRenderer([_StaticRendererOne()])
-        assert (
-            await sut.render("", _StaticRendererOne.MEDIA_TYPE)
-            == _StaticRendererOne.RENDERED_CONTENT
-        )
 
 
 async def test_make_copy_function__www_directory(tmp_path: Path) -> None:


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/3031

## To do
- Split renderers up into templaters (type 2), converters (type 1), and utilities (type 3)
- We may just want to keep one templater (Jinja2), because we're unlikely to add another soon, while we do want multiple converters. That would let us simplify some of the Jinja2 code, and refactor renderers into converters.
- type 2 need a copy function 
- types 1 and 2 need logic. Type 3 never involve media type changes anyway