### PR TITLE
Add source types

### DIFF
--- a/betty/ancestry/source.py
+++ b/betty/ancestry/source.py
@@ -7,11 +7,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, final
 
 from typing_extensions import override
-from betty.ancestry.source_type.source_types import Unknown as UnknownSourceType
+
 from betty.ancestry.date import HasDate
 from betty.ancestry.has_file_references import HasFileReferences
 from betty.ancestry.has_links import HasLinks
 from betty.ancestry.has_notes import HasNotes
+from betty.ancestry.source_type.source_types import Unknown as UnknownSourceType
 from betty.json.linked_data import JsonLdObject, dump_context
 from betty.locale.localizable.attr import OptionalLocalizableAttr
 from betty.locale.localizable.gettext import _, ngettext
@@ -33,6 +34,7 @@ if TYPE_CHECKING:
     from betty.ancestry.file_reference import FileReference
     from betty.ancestry.link import Link
     from betty.ancestry.note import Note
+    from betty.ancestry.source_type import SourceType
     from betty.date import DateLike
     from betty.locale.localizable import Localizable, LocalizableLike
     from betty.project import Project

--- a/betty/ancestry/source.py
+++ b/betty/ancestry/source.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, final
 
 from typing_extensions import override
-
+from betty.ancestry.source_type.source_types import Unknown as UnknownSourceType
 from betty.ancestry.date import HasDate
 from betty.ancestry.has_file_references import HasFileReferences
 from betty.ancestry.has_links import HasLinks
@@ -118,6 +118,7 @@ class Source(HasDate, HasFileReferences, HasNotes, HasLinks, HasPrivacy, Entity)
         privacy: Privacy | None = None,
         public: bool | None = None,
         private: bool | None = None,
+        source_type: SourceType | None = None,
     ):
         super().__init__(
             id,
@@ -136,6 +137,7 @@ class Source(HasDate, HasFileReferences, HasNotes, HasLinks, HasPrivacy, Entity)
             self.contained_by = contained_by
         if contains is not None:
             self.contains = contains
+        self._source_type = source_type or UnknownSourceType()
 
     @override
     def _get_effective_privacy(self) -> Privacy:
@@ -157,6 +159,13 @@ class Source(HasDate, HasFileReferences, HasNotes, HasLinks, HasPrivacy, Entity)
     @property
     def label(self) -> Localizable:
         return self.name if self.name else super().label
+
+    @property
+    def source_type(self) -> SourceType:
+        """
+        The type of this source.
+        """
+        return self._source_type
 
     @override
     @classmethod

--- a/betty/ancestry/source_type/__init__.py
+++ b/betty/ancestry/source_type/__init__.py
@@ -1,0 +1,45 @@
+"""
+Provide Betty's ancestry source types.
+"""
+
+from __future__ import annotations
+
+from typing import final
+
+from betty.locale.localizable.gettext import _, ngettext
+from betty.plugin import Plugin, PluginTypeDefinition
+from betty.plugin.discovery.entry_point import EntryPointDiscovery
+from betty.plugin.discovery.project import ProjectDiscovery
+from betty.plugin.human_facing import (
+    CountableHumanFacingPluginDefinition,
+)
+
+
+class SourceType(Plugin["SourceTypeDefinition"]):
+    """
+    Define an :py:class:`betty.ancestry.source.Source` type.
+
+    Read more about :doc:`/development/plugin/source-type`.
+    """
+
+
+@final
+@PluginTypeDefinition(
+    "source-type",
+    base_cls=SourceType,
+    label=_("Source type"),
+    label_plural=_("Source types"),
+    label_countable=ngettext("{count} source type", "{count} source types"),
+    discovery=[
+        EntryPointDiscovery("betty.source_type"),
+        ProjectDiscovery(
+            lambda project: project.configuration.source_types.new_plugins(),
+        ),
+    ],
+)
+class SourceTypeDefinition(CountableHumanFacingPluginDefinition[SourceType]):
+    """
+    A source type definition.
+
+    Read more about :doc:`/development/plugin/source-type`.
+    """

--- a/betty/ancestry/source_type/source_types.py
+++ b/betty/ancestry/source_type/source_types.py
@@ -36,6 +36,7 @@ class Book(SourceType):
     A book.
     """
 
+
 @final
 @SourceTypeDefinition(
     "unknown",
@@ -47,6 +48,7 @@ class Unknown(SourceType, Singleton):
     """
     A source of an unknown type.
     """
+
 
 @final
 @SourceTypeDefinition(

--- a/betty/ancestry/source_type/source_types.py
+++ b/betty/ancestry/source_type/source_types.py
@@ -1,0 +1,61 @@
+"""
+Provide Betty's ancestry source types.
+"""
+
+from __future__ import annotations
+
+from typing import final
+
+from betty.ancestry.source_type import SourceType, SourceTypeDefinition
+from betty.classtools import Singleton
+from betty.locale.localizable.gettext import _, ngettext
+
+
+@final
+@SourceTypeDefinition(
+    "archive",
+    label=_("Archive"),
+    label_plural=_("Archives"),
+    label_countable=ngettext("{count} archive", "{count} archives"),
+)
+class Archive(SourceType):
+    """
+    A archive.
+    """
+
+
+@final
+@SourceTypeDefinition(
+    "book",
+    label=_("Book"),
+    label_plural=_("Books"),
+    label_countable=ngettext("{count} book", "{count} books"),
+)
+class Book(SourceType):
+    """
+    A book.
+    """
+
+@final
+@SourceTypeDefinition(
+    "unknown",
+    label=_("Unknown"),
+    label_plural=_("Unknowns"),
+    label_countable=ngettext("{count} unknown", "{count} unknowns"),
+)
+class Unknown(SourceType, Singleton):
+    """
+    A source of an unknown type.
+    """
+
+@final
+@SourceTypeDefinition(
+    "website",
+    label=_("Website"),
+    label_plural=_("Websites"),
+    label_countable=ngettext("{count} website", "{count} websites"),
+)
+class Website(SourceType):
+    """
+    A website.
+    """

--- a/betty/assets/locale/ar/betty.po
+++ b/betty/assets/locale/ar/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-02 00:35+0000\n"
+"POT-Creation-Date: 2026-01-02 12:48+0000\n"
 "PO-Revision-Date: 2024-11-30 19:00+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: ar\n"
@@ -131,6 +131,12 @@ msgstr ""
 msgid "Appearances"
 msgstr ""
 
+msgid "Archive"
+msgstr ""
+
+msgid "Archives"
+msgstr ""
+
 msgid "Assets directory"
 msgstr ""
 
@@ -241,6 +247,12 @@ msgid "Birth"
 msgstr "الولادة"
 
 msgid "Births"
+msgstr ""
+
+msgid "Book"
+msgstr ""
+
+msgid "Books"
 msgstr ""
 
 msgid "Borough"
@@ -1227,6 +1239,12 @@ msgstr ""
 msgid "Source"
 msgstr "مصدر"
 
+msgid "Source type"
+msgstr ""
+
+msgid "Source types"
+msgstr ""
+
 msgid "Sources"
 msgstr "مصادر"
 
@@ -1517,6 +1535,12 @@ msgstr ""
 msgid "Villages"
 msgstr ""
 
+msgid "Website"
+msgstr ""
+
+msgid "Websites"
+msgstr ""
+
 msgid "Welcome"
 msgstr ""
 
@@ -1773,6 +1797,16 @@ msgstr[4] ""
 msgstr[5] ""
 
 #, python-brace-format
+msgid "{count} archive"
+msgid_plural "{count} archives"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#, python-brace-format
 msgid "{count} attendee"
 msgid_plural "{count} attendees"
 msgstr[0] ""
@@ -1825,6 +1859,16 @@ msgstr[5] ""
 #, python-brace-format
 msgid "{count} birth"
 msgid_plural "{count} births"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#, python-brace-format
+msgid "{count} book"
+msgid_plural "{count} books"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
@@ -2453,6 +2497,16 @@ msgstr[4] ""
 msgstr[5] ""
 
 #, python-brace-format
+msgid "{count} source type"
+msgid_plural "{count} source types"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#, python-brace-format
 msgid "{count} speaker"
 msgid_plural "{count} speakers"
 msgstr[0] ""
@@ -2515,6 +2569,16 @@ msgstr[5] ""
 #, python-brace-format
 msgid "{count} village"
 msgid_plural "{count} villages"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#, python-brace-format
+msgid "{count} website"
+msgid_plural "{count} websites"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""

--- a/betty/assets/locale/betty.pot
+++ b/betty/assets/locale/betty.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-02 00:35+0000\n"
+"POT-Creation-Date: 2026-01-02 12:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -128,6 +128,12 @@ msgstr ""
 msgid "Appearances"
 msgstr ""
 
+msgid "Archive"
+msgstr ""
+
+msgid "Archives"
+msgstr ""
+
 msgid "Assets directory"
 msgstr ""
 
@@ -237,6 +243,12 @@ msgid "Birth"
 msgstr ""
 
 msgid "Births"
+msgstr ""
+
+msgid "Book"
+msgstr ""
+
+msgid "Books"
 msgstr ""
 
 msgid "Borough"
@@ -1214,6 +1226,12 @@ msgstr ""
 msgid "Source"
 msgstr ""
 
+msgid "Source type"
+msgstr ""
+
+msgid "Source types"
+msgstr ""
+
 msgid "Sources"
 msgstr ""
 
@@ -1492,6 +1510,12 @@ msgstr ""
 msgid "Villages"
 msgstr ""
 
+msgid "Website"
+msgstr ""
+
+msgid "Websites"
+msgstr ""
+
 msgid "Welcome"
 msgstr ""
 
@@ -1728,6 +1752,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, python-brace-format
+msgid "{count} archive"
+msgid_plural "{count} archives"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
 msgid "{count} attendee"
 msgid_plural "{count} attendees"
 msgstr[0] ""
@@ -1760,6 +1790,12 @@ msgstr[1] ""
 #, python-brace-format
 msgid "{count} birth"
 msgid_plural "{count} births"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
+msgid "{count} book"
+msgid_plural "{count} books"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -2136,6 +2172,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, python-brace-format
+msgid "{count} source type"
+msgid_plural "{count} source types"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
 msgid "{count} speaker"
 msgid_plural "{count} speakers"
 msgstr[0] ""
@@ -2174,6 +2216,12 @@ msgstr[1] ""
 #, python-brace-format
 msgid "{count} village"
 msgid_plural "{count} villages"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
+msgid "{count} website"
+msgid_plural "{count} websites"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/betty/assets/locale/de-DE/betty.po
+++ b/betty/assets/locale/de-DE/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-02 00:35+0000\n"
+"POT-Creation-Date: 2026-01-02 12:48+0000\n"
 "PO-Revision-Date: 2025-03-28 20:02+0000\n"
 "Last-Translator: Ettore Atalan <atalanttore@googlemail.com>\n"
 "Language: de_DE\n"
@@ -132,6 +132,12 @@ msgstr ""
 msgid "Appearances"
 msgstr "Erscheinungen"
 
+msgid "Archive"
+msgstr ""
+
+msgid "Archives"
+msgstr ""
+
 msgid "Assets directory"
 msgstr ""
 
@@ -254,6 +260,12 @@ msgid "Birth"
 msgstr "Geburt"
 
 msgid "Births"
+msgstr ""
+
+msgid "Book"
+msgstr ""
+
+msgid "Books"
 msgstr ""
 
 msgid "Borough"
@@ -1255,6 +1267,12 @@ msgstr ""
 msgid "Source"
 msgstr "Quelle"
 
+msgid "Source type"
+msgstr ""
+
+msgid "Source types"
+msgstr ""
+
 msgid "Sources"
 msgstr "Quellen"
 
@@ -1540,6 +1558,12 @@ msgstr "Dorf"
 msgid "Villages"
 msgstr ""
 
+msgid "Website"
+msgstr ""
+
+msgid "Websites"
+msgstr ""
+
 msgid "Welcome"
 msgstr ""
 
@@ -1779,6 +1803,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, python-brace-format
+msgid "{count} archive"
+msgid_plural "{count} archives"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
 msgid "{count} attendee"
 msgid_plural "{count} attendees"
 msgstr[0] ""
@@ -1811,6 +1841,12 @@ msgstr[1] ""
 #, python-brace-format
 msgid "{count} birth"
 msgid_plural "{count} births"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
+msgid "{count} book"
+msgid_plural "{count} books"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -2187,6 +2223,12 @@ msgstr[0] "{count} Quelle"
 msgstr[1] "{count} Quellen"
 
 #, python-brace-format
+msgid "{count} source type"
+msgid_plural "{count} source types"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
 msgid "{count} speaker"
 msgid_plural "{count} speakers"
 msgstr[0] ""
@@ -2225,6 +2267,12 @@ msgstr[1] ""
 #, python-brace-format
 msgid "{count} village"
 msgid_plural "{count} villages"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
+msgid "{count} website"
+msgid_plural "{count} websites"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/betty/assets/locale/en-GB/betty.po
+++ b/betty/assets/locale/en-GB/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-02 00:35+0000\n"
+"POT-Creation-Date: 2026-01-02 12:48+0000\n"
 "PO-Revision-Date: 2025-12-29 14:25+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: en_GB\n"
@@ -133,6 +133,12 @@ msgstr ""
 
 msgid "Appearances"
 msgstr "Appearances"
+
+msgid "Archive"
+msgstr ""
+
+msgid "Archives"
+msgstr ""
 
 msgid "Assets directory"
 msgstr ""
@@ -263,6 +269,12 @@ msgid "Birth"
 msgstr "Birth"
 
 msgid "Births"
+msgstr ""
+
+msgid "Book"
+msgstr ""
+
+msgid "Books"
 msgstr ""
 
 msgid "Borough"
@@ -1275,6 +1287,12 @@ msgstr ""
 msgid "Source"
 msgstr "Source"
 
+msgid "Source type"
+msgstr ""
+
+msgid "Source types"
+msgstr ""
+
 msgid "Sources"
 msgstr "Sources"
 
@@ -1566,6 +1584,12 @@ msgstr "Village"
 msgid "Villages"
 msgstr ""
 
+msgid "Website"
+msgstr ""
+
+msgid "Websites"
+msgstr ""
+
 msgid "Welcome"
 msgstr ""
 
@@ -1809,6 +1833,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, python-brace-format
+msgid "{count} archive"
+msgid_plural "{count} archives"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
 msgid "{count} attendee"
 msgid_plural "{count} attendees"
 msgstr[0] ""
@@ -1841,6 +1871,12 @@ msgstr[1] ""
 #, python-brace-format
 msgid "{count} birth"
 msgid_plural "{count} births"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
+msgid "{count} book"
+msgid_plural "{count} books"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -2217,6 +2253,12 @@ msgstr[0] "{count} source"
 msgstr[1] "{count} sources"
 
 #, python-brace-format
+msgid "{count} source type"
+msgid_plural "{count} source types"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
 msgid "{count} speaker"
 msgid_plural "{count} speakers"
 msgstr[0] ""
@@ -2255,6 +2297,12 @@ msgstr[1] ""
 #, python-brace-format
 msgid "{count} village"
 msgid_plural "{count} villages"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
+msgid "{count} website"
+msgid_plural "{count} websites"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/betty/assets/locale/es-ES/betty.po
+++ b/betty/assets/locale/es-ES/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-02 00:35+0000\n"
+"POT-Creation-Date: 2026-01-02 12:48+0000\n"
 "PO-Revision-Date: 2025-12-29 14:48+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: es_ES\n"
@@ -132,6 +132,12 @@ msgstr ""
 msgid "Appearances"
 msgstr "Apariciónes"
 
+msgid "Archive"
+msgstr ""
+
+msgid "Archives"
+msgstr ""
+
 msgid "Assets directory"
 msgstr ""
 
@@ -242,6 +248,12 @@ msgid "Birth"
 msgstr "Nacimiento"
 
 msgid "Births"
+msgstr ""
+
+msgid "Book"
+msgstr ""
+
+msgid "Books"
 msgstr ""
 
 msgid "Borough"
@@ -1226,6 +1238,12 @@ msgstr ""
 msgid "Source"
 msgstr "Fuente"
 
+msgid "Source type"
+msgstr ""
+
+msgid "Source types"
+msgstr ""
+
 msgid "Sources"
 msgstr "Fuentes"
 
@@ -1504,6 +1522,12 @@ msgstr "Pueblo"
 msgid "Villages"
 msgstr ""
 
+msgid "Website"
+msgstr ""
+
+msgid "Websites"
+msgstr ""
+
 msgid "Welcome"
 msgstr ""
 
@@ -1742,6 +1766,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, python-brace-format
+msgid "{count} archive"
+msgid_plural "{count} archives"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
 msgid "{count} attendee"
 msgid_plural "{count} attendees"
 msgstr[0] ""
@@ -1774,6 +1804,12 @@ msgstr[1] ""
 #, python-brace-format
 msgid "{count} birth"
 msgid_plural "{count} births"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
+msgid "{count} book"
+msgid_plural "{count} books"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -2150,6 +2186,12 @@ msgstr[0] "{count} fuente"
 msgstr[1] "{count} fuentes"
 
 #, python-brace-format
+msgid "{count} source type"
+msgid_plural "{count} source types"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
 msgid "{count} speaker"
 msgid_plural "{count} speakers"
 msgstr[0] ""
@@ -2188,6 +2230,12 @@ msgstr[1] ""
 #, python-brace-format
 msgid "{count} village"
 msgid_plural "{count} villages"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
+msgid "{count} website"
+msgid_plural "{count} websites"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/betty/assets/locale/fr-FR/betty.po
+++ b/betty/assets/locale/fr-FR/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-02 00:35+0000\n"
+"POT-Creation-Date: 2026-01-02 12:48+0000\n"
 "PO-Revision-Date: 2025-08-27 20:02+0000\n"
 "Last-Translator: \"David D.\" <dadu042@users.noreply.hosted.weblate.org>\n"
 "Language: fr_FR\n"
@@ -132,6 +132,12 @@ msgstr ""
 msgid "Appearances"
 msgstr "Caractéristiques"
 
+msgid "Archive"
+msgstr ""
+
+msgid "Archives"
+msgstr ""
+
 msgid "Assets directory"
 msgstr ""
 
@@ -247,6 +253,12 @@ msgid "Birth"
 msgstr "Naissance"
 
 msgid "Births"
+msgstr ""
+
+msgid "Book"
+msgstr ""
+
+msgid "Books"
 msgstr ""
 
 msgid "Borough"
@@ -1235,6 +1247,12 @@ msgstr ""
 msgid "Source"
 msgstr "Source"
 
+msgid "Source type"
+msgstr ""
+
+msgid "Source types"
+msgstr ""
+
 msgid "Sources"
 msgstr "Sources"
 
@@ -1515,6 +1533,12 @@ msgstr "Village"
 msgid "Villages"
 msgstr ""
 
+msgid "Website"
+msgstr ""
+
+msgid "Websites"
+msgstr ""
+
 msgid "Welcome"
 msgstr ""
 
@@ -1780,6 +1804,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, python-brace-format
+msgid "{count} archive"
+msgid_plural "{count} archives"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
 msgid "{count} attendee"
 msgid_plural "{count} attendees"
 msgstr[0] ""
@@ -1812,6 +1842,12 @@ msgstr[1] ""
 #, python-brace-format
 msgid "{count} birth"
 msgid_plural "{count} births"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
+msgid "{count} book"
+msgid_plural "{count} books"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -2188,6 +2224,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, python-brace-format
+msgid "{count} source type"
+msgid_plural "{count} source types"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
 msgid "{count} speaker"
 msgid_plural "{count} speakers"
 msgstr[0] ""
@@ -2226,6 +2268,12 @@ msgstr[1] ""
 #, python-brace-format
 msgid "{count} village"
 msgid_plural "{count} villages"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
+msgid "{count} website"
+msgid_plural "{count} websites"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/betty/assets/locale/he/betty.po
+++ b/betty/assets/locale/he/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-02 00:35+0000\n"
+"POT-Creation-Date: 2026-01-02 12:48+0000\n"
 "PO-Revision-Date: 2025-05-06 10:01+0000\n"
 "Last-Translator: Yaron Shahrabani <sh.yaron@gmail.com>\n"
 "Language: he\n"
@@ -132,6 +132,12 @@ msgstr ""
 msgid "Appearances"
 msgstr ""
 
+msgid "Archive"
+msgstr ""
+
+msgid "Archives"
+msgstr ""
+
 msgid "Assets directory"
 msgstr ""
 
@@ -242,6 +248,12 @@ msgid "Birth"
 msgstr ""
 
 msgid "Births"
+msgstr ""
+
+msgid "Book"
+msgstr ""
+
+msgid "Books"
 msgstr ""
 
 msgid "Borough"
@@ -1224,6 +1236,12 @@ msgstr ""
 msgid "Source"
 msgstr ""
 
+msgid "Source type"
+msgstr ""
+
+msgid "Source types"
+msgstr ""
+
 msgid "Sources"
 msgstr ""
 
@@ -1502,6 +1520,12 @@ msgstr ""
 msgid "Villages"
 msgstr ""
 
+msgid "Website"
+msgstr ""
+
+msgid "Websites"
+msgstr ""
+
 msgid "Welcome"
 msgstr ""
 
@@ -1738,6 +1762,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, python-brace-format
+msgid "{count} archive"
+msgid_plural "{count} archives"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
 msgid "{count} attendee"
 msgid_plural "{count} attendees"
 msgstr[0] ""
@@ -1770,6 +1800,12 @@ msgstr[1] ""
 #, python-brace-format
 msgid "{count} birth"
 msgid_plural "{count} births"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
+msgid "{count} book"
+msgid_plural "{count} books"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -2146,6 +2182,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, python-brace-format
+msgid "{count} source type"
+msgid_plural "{count} source types"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
 msgid "{count} speaker"
 msgid_plural "{count} speakers"
 msgstr[0] ""
@@ -2184,6 +2226,12 @@ msgstr[1] ""
 #, python-brace-format
 msgid "{count} village"
 msgid_plural "{count} villages"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
+msgid "{count} website"
+msgid_plural "{count} websites"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/betty/assets/locale/nl-NL/betty.po
+++ b/betty/assets/locale/nl-NL/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-02 00:35+0000\n"
+"POT-Creation-Date: 2026-01-02 12:48+0000\n"
 "PO-Revision-Date: 2025-11-08 23:46+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: nl_NL\n"
@@ -135,6 +135,12 @@ msgstr ""
 
 msgid "Appearances"
 msgstr "Verschijningen"
+
+msgid "Archive"
+msgstr ""
+
+msgid "Archives"
+msgstr ""
 
 msgid "Assets directory"
 msgstr ""
@@ -267,6 +273,12 @@ msgid "Birth"
 msgstr "Geboorte"
 
 msgid "Births"
+msgstr ""
+
+msgid "Book"
+msgstr ""
+
+msgid "Books"
 msgstr ""
 
 msgid "Borough"
@@ -1284,6 +1296,12 @@ msgstr ""
 msgid "Source"
 msgstr "Bron"
 
+msgid "Source type"
+msgstr ""
+
+msgid "Source types"
+msgstr ""
+
 msgid "Sources"
 msgstr "Bronnen"
 
@@ -1574,6 +1592,12 @@ msgstr "Dorp"
 msgid "Villages"
 msgstr ""
 
+msgid "Website"
+msgstr ""
+
+msgid "Websites"
+msgstr ""
+
 msgid "Welcome"
 msgstr ""
 
@@ -1819,6 +1843,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, python-brace-format
+msgid "{count} archive"
+msgid_plural "{count} archives"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
 msgid "{count} attendee"
 msgid_plural "{count} attendees"
 msgstr[0] ""
@@ -1851,6 +1881,12 @@ msgstr[1] ""
 #, python-brace-format
 msgid "{count} birth"
 msgid_plural "{count} births"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
+msgid "{count} book"
+msgid_plural "{count} books"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -2227,6 +2263,12 @@ msgstr[0] "{count} bron"
 msgstr[1] "{count} bronnen"
 
 #, python-brace-format
+msgid "{count} source type"
+msgid_plural "{count} source types"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
 msgid "{count} speaker"
 msgid_plural "{count} speakers"
 msgstr[0] ""
@@ -2265,6 +2307,12 @@ msgstr[1] ""
 #, python-brace-format
 msgid "{count} village"
 msgid_plural "{count} villages"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
+msgid "{count} website"
+msgid_plural "{count} websites"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/betty/assets/locale/pt-BR/betty.po
+++ b/betty/assets/locale/pt-BR/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-02 00:35+0000\n"
+"POT-Creation-Date: 2026-01-02 12:48+0000\n"
 "PO-Revision-Date: 2025-12-16 20:00+0000\n"
 "Last-Translator: Mateus Liberale Gomes <sergiogomes209403@gmail.com>\n"
 "Language: pt_BR\n"
@@ -135,6 +135,12 @@ msgstr ""
 
 msgid "Appearances"
 msgstr "Aparências"
+
+msgid "Archive"
+msgstr ""
+
+msgid "Archives"
+msgstr ""
 
 msgid "Assets directory"
 msgstr ""
@@ -267,6 +273,12 @@ msgid "Birth"
 msgstr "Nascimento"
 
 msgid "Births"
+msgstr ""
+
+msgid "Book"
+msgstr ""
+
+msgid "Books"
 msgstr ""
 
 msgid "Borough"
@@ -1265,6 +1277,12 @@ msgstr ""
 msgid "Source"
 msgstr ""
 
+msgid "Source type"
+msgstr ""
+
+msgid "Source types"
+msgstr ""
+
 msgid "Sources"
 msgstr ""
 
@@ -1543,6 +1561,12 @@ msgstr ""
 msgid "Villages"
 msgstr ""
 
+msgid "Website"
+msgstr ""
+
+msgid "Websites"
+msgstr ""
+
 msgid "Welcome"
 msgstr ""
 
@@ -1779,6 +1803,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, python-brace-format
+msgid "{count} archive"
+msgid_plural "{count} archives"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
 msgid "{count} attendee"
 msgid_plural "{count} attendees"
 msgstr[0] ""
@@ -1811,6 +1841,12 @@ msgstr[1] ""
 #, python-brace-format
 msgid "{count} birth"
 msgid_plural "{count} births"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
+msgid "{count} book"
+msgid_plural "{count} books"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -2187,6 +2223,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, python-brace-format
+msgid "{count} source type"
+msgid_plural "{count} source types"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
 msgid "{count} speaker"
 msgid_plural "{count} speakers"
 msgstr[0] ""
@@ -2225,6 +2267,12 @@ msgstr[1] ""
 #, python-brace-format
 msgid "{count} village"
 msgid_plural "{count} villages"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-brace-format
+msgid "{count} website"
+msgid_plural "{count} websites"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/betty/assets/locale/ru-RU/betty.po
+++ b/betty/assets/locale/ru-RU/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-02 00:35+0000\n"
+"POT-Creation-Date: 2026-01-02 12:48+0000\n"
 "PO-Revision-Date: 2025-12-08 19:00+0000\n"
 "Last-Translator: Artur Kalagov "
 "<artur.kalagov@users.noreply.hosted.weblate.org>\n"
@@ -137,6 +137,12 @@ msgstr ""
 
 msgid "Appearances"
 msgstr "Источники"
+
+msgid "Archive"
+msgstr ""
+
+msgid "Archives"
+msgstr ""
 
 msgid "Assets directory"
 msgstr ""
@@ -269,6 +275,12 @@ msgid "Birth"
 msgstr "Рождение"
 
 msgid "Births"
+msgstr ""
+
+msgid "Book"
+msgstr ""
+
+msgid "Books"
 msgstr ""
 
 msgid "Borough"
@@ -1287,6 +1299,12 @@ msgstr ""
 msgid "Source"
 msgstr "Хранилище"
 
+msgid "Source type"
+msgstr ""
+
+msgid "Source types"
+msgstr ""
+
 msgid "Sources"
 msgstr "Источники"
 
@@ -1581,6 +1599,12 @@ msgstr "Село"
 msgid "Villages"
 msgstr ""
 
+msgid "Website"
+msgstr ""
+
+msgid "Websites"
+msgstr ""
+
 msgid "Welcome"
 msgstr ""
 
@@ -1831,6 +1855,13 @@ msgstr[1] ""
 msgstr[2] ""
 
 #, python-brace-format
+msgid "{count} archive"
+msgid_plural "{count} archives"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, python-brace-format
 msgid "{count} attendee"
 msgid_plural "{count} attendees"
 msgstr[0] ""
@@ -1868,6 +1899,13 @@ msgstr[2] ""
 #, python-brace-format
 msgid "{count} birth"
 msgid_plural "{count} births"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, python-brace-format
+msgid "{count} book"
+msgid_plural "{count} books"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
@@ -2307,6 +2345,13 @@ msgstr[1] "{count} источника"
 msgstr[2] "{count} источников"
 
 #, python-brace-format
+msgid "{count} source type"
+msgid_plural "{count} source types"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, python-brace-format
 msgid "{count} speaker"
 msgid_plural "{count} speakers"
 msgstr[0] ""
@@ -2351,6 +2396,13 @@ msgstr[2] ""
 #, python-brace-format
 msgid "{count} village"
 msgid_plural "{count} villages"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, python-brace-format
+msgid "{count} website"
+msgid_plural "{count} websites"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""

--- a/betty/assets/locale/uk/betty.po
+++ b/betty/assets/locale/uk/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty 0.4\n"
 "Report-Msgid-Bugs-To: illia@maier.page\n"
-"POT-Creation-Date: 2026-01-02 00:35+0000\n"
+"POT-Creation-Date: 2026-01-02 12:48+0000\n"
 "PO-Revision-Date: 2025-05-13 17:01+0000\n"
 "Last-Translator: Максим Горпиніч <maksimgorpinic4@gmail.com>\n"
 "Language: uk\n"
@@ -134,6 +134,12 @@ msgstr ""
 
 msgid "Appearances"
 msgstr "Знайдено в"
+
+msgid "Archive"
+msgstr ""
+
+msgid "Archives"
+msgstr ""
 
 msgid "Assets directory"
 msgstr ""
@@ -264,6 +270,12 @@ msgid "Birth"
 msgstr "Народження"
 
 msgid "Births"
+msgstr ""
+
+msgid "Book"
+msgstr ""
+
+msgid "Books"
 msgstr ""
 
 msgid "Borough"
@@ -1279,6 +1291,12 @@ msgstr ""
 msgid "Source"
 msgstr "Джерелo"
 
+msgid "Source type"
+msgstr ""
+
+msgid "Source types"
+msgstr ""
+
 msgid "Sources"
 msgstr "Джерела"
 
@@ -1572,6 +1590,12 @@ msgstr "Село"
 msgid "Villages"
 msgstr ""
 
+msgid "Website"
+msgstr ""
+
+msgid "Websites"
+msgstr ""
+
 msgid "Welcome"
 msgstr ""
 
@@ -1820,6 +1844,13 @@ msgstr[1] ""
 msgstr[2] ""
 
 #, python-brace-format
+msgid "{count} archive"
+msgid_plural "{count} archives"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, python-brace-format
 msgid "{count} attendee"
 msgid_plural "{count} attendees"
 msgstr[0] ""
@@ -1857,6 +1888,13 @@ msgstr[2] ""
 #, python-brace-format
 msgid "{count} birth"
 msgid_plural "{count} births"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, python-brace-format
+msgid "{count} book"
+msgid_plural "{count} books"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
@@ -2296,6 +2334,13 @@ msgstr[1] "{count} джерела"
 msgstr[2] "{count} джерела"
 
 #, python-brace-format
+msgid "{count} source type"
+msgid_plural "{count} source types"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, python-brace-format
 msgid "{count} speaker"
 msgid_plural "{count} speakers"
 msgstr[0] ""
@@ -2340,6 +2385,13 @@ msgstr[2] ""
 #, python-brace-format
 msgid "{count} village"
 msgid_plural "{count} villages"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, python-brace-format
+msgid "{count} website"
+msgid_plural "{count} websites"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""

--- a/betty/project/config.py
+++ b/betty/project/config.py
@@ -15,6 +15,7 @@ from betty.ancestry.event_type import EventType, EventTypeDefinition
 from betty.ancestry.gender import Gender, GenderDefinition
 from betty.ancestry.place_type import PlaceType, PlaceTypeDefinition
 from betty.ancestry.presence_role import PresenceRole, PresenceRoleDefinition
+from betty.ancestry.source_type import SourceType, SourceTypeDefinition
 from betty.assertion import (
     Field,
     OptionalField,
@@ -537,6 +538,43 @@ class PlaceTypePluginConfigurationMapping(
         return _ProjectConfigurationPlaceType.plugin()
 
 
+class SourceTypePluginConfiguration(CountableHumanFacingPluginDefinitionConfiguration):
+    """
+    Configure a :py:class:`betty.ancestry.source_type.SourceTypeDefinition`.
+    """
+
+
+class SourceTypePluginConfigurationMapping(
+    PluginDefinitionConfigurationMapping[
+        SourceTypeDefinition, SourceTypePluginConfiguration
+    ]
+):
+    """
+    A configuration mapping for source types.
+    """
+
+    @override
+    @classmethod
+    def _item_cls(cls) -> type[SourceTypePluginConfiguration]:
+        return SourceTypePluginConfiguration
+
+    @override
+    def _new_plugin(
+        self, configuration: SourceTypePluginConfiguration, /
+    ) -> SourceTypeDefinition:
+        @SourceTypeDefinition(
+            configuration.id,
+            label=configuration.label,
+            label_plural=configuration.label_plural,
+            label_countable=configuration.label_countable,
+            description=configuration.description,
+        )
+        class _ProjectConfigurationSourceType(SourceType):
+            pass
+
+        return _ProjectConfigurationSourceType.plugin()
+
+
 class PresenceRolePluginConfiguration(
     CountableHumanFacingPluginDefinitionConfiguration
 ):
@@ -630,6 +668,7 @@ class ProjectConfiguration(Configuration):
         entity_types: EntityTypeConfigurationMapping | None = None,
         event_types: EventTypePluginConfigurationMapping | None = None,
         place_types: PlaceTypePluginConfigurationMapping | None = None,
+        source_types: SourceTypePluginConfigurationMapping | None = None,
         presence_roles: PresenceRolePluginConfigurationMapping | None = None,
         copyright_notice: PluginInstanceConfiguration[
             CopyrightNoticeDefinition, CopyrightNotice
@@ -681,6 +720,11 @@ class ProjectConfiguration(Configuration):
             PlaceTypePluginConfigurationMapping()
             if place_types is None
             else place_types
+        )
+        self._source_types = (
+            SourceTypePluginConfigurationMapping()
+            if source_types is None
+            else source_types
         )
         self._presence_roles = (
             PresenceRolePluginConfigurationMapping()
@@ -877,6 +921,13 @@ class ProjectConfiguration(Configuration):
         The place type plugins created by this project.
         """
         return self._place_types
+
+    @property
+    def source_types(self) -> SourceTypePluginConfigurationMapping:
+        """
+        The source type plugins created by this project.
+        """
+        return self._source_types
 
     @property
     def presence_roles(self) -> PresenceRolePluginConfigurationMapping:

--- a/betty/test_utils/documentation.py
+++ b/betty/test_utils/documentation.py
@@ -33,8 +33,11 @@ class PluginDocumentationTestBase(Generic[_PluginDefinitionT]):
         )
         async with aiofiles.open(documentation_file_path) as f:
             documentation = await f.read()
+        print(documentation)
         async with Project.new_isolated(isolated_app) as project, project:
             for plugin in await project.plugins(self._plugin_type):
+                print(plugin.id)
+                print(self._get_expected(plugin))
                 if plugin.id.startswith("-"):
                     continue
                 for expected in self._get_expected(plugin):

--- a/betty/tests/ancestry/place_type/test___init__.py
+++ b/betty/tests/ancestry/place_type/test___init__.py
@@ -1,8 +1,11 @@
+from pathlib import Path
+
 import pytest
 from typing_extensions import override
 
 from betty.ancestry.place_type import PlaceTypeDefinition
 from betty.plugin import PluginDefinition
+from betty.test_utils.documentation import PluginDocumentationTestBase
 from betty.test_utils.plugin import PluginDefinitionClassTestBase
 
 
@@ -11,3 +14,7 @@ class TestPlaceTypeDefinition(PluginDefinitionClassTestBase):
     @pytest.fixture
     def sut(self) -> type[PluginDefinition]:
         return PlaceTypeDefinition
+
+class TestPlaceTypeDocumentation(PluginDocumentationTestBase[PlaceTypeDefinition]):
+    _plugin_type = PlaceTypeDefinition
+    _plugin_type_documentation_path = Path("usage") / "ancestry" / "place-type.rst"

--- a/betty/tests/ancestry/source_type/test___init__.py
+++ b/betty/tests/ancestry/source_type/test___init__.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+import pytest
+from typing_extensions import override
+
+from betty.ancestry.source_type import SourceTypeDefinition
+from betty.plugin import PluginDefinition
+from betty.test_utils.documentation import PluginDocumentationTestBase
+from betty.test_utils.plugin import PluginDefinitionClassTestBase
+
+
+class TestSourceTypeDefinition(PluginDefinitionClassTestBase):
+    @override
+    @pytest.fixture
+    def sut(self) -> type[PluginDefinition]:
+        return SourceTypeDefinition
+
+class TestSourceTypeDocumentation(PluginDocumentationTestBase[SourceTypeDefinition]):
+    _plugin_type = SourceTypeDefinition
+    _plugin_type_documentation_path = Path("usage") / "ancestry" / "source-type.rst"

--- a/betty/tests/ancestry/test_place.py
+++ b/betty/tests/ancestry/test_place.py
@@ -37,10 +37,6 @@ class TestPlaceDefinition(EntityDefinitionTestBase):
         return Place.plugin()
 
 
-class TestPlaceTypeDocumentation(PluginDocumentationTestBase[PlaceTypeDefinition]):
-    _plugin_type = PlaceTypeDefinition
-    _plugin_type_documentation_path = Path("usage") / "ancestry" / "place-type.rst"
-
 
 class TestPlace(EntityTestBase):
     @staticmethod

--- a/documentation/development/plugin.rst
+++ b/documentation/development/plugin.rst
@@ -35,6 +35,7 @@ plugin repository, how to use the plugins, and how to create your own.
 - :doc:`Presence roles </development/plugin/presence-role>`
 - :doc:`Renderers </development/plugin/renderer>`
 - :doc:`Serialization formats </development/plugin/format>`
+- :doc:`Source types </development/plugin/source-type>`
 
 Creating a new plugin type
 --------------------------

--- a/documentation/usage/ancestry/source-type.rst
+++ b/documentation/usage/ancestry/source-type.rst
@@ -1,0 +1,15 @@
+Source Type
+===========
+
+:doc:`Source </usage/ancestry/source>` types are what indicate what kind of a source it is, such as a book. They inherit
+from :py:class:`betty.ancestry.source_type.SourceType`.
+
+Built-in source types
+---------------------
+
+``unknown`` (:py:class:`betty.ancestry.source_type.source_types.Unknown`)
+    A source of an unknown type.
+
+See also
+--------
+- :doc:`/development/plugin/source-type`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ betty = 'betty.console:main_standalone'
 'place-type' = 'betty.ancestry.place_type:PlaceTypeDefinition'
 'presence-role' = 'betty.ancestry.presence_role:PresenceRoleDefinition'
 'renderer' = 'betty.render:RendererDefinition'
+'source-type' = 'betty.ancestry.source_type:SourceTypeDefinition'
 
 [project.entry-points.'betty.command']
 'about' = 'betty.console.command.commands.about:About'
@@ -219,6 +220,12 @@ betty = 'betty.console:main_standalone'
 [project.entry-points.'betty.serde_format']
 'json' = 'betty.serde.format.formats:Json'
 'yaml' = 'betty.serde.format.formats:Yaml'
+
+[project.entry-points.'betty.source_type']
+'archive' = 'betty.ancestry.source_type.source_types:Archive'
+'book' = 'betty.ancestry.source_type.source_types:Book'
+'unknown' = 'betty.ancestry.source_type.source_types:Unknown'
+'website' = 'betty.ancestry.source_type.source_types:Website'
 
 [project.entry-points.'betty.renderer']
 'html' = 'betty.render.html:Html'


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/3405

## To do
- allow projects to define additional source types
- Map Gramps repository types to source types
- parse a Gramps attribute for sources to set the type
- Show source type in source summary template
- does Gramps have citation types? 