### PR TITLE
Allow plugins to express system requirements

### DIFF
--- a/betty/app/__init__.py
+++ b/betty/app/__init__.py
@@ -95,7 +95,7 @@ class App(Configurable[AppConfiguration], TargetFactory, ServiceProvider):
         if entity_type_repository is not None:
             cls.entity_type_repository.override(self, entity_type_repository)
         if extension_repository is not None:
-            cls.extension_repository.override(self, extension_repository)
+            cls._extension_repository.override(self, extension_repository)
         if command_repository is not None:
             cls.command_repository.override(self, command_repository)
         if renderer_repository is not None:
@@ -311,12 +311,7 @@ class App(Configurable[AppConfiguration], TargetFactory, ServiceProvider):
         return EntryPointPluginRepository(EntityDefinition, "betty.entity_type")
 
     @service
-    def extension_repository(self) -> PluginRepository[ExtensionDefinition]:
-        """
-        The extensions available to this application.
-
-        Read more about :doc:`/development/plugin/extension`.
-        """
+    def _extension_repository(self) -> PluginRepository[ExtensionDefinition]:
         return EntryPointPluginRepository(ExtensionDefinition, "betty.extension")
 
     @service

--- a/betty/assets/locale/ar/betty.po
+++ b/betty/assets/locale/ar/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-11-17 21:03+0000\n"
+"POT-Creation-Date: 2025-11-18 02:03+0000\n"
 "PO-Revision-Date: 2024-11-30 19:00+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: ar\n"
@@ -214,10 +214,6 @@ msgid "Burial"
 msgstr ""
 
 msgid "Cannot find an available port to bind the web server to."
-msgstr ""
-
-#, python-brace-format
-msgid "Cannot find and import \"{plugin_id}\"."
 msgstr ""
 
 #, python-brace-format
@@ -1182,6 +1178,10 @@ msgstr ""
 msgid "Unknown locale {locale}."
 msgstr ""
 
+#, python-brace-format
+msgid "Unknown plugin \"{plugin_id}\"."
+msgstr ""
+
 msgid "Update all existing translations"
 msgstr ""
 
@@ -1562,6 +1562,10 @@ msgstr ""
 
 #, python-brace-format
 msgid "{plugin_type_label} {plugin_label} depends on {dependency_labels}."
+msgstr ""
+
+#, python-brace-format
+msgid "{plugin_type} \"{plugin_id}\" has unmet requirements:"
 msgstr ""
 
 msgid "© Copyright the author, unless otherwise credited"

--- a/betty/assets/locale/betty.pot
+++ b/betty/assets/locale/betty.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-11-17 21:03+0000\n"
+"POT-Creation-Date: 2025-11-18 02:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -210,10 +210,6 @@ msgid "Burial"
 msgstr ""
 
 msgid "Cannot find an available port to bind the web server to."
-msgstr ""
-
-#, python-brace-format
-msgid "Cannot find and import \"{plugin_id}\"."
 msgstr ""
 
 #, python-brace-format
@@ -1159,6 +1155,10 @@ msgstr ""
 msgid "Unknown locale {locale}."
 msgstr ""
 
+#, python-brace-format
+msgid "Unknown plugin \"{plugin_id}\"."
+msgstr ""
+
 msgid "Update all existing translations"
 msgstr ""
 
@@ -1491,6 +1491,10 @@ msgstr ""
 
 #, python-brace-format
 msgid "{plugin_type_label} {plugin_label} depends on {dependency_labels}."
+msgstr ""
+
+#, python-brace-format
+msgid "{plugin_type} \"{plugin_id}\" has unmet requirements:"
 msgstr ""
 
 msgid "© Copyright the author, unless otherwise credited"

--- a/betty/assets/locale/de-DE/betty.po
+++ b/betty/assets/locale/de-DE/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-11-17 21:03+0000\n"
+"POT-Creation-Date: 2025-11-18 02:03+0000\n"
 "PO-Revision-Date: 2025-03-28 20:02+0000\n"
 "Last-Translator: Ettore Atalan <atalanttore@googlemail.com>\n"
 "Language: de_DE\n"
@@ -234,10 +234,6 @@ msgid "Cannot find an available port to bind the web server to."
 msgstr ""
 "Es wurde kein verfügbarer Port gefunden, an den der Webserver gebunden "
 "werden kann."
-
-#, python-brace-format
-msgid "Cannot find and import \"{plugin_id}\"."
-msgstr ""
 
 #, python-brace-format
 msgid ""
@@ -1213,6 +1209,10 @@ msgstr "Unbekannter Schlüssel: {unknown_key}."
 msgid "Unknown locale {locale}."
 msgstr ""
 
+#, python-brace-format
+msgid "Unknown plugin \"{plugin_id}\"."
+msgstr ""
+
 msgid "Update all existing translations"
 msgstr "Alle vorhandenen Übersetzungen aktualisieren"
 
@@ -1550,6 +1550,10 @@ msgstr ""
 
 #, python-brace-format
 msgid "{plugin_type_label} {plugin_label} depends on {dependency_labels}."
+msgstr ""
+
+#, python-brace-format
+msgid "{plugin_type} \"{plugin_id}\" has unmet requirements:"
 msgstr ""
 
 msgid "© Copyright the author, unless otherwise credited"

--- a/betty/assets/locale/fr-FR/betty.po
+++ b/betty/assets/locale/fr-FR/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-11-17 21:03+0000\n"
+"POT-Creation-Date: 2025-11-18 02:03+0000\n"
 "PO-Revision-Date: 2025-08-27 20:02+0000\n"
 "Last-Translator: \"David D.\" <dadu042@users.noreply.hosted.weblate.org>\n"
 "Language: fr_FR\n"
@@ -220,10 +220,6 @@ msgid "Burial"
 msgstr "Enterrement"
 
 msgid "Cannot find an available port to bind the web server to."
-msgstr ""
-
-#, python-brace-format
-msgid "Cannot find and import \"{plugin_id}\"."
 msgstr ""
 
 #, python-brace-format
@@ -1180,6 +1176,10 @@ msgstr ""
 msgid "Unknown locale {locale}."
 msgstr ""
 
+#, python-brace-format
+msgid "Unknown plugin \"{plugin_id}\"."
+msgstr ""
+
 msgid "Update all existing translations"
 msgstr "Mettre à jour toutes les traductions existantes"
 
@@ -1543,6 +1543,10 @@ msgstr ""
 
 #, python-brace-format
 msgid "{plugin_type_label} {plugin_label} depends on {dependency_labels}."
+msgstr ""
+
+#, python-brace-format
+msgid "{plugin_type} \"{plugin_id}\" has unmet requirements:"
 msgstr ""
 
 msgid "© Copyright the author, unless otherwise credited"

--- a/betty/assets/locale/he/betty.po
+++ b/betty/assets/locale/he/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-11-17 21:03+0000\n"
+"POT-Creation-Date: 2025-11-18 02:03+0000\n"
 "PO-Revision-Date: 2025-05-06 10:01+0000\n"
 "Last-Translator: Yaron Shahrabani <sh.yaron@gmail.com>\n"
 "Language: he\n"
@@ -215,10 +215,6 @@ msgid "Burial"
 msgstr ""
 
 msgid "Cannot find an available port to bind the web server to."
-msgstr ""
-
-#, python-brace-format
-msgid "Cannot find and import \"{plugin_id}\"."
 msgstr ""
 
 #, python-brace-format
@@ -1167,6 +1163,10 @@ msgstr ""
 msgid "Unknown locale {locale}."
 msgstr ""
 
+#, python-brace-format
+msgid "Unknown plugin \"{plugin_id}\"."
+msgstr ""
+
 msgid "Update all existing translations"
 msgstr ""
 
@@ -1499,6 +1499,10 @@ msgstr ""
 
 #, python-brace-format
 msgid "{plugin_type_label} {plugin_label} depends on {dependency_labels}."
+msgstr ""
+
+#, python-brace-format
+msgid "{plugin_type} \"{plugin_id}\" has unmet requirements:"
 msgstr ""
 
 msgid "© Copyright the author, unless otherwise credited"

--- a/betty/assets/locale/nl-NL/betty.po
+++ b/betty/assets/locale/nl-NL/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-11-17 21:03+0000\n"
+"POT-Creation-Date: 2025-11-18 02:03+0000\n"
 "PO-Revision-Date: 2025-11-08 23:46+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: nl_NL\n"
@@ -245,10 +245,6 @@ msgstr "Begravenis"
 
 msgid "Cannot find an available port to bind the web server to."
 msgstr "Kan geen beschikbare poort voor de webserver vinden."
-
-#, python-brace-format
-msgid "Cannot find and import \"{plugin_id}\"."
-msgstr "Kan plugin \"{plugin_id}\" niet vinden en importeren."
 
 #, python-brace-format
 msgid ""
@@ -1246,6 +1242,10 @@ msgstr "Onbekende sleutel: {unknown_key}."
 msgid "Unknown locale {locale}."
 msgstr ""
 
+#, python-brace-format
+msgid "Unknown plugin \"{plugin_id}\"."
+msgstr ""
+
 msgid "Update all existing translations"
 msgstr "Update alle bestaande vertalingen"
 
@@ -1591,6 +1591,10 @@ msgstr ""
 
 #, python-brace-format
 msgid "{plugin_type_label} {plugin_label} depends on {dependency_labels}."
+msgstr ""
+
+#, python-brace-format
+msgid "{plugin_type} \"{plugin_id}\" has unmet requirements:"
 msgstr ""
 
 msgid "© Copyright the author, unless otherwise credited"

--- a/betty/assets/locale/pt-BR/betty.po
+++ b/betty/assets/locale/pt-BR/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-11-17 21:03+0000\n"
+"POT-Creation-Date: 2025-11-18 02:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language: pt_BR\n"
@@ -212,10 +212,6 @@ msgid "Burial"
 msgstr ""
 
 msgid "Cannot find an available port to bind the web server to."
-msgstr ""
-
-#, python-brace-format
-msgid "Cannot find and import \"{plugin_id}\"."
 msgstr ""
 
 #, python-brace-format
@@ -1164,6 +1160,10 @@ msgstr ""
 msgid "Unknown locale {locale}."
 msgstr ""
 
+#, python-brace-format
+msgid "Unknown plugin \"{plugin_id}\"."
+msgstr ""
+
 msgid "Update all existing translations"
 msgstr ""
 
@@ -1496,6 +1496,10 @@ msgstr ""
 
 #, python-brace-format
 msgid "{plugin_type_label} {plugin_label} depends on {dependency_labels}."
+msgstr ""
+
+#, python-brace-format
+msgid "{plugin_type} \"{plugin_id}\" has unmet requirements:"
 msgstr ""
 
 msgid "© Copyright the author, unless otherwise credited"

--- a/betty/assets/locale/ru-RU/betty.po
+++ b/betty/assets/locale/ru-RU/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-11-17 21:03+0000\n"
+"POT-Creation-Date: 2025-11-18 02:03+0000\n"
 "PO-Revision-Date: 2025-11-16 18:38+0000\n"
 "Last-Translator: Артур Калагов "
 "<artur.kalagov@users.noreply.hosted.weblate.org>\n"
@@ -247,10 +247,6 @@ msgstr "Погребение"
 
 msgid "Cannot find an available port to bind the web server to."
 msgstr "Не удается найти доступный порт для веб-сервера."
-
-#, python-brace-format
-msgid "Cannot find and import \"{plugin_id}\"."
-msgstr "Не удается найти и импортировать \"{plugin_id}\"."
 
 #, python-brace-format
 msgid ""
@@ -1226,6 +1222,10 @@ msgstr "Неизвестный ключ: {unknown_key}."
 msgid "Unknown locale {locale}."
 msgstr ""
 
+#, python-brace-format
+msgid "Unknown plugin \"{plugin_id}\"."
+msgstr ""
+
 msgid "Update all existing translations"
 msgstr "Обновление всех существующих переводов"
 
@@ -1583,6 +1583,10 @@ msgstr ""
 
 #, python-brace-format
 msgid "{plugin_type_label} {plugin_label} depends on {dependency_labels}."
+msgstr ""
+
+#, python-brace-format
+msgid "{plugin_type} \"{plugin_id}\" has unmet requirements:"
 msgstr ""
 
 msgid "© Copyright the author, unless otherwise credited"

--- a/betty/assets/locale/uk/betty.po
+++ b/betty/assets/locale/uk/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty 0.4\n"
 "Report-Msgid-Bugs-To: illia@maier.page\n"
-"POT-Creation-Date: 2025-11-17 21:03+0000\n"
+"POT-Creation-Date: 2025-11-18 02:03+0000\n"
 "PO-Revision-Date: 2025-05-13 17:01+0000\n"
 "Last-Translator: Максим Горпиніч <maksimgorpinic4@gmail.com>\n"
 "Language: uk\n"
@@ -242,10 +242,6 @@ msgstr "Поховання"
 
 msgid "Cannot find an available port to bind the web server to."
 msgstr "Не вдалося знайти доступний порт для прив'язки вебсерверу."
-
-#, python-brace-format
-msgid "Cannot find and import \"{plugin_id}\"."
-msgstr "Не вдалося знайти та імпортувати \"{plugin_id}\"."
 
 #, python-brace-format
 msgid ""
@@ -1245,6 +1241,10 @@ msgstr "Невідомий ключ: {unknown_key}."
 msgid "Unknown locale {locale}."
 msgstr ""
 
+#, python-brace-format
+msgid "Unknown plugin \"{plugin_id}\"."
+msgstr ""
+
 msgid "Update all existing translations"
 msgstr "Оновити всі наявні переклади"
 
@@ -1600,6 +1600,10 @@ msgstr ""
 
 #, python-brace-format
 msgid "{plugin_type_label} {plugin_label} depends on {dependency_labels}."
+msgstr ""
+
+#, python-brace-format
+msgid "{plugin_type} \"{plugin_id}\" has unmet requirements:"
 msgstr ""
 
 msgid "© Copyright the author, unless otherwise credited"

--- a/betty/console/command/commands/about.py
+++ b/betty/console/command/commands/about.py
@@ -21,9 +21,11 @@ from betty.plugin import (
     PluginRepositoryUnavailable,
     HumanFacingPluginDefinition,
 )
+from betty.plugin.requirement import get_requirement
 
 if TYPE_CHECKING:
     import argparse
+    from collections.abc import MutableSequence
 
     from betty.app import App
     from betty.project import Project
@@ -93,6 +95,7 @@ class About(AppDependentFactory, Command):
         user.console.print(about_project)
 
     async def _about_plugins(self, user: ConsoleUser, project: Project | None) -> None:
+        service_level = self._app if project is None else project
         about_plugins = Table(title=user.localizer._("Plugins"))
         about_plugins.add_column(user.localizer._("Type"), style=self._KEY_STYLE)
         about_plugins.add_column(user.localizer._("ID"))
@@ -103,7 +106,7 @@ class About(AppDependentFactory, Command):
         ):
             try:
                 repository = await plugin_type.type.repository(
-                    self._app if project is None else project
+                    service_level, unavailable=True
                 )
             except PluginRepositoryUnavailable:
                 about_plugins.add_row(
@@ -118,6 +121,14 @@ class About(AppDependentFactory, Command):
                 for index, plugin in enumerate(
                     sorted(repository, key=lambda plugin: plugin.id)
                 ):
+                    third_column_lines: MutableSequence[str] = []
+                    if isinstance(plugin, HumanFacingPluginDefinition):
+                        third_column_lines.append(plugin.label.localize(user.localizer))
+                    requirement = await get_requirement(plugin, service_level)
+                    if requirement and not requirement.is_met():
+                        third_column_lines.append(
+                            "[yellow]" + requirement.localize(user.localizer)
+                        )
                     first_column = (
                         plugin_type.type.label.localize(user.localizer)
                         if index == 0
@@ -126,9 +137,7 @@ class About(AppDependentFactory, Command):
                     about_plugins.add_row(
                         first_column,
                         plugin.id,
-                        plugin.label.localize(user.localizer)
-                        if isinstance(plugin, HumanFacingPluginDefinition)
-                        else None,
+                        "\n".join(third_column_lines),
                     )
         user.console.print(about_plugins)
         if project is None:

--- a/betty/console/command/commands/extension_new_translation.py
+++ b/betty/console/command/commands/extension_new_translation.py
@@ -11,12 +11,12 @@ from betty.console.command import Command, CommandFunction, CommandDefinition
 from betty.locale import translation
 from betty.locale.localizable import _
 from betty.locale.translation.project import extension as extension_translation
+from betty.project.extension import ExtensionDefinition
 
 if TYPE_CHECKING:
     import argparse
 
     from betty.app import App
-    from betty.project.extension import ExtensionDefinition
 
 
 @final
@@ -40,11 +40,12 @@ class ExtensionNewTranslation(AppDependentFactory, Command):
     @override
     async def configure(self, parser: argparse.ArgumentParser) -> CommandFunction:
         localizer = await self._app.localizer
+        extension_repository = await ExtensionDefinition.type.repository(self._app)
         parser.add_argument(
             "extension",
             type=assertion_to_argument_type(
                 lambda extension_id: translation.project.extension.assert_extension_has_assets_directory_path(
-                    self._app.extension_repository[extension_id]
+                    extension_repository[extension_id]
                 ),
                 localizer=localizer,
             ),

--- a/betty/console/command/commands/extension_update_translations.py
+++ b/betty/console/command/commands/extension_update_translations.py
@@ -13,13 +13,13 @@ from betty.locale.translation.project import extension as extension_translation
 from betty.locale.translation.project.extension import (
     assert_extension_has_assets_directory_path,
 )
+from betty.project.extension import ExtensionDefinition
 
 if TYPE_CHECKING:
     import argparse
     from pathlib import Path
 
     from betty.app import App
-    from betty.project.extension import ExtensionDefinition
 
 
 @final
@@ -43,12 +43,13 @@ class ExtensionUpdateTranslations(AppDependentFactory, Command):
     @override
     async def configure(self, parser: argparse.ArgumentParser) -> CommandFunction:
         localizer = await self._app.localizer
+        extension_repository = await ExtensionDefinition.type.repository(self._app)
 
         parser.add_argument(
             "extension",
             type=assertion_to_argument_type(
                 lambda extension_id: assert_extension_has_assets_directory_path(
-                    self._app.extension_repository[extension_id]
+                    extension_repository[extension_id]
                 ),
                 localizer=localizer,
             ),

--- a/betty/gramps/loader.py
+++ b/betty/gramps/loader.py
@@ -108,7 +108,7 @@ from betty.locale.localizable import (
 from betty.media_type import InvalidMediaType, MediaType
 from betty.model import Entity
 from betty.model.association import ToManyResolver, ToOneResolver, resolve
-from betty.plugin import PluginNotFound
+from betty.plugin import PluginUnavailable
 from betty.privacy import HasPrivacy
 from betty.typing import internal
 
@@ -772,7 +772,7 @@ class GrampsLoader:
                 file.copyright_notice = await self._factory(
                     self._copyright_notices[copyright_notice_id].cls
                 )
-            except PluginNotFound:
+            except PluginUnavailable:
                 await self._user.message_warning(
                     _(
                         'Betty is unfamiliar with Gramps file "{file_id}"\'s copyright notice ID of "{copyright_notice_id}" and ignored it.',
@@ -782,7 +782,7 @@ class GrampsLoader:
         if license_id:
             try:
                 file.license = await self._factory(self._licenses[license_id].cls)
-            except PluginNotFound:
+            except PluginUnavailable:
                 await self._user.message_warning(
                     _(
                         'Betty is unfamiliar with Gramps file "{file_id}"\'s license ID of "{license_id}" and ignored it.',

--- a/betty/locale/localizable/__init__.py
+++ b/betty/locale/localizable/__init__.py
@@ -571,7 +571,7 @@ class Paragraphs(_Join):
     Represent multiple localizables as multiple paragraphs of text.
     """
 
-    _SEPARATOR = "\n\n"
+    _SEPARATOR = "\n"
 
 
 class _List(_LocalizableSequence, Localizable):

--- a/betty/plugin/__init__.py
+++ b/betty/plugin/__init__.py
@@ -505,11 +505,11 @@ class PluginRepositoryDefinition(Generic[_PluginDefinitionT], ABC):
         """
         Get the repository for this plugin type.
         """
-        from betty.plugin.requirement import new_requirement_met_plugin_repository
+        from betty.plugin.requirement import PluginRequirementRepository
 
         repository = await self._get(service_level)
         if not unavailable:
-            repository = await new_requirement_met_plugin_repository(
+            repository = await PluginRequirementRepository.new(
                 repository, service_level
             )
         return repository

--- a/betty/plugin/__init__.py
+++ b/betty/plugin/__init__.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
         Iterable,
         Iterator,
         Mapping,
+        MutableMapping,
         Sequence,
         Set,
     )
@@ -673,6 +674,36 @@ class ExtensionPluginRepositoryDefinition(
                     self._repository(extensions[self._extension_id])
                 )
         return await self._try_fallback(service_level, unavailable=True)
+
+
+class PluginRepositoryProvider:
+    """
+    Provide plugin repositories.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        # @todo Maybe if we store data as tuples we can keep things type safe?
+        self._plugin_repositories: MutableMapping[
+            MachineName, MutableMapping[bool, PluginRepository]
+        ] = {}
+
+    async def get_plugin_repository(
+        self: PluginRepositoryProvider & ServiceLevel,
+        plugin: _PluginDefinitionT,
+        *,
+        unavailable: bool = False,
+    ) -> PluginRepository[_PluginDefinitionT]:
+        """
+        Get the plugin repository for a plugin type.
+        """
+        try:
+            return self._plugin_repositories[plugin.id][unavailable]
+        except KeyError:
+            self._plugin_repositories[plugin.id][
+                unavailable
+            ] = await plugin.type.repository(self, unavailable=unavailable)
+            return self._plugin_repositories[plugin.id][unavailable]
 
 
 class CyclicDependencyError(PluginError):

--- a/betty/plugin/__init__.py
+++ b/betty/plugin/__init__.py
@@ -31,7 +31,13 @@ from typing_extensions import TypeVar, override
 from betty.asyncio import ensure_await
 from betty.exception import HumanFacingException
 from betty.json.schema import Enum
-from betty.locale.localizable import CountableLocalizable, Paragraph, _, do_you_mean
+from betty.locale.localizable import (
+    CountableLocalizable,
+    Paragraph,
+    Paragraphs,
+    _,
+    do_you_mean,
+)
 from betty.locale.localizer import DEFAULT_LOCALIZER
 from betty.machine_name import InvalidMachineName, MachineName, validate_machine_name
 from betty.string import kebab_case_to_lower_camel_case
@@ -53,6 +59,8 @@ if TYPE_CHECKING:
     from betty.locale.localizable import Localizable
     from betty.project import Project
     from betty.project.extension import Extension, ExtensionDefinition
+    from betty.requirement import Requirement
+    from betty.service_level import ServiceLevel
 
 _PluginT = TypeVar("_PluginT")
 
@@ -379,7 +387,13 @@ def resolve_id(plugin_id: PluginIdentifier, /) -> MachineName:
     return resolve_definition(plugin_id).id
 
 
-class PluginNotFound(PluginError, HumanFacingException):
+class PluginUnavailable(PluginError, HumanFacingException):
+    """
+    Raised when a plugin is unavailable for use.
+    """
+
+
+class PluginNotFound(PluginUnavailable):
     """
     Raised when a plugin cannot be found.
     """
@@ -409,6 +423,22 @@ class PluginNotFound(PluginError, HumanFacingException):
         )
 
 
+class UnmetPluginRequirement(PluginUnavailable):
+    """
+    Raised when a plugin cannot be found.
+    """
+
+    def __init__(self, plugin: PluginDefinition, requirement: Requirement, /):
+        super().__init__(
+            Paragraphs(
+                _('{plugin_type} "{plugin_id}" has unmet requirements:').format(
+                    plugin_type=plugin.type.label, plugin_id=plugin.id
+                ),
+                requirement,
+            )
+        )
+
+
 class PluginRepository(Generic[_PluginDefinitionCoT], ABC):
     """
     Discover and manage plugins.
@@ -421,6 +451,13 @@ class PluginRepository(Generic[_PluginDefinitionCoT], ABC):
     ):
         self._plugin = plugin
         self._plugin_id_schema: Enum | None = None
+
+    @property
+    def plugin(self) -> type[_PluginDefinitionCoT]:
+        """
+        The plugin type contained by this repository.
+        """
+        return self._plugin
 
     @abstractmethod
     def get(self, plugin_id: MachineName, /) -> _PluginDefinitionCoT:
@@ -462,13 +499,26 @@ class PluginRepositoryDefinition(Generic[_PluginDefinitionT], ABC):
     A plugin repository definition.
     """
 
-    @abstractmethod
     async def __call__(
-        self, context: App | Project | None = None
+        self, service_level: ServiceLevel = None, *, unavailable: bool = False
     ) -> PluginRepository[_PluginDefinitionT]:
         """
         Get the repository for this plugin type.
         """
+        from betty.plugin.requirement import new_requirement_met_plugin_repository
+
+        repository = await self._get(service_level)
+        if not unavailable:
+            repository = await new_requirement_met_plugin_repository(
+                repository, service_level
+            )
+        return repository
+
+    @abstractmethod
+    async def _get(
+        self, service_level: ServiceLevel = None, /
+    ) -> PluginRepository[_PluginDefinitionT]:
+        pass
 
 
 @final
@@ -489,8 +539,8 @@ class GlobalPluginRepositoryDefinition(
         self._repository = repository
 
     @override
-    async def __call__(
-        self, context: App | Project | None = None
+    async def _get(
+        self, service_level: ServiceLevel = None, /
     ) -> PluginRepository[_PluginDefinitionT]:
         if isinstance(self._repository, PluginRepository):
             return self._repository
@@ -503,22 +553,22 @@ class _FallbackPluginRepositoryDefinition(
     _fallback: PluginRepositoryDefinition[_PluginDefinitionT] | None
 
     async def _try_fallback(
-        self, context: App | Project | None = None
+        self, service_level: ServiceLevel = None, *, unavailable: bool = False
     ) -> PluginRepository[_PluginDefinitionT]:
         if self._fallback:
             try:
-                return await self._fallback(context)
+                return await self._fallback(service_level, unavailable=unavailable)
             except PluginRepositoryUnavailable as error:
-                raise self._create_error(context) from error
+                raise self._create_error(service_level) from error
         raise self._create_error()
 
     def _create_error(
-        self, context: App | Project | None = None
+        self, service_level: ServiceLevel = None, *, unavailable: bool = False
     ) -> PluginRepositoryUnavailable:
         message = (
-            f"This plugin type does not provide a plugin repository for {context}"
-            if context
-            else "This plugin type does not provide a plugin repository without a context."
+            f"This plugin type does not provide a plugin repository for {service_level}"
+            if service_level
+            else "This plugin type does not provide a plugin repository without a service level."
         )
         return PluginRepositoryUnavailable(message)
 
@@ -543,17 +593,17 @@ class AppPluginRepositoryDefinition(
         self._fallback = fallback
 
     @override
-    async def __call__(
-        self, context: App | Project | None = None
+    async def _get(
+        self, service_level: ServiceLevel = None, /
     ) -> PluginRepository[_PluginDefinitionT]:
         from betty.app import App
         from betty.project import Project
 
-        if isinstance(context, Project):
-            context = context.app
-        if isinstance(context, App):
-            return await ensure_await(self._repository(context))
-        return await self._try_fallback(context)
+        if isinstance(service_level, Project):
+            service_level = service_level.app
+        if isinstance(service_level, App):
+            return await ensure_await(self._repository(service_level))
+        return await self._try_fallback(service_level, unavailable=True)
 
 
 @final
@@ -578,14 +628,14 @@ class ProjectPluginRepositoryDefinition(
         self._fallback = fallback
 
     @override
-    async def __call__(
-        self, context: App | Project | None = None
+    async def _get(
+        self, service_level: ServiceLevel = None, /
     ) -> PluginRepository[_PluginDefinitionT]:
         from betty.project import Project
 
-        if isinstance(context, Project):
-            return await ensure_await(self._repository(context))
-        return await self._try_fallback(context)
+        if isinstance(service_level, Project):
+            return await ensure_await(self._repository(service_level))
+        return await self._try_fallback(service_level, unavailable=True)
 
 
 @final
@@ -611,18 +661,18 @@ class ExtensionPluginRepositoryDefinition(
         self._fallback = fallback
 
     @override
-    async def __call__(
-        self, context: App | Project | None = None
+    async def _get(
+        self, service_level: ServiceLevel = None, /
     ) -> PluginRepository[_PluginDefinitionT]:
         from betty.project import Project
 
-        if isinstance(context, Project):
-            extensions = await context.extensions
+        if isinstance(service_level, Project):
+            extensions = await service_level.extensions
             if self._extension_id in extensions:
                 return await ensure_await(
                     self._repository(extensions[self._extension_id])
                 )
-        return await self._try_fallback(context)
+        return await self._try_fallback(service_level, unavailable=True)
 
 
 class CyclicDependencyError(PluginError):

--- a/betty/plugin/assertion.py
+++ b/betty/plugin/assertion.py
@@ -32,9 +32,7 @@ def assert_plugin(
         except PluginNotFound:
             raise HumanFacingException(
                 Paragraph(
-                    _(
-                        'Cannot find and import "{plugin_id}".',
-                    ).format(plugin_id=plugin_id),
+                    _('Unknown plugin "{plugin_id}".').format(plugin_id=plugin_id),
                     do_you_mean(*(f'"{plugin.id}"' for plugin in plugins)),
                 )
             ) from None

--- a/betty/plugin/requirement.py
+++ b/betty/plugin/requirement.py
@@ -4,7 +4,9 @@ Requirements for plugins.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Self, TypeVar
+
+from typing_extensions import override
 
 from betty.locale.localizable import AnyEnumeration, _
 from betty.plugin import (
@@ -13,16 +15,18 @@ from betty.plugin import (
     DependentPluginDefinition,
     HumanFacingPluginDefinition,
     PluginDefinition,
+    PluginNotFound,
     PluginRepository,
+    UnmetPluginRequirement,
     resolve_id,
 )
-from betty.plugin.static import StaticPluginRepository
 from betty.requirement import AllRequirements, HasRequirement
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Iterator, Mapping
 
     from betty.app import App
+    from betty.machine_name import MachineName
     from betty.requirement import Requirement
     from betty.service_level import ServiceLevel
 
@@ -92,18 +96,52 @@ async def get_requirement(
     return None
 
 
-async def new_requirement_met_plugin_repository(
-    upstream: PluginRepository[_PluginDefinitionT], service_level: ServiceLevel, /
-) -> PluginRepository[_PluginDefinitionT]:
+class PluginRequirementRepository(
+    PluginRepository[_PluginDefinitionT], Generic[_PluginDefinitionT]
+):
     """
-    Create a new plugin repository with only those plugins from the given repository whose requirements are met.
+    A plugin repository that checks plugins' requirements.
     """
-    return StaticPluginRepository(
-        upstream.plugin,
-        *[
-            plugin
-            for plugin in upstream
-            if (requirement := await get_requirement(plugin, service_level))
-            and (requirement is None or requirement.is_met())  # type: ignore[redundant-expr]
-        ],
-    )
+
+    def __init__(
+        self,
+        plugin: type[_PluginDefinitionT],
+        plugins: Mapping[MachineName, tuple[_PluginDefinitionT, Requirement | None]],
+        /,
+    ):
+        super().__init__(plugin)
+        self._plugins = plugins
+
+    @classmethod
+    async def new(
+        cls,
+        upstream: PluginRepository[_PluginDefinitionT],
+        service_level: ServiceLevel,
+        /,
+    ) -> Self:
+        """
+        Create a new instance.
+        """
+        return cls(
+            upstream.plugin,
+            {
+                plugin.id: (plugin, await get_requirement(plugin, service_level))
+                for plugin in upstream
+            },
+        )
+
+    @override
+    def get(self, plugin_id: MachineName) -> _PluginDefinitionT:
+        try:
+            plugin, requirement = self._plugins[plugin_id]
+            if requirement and not requirement.is_met():
+                raise UnmetPluginRequirement(plugin, requirement)
+            return plugin
+        except KeyError:
+            raise PluginNotFound.new(plugin_id, list(self)) from None
+
+    @override
+    def __iter__(self) -> Iterator[_PluginDefinitionT]:
+        for plugin, requirement in self._plugins.values():
+            if requirement and requirement.is_met():
+                yield plugin

--- a/betty/plugin/requirement.py
+++ b/betty/plugin/requirement.py
@@ -12,16 +12,21 @@ from betty.plugin import (
     CyclicDependencyError,
     DependentPluginDefinition,
     HumanFacingPluginDefinition,
+    PluginDefinition,
+    PluginRepository,
     resolve_id,
 )
-from betty.requirement import AllRequirements
+from betty.plugin.static import StaticPluginRepository
+from betty.requirement import AllRequirements, HasRequirement
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from betty.app import App
     from betty.requirement import Requirement
+    from betty.service_level import ServiceLevel
 
+_PluginDefinitionT = TypeVar("_PluginDefinitionT", bound=PluginDefinition)
 _ClassedPluginDefinitionT = TypeVar(
     "_ClassedPluginDefinitionT", bound=ClassedPluginDefinition[Any]
 )
@@ -44,7 +49,7 @@ async def new_dependencies_requirement(
         dependencies = []
         for dependency_identifier in dependent.depends_on:
             dependency = plugins_by_id[resolve_id(dependency_identifier)]
-            dependency_requirement = await dependency.cls.requirement(app=app)
+            dependency_requirement = await dependency.cls.requirement(app)
             if dependency_requirement is not None:
                 dependency_requirements.append(dependency_requirement)
             dependencies.append(dependency)
@@ -72,3 +77,33 @@ async def new_dependencies_requirement(
                 ),
             ),
         )
+
+
+async def get_requirement(
+    plugin: PluginDefinition, service_level: ServiceLevel
+) -> Requirement | None:
+    """
+    Get the requirement for the given plugin.
+    """
+    if isinstance(plugin, ClassedPluginDefinition) and issubclass(
+        plugin.cls, HasRequirement
+    ):
+        return await plugin.cls.requirement(service_level)
+    return None
+
+
+async def new_requirement_met_plugin_repository(
+    upstream: PluginRepository[_PluginDefinitionT], service_level: ServiceLevel, /
+) -> PluginRepository[_PluginDefinitionT]:
+    """
+    Create a new plugin repository with only those plugins from the given repository whose requirements are met.
+    """
+    return StaticPluginRepository(
+        upstream.plugin,
+        *[
+            plugin
+            for plugin in upstream
+            if (requirement := await get_requirement(plugin, service_level))
+            and (requirement is None or requirement.is_met())  # type: ignore[redundant-expr]
+        ],
+    )

--- a/betty/plugin/static.py
+++ b/betty/plugin/static.py
@@ -8,7 +8,11 @@ from typing import Generic, TypeVar
 from typing_extensions import override
 
 from betty.machine_name import MachineName
-from betty.plugin import PluginDefinition, PluginNotFound, PluginRepository
+from betty.plugin import (
+    PluginDefinition,
+    PluginNotFound,
+    PluginRepository,
+)
 
 _PluginDefinitionT = TypeVar("_PluginDefinitionT", bound=PluginDefinition)
 

--- a/betty/project/__init__.py
+++ b/betty/project/__init__.py
@@ -254,18 +254,19 @@ class Project(Configurable[ProjectConfiguration], TargetFactory, ServiceProvider
         """
         The enabled extensions.
         """
+        extension_repository = await ExtensionDefinition.type.repository(self._app)
         configured_extension_definitions = []
         configured_extension_configurations = {}
         for extension_configuration in self.configuration.extensions.values():
             configured_extension_definitions.append(
-                self.app.extension_repository[extension_configuration.id]
+                extension_repository[extension_configuration.id]
             )
             configured_extension_configurations[extension_configuration.id] = (
                 extension_configuration
             )
 
         extensions_sorter = await sort_dependent_plugin_graph(
-            self.app.extension_repository, configured_extension_definitions
+            extension_repository, configured_extension_definitions
         )
         extensions_sorter.prepare()
 
@@ -275,7 +276,7 @@ class Project(Configurable[ProjectConfiguration], TargetFactory, ServiceProvider
             enabled_extension_ids_batch = extensions_sorter.get_ready()
             enabled_extension_batch: MutableSequence[Extension] = []
             for enabled_extension_id in enabled_extension_ids_batch:
-                enabled_extension_definition = self.app.extension_repository[
+                enabled_extension_definition = extension_repository[
                     enabled_extension_id
                 ]
                 enabled_extension_requirement = (
@@ -288,9 +289,7 @@ class Project(Configurable[ProjectConfiguration], TargetFactory, ServiceProvider
                 if enabled_extension_id in configured_extension_configurations:
                     extension = await configured_extension_configurations[
                         enabled_extension_id
-                    ].new_plugin_instance(
-                        self.app.extension_repository, factory=self.new_target
-                    )
+                    ].new_plugin_instance(extension_repository, factory=self.new_target)
                 else:
                     extension = await self.new_target(enabled_extension_definition.cls)
                 enabled_extension_batch.append(extension)

--- a/betty/project/__init__.py
+++ b/betty/project/__init__.py
@@ -279,7 +279,7 @@ class Project(Configurable[ProjectConfiguration], TargetFactory, ServiceProvider
                     enabled_extension_id
                 ]
                 enabled_extension_requirement = (
-                    await enabled_extension_definition.cls.requirement(app=self.app)
+                    await enabled_extension_definition.cls.requirement(self.app)
                 )
                 if enabled_extension_requirement is not None:
                     enabled_extension_requirement.assert_met()

--- a/betty/project/__init__.py
+++ b/betty/project/__init__.py
@@ -41,7 +41,11 @@ from betty.locale.translation import (
     TranslationRepository,
 )
 from betty.model import Entity, ToManySchema
-from betty.plugin import resolve_id, sort_dependent_plugin_graph
+from betty.plugin import (
+    PluginRepositoryProvider,
+    resolve_id,
+    sort_dependent_plugin_graph,
+)
 from betty.plugin.entry_point import EntryPointPluginRepository
 from betty.plugin.proxy import ProxyPluginRepository
 from betty.plugin.static import StaticPluginRepository
@@ -76,7 +80,12 @@ _ProjectDependentT = TypeVar("_ProjectDependentT")
 
 
 @final
-class Project(Configurable[ProjectConfiguration], TargetFactory, ServiceProvider):
+class Project(
+    Configurable[ProjectConfiguration],
+    TargetFactory,
+    ServiceProvider,
+    PluginRepositoryProvider,
+):
     """
     Define a Betty project.
 
@@ -89,6 +98,7 @@ class Project(Configurable[ProjectConfiguration], TargetFactory, ServiceProvider
         configuration: ProjectConfiguration,
         *,
         ancestry: Ancestry,
+        PluginRepositoryProvider,
     ):
         super().__init__(configuration=configuration)
         self._app = app

--- a/betty/project/extension/__init__.py
+++ b/betty/project/extension/__init__.py
@@ -70,7 +70,10 @@ class Extension(
     @requires_app
     async def requirement(cls, app: App, /) -> Requirement | None:
         return await new_dependencies_requirement(
-            cls.plugin, app.extension_repository, app=app
+            cls.plugin,
+            # Do not access the repository through the plugin definition to avoid infinite recursion.
+            app._extension_repository,
+            app=app,
         )
 
 
@@ -92,7 +95,7 @@ class ExtensionDefinition(
     type = PluginTypeDefinition(
         id="extension",
         label=_("Extension"),
-        repository=AppPluginRepositoryDefinition(lambda app: app.extension_repository),
+        repository=AppPluginRepositoryDefinition(lambda app: app._extension_repository),
     )
 
     def __init__(

--- a/betty/project/extension/__init__.py
+++ b/betty/project/extension/__init__.py
@@ -20,7 +20,7 @@ from betty.plugin import (
 )
 from betty.plugin.requirement import new_dependencies_requirement
 from betty.project.factory import ProjectDependentFactory
-from betty.requirement import HasRequirement
+from betty.requirement import HasRequirement, requires_app
 from betty.service import ServiceProvider
 
 if TYPE_CHECKING:
@@ -67,7 +67,8 @@ class Extension(
 
     @override
     @classmethod
-    async def requirement(cls, *, app: App) -> Requirement | None:
+    @requires_app
+    async def requirement(cls, app: App, /) -> Requirement | None:
         return await new_dependencies_requirement(
             cls.plugin, app.extension_repository, app=app
         )

--- a/betty/project/extension/gramps/jobs.py
+++ b/betty/project/extension/gramps/jobs.py
@@ -8,8 +8,14 @@ from typing import TYPE_CHECKING, TypeVar
 
 from typing_extensions import override
 
+from betty.ancestry.event_type import EventTypeDefinition
+from betty.ancestry.gender import GenderDefinition
+from betty.ancestry.place_type import PlaceTypeDefinition
+from betty.ancestry.presence_role import PresenceRoleDefinition
+from betty.copyright_notice import CopyrightNoticeDefinition
 from betty.gramps.loader import GrampsLoader
 from betty.job import Job
+from betty.license import LicenseDefinition
 from betty.project import ProjectContext
 
 if TYPE_CHECKING:
@@ -60,21 +66,23 @@ class LoadAncestry(Job[ProjectContext]):
                 factory=project.new_target,
                 attribute_prefix_key=project.configuration.name,
                 user=project.app.user,
-                copyright_notices=project.copyright_notice_repository,
-                licenses=await project.license_repository,
+                copyright_notices=await CopyrightNoticeDefinition.type.repository(
+                    project
+                ),
+                licenses=await LicenseDefinition.type.repository(project),
                 event_type_mapping={
                     gramps_type: _new_plugin_instance_factory(
                         family_tree_configuration.event_types[gramps_type],
-                        project.event_type_repository,
+                        await EventTypeDefinition.type.repository(project),
                         factory=project.new_target,
                     )
                     for gramps_type in family_tree_configuration.event_types
                 },
-                genders=project.gender_repository,
+                genders=await GenderDefinition.type.repository(project),
                 place_type_mapping={
                     gramps_type: _new_plugin_instance_factory(
                         family_tree_configuration.place_types[gramps_type],
-                        project.place_type_repository,
+                        await PlaceTypeDefinition.type.repository(project),
                         factory=project.new_target,
                     )
                     for gramps_type in family_tree_configuration.place_types
@@ -82,7 +90,7 @@ class LoadAncestry(Job[ProjectContext]):
                 presence_role_mapping={
                     gramps_type: _new_plugin_instance_factory(
                         family_tree_configuration.presence_roles[gramps_type],
-                        project.presence_role_repository,
+                        await PresenceRoleDefinition.type.repository(project),
                         factory=project.new_target,
                     )
                     for gramps_type in family_tree_configuration.presence_roles

--- a/betty/project/extension/webpack/__init__.py
+++ b/betty/project/extension/webpack/__init__.py
@@ -24,7 +24,12 @@ from betty.project.extension.webpack import build
 from betty.project.extension.webpack.build import EntryPointProvider
 from betty.project.extension.webpack.jinja2.filter import FILTERS
 from betty.project.generate import Generator
-from betty.requirement import AllRequirements, Requirement, RequirementError
+from betty.requirement import (
+    AllRequirements,
+    Requirement,
+    RequirementError,
+    requires_app,
+)
 from betty.resource import ContextProvider, ContextVars
 from betty.typing import internal
 
@@ -76,10 +81,11 @@ class Webpack(
 
     @override
     @classmethod
-    async def requirement(cls, *, app: App) -> Requirement:
+    @requires_app
+    async def requirement(cls, app: App, /) -> Requirement | None:
         if cls._requirement is None:
             cls._requirement = AllRequirements(
-                await super().requirement(app=app),
+                await super().requirement(app),
                 await NpmRequirement.new(user=app.user),
             )
         return cls._requirement
@@ -161,6 +167,6 @@ class Webpack(
             # (Re)build the assets if `npm` is available.
             return await builder.build()
         except NpmUnavailable:
-            raise RequirementError(
-                await self.requirement(app=self._project.app)
-            ) from None
+            requirement = await self.requirement(self._project)
+            assert requirement
+            raise RequirementError(requirement) from None

--- a/betty/project/new.py
+++ b/betty/project/new.py
@@ -59,7 +59,7 @@ async def new(app: App) -> None:
         Wiki,
     )
     AllRequirements(
-        *[await extension.plugin.cls.requirement(app=app) for extension in extensions]
+        *[await extension.plugin.cls.requirement(app) for extension in extensions]
     ).assert_met()
 
     configuration_file_path = await app.user.ask_input(
@@ -129,7 +129,7 @@ async def new(app: App) -> None:
     )
 
     if await app.user.ask_confirmation(_("Do you want to load a Gramps family tree?")):
-        gramps_requirement = await Gramps.requirement(app=app)
+        gramps_requirement = await Gramps.requirement(app)
         if gramps_requirement is not None:
             gramps_requirement.assert_met()
         configuration.extensions.append(

--- a/betty/requirement.py
+++ b/betty/requirement.py
@@ -5,19 +5,25 @@ Provide an API that lets code express arbitrary requirements.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, cast, final
+from typing import TYPE_CHECKING, Any, TypeVar, cast, final
 
 from typing_extensions import override
 
 from betty.exception import HumanFacingException
-from betty.locale.localizable import Localizable, Paragraphs, UnorderedList, _
+from betty.locale.localizable import Localizable, Paragraphs, Plain, UnorderedList, _
 from betty.locale.localized import Localized, LocalizedStr
 
 if TYPE_CHECKING:
-    from collections.abc import MutableSequence, Sequence
+    from collections.abc import (
+        Callable,
+        Coroutine,
+        MutableSequence,
+        Sequence,
+    )
 
     from betty.app import App
     from betty.locale.localizer import Localizer
+    from betty.service_level import ServiceLevel
 
 
 class Requirement(Localizable):
@@ -208,10 +214,34 @@ class HasRequirement(ABC):
 
     @classmethod
     @abstractmethod
-    async def requirement(cls, *, app: App) -> Requirement | None:
+    async def requirement(cls, service_level: ServiceLevel, /) -> Requirement | None:
         """
-        Define the requirement for this extension to be enabled.
-
-        This defaults to the extension's dependencies.
+        Define the requirement for this class to be used.
         """
         return None
+
+
+_HasRequirementT = TypeVar("_HasRequirementT", bound=HasRequirement)
+
+
+def requires_app(
+    f: Callable[[type[_HasRequirementT], App], Coroutine[Any, Any, Requirement | None]],
+) -> Callable[
+    [type[_HasRequirementT], ServiceLevel], Coroutine[Any, Any, Requirement | None]
+]:
+    """
+    Decorate a :py:meth:`betty.requirement.HasRequirement.requirement` implementation to require an :py:class:`betty.app.App`.
+    """
+
+    async def _requires_app(
+        cls: type[_HasRequirementT], service_level: ServiceLevel
+    ) -> Requirement | None:
+        from betty.app import App
+
+        if service_level is None:
+            return StaticRequirement(False, Plain("An App is required."))
+        return await f(
+            cls, service_level if isinstance(service_level, App) else service_level.app
+        )
+
+    return _requires_app

--- a/betty/requirement.py
+++ b/betty/requirement.py
@@ -10,7 +10,13 @@ from typing import TYPE_CHECKING, Any, TypeVar, cast, final
 from typing_extensions import override
 
 from betty.exception import HumanFacingException
-from betty.locale.localizable import Localizable, Paragraphs, Plain, UnorderedList, _
+from betty.locale.localizable import (
+    Lines,
+    Localizable,
+    Plain,
+    UnorderedList,
+    _,
+)
 from betty.locale.localized import Localized, LocalizedStr
 
 if TYPE_CHECKING:
@@ -115,7 +121,7 @@ class RequirementCollection(Requirement):
 
     @override
     def localize(self, localizer: Localizer) -> Localized & str:
-        return Paragraphs(
+        return Lines(
             super().localize(localizer),
             UnorderedList(*self._requirements),
         ).localize(localizer)

--- a/betty/service_level.py
+++ b/betty/service_level.py
@@ -1,0 +1,22 @@
+"""
+The Betty service levels.
+
+A runtime Betty application consists of three types of service providers:
+
+- :py:class:`betty.app.App`
+- :py:class:`betty.project.Project`
+- :py:class:`betty.project.extension.Extension`
+
+Extensions always exist in the context of a project, so they are the same level. Additionally, Betty may not be running,
+leaving us with three levels: none, app, and project.
+"""
+
+from typing import TypeAlias
+
+from betty.app import App
+from betty.project import Project
+
+ServiceLevel: TypeAlias = None | App | Project
+"""
+A service level.
+"""

--- a/betty/tests/coverage/test_coverage.py
+++ b/betty/tests/coverage/test_coverage.py
@@ -375,6 +375,7 @@ _BASELINE: Mapping[str, _ModuleIgnore] = {
         },
         "PluginRepositoryDefinition": MissingReason.ABSTRACT,
         "PluginRepositoryUnavailable": MissingReason.STATIC_CONTENT_ONLY,
+        "PluginUnavailable": MissingReason.STATIC_CONTENT_ONLY,
     },
     "betty/plugin/assertion.py": {
         "assert_plugin": MissingReason.SHOULD_BE_COVERED,

--- a/betty/tests/plugin/test___init__.py
+++ b/betty/tests/plugin/test___init__.py
@@ -146,6 +146,10 @@ class TestPluginRepository:
         def __iter__(self) -> Iterator[DummyPluginDefinition]:
             yield from self._plugins.values()
 
+    def test_plugin(self) -> None:
+        sut = self._Sut()
+        assert sut.plugin is DummyPluginDefinition
+
     def test___len__(self) -> None:
         sut = self._Sut(DUMMY_PLUGIN_ONE, DUMMY_PLUGIN_TWO, DUMMY_PLUGIN_THREE)
         assert len(sut) == 3
@@ -700,14 +704,14 @@ class TestGlobalPluginRepositoryDefinition:
     ) -> None:
         expected, definition = sut_params
         sut = GlobalPluginRepositoryDefinition(definition)
-        assert await sut() is expected
+        assert await sut(unavailable=True) is expected
 
     async def test___call____with_app(
         self, sut_params: GlobalPluginRepositoryDefinitionTestParams, temporary_app: App
     ) -> None:
         expected, definition = sut_params
         sut = GlobalPluginRepositoryDefinition(definition)
-        assert await sut(temporary_app) is expected
+        assert await sut(temporary_app, unavailable=True) is expected
 
     async def test___call____with_project(
         self, sut_params: GlobalPluginRepositoryDefinitionTestParams, temporary_app: App
@@ -715,7 +719,7 @@ class TestGlobalPluginRepositoryDefinition:
         expected, definition = sut_params
         async with Project.new_temporary(temporary_app) as project, project:
             sut = GlobalPluginRepositoryDefinition(definition)
-            assert await sut(project) is expected
+            assert await sut(project, unavailable=True) is expected
 
 
 AppPluginRepositoryDefinitionTestParams: TypeAlias = tuple[
@@ -750,7 +754,7 @@ class TestAppPluginRepositoryDefinition:
         expected, definition = sut_params
         sut = AppPluginRepositoryDefinition(definition)
         with pytest.raises(PluginRepositoryUnavailable):
-            await sut()
+            await sut(unavailable=True)
 
     async def test___call___global_with_fallback(
         self, sut_params: AppPluginRepositoryDefinitionTestParams
@@ -759,14 +763,14 @@ class TestAppPluginRepositoryDefinition:
         sut = AppPluginRepositoryDefinition(
             definition, GlobalPluginRepositoryDefinition(expected)
         )
-        assert await sut() is expected
+        assert await sut(unavailable=True) is expected
 
     async def test___call____with_app(
         self, sut_params: AppPluginRepositoryDefinitionTestParams, temporary_app: App
     ) -> None:
         expected, definition = sut_params
         sut = AppPluginRepositoryDefinition(definition)
-        assert await sut(temporary_app) is expected
+        assert await sut(temporary_app, unavailable=True) is expected
 
     async def test___call____with_project(
         self, sut_params: AppPluginRepositoryDefinitionTestParams, temporary_app: App
@@ -774,7 +778,7 @@ class TestAppPluginRepositoryDefinition:
         expected, definition = sut_params
         async with Project.new_temporary(temporary_app) as project, project:
             sut = AppPluginRepositoryDefinition(definition)
-            assert await sut(project) is expected
+            assert await sut(project, unavailable=True) is expected
 
 
 ProjectPluginRepositoryDefinitionTestParams: TypeAlias = tuple[
@@ -809,7 +813,7 @@ class TestProjectPluginRepositoryDefinition:
         expected, definition = sut_params
         sut = ProjectPluginRepositoryDefinition(definition)
         with pytest.raises(PluginRepositoryUnavailable):
-            await sut()
+            await sut(unavailable=True)
 
     async def test___call___global_with_fallback(
         self, sut_params: ProjectPluginRepositoryDefinitionTestParams
@@ -818,7 +822,7 @@ class TestProjectPluginRepositoryDefinition:
         sut = ProjectPluginRepositoryDefinition(
             definition, GlobalPluginRepositoryDefinition(expected)
         )
-        assert await sut() is expected
+        assert await sut(unavailable=True) is expected
 
     async def test___call____with_app(
         self,
@@ -828,7 +832,7 @@ class TestProjectPluginRepositoryDefinition:
         expected, definition = sut_params
         sut = ProjectPluginRepositoryDefinition(definition)
         with pytest.raises(PluginRepositoryUnavailable):
-            await sut(temporary_app)
+            await sut(temporary_app, unavailable=True)
 
     async def test___call____with_project(
         self,
@@ -838,7 +842,7 @@ class TestProjectPluginRepositoryDefinition:
         expected, definition = sut_params
         async with Project.new_temporary(temporary_app) as project, project:
             sut = ProjectPluginRepositoryDefinition(definition)
-            assert await sut(project) is expected
+            assert await sut(project, unavailable=True) is expected
 
 
 ExtensionPluginRepositoryDefinitionTestParams: TypeAlias = tuple[
@@ -873,7 +877,7 @@ class TestExtensionPluginRepositoryDefinition:
         expected, definition = sut_params
         sut = ExtensionPluginRepositoryDefinition(DummyExtension, definition)
         with pytest.raises(PluginRepositoryUnavailable):
-            await sut()
+            await sut(unavailable=True)
 
     async def test___call___global_with_fallback(
         self, sut_params: ExtensionPluginRepositoryDefinitionTestParams
@@ -882,7 +886,7 @@ class TestExtensionPluginRepositoryDefinition:
         sut = ExtensionPluginRepositoryDefinition(
             DummyExtension, definition, GlobalPluginRepositoryDefinition(expected)
         )
-        assert await sut() is expected
+        assert await sut(unavailable=True) is expected
 
     async def test___call____with_app(
         self,
@@ -892,7 +896,7 @@ class TestExtensionPluginRepositoryDefinition:
         expected, definition = sut_params
         sut = ExtensionPluginRepositoryDefinition(DummyExtension, definition)
         with pytest.raises(PluginRepositoryUnavailable):
-            await sut(temporary_app)
+            await sut(temporary_app, unavailable=True)
 
     async def test___call____with_app_with_fallback(
         self,
@@ -903,7 +907,7 @@ class TestExtensionPluginRepositoryDefinition:
         sut = ExtensionPluginRepositoryDefinition(
             DummyExtension, definition, GlobalPluginRepositoryDefinition(expected)
         )
-        assert await sut(temporary_app) is expected
+        assert await sut(temporary_app, unavailable=True) is expected
 
     async def test___call____with_project_without_extension(
         self,
@@ -914,7 +918,7 @@ class TestExtensionPluginRepositoryDefinition:
         async with Project.new_temporary(temporary_app) as project, project:
             sut = ExtensionPluginRepositoryDefinition(DummyExtension, definition)
             with pytest.raises(PluginRepositoryUnavailable):
-                await sut(project)
+                await sut(project, unavailable=True)
 
     async def test___call____with_project_without_extension_with_fallback(
         self,
@@ -926,7 +930,7 @@ class TestExtensionPluginRepositoryDefinition:
             sut = ExtensionPluginRepositoryDefinition(
                 DummyExtension, definition, GlobalPluginRepositoryDefinition(expected)
             )
-            assert await sut(project) is expected
+            assert await sut(project, unavailable=True) is expected
 
     async def test___call____with_project_with_extension(
         self,
@@ -946,4 +950,4 @@ class TestExtensionPluginRepositoryDefinition:
             project.configuration.extensions.enable(DummyExtension)
             async with project:
                 sut = ExtensionPluginRepositoryDefinition(DummyExtension, definition)
-                assert await sut(project) is expected
+                assert await sut(project, unavailable=True) is expected

--- a/betty/tests/plugin/test_entry_point.py
+++ b/betty/tests/plugin/test_entry_point.py
@@ -3,7 +3,7 @@ from importlib.metadata import EntryPoint, EntryPoints
 import pytest
 from pytest_mock import MockerFixture
 
-from betty.plugin import PluginNotFound
+from betty.plugin import PluginUnavailable
 from betty.plugin.entry_point import EntryPointPluginRepository
 from betty.test_utils.plugin import ClassedDummyPluginDefinition, ClassedDummyPluginOne
 
@@ -42,7 +42,7 @@ class TestEntryPointPluginRepository:
         )
         # Hit the cache.
         for _ in range(2):
-            with pytest.raises(PluginNotFound):
+            with pytest.raises(PluginUnavailable):
                 sut.get(ClassedDummyPluginOne.plugin.id)
 
     def test___aiter___with_plugins(self, mocker: MockerFixture) -> None:

--- a/betty/tests/plugin/test_proxy.py
+++ b/betty/tests/plugin/test_proxy.py
@@ -1,6 +1,6 @@
 import pytest
 
-from betty.plugin import PluginNotFound
+from betty.plugin import PluginUnavailable
 from betty.plugin.proxy import ProxyPluginRepository
 from betty.plugin.static import StaticPluginRepository
 from betty.test_utils.plugin import (
@@ -21,7 +21,7 @@ class TestProxyPluginRepository:
 
     def test_get__not_found_without_upstreams(self) -> None:
         sut = ProxyPluginRepository(DummyPluginDefinition)
-        with pytest.raises(PluginNotFound):
+        with pytest.raises(PluginUnavailable):
             sut.get(DUMMY_PLUGIN_ONE.id)
 
     def test_get__not_found_with_upstreams(self) -> None:
@@ -30,7 +30,7 @@ class TestProxyPluginRepository:
             StaticPluginRepository(DummyPluginDefinition, DUMMY_PLUGIN_ONE),
             StaticPluginRepository(DummyPluginDefinition, DUMMY_PLUGIN_TWO),
         )
-        with pytest.raises(PluginNotFound):
+        with pytest.raises(PluginUnavailable):
             sut.get(DUMMY_PLUGIN_THREE.id)
 
     def test___iter____without_upstreams(self) -> None:

--- a/betty/tests/plugin/test_requirement.py
+++ b/betty/tests/plugin/test_requirement.py
@@ -10,15 +10,22 @@ from betty.plugin import (
     ClassedPluginDefinition,
     DependentPluginDefinition,
     GlobalPluginRepositoryDefinition,
+    PluginDefinition,
     PluginTypeDefinition,
 )
-from betty.plugin.requirement import new_dependencies_requirement
+from betty.plugin.requirement import get_requirement, new_dependencies_requirement
 from betty.plugin.static import StaticPluginRepository
+from betty.project import Project
 from betty.requirement import HasRequirement, Requirement, StaticRequirement
-from betty.test_utils.plugin import ClassedDummyPlugin, ClassedDummyPluginOne
+from betty.test_utils.plugin import (
+    ClassedDummyPlugin,
+    ClassedDummyPluginDefinition,
+    ClassedDummyPluginOne,
+)
 
 if TYPE_CHECKING:
     from betty.app import App
+    from betty.service_level import ServiceLevel
 
 
 class HasRequirementPlugin(HasRequirement):
@@ -67,7 +74,7 @@ class UpstreamWithUnmetRequirements(HasRequirementPlugin):
 class DownstreamWithUnmetRequirements(HasRequirementPlugin):
     @override
     @classmethod
-    async def requirement(cls, *, app: App) -> Requirement:
+    async def requirement(cls, service_level: ServiceLevel, /) -> Requirement | None:
         return StaticRequirement(
             False,
             Plain("downstream-requirement-summary"),
@@ -89,7 +96,7 @@ class UpstreamWithMetRequirements(HasRequirementPlugin):
 class DownstreamWithMetRequirements(HasRequirementPlugin):
     @override
     @classmethod
-    async def requirement(cls, *, app: App) -> Requirement:
+    async def requirement(cls, service_level: ServiceLevel, /) -> Requirement | None:
         return StaticRequirement(
             True,
             Plain("downstream-requirement-summary"),
@@ -147,3 +154,74 @@ async def test_new_dependencies_requirement__with_met_requirements(
     message = actual.localize(DEFAULT_LOCALIZER)
     assert UpstreamWithMetRequirements.plugin.id in message
     assert DownstreamWithMetRequirements.plugin.id in message
+
+
+async def test_get_requirement__minimal_with_app(temporary_app: App) -> None:
+    assert await get_requirement(PluginDefinition(id="-"), temporary_app) is None
+
+
+async def test_get_requirement__minimal_with_project(temporary_app: App) -> None:
+    async with Project.new_temporary(temporary_app) as project, project:
+        assert await get_requirement(PluginDefinition(id="-"), project) is None
+
+
+async def test_get_requirement__minimal_classed_with_app(temporary_app: App) -> None:
+    @ClassedDummyPluginDefinition(
+        id="-",
+    )
+    class _Plugin(ClassedDummyPlugin):
+        pass
+
+    assert await get_requirement(_Plugin.plugin, temporary_app) is None
+
+
+async def test_get_requirement__minimal_classed_with_project(
+    temporary_app: App,
+) -> None:
+    @ClassedDummyPluginDefinition(
+        id="-",
+    )
+    class _Plugin(ClassedDummyPlugin):
+        pass
+
+    async with Project.new_temporary(temporary_app) as project, project:
+        assert await get_requirement(_Plugin.plugin, project) is None
+
+
+async def test_get_requirement__with_has_requirement_with_app(
+    temporary_app: App,
+) -> None:
+    requirement = StaticRequirement(True, Plain(""))
+
+    @HasRequirementPluginDefinition(
+        id="-",
+    )
+    class _Plugin(HasRequirementPlugin):
+        @override
+        @classmethod
+        async def requirement(
+            cls, service_level: ServiceLevel, /
+        ) -> Requirement | None:
+            return requirement
+
+    assert await get_requirement(_Plugin.plugin, temporary_app) is requirement
+
+
+async def test_get_requirement__with_has_requirement_with_project(
+    temporary_app: App,
+) -> None:
+    requirement = StaticRequirement(True, Plain(""))
+
+    @HasRequirementPluginDefinition(
+        id="-",
+    )
+    class _Plugin(HasRequirementPlugin):
+        @override
+        @classmethod
+        async def requirement(
+            cls, service_level: ServiceLevel, /
+        ) -> Requirement | None:
+            return requirement
+
+    async with Project.new_temporary(temporary_app) as project, project:
+        assert await get_requirement(_Plugin.plugin, project) is requirement

--- a/betty/tests/plugin/test_static.py
+++ b/betty/tests/plugin/test_static.py
@@ -1,6 +1,6 @@
 import pytest
 
-from betty.plugin import PluginNotFound
+from betty.plugin import PluginUnavailable
 from betty.plugin.static import StaticPluginRepository
 from betty.test_utils.plugin import DUMMY_PLUGIN_ONE, DummyPluginDefinition
 
@@ -12,7 +12,7 @@ class TestStaticPluginRepository:
 
     def test_get_not_found(self) -> None:
         sut = StaticPluginRepository(DummyPluginDefinition)
-        with pytest.raises(PluginNotFound):
+        with pytest.raises(PluginUnavailable):
             sut.get(DUMMY_PLUGIN_ONE.id)
 
     def test___iter__(self) -> None:

--- a/betty/tests/project/test___init__.py
+++ b/betty/tests/project/test___init__.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
     from betty.app import App
+    from betty.service_level import ServiceLevel
     from betty.test_utils.conftest import TemporaryAppFactory
 
 
@@ -72,7 +73,7 @@ class _UnmetRequirement(Requirement):
 class _DummyExtensionWithUnmetRequirement(Extension):
     @override
     @classmethod
-    async def requirement(cls, *, app: App) -> Requirement:
+    async def requirement(cls, service_level: ServiceLevel, /) -> Requirement | None:
         return _UnmetRequirement()
 
 

--- a/betty/tests/project/test___init__.py
+++ b/betty/tests/project/test___init__.py
@@ -174,7 +174,9 @@ class TestProject:
         async with Project.new_temporary(temporary_app) as sut, sut:
             extensions = await sut.extensions
 
-            for betty_extension in temporary_app.extension_repository:
+            for betty_extension in await ExtensionDefinition.type.repository(
+                temporary_app
+            ):
                 if betty_extension.id.startswith("betty-"):
                     assert betty_extension.id in extensions
 

--- a/betty/tests/project/test_new.py
+++ b/betty/tests/project/test_new.py
@@ -8,8 +8,9 @@ from betty.exception import HumanFacingException
 from betty.locale import DEFAULT_LOCALE
 from betty.locale.localizable import Plain
 from betty.locale.localizer import DEFAULT_LOCALIZER
-from betty.project import ExtensionDefinition, Project
+from betty.project import Project
 from betty.project.config import ProjectConfiguration
+from betty.project.extension import ExtensionDefinition
 from betty.project.extension.gramps import Gramps
 from betty.project.new import new
 from betty.requirement import StaticRequirement

--- a/betty/tests/project/test_new.py
+++ b/betty/tests/project/test_new.py
@@ -8,7 +8,7 @@ from betty.exception import HumanFacingException
 from betty.locale import DEFAULT_LOCALE
 from betty.locale.localizable import Plain
 from betty.locale.localizer import DEFAULT_LOCALIZER
-from betty.project import Project
+from betty.project import ExtensionDefinition, Project
 from betty.project.config import ProjectConfiguration
 from betty.project.extension.gramps import Gramps
 from betty.project.new import new
@@ -225,7 +225,8 @@ async def test_new__with_gramps(
         assert Gramps.plugin in configuration.extensions
         async with Project.new_temporary(app) as project, project:
             gramps = await configuration.extensions[Gramps.plugin].new_plugin_instance(
-                project.app.extension_repository, factory=project.new_target
+                await ExtensionDefinition.type.repository(project.app),
+                factory=project.new_target,
             )
             assert isinstance(gramps, Gramps)
             assert (


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/3086

## To do
- Refactor all plugin repository services to be marked `@internal` or just make them all private to be really, really clear.
- Make `PluginRepositoryProvider` internal
- Refactor all code calling to plugin repository services to use plugin type definitions instead
- Refactor the original extension requirement handling to leverage this new solution