### PR TITLE
Add factories back to plugin repositories

### DIFF
--- a/betty/plugin/config/__init__.py
+++ b/betty/plugin/config/__init__.py
@@ -17,13 +17,10 @@ from betty.assertion import (
     assert_or,
     assert_record,
 )
-from betty.config import Configurable, Configuration
+from betty.config import Configuration
 from betty.config.collections import ConfigurationKey
 from betty.config.collections.mapping import ConfigurationMapping
 from betty.config.collections.sequence import ConfigurationSequence
-from betty.config.factory import ConfigurationDependentSelfFactory
-from betty.exception import HumanFacingException
-from betty.importlib import fully_qualified_name
 from betty.locale.localizable.assertion import (
     assert_load_countable_localizable,
     assert_load_localizable,
@@ -38,7 +35,6 @@ from betty.locale.localizable.ensure import (
     ensure_countable_localizable,
     ensure_localizable,
 )
-from betty.locale.localizable.gettext import _
 from betty.machine_name import MachineName, assert_machine_name
 from betty.plugin import Plugin, PluginDefinition
 from betty.plugin.resolve import ResolvableId, resolve_id
@@ -50,7 +46,6 @@ if TYPE_CHECKING:
     from betty.locale.localizable import CountableLocalizableLike, LocalizableLike
     from betty.plugin.repository import PluginRepository
     from betty.serde.dump import Dump, DumpMapping
-    from betty.service.level.factory import AnyFactory
 
 _PluginT = TypeVar("_PluginT", bound=Plugin)
 _ConfigurationT = TypeVar("_ConfigurationT", bound=Configuration)
@@ -283,39 +278,13 @@ class PluginInstanceConfiguration(Generic[_PluginDefinitionT, _PluginT], Configu
             else self._configuration
         )
 
-    async def new_plugin_instance(
-        self,
-        repository: PluginRepository[_PluginDefinitionT],
-        *,
-        factory: AnyFactory,
+    async def new_target(
+        self, repository: PluginRepository[_PluginDefinitionT, _PluginT], /
     ) -> _PluginT:
         """
         Create a new plugin instance.
         """
-        plugin_definition = repository[self._id]
-        if not isinstance(self._configuration, Void):
-            if not issubclass(plugin_definition.cls, Configurable):
-                raise HumanFacingException(
-                    _(
-                        'Plugin "{plugin_id}" is not configurable, but configuration was given.'
-                    ).format(plugin_id=plugin_definition.id)
-                )
-            if not issubclass(plugin_definition.cls, ConfigurationDependentSelfFactory):
-                raise HumanFacingException(
-                    f"Cannot instantiate {fully_qualified_name(plugin_definition.cls)} with configuration because it does not subclass {fully_qualified_name(ConfigurationDependentSelfFactory)}."
-                )
-            if isinstance(self._configuration, Configuration):
-                configuration = self._configuration
-            else:
-                configuration = plugin_definition.cls.configuration_cls().load(
-                    self._configuration
-                )
-            return await factory(
-                plugin_definition.cls.new_for_configuration(configuration)  # type: ignore[arg-type]
-            )
-        return await factory(
-            plugin_definition.cls,  # type: ignore[arg-type]
-        )
+        return await repository.new_target(self.id, self.configuration)
 
     @override
     @classmethod

--- a/betty/plugin/repository/__init__.py
+++ b/betty/plugin/repository/__init__.py
@@ -9,16 +9,23 @@ from typing import TYPE_CHECKING, Generic
 
 from typing_extensions import TypeVar
 
+from betty.config import Configurable, Configuration
+from betty.config.factory import ConfigurationDependentSelfFactory
+from betty.exception import HumanFacingException
+from betty.importlib import fully_qualified_name
 from betty.json.schema import Enum
+from betty.locale.localizable.gettext import _
 from betty.locale.localizer import DEFAULT_LOCALIZER
 from betty.plugin import Plugin, PluginDefinition
 from betty.string import kebab_case_to_lower_camel_case
+from betty.typing import Void, Voidable
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-    from betty.machine_name import MachineName
     from betty.plugin.resolve import ResolvableId
+    from betty.serde.dump import Dump
+    from betty.service.level.factory import AnyFactory
 
 _PluginT = TypeVar("_PluginT", bound=Plugin, default=Plugin)
 _PluginDefinitionT = TypeVar(
@@ -31,8 +38,9 @@ class PluginRepository(ABC, Generic[_PluginDefinitionT, _PluginT]):
     Access discovered plugins.
     """
 
-    def __init__(self, plugin_type: type[_PluginDefinitionT]):
+    def __init__(self, plugin_type: type[_PluginDefinitionT], *, factory: AnyFactory):
         self._type = plugin_type
+        self._factory = factory
         self._plugin_id_schema: Enum | None = None
 
     @property
@@ -59,7 +67,9 @@ class PluginRepository(ABC, Generic[_PluginDefinitionT, _PluginT]):
     def __iter__(self) -> Iterator[_PluginDefinitionT]:
         pass
 
-    def __getitem__(self, plugin_id: MachineName) -> _PluginDefinitionT:
+    def __getitem__(
+        self, plugin_id: ResolvableId[_PluginDefinitionT, _PluginT]
+    ) -> _PluginDefinitionT:
         return self.get(plugin_id)
 
     @property
@@ -76,3 +86,38 @@ class PluginRepository(ABC, Generic[_PluginDefinitionT, _PluginT]):
                 description=f"A {label} plugin ID",
             )
         return self._plugin_id_schema
+
+    async def new_target(
+        self,
+        target: ResolvableId[_PluginDefinitionT, _PluginT],
+        configuration: Voidable[Configuration | Dump] = Void(),  # noqa B008
+    ) -> _PluginT:
+        """
+        Create a new plugin instance.
+
+        :raises FactoryError: raised when ``target`` could not be called.
+        """
+        plugin_definition = self[target]
+        if not isinstance(configuration, Void):
+            if not issubclass(plugin_definition.cls, Configurable):
+                raise HumanFacingException(
+                    _(
+                        'Plugin "{plugin_id}" is not configurable, but configuration was given.'
+                    ).format(plugin_id=plugin_definition.id)
+                )
+            if not issubclass(plugin_definition.cls, ConfigurationDependentSelfFactory):
+                raise HumanFacingException(
+                    f"Cannot instantiate {fully_qualified_name(plugin_definition.cls)} with configuration because it does not subclass {fully_qualified_name(ConfigurationDependentSelfFactory)}."
+                )
+            if isinstance(configuration, Configuration):
+                configuration = configuration
+            else:
+                configuration = plugin_definition.cls.configuration_cls().load(
+                    configuration
+                )
+            return await self._factory(
+                plugin_definition.cls.new_for_configuration(configuration)  # type: ignore[arg-type]
+            )
+        return await self._factory(
+            plugin_definition.cls,  # type: ignore[arg-type]
+        )

--- a/betty/plugin/repository/static.py
+++ b/betty/plugin/repository/static.py
@@ -11,6 +11,7 @@ from betty.plugin import Plugin, PluginDefinition
 from betty.plugin.error import PluginNotFound
 from betty.plugin.repository import PluginRepository
 from betty.plugin.resolve import ResolvableId, resolve_id
+from betty.service.level.factory import AnyFactory
 
 _PluginT = TypeVar("_PluginT", bound=Plugin, default=Plugin)
 _PluginDefinitionT = TypeVar("_PluginDefinitionT", bound=PluginDefinition)
@@ -26,8 +27,9 @@ class StaticPluginRepository(PluginRepository[_PluginDefinitionT, _PluginT]):
         self,
         plugin_type: type[_PluginDefinitionT],  # noqa A002
         *plugins: _PluginDefinitionT,
+        factory: AnyFactory,
     ):
-        super().__init__(plugin_type)
+        super().__init__(plugin_type, factory=factory)
         self._plugins = {plugin.id: plugin for plugin in plugins}
 
     @override

--- a/betty/plugin/requirement.py
+++ b/betty/plugin/requirement.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from betty.machine_name import MachineName
     from betty.requirement import Requirement
     from betty.service.level import ServiceLevel
+    from betty.service.level.factory import AnyFactory
 
 _PluginT = TypeVar("_PluginT", bound=Plugin, default=Plugin)
 _PluginDefinitionT = TypeVar(
@@ -115,9 +116,10 @@ class CheckRequirementRepository(PluginRepository[_PluginDefinitionT, _PluginT])
         plugins_and_requirements: Iterable[
             tuple[_PluginDefinitionT, Requirement | None]
         ],
-        /,
+        *,
+        factory: AnyFactory,
     ):
-        super().__init__(plugin_type)
+        super().__init__(plugin_type, factory=factory)
         self._plugins_and_requirements = {
             plugin.id: (plugin, requirement)
             for plugin, requirement in plugins_and_requirements

--- a/betty/project/__init__.py
+++ b/betty/project/__init__.py
@@ -372,7 +372,7 @@ class Project(
                 if enabled_extension_id in configured_extension_configurations:
                     extension = await configured_extension_configurations[
                         enabled_extension_id
-                    ].new_plugin_instance(extensions, factory=self.new_target)
+                    ].new_target(extensions)
                 else:
                     extension = await self.new_target(enabled_extension_definition.cls)
                 enabled_extension_batch.append(extension)
@@ -424,8 +424,8 @@ class Project(
         """
         The overall project copyright.
         """
-        return await self.configuration.copyright_notice.new_plugin_instance(
-            await self.plugins(CopyrightNoticePlugin), factory=self.new_target
+        return await self.configuration.copyright_notice.new_target(
+            await self.plugins(CopyrightNoticePlugin)
         )
 
     @service
@@ -433,8 +433,8 @@ class Project(
         """
         The overall project license.
         """
-        return await self.configuration.license.new_plugin_instance(
-            await self.plugins(LicensePlugin), factory=self.new_target
+        return await self.configuration.license.new_target(
+            await self.plugins(LicensePlugin)
         )
 
     @service

--- a/betty/project/extension/gramps/jobs.py
+++ b/betty/project/extension/gramps/jobs.py
@@ -4,6 +4,7 @@ Jobs.
 
 from __future__ import annotations
 
+from functools import partial
 from typing import TYPE_CHECKING, TypeVar
 
 from typing_extensions import override
@@ -20,27 +21,10 @@ from betty.plugin import Plugin, PluginDefinition
 from betty.project import ProjectContext
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
-
     from betty.job.scheduler import Scheduler
-    from betty.plugin.config import PluginInstanceConfiguration
-    from betty.plugin.repository import PluginRepository
-    from betty.project.factory import ProjectFactory
 
 _PluginT = TypeVar("_PluginT", bound=Plugin)
 _PluginDefinitionT = TypeVar("_PluginDefinitionT", bound=PluginDefinition)
-
-
-def _new_plugin_instance_factory(
-    configuration: PluginInstanceConfiguration[_PluginDefinitionT, _PluginT],
-    repository: PluginRepository[_PluginDefinitionT],
-    *,
-    factory: ProjectFactory,
-) -> Callable[[], Awaitable[_PluginT]]:
-    async def plugin_instance_factory() -> _PluginT:
-        return await configuration.new_plugin_instance(repository, factory=factory)
-
-    return plugin_instance_factory
 
 
 class LoadAncestry(Job[ProjectContext]):
@@ -69,27 +53,26 @@ class LoadAncestry(Job[ProjectContext]):
                 copyright_notices=await project.plugins(CopyrightNoticePlugin),
                 licenses=await project.plugins(LicensePlugin),
                 event_type_mapping={
-                    gramps_type: _new_plugin_instance_factory(
-                        family_tree_configuration.event_types[gramps_type],
+                    gramps_type: partial(
+                        family_tree_configuration.event_types[gramps_type].new_target,
                         await project.plugins(EventTypePlugin),
-                        factory=project.new_target,
                     )
                     for gramps_type in family_tree_configuration.event_types
                 },
                 genders=await project.plugins(GenderPlugin),
                 place_type_mapping={
-                    gramps_type: _new_plugin_instance_factory(
-                        family_tree_configuration.place_types[gramps_type],
+                    gramps_type: partial(
+                        family_tree_configuration.place_types[gramps_type].new_target,
                         await project.plugins(PlaceTypePlugin),
-                        factory=project.new_target,
                     )
                     for gramps_type in family_tree_configuration.place_types
                 },
                 presence_role_mapping={
-                    gramps_type: _new_plugin_instance_factory(
-                        family_tree_configuration.presence_roles[gramps_type],
+                    gramps_type: partial(
+                        family_tree_configuration.presence_roles[
+                            gramps_type
+                        ].new_target,
                         await project.plugins(PresenceRolePlugin),
-                        factory=project.new_target,
                     )
                     for gramps_type in family_tree_configuration.presence_roles
                 },

--- a/betty/tests/plugin/config/test___init__.py
+++ b/betty/tests/plugin/config/test___init__.py
@@ -5,7 +5,6 @@ import pytest
 from typing_extensions import override
 
 from betty.exception import HumanFacingException
-from betty.factory import new_target
 from betty.locale import DEFAULT_LOCALE_TAG
 from betty.locale.localizable.static import StaticTranslations
 from betty.locale.localizer import DEFAULT_LOCALIZER
@@ -19,7 +18,6 @@ from betty.plugin.config import (
     PluginInstanceConfigurationMapping,
     PluginInstanceConfigurationSequence,
 )
-from betty.plugin.repository.static import StaticPluginRepository
 from betty.plugin.resolve import ResolvableId
 from betty.serde.dump import Dump
 from betty.test_utils.config import DummyConfiguration
@@ -305,57 +303,6 @@ class TestPluginInstanceConfiguration:
             },
         }
         assert sut.dump() == expected
-
-    async def test_new_plugin_instance__with_configurable_plugin_with_configuration(
-        self,
-    ) -> None:
-        value = "Hello, world!"
-        sut = PluginInstanceConfiguration[
-            ConfigurableDummyPluginDefinition, ConfigurableDummyPlugin
-        ](ConfigurableDummyPluginOne.plugin, DummyConfiguration(value))
-        repository = StaticPluginRepository(
-            ConfigurableDummyPluginDefinition, ConfigurableDummyPluginOne.plugin
-        )
-        instance = await sut.new_plugin_instance(repository, factory=new_target)
-        assert isinstance(instance, ConfigurableDummyPluginOne)
-        assert instance.configuration.value == value
-
-    async def test_new_plugin_instance__with_configurable_plugin_without_configuration(
-        self,
-    ) -> None:
-        sut = PluginInstanceConfiguration[
-            ConfigurableDummyPluginDefinition, ConfigurableDummyPlugin
-        ](ConfigurableDummyPluginOne.plugin)
-        repository = StaticPluginRepository(
-            ConfigurableDummyPluginDefinition, ConfigurableDummyPluginOne.plugin
-        )
-        instance = await sut.new_plugin_instance(repository, factory=new_target)
-        assert isinstance(instance, ConfigurableDummyPluginOne)
-
-    async def test_new_plugin_instance__with_non_configurable_plugin_with_configuration(
-        self,
-    ) -> None:
-        value = "Hello, world!"
-        sut = PluginInstanceConfiguration[DummyPluginDefinition, DummyPlugin](
-            DummyPluginOne.plugin, DummyConfiguration(value)
-        )
-        repository = StaticPluginRepository(
-            DummyPluginDefinition, DummyPluginOne.plugin
-        )
-        with pytest.raises(HumanFacingException):
-            await sut.new_plugin_instance(repository, factory=new_target)
-
-    async def test_new_plugin_instance__with_non_configurable_plugin_without_configuration(
-        self,
-    ) -> None:
-        sut = PluginInstanceConfiguration[DummyPluginDefinition, DummyPlugin](
-            DummyPluginOne.plugin.id
-        )
-        repository = StaticPluginRepository(
-            DummyPluginDefinition, DummyPluginOne.plugin
-        )
-        instance = await sut.new_plugin_instance(repository, factory=new_target)
-        assert isinstance(instance, DummyPluginOne)
 
 
 class TestPluginInstanceConfigurationMapping(

--- a/betty/tests/plugin/repository/test___init__.py
+++ b/betty/tests/plugin/repository/test___init__.py
@@ -19,12 +19,13 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from betty.plugin.resolve import ResolvableId
+    from betty.service.level.factory import AnyFactory
 
 
 class TestPluginRepository:
     class _Sut(PluginRepository[DummyPluginDefinition, DummyPlugin]):
-        def __init__(self, *plugins: DummyPluginDefinition):
-            super().__init__(DummyPluginDefinition)
+        def __init__(self, *plugins: DummyPluginDefinition, factory: AnyFactory):
+            super().__init__(DummyPluginDefinition, factory=factory)
             self._plugins = {plugin.id: plugin for plugin in plugins}
 
         @override

--- a/betty/tests/project/test_new.py
+++ b/betty/tests/project/test_new.py
@@ -206,8 +206,8 @@ async def test_new__with_gramps(
         configuration = await _assert_new(configuration_file_path)
         assert Gramps.plugin in configuration.extensions
         async with Project.new_isolated(app) as project, project:
-            gramps = await configuration.extensions[Gramps.plugin].new_plugin_instance(
-                await project.plugins(ExtensionPlugin), factory=project.new_target
+            gramps = await configuration.extensions[Gramps.plugin].new_target(
+                await project.plugins(ExtensionPlugin)
             )
             assert isinstance(gramps, Gramps)
             assert (


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/3125

**ACTUALLY...**
We're having lots of trouble getting everything to be type-safe because Python does not support higher kinded types. That's an argument for keeping plugin classes out of plugin repos so they are only generic over definitions. Additionally, all this factory stuff mostly isn't specific to plugins: it's specific to configurable targets. Acknowledge that by moving this functionality next to existing factory functionality rather than in a more specific API such as the plugin API. Or add it to `betty.config.factory`.

## Blocked by
- https://github.com/bartfeenstra/betty/pull/3300