### PR TITLE
Make Playwright optional

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,10 @@ jobs:
             os: windows-latest
             nodejs: 24.x
             python: '3.14'
+          - name: 'Playwright'
+            os: ubuntu-latest
+            nodejs: 24.x
+            python: '3.14'
     timeout-minutes: 60
     steps:
       - name: Check out the source code

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,4 +3,4 @@ codecov:
     # The number of builds configured here MUST be identical to the number
     # of matrix options in /.github/workflows/test.yml that submit code coverage
     # reports to Codecov.io.
-    after_n_builds: 6
+    after_n_builds: 7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,7 +241,7 @@ setuptools = [
     'twine ~= 6.0',
     'wheel ~= 0.45.1',
 ]
-test = [
+test_without_gil = [
     'aioresponses ~= 0.7.8',
     'basedmypy ~= 2.6',
     'coverage ~= 7.6',
@@ -251,7 +251,6 @@ test = [
     'pytest-aioresponses ~= 0.3.0',
     'pytest-asyncio ~= 1.0',
     'pytest-mock ~= 3.14',
-    'pytest-playwright-asyncio ~= 0.7.0',
     'requests ~= 2.32',
     'ruff ~= 0.14.0',
     'types-aiofiles ~= 25.1',
@@ -265,6 +264,10 @@ test = [
     'virtualenv ~= 20.27',
     'yarl ~= 1.22',
     'betty[setuptools]',
+]
+test_playwright = [
+    'pytest-playwright-asyncio ~= 0.7.0',
+    'betty[test]',
 ]
 development = [
     'pytest-repeat ~= 0.9.4',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,7 +241,7 @@ setuptools = [
     'twine ~= 6.0',
     'wheel ~= 0.45.1',
 ]
-test_without_gil = [
+test = [
     'aioresponses ~= 0.7.8',
     'basedmypy ~= 2.6',
     'coverage ~= 7.6',


### PR DESCRIPTION
## To do
- Do not run any tests but Playwright in the new CI build. Should we separate out Playwright tests? That would also avoid some of the asyncio requirements of pytest-asyncio. We'd have to merge coverage statistics though....
- Fix https://github.com/bartfeenstra/betty/issues/4033
- Do we need `BETTY_TEST_SKIP_WEBPACK_ENTRY_POINT_PROVIDER` still?
- use macOS for these builds because no other OS supports all of the browsers we want to test against 