### PR TITLE
Show GitHub contributors in the documentation using sphinx-contributors

### DIFF
--- a/documentation/about.rst
+++ b/documentation/about.rst
@@ -30,6 +30,13 @@ Find Betty on
 - `GitHub <https://github.com/bartfeenstra/betty>`_
 - `PyPI <https://pypi.org/project/betty>`_
 
+Contributors
+------------
+
+..  contributors:: bartfeenstra/betty
+    :avatars:
+
+
 In this section
 ---------------
 - :doc:`/about/contributing`

--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -44,6 +44,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
+    "sphinx_contributors",
     "sphinx_design",
 ]
 modindex_common_prefix = ["betty."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     'rich-argparse ~= 1.7',
     'shibuya == 2025.12.19',
     'sphinx ~= 8.2',
+    'sphinx_contributors ~= 0.2.7',
     'sphinx-design ~= 0.6.1',
     'typing_extensions ~= 4.12',
 ]


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/3438