### PR TITLE
Add data definitions

### DIFF
--- a/assets/locale/ar/betty.po
+++ b/assets/locale/ar/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-17 22:03+0000\n"
+"POT-Creation-Date: 2026-01-19 20:08+0000\n"
 "PO-Revision-Date: 2024-11-30 19:00+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: ar\n"
@@ -65,6 +65,9 @@ msgstr ""
 msgid "A Betty demonstration"
 msgstr ""
 
+msgid "A countable localizable string"
+msgstr ""
+
 msgid ""
 "A family history as told by <a "
 "href=\"https://betty.readthedocs.io\">Betty👵</a>"
@@ -73,10 +76,16 @@ msgstr ""
 msgid "A formal witness to an event."
 msgstr ""
 
+msgid "A localizable string"
+msgstr ""
+
 msgid "A person's presence at an event."
 msgstr ""
 
 msgid "A place number, such as a house or flat number."
+msgstr ""
+
+msgid "A plugin ID"
 msgstr ""
 
 msgid "A single file in a media display"
@@ -138,6 +147,9 @@ msgid "Announcements of marriage"
 msgstr ""
 
 msgid "Appearances"
+msgstr ""
+
+msgid "Application configuration"
 msgstr ""
 
 msgid "Assets directory"
@@ -326,6 +338,9 @@ msgstr ""
 msgid "City"
 msgstr ""
 
+msgid "Clean URLs"
+msgstr ""
+
 msgid "Clear all caches"
 msgstr ""
 
@@ -460,13 +475,24 @@ msgid "Cremations"
 msgstr ""
 
 #, python-brace-format
-msgid "Data has no {attribute} attribute."
+msgid "Data has no attribute {attribute}"
+msgstr ""
+
+#, python-brace-format
+msgid "Data has no index {index}"
+msgstr ""
+
+#, python-brace-format
+msgid "Data has no key \"{key}\""
 msgstr ""
 
 msgid "Death"
 msgstr "موت"
 
 msgid "Deaths"
+msgstr ""
+
+msgid "Debugging mode"
 msgstr ""
 
 msgid "Department"
@@ -572,6 +598,12 @@ msgstr ""
 msgid "Entity type"
 msgstr ""
 
+msgid "Entity type configuration"
+msgstr ""
+
+msgid "Entity types"
+msgstr ""
+
 msgid "Event"
 msgstr ""
 
@@ -667,6 +699,9 @@ msgid "Genders"
 msgstr ""
 
 msgid "Generate a static site"
+msgstr ""
+
+msgid "Generate list HTML page"
 msgstr ""
 
 msgid "Generating site..."
@@ -792,6 +827,9 @@ msgstr ""
 msgid "Licenses"
 msgstr ""
 
+msgid "Lifetime threshold"
+msgstr ""
+
 msgid "Link"
 msgstr ""
 
@@ -841,6 +879,9 @@ msgstr ""
 msgid "Loading \"{file_path}\"..."
 msgstr ""
 
+msgid "Locale"
+msgstr ""
+
 msgid "Locale aliases must not contain slashes."
 msgstr ""
 
@@ -848,10 +889,16 @@ msgstr ""
 msgid "Locale {locale} is not known by your system."
 msgstr ""
 
+msgid "Locales"
+msgstr ""
+
 msgid "Localities"
 msgstr ""
 
 msgid "Locality"
+msgstr ""
+
+msgid "Logo"
 msgstr ""
 
 msgid "MMMM"
@@ -864,6 +911,9 @@ msgid "MMMM d, y"
 msgstr ""
 
 msgid "MMMM, y"
+msgstr ""
+
+msgid "Machine name"
 msgstr ""
 
 msgid "Man"
@@ -1069,6 +1119,9 @@ msgstr ""
 msgid "Plugins"
 msgstr ""
 
+msgid "Populate images"
+msgstr ""
+
 msgid "Positional arguments"
 msgstr ""
 
@@ -1129,6 +1182,9 @@ msgid ""
 msgstr ""
 
 msgid "Project author"
+msgstr ""
+
+msgid "Project configuration"
 msgstr ""
 
 msgid "Province"
@@ -1342,11 +1398,19 @@ msgstr ""
 msgid "The URL must start with a scheme such as https:// or http://."
 msgstr ""
 
+msgid "The absolute, public URL at which the site will be published."
+msgstr ""
+
 #, python-brace-format
 msgid ""
 "The betty:privacy Gramps attribute must have a value of \"public\" or "
 "\"private\", but \"{privacy_value}\" was given for {entity_type} "
 "{entity_id} ({entity_label}), which was ignored."
+msgstr ""
+
+msgid ""
+"The number of years people are expected to live at most, e.g. after which"
+" they are presumed to have died."
 msgstr ""
 
 #, python-brace-format
@@ -1461,6 +1525,9 @@ msgstr ""
 msgid "Timeline"
 msgstr "الخط الزمني"
 
+msgid "Title"
+msgstr ""
+
 msgid "Toggle full screen"
 msgstr ""
 
@@ -1479,6 +1546,9 @@ msgid "Translations for {locale} initialized at {po_file_path}."
 msgstr ""
 
 msgid "Type"
+msgstr ""
+
+msgid "URL"
 msgstr ""
 
 msgid "Unauthorized"
@@ -1572,8 +1642,24 @@ msgid "Where do you want to save your project's configuration file?"
 msgstr ""
 
 msgid ""
+"Whether to download additional images found through Wikipedia links in "
+"the ancestry"
+msgstr ""
+
+msgid ""
+"Whether to output more detailed logs and disable optimizations that make "
+"debugging harder."
+msgstr ""
+
+msgid "Whether to use clean URLs: \"/path\" instead of \"/path/index.html\"."
+msgstr ""
+
+msgid ""
 "Which language should your project site be generated in? Enter a language"
 " code."
+msgstr ""
+
+msgid "Wiki extension configuration"
 msgstr ""
 
 msgid "Wikipedia contributors"

--- a/assets/locale/betty.pot
+++ b/assets/locale/betty.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-17 22:03+0000\n"
+"POT-Creation-Date: 2026-01-19 20:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -62,6 +62,9 @@ msgstr ""
 msgid "A Betty demonstration"
 msgstr ""
 
+msgid "A countable localizable string"
+msgstr ""
+
 msgid ""
 "A family history as told by <a "
 "href=\"https://betty.readthedocs.io\">Betty👵</a>"
@@ -70,10 +73,16 @@ msgstr ""
 msgid "A formal witness to an event."
 msgstr ""
 
+msgid "A localizable string"
+msgstr ""
+
 msgid "A person's presence at an event."
 msgstr ""
 
 msgid "A place number, such as a house or flat number."
+msgstr ""
+
+msgid "A plugin ID"
 msgstr ""
 
 msgid "A single file in a media display"
@@ -135,6 +144,9 @@ msgid "Announcements of marriage"
 msgstr ""
 
 msgid "Appearances"
+msgstr ""
+
+msgid "Application configuration"
 msgstr ""
 
 msgid "Assets directory"
@@ -322,6 +334,9 @@ msgstr ""
 msgid "City"
 msgstr ""
 
+msgid "Clean URLs"
+msgstr ""
+
 msgid "Clear all caches"
 msgstr ""
 
@@ -456,13 +471,24 @@ msgid "Cremations"
 msgstr ""
 
 #, python-brace-format
-msgid "Data has no {attribute} attribute."
+msgid "Data has no attribute {attribute}"
+msgstr ""
+
+#, python-brace-format
+msgid "Data has no index {index}"
+msgstr ""
+
+#, python-brace-format
+msgid "Data has no key \"{key}\""
 msgstr ""
 
 msgid "Death"
 msgstr ""
 
 msgid "Deaths"
+msgstr ""
+
+msgid "Debugging mode"
 msgstr ""
 
 msgid "Department"
@@ -566,6 +592,12 @@ msgstr ""
 msgid "Entity type"
 msgstr ""
 
+msgid "Entity type configuration"
+msgstr ""
+
+msgid "Entity types"
+msgstr ""
+
 msgid "Event"
 msgstr ""
 
@@ -661,6 +693,9 @@ msgid "Genders"
 msgstr ""
 
 msgid "Generate a static site"
+msgstr ""
+
+msgid "Generate list HTML page"
 msgstr ""
 
 msgid "Generating site..."
@@ -785,6 +820,9 @@ msgstr ""
 msgid "Licenses"
 msgstr ""
 
+msgid "Lifetime threshold"
+msgstr ""
+
 msgid "Link"
 msgstr ""
 
@@ -834,6 +872,9 @@ msgstr ""
 msgid "Loading \"{file_path}\"..."
 msgstr ""
 
+msgid "Locale"
+msgstr ""
+
 msgid "Locale aliases must not contain slashes."
 msgstr ""
 
@@ -841,10 +882,16 @@ msgstr ""
 msgid "Locale {locale} is not known by your system."
 msgstr ""
 
+msgid "Locales"
+msgstr ""
+
 msgid "Localities"
 msgstr ""
 
 msgid "Locality"
+msgstr ""
+
+msgid "Logo"
 msgstr ""
 
 msgid "MMMM"
@@ -857,6 +904,9 @@ msgid "MMMM d, y"
 msgstr ""
 
 msgid "MMMM, y"
+msgstr ""
+
+msgid "Machine name"
 msgstr ""
 
 msgid "Man"
@@ -1060,6 +1110,9 @@ msgstr ""
 msgid "Plugins"
 msgstr ""
 
+msgid "Populate images"
+msgstr ""
+
 msgid "Positional arguments"
 msgstr ""
 
@@ -1116,6 +1169,9 @@ msgid ""
 msgstr ""
 
 msgid "Project author"
+msgstr ""
+
+msgid "Project configuration"
 msgstr ""
 
 msgid "Province"
@@ -1329,11 +1385,19 @@ msgstr ""
 msgid "The URL must start with a scheme such as https:// or http://."
 msgstr ""
 
+msgid "The absolute, public URL at which the site will be published."
+msgstr ""
+
 #, python-brace-format
 msgid ""
 "The betty:privacy Gramps attribute must have a value of \"public\" or "
 "\"private\", but \"{privacy_value}\" was given for {entity_type} "
 "{entity_id} ({entity_label}), which was ignored."
+msgstr ""
+
+msgid ""
+"The number of years people are expected to live at most, e.g. after which "
+"they are presumed to have died."
 msgstr ""
 
 #, python-brace-format
@@ -1436,6 +1500,9 @@ msgstr ""
 msgid "Timeline"
 msgstr ""
 
+msgid "Title"
+msgstr ""
+
 msgid "Toggle full screen"
 msgstr ""
 
@@ -1454,6 +1521,9 @@ msgid "Translations for {locale} initialized at {po_file_path}."
 msgstr ""
 
 msgid "Type"
+msgstr ""
+
+msgid "URL"
 msgstr ""
 
 msgid "Unauthorized"
@@ -1547,8 +1617,24 @@ msgid "Where do you want to save your project's configuration file?"
 msgstr ""
 
 msgid ""
+"Whether to download additional images found through Wikipedia links in the"
+" ancestry"
+msgstr ""
+
+msgid ""
+"Whether to output more detailed logs and disable optimizations that make "
+"debugging harder."
+msgstr ""
+
+msgid "Whether to use clean URLs: \"/path\" instead of \"/path/index.html\"."
+msgstr ""
+
+msgid ""
 "Which language should your project site be generated in? Enter a language "
 "code."
+msgstr ""
+
+msgid "Wiki extension configuration"
 msgstr ""
 
 msgid "Wikipedia contributors"

--- a/assets/locale/de-DE/betty.po
+++ b/assets/locale/de-DE/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-17 22:03+0000\n"
+"POT-Creation-Date: 2026-01-19 20:08+0000\n"
 "PO-Revision-Date: 2025-03-28 20:02+0000\n"
 "Last-Translator: Ettore Atalan <atalanttore@googlemail.com>\n"
 "Language: de_DE\n"
@@ -64,6 +64,9 @@ msgstr "%(event)s mit %(subjects)s"
 msgid "A Betty demonstration"
 msgstr ""
 
+msgid "A countable localizable string"
+msgstr ""
+
 msgid ""
 "A family history as told by <a "
 "href=\"https://betty.readthedocs.io\">Betty👵</a>"
@@ -74,10 +77,16 @@ msgstr ""
 msgid "A formal witness to an event."
 msgstr ""
 
+msgid "A localizable string"
+msgstr ""
+
 msgid "A person's presence at an event."
 msgstr ""
 
 msgid "A place number, such as a house or flat number."
+msgstr ""
+
+msgid "A plugin ID"
 msgstr ""
 
 msgid "A single file in a media display"
@@ -140,6 +149,9 @@ msgstr ""
 
 msgid "Appearances"
 msgstr "Erscheinungen"
+
+msgid "Application configuration"
+msgstr ""
 
 msgid "Assets directory"
 msgstr ""
@@ -343,6 +355,9 @@ msgstr ""
 msgid "City"
 msgstr "Großstadt"
 
+msgid "Clean URLs"
+msgstr ""
+
 msgid "Clear all caches"
 msgstr ""
 
@@ -481,13 +496,24 @@ msgid "Cremations"
 msgstr ""
 
 #, python-brace-format
-msgid "Data has no {attribute} attribute."
+msgid "Data has no attribute {attribute}"
+msgstr ""
+
+#, python-brace-format
+msgid "Data has no index {index}"
+msgstr ""
+
+#, python-brace-format
+msgid "Data has no key \"{key}\""
 msgstr ""
 
 msgid "Death"
 msgstr "Tod"
 
 msgid "Deaths"
+msgstr ""
+
+msgid "Debugging mode"
 msgstr ""
 
 msgid "Department"
@@ -595,6 +621,12 @@ msgstr ""
 msgid "Entity type"
 msgstr ""
 
+msgid "Entity type configuration"
+msgstr ""
+
+msgid "Entity types"
+msgstr ""
+
 msgid "Event"
 msgstr "Ereignis"
 
@@ -690,6 +722,9 @@ msgid "Genders"
 msgstr ""
 
 msgid "Generate a static site"
+msgstr ""
+
+msgid "Generate list HTML page"
 msgstr ""
 
 msgid "Generating site..."
@@ -815,6 +850,9 @@ msgstr "Lizenz"
 msgid "Licenses"
 msgstr ""
 
+msgid "Lifetime threshold"
+msgstr ""
+
 msgid "Link"
 msgstr ""
 
@@ -864,6 +902,9 @@ msgstr "{source_count} Quellen geladen."
 msgid "Loading \"{file_path}\"..."
 msgstr "Lade \"{file_path}\"..."
 
+msgid "Locale"
+msgstr ""
+
 msgid "Locale aliases must not contain slashes."
 msgstr "Gebietsschema-Aliase dürfen keine Schrägstriche enthalten."
 
@@ -871,11 +912,17 @@ msgstr "Gebietsschema-Aliase dürfen keine Schrägstriche enthalten."
 msgid "Locale {locale} is not known by your system."
 msgstr ""
 
+msgid "Locales"
+msgstr ""
+
 msgid "Localities"
 msgstr ""
 
 msgid "Locality"
 msgstr "Örtlichkeit"
+
+msgid "Logo"
+msgstr ""
 
 msgid "MMMM"
 msgstr "MMMM"
@@ -888,6 +935,9 @@ msgstr "d MMMM y"
 
 msgid "MMMM, y"
 msgstr "MMMM y"
+
+msgid "Machine name"
+msgstr ""
 
 msgid "Man"
 msgstr ""
@@ -1092,6 +1142,9 @@ msgstr ""
 msgid "Plugins"
 msgstr ""
 
+msgid "Populate images"
+msgstr ""
+
 msgid "Positional arguments"
 msgstr ""
 
@@ -1156,6 +1209,9 @@ msgstr ""
 
 msgid "Project author"
 msgstr "Projektautor"
+
+msgid "Project configuration"
+msgstr ""
 
 msgid "Province"
 msgstr "Provinz"
@@ -1368,6 +1424,9 @@ msgstr ""
 msgid "The URL must start with a scheme such as https:// or http://."
 msgstr "Die URL muss mit einem Schema, wie https://, oder http:// starten."
 
+msgid "The absolute, public URL at which the site will be published."
+msgstr ""
+
 #, python-brace-format
 msgid ""
 "The betty:privacy Gramps attribute must have a value of \"public\" or "
@@ -1377,6 +1436,11 @@ msgstr ""
 "Das betty:privacy Gramps-Attribut muss einen Wert von \"public\" oder "
 "\"private\" haben, aber \"{privacy_value}\" wurde für {entity_type} "
 "{entity_id} ({entity_label}) angegeben, was ignoriert wurde."
+
+msgid ""
+"The number of years people are expected to live at most, e.g. after which"
+" they are presumed to have died."
+msgstr ""
 
 #, python-brace-format
 msgid ""
@@ -1478,6 +1542,9 @@ msgstr ""
 msgid "Timeline"
 msgstr "Zeitschiene"
 
+msgid "Title"
+msgstr ""
+
 msgid "Toggle full screen"
 msgstr "Vollbild umschalten"
 
@@ -1496,6 +1563,9 @@ msgid "Translations for {locale} initialized at {po_file_path}."
 msgstr ""
 
 msgid "Type"
+msgstr ""
+
+msgid "URL"
 msgstr ""
 
 msgid "Unauthorized"
@@ -1591,8 +1661,24 @@ msgid "Where do you want to save your project's configuration file?"
 msgstr ""
 
 msgid ""
+"Whether to download additional images found through Wikipedia links in "
+"the ancestry"
+msgstr ""
+
+msgid ""
+"Whether to output more detailed logs and disable optimizations that make "
+"debugging harder."
+msgstr ""
+
+msgid "Whether to use clean URLs: \"/path\" instead of \"/path/index.html\"."
+msgstr ""
+
+msgid ""
 "Which language should your project site be generated in? Enter a language"
 " code."
+msgstr ""
+
+msgid "Wiki extension configuration"
 msgstr ""
 
 msgid "Wikipedia contributors"

--- a/assets/locale/en-GB/betty.po
+++ b/assets/locale/en-GB/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-17 22:03+0000\n"
+"POT-Creation-Date: 2026-01-19 20:08+0000\n"
 "PO-Revision-Date: 2025-12-29 14:25+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: en_GB\n"
@@ -66,6 +66,9 @@ msgstr "%(event)s with %(subjects)s"
 msgid "A Betty demonstration"
 msgstr ""
 
+msgid "A countable localizable string"
+msgstr ""
+
 msgid ""
 "A family history as told by <a "
 "href=\"https://betty.readthedocs.io\">Betty👵</a>"
@@ -76,10 +79,16 @@ msgstr ""
 msgid "A formal witness to an event."
 msgstr ""
 
+msgid "A localizable string"
+msgstr ""
+
 msgid "A person's presence at an event."
 msgstr ""
 
 msgid "A place number, such as a house or flat number."
+msgstr ""
+
+msgid "A plugin ID"
 msgstr ""
 
 msgid "A single file in a media display"
@@ -142,6 +151,9 @@ msgstr ""
 
 msgid "Appearances"
 msgstr "Appearances"
+
+msgid "Application configuration"
+msgstr ""
 
 msgid "Assets directory"
 msgstr ""
@@ -353,6 +365,9 @@ msgstr ""
 msgid "City"
 msgstr "City"
 
+msgid "Clean URLs"
+msgstr ""
+
 msgid "Clear all caches"
 msgstr "Clear all caches"
 
@@ -495,13 +510,24 @@ msgid "Cremations"
 msgstr ""
 
 #, python-brace-format
-msgid "Data has no {attribute} attribute."
+msgid "Data has no attribute {attribute}"
+msgstr ""
+
+#, python-brace-format
+msgid "Data has no index {index}"
+msgstr ""
+
+#, python-brace-format
+msgid "Data has no key \"{key}\""
 msgstr ""
 
 msgid "Death"
 msgstr "Death"
 
 msgid "Deaths"
+msgstr ""
+
+msgid "Debugging mode"
 msgstr ""
 
 msgid "Department"
@@ -609,6 +635,12 @@ msgstr ""
 msgid "Entity type"
 msgstr "Entity type"
 
+msgid "Entity type configuration"
+msgstr ""
+
+msgid "Entity types"
+msgstr ""
+
 msgid "Event"
 msgstr "Event"
 
@@ -705,6 +737,9 @@ msgstr ""
 
 msgid "Generate a static site"
 msgstr "Generate a static site"
+
+msgid "Generate list HTML page"
+msgstr ""
 
 msgid "Generating site..."
 msgstr ""
@@ -832,6 +867,9 @@ msgstr "Licence"
 msgid "Licenses"
 msgstr ""
 
+msgid "Lifetime threshold"
+msgstr ""
+
 msgid "Link"
 msgstr ""
 
@@ -881,6 +919,9 @@ msgstr "Loaded {source_count} sources."
 msgid "Loading \"{file_path}\"..."
 msgstr "Loading \"{file_path}\"..."
 
+msgid "Locale"
+msgstr ""
+
 msgid "Locale aliases must not contain slashes."
 msgstr "Locale aliases must not contain slashes."
 
@@ -888,11 +929,17 @@ msgstr "Locale aliases must not contain slashes."
 msgid "Locale {locale} is not known by your system."
 msgstr ""
 
+msgid "Locales"
+msgstr ""
+
 msgid "Localities"
 msgstr ""
 
 msgid "Locality"
 msgstr "Locality"
+
+msgid "Logo"
+msgstr ""
 
 msgid "MMMM"
 msgstr "MMMM"
@@ -905,6 +952,9 @@ msgstr "d MMMM y"
 
 msgid "MMMM, y"
 msgstr "MMMM y"
+
+msgid "Machine name"
+msgstr ""
 
 msgid "Man"
 msgstr ""
@@ -1112,6 +1162,9 @@ msgstr ""
 msgid "Plugins"
 msgstr ""
 
+msgid "Populate images"
+msgstr ""
+
 msgid "Positional arguments"
 msgstr ""
 
@@ -1176,6 +1229,9 @@ msgstr ""
 
 msgid "Project author"
 msgstr "Project author"
+
+msgid "Project configuration"
+msgstr ""
 
 msgid "Province"
 msgstr "Province"
@@ -1394,6 +1450,9 @@ msgstr "The URL must include a host."
 msgid "The URL must start with a scheme such as https:// or http://."
 msgstr "The URL must start with a scheme such as https:// or http://."
 
+msgid "The absolute, public URL at which the site will be published."
+msgstr ""
+
 #, python-brace-format
 msgid ""
 "The betty:privacy Gramps attribute must have a value of \"public\" or "
@@ -1403,6 +1462,11 @@ msgstr ""
 "The betty:privacy Gramps attribute must have a value of \"public\" or "
 "\"private\", but \"{privacy_value}\" was given for {entity_type} "
 "{entity_id} ({entity_label}), which was ignored."
+
+msgid ""
+"The number of years people are expected to live at most, e.g. after which"
+" they are presumed to have died."
+msgstr ""
 
 #, python-brace-format
 msgid ""
@@ -1504,6 +1568,9 @@ msgstr ""
 msgid "Timeline"
 msgstr "Timeline"
 
+msgid "Title"
+msgstr ""
+
 msgid "Toggle full screen"
 msgstr "Toggle full screen"
 
@@ -1522,6 +1589,9 @@ msgid "Translations for {locale} initialized at {po_file_path}."
 msgstr ""
 
 msgid "Type"
+msgstr ""
+
+msgid "URL"
 msgstr ""
 
 msgid "Unauthorized"
@@ -1617,8 +1687,24 @@ msgid "Where do you want to save your project's configuration file?"
 msgstr "Where do you want to save your project's configuration file?"
 
 msgid ""
+"Whether to download additional images found through Wikipedia links in "
+"the ancestry"
+msgstr ""
+
+msgid ""
+"Whether to output more detailed logs and disable optimizations that make "
+"debugging harder."
+msgstr ""
+
+msgid "Whether to use clean URLs: \"/path\" instead of \"/path/index.html\"."
+msgstr ""
+
+msgid ""
 "Which language should your project site be generated in? Enter a language"
 " code."
+msgstr ""
+
+msgid "Wiki extension configuration"
 msgstr ""
 
 msgid "Wikipedia contributors"

--- a/assets/locale/es-ES/betty.po
+++ b/assets/locale/es-ES/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-17 22:03+0000\n"
+"POT-Creation-Date: 2026-01-19 20:08+0000\n"
 "PO-Revision-Date: 2025-12-29 14:48+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: es_ES\n"
@@ -64,6 +64,9 @@ msgstr "%(event)s con %(subjects)s"
 msgid "A Betty demonstration"
 msgstr ""
 
+msgid "A countable localizable string"
+msgstr ""
+
 msgid ""
 "A family history as told by <a "
 "href=\"https://betty.readthedocs.io\">Betty👵</a>"
@@ -74,10 +77,16 @@ msgstr ""
 msgid "A formal witness to an event."
 msgstr ""
 
+msgid "A localizable string"
+msgstr ""
+
 msgid "A person's presence at an event."
 msgstr ""
 
 msgid "A place number, such as a house or flat number."
+msgstr ""
+
+msgid "A plugin ID"
 msgstr ""
 
 msgid "A single file in a media display"
@@ -140,6 +149,9 @@ msgstr ""
 
 msgid "Appearances"
 msgstr "Apariciónes"
+
+msgid "Application configuration"
+msgstr ""
 
 msgid "Assets directory"
 msgstr ""
@@ -327,6 +339,9 @@ msgstr ""
 msgid "City"
 msgstr "Ciudad"
 
+msgid "Clean URLs"
+msgstr ""
+
 msgid "Clear all caches"
 msgstr ""
 
@@ -463,13 +478,24 @@ msgid "Cremations"
 msgstr ""
 
 #, python-brace-format
-msgid "Data has no {attribute} attribute."
+msgid "Data has no attribute {attribute}"
+msgstr ""
+
+#, python-brace-format
+msgid "Data has no index {index}"
+msgstr ""
+
+#, python-brace-format
+msgid "Data has no key \"{key}\""
 msgstr ""
 
 msgid "Death"
 msgstr "Muerte"
 
 msgid "Deaths"
+msgstr ""
+
+msgid "Debugging mode"
 msgstr ""
 
 msgid "Department"
@@ -575,6 +601,12 @@ msgstr ""
 msgid "Entity type"
 msgstr "Tipo de entidad"
 
+msgid "Entity type configuration"
+msgstr ""
+
+msgid "Entity types"
+msgstr ""
+
 msgid "Event"
 msgstr ""
 
@@ -670,6 +702,9 @@ msgid "Genders"
 msgstr ""
 
 msgid "Generate a static site"
+msgstr ""
+
+msgid "Generate list HTML page"
 msgstr ""
 
 msgid "Generating site..."
@@ -795,6 +830,9 @@ msgstr ""
 msgid "Licenses"
 msgstr ""
 
+msgid "Lifetime threshold"
+msgstr ""
+
 msgid "Link"
 msgstr ""
 
@@ -844,6 +882,9 @@ msgstr ""
 msgid "Loading \"{file_path}\"..."
 msgstr ""
 
+msgid "Locale"
+msgstr ""
+
 msgid "Locale aliases must not contain slashes."
 msgstr ""
 
@@ -851,10 +892,16 @@ msgstr ""
 msgid "Locale {locale} is not known by your system."
 msgstr ""
 
+msgid "Locales"
+msgstr ""
+
 msgid "Localities"
 msgstr ""
 
 msgid "Locality"
+msgstr ""
+
+msgid "Logo"
 msgstr ""
 
 msgid "MMMM"
@@ -868,6 +915,9 @@ msgstr "d 'de' MMMM 'de' y"
 
 msgid "MMMM, y"
 msgstr "MMMM 'de' y"
+
+msgid "Machine name"
+msgstr ""
 
 msgid "Man"
 msgstr ""
@@ -1072,6 +1122,9 @@ msgstr ""
 msgid "Plugins"
 msgstr ""
 
+msgid "Populate images"
+msgstr ""
+
 msgid "Positional arguments"
 msgstr ""
 
@@ -1128,6 +1181,9 @@ msgid ""
 msgstr ""
 
 msgid "Project author"
+msgstr ""
+
+msgid "Project configuration"
 msgstr ""
 
 msgid "Province"
@@ -1341,11 +1397,19 @@ msgstr ""
 msgid "The URL must start with a scheme such as https:// or http://."
 msgstr ""
 
+msgid "The absolute, public URL at which the site will be published."
+msgstr ""
+
 #, python-brace-format
 msgid ""
 "The betty:privacy Gramps attribute must have a value of \"public\" or "
 "\"private\", but \"{privacy_value}\" was given for {entity_type} "
 "{entity_id} ({entity_label}), which was ignored."
+msgstr ""
+
+msgid ""
+"The number of years people are expected to live at most, e.g. after which"
+" they are presumed to have died."
 msgstr ""
 
 #, python-brace-format
@@ -1448,6 +1512,9 @@ msgstr ""
 msgid "Timeline"
 msgstr "Linea de tiempo"
 
+msgid "Title"
+msgstr ""
+
 msgid "Toggle full screen"
 msgstr ""
 
@@ -1466,6 +1533,9 @@ msgid "Translations for {locale} initialized at {po_file_path}."
 msgstr ""
 
 msgid "Type"
+msgstr ""
+
+msgid "URL"
 msgstr ""
 
 msgid "Unauthorized"
@@ -1559,8 +1629,24 @@ msgid "Where do you want to save your project's configuration file?"
 msgstr ""
 
 msgid ""
+"Whether to download additional images found through Wikipedia links in "
+"the ancestry"
+msgstr ""
+
+msgid ""
+"Whether to output more detailed logs and disable optimizations that make "
+"debugging harder."
+msgstr ""
+
+msgid "Whether to use clean URLs: \"/path\" instead of \"/path/index.html\"."
+msgstr ""
+
+msgid ""
 "Which language should your project site be generated in? Enter a language"
 " code."
+msgstr ""
+
+msgid "Wiki extension configuration"
 msgstr ""
 
 msgid "Wikipedia contributors"

--- a/assets/locale/fr-FR/betty.po
+++ b/assets/locale/fr-FR/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-17 22:03+0000\n"
+"POT-Creation-Date: 2026-01-19 20:08+0000\n"
 "PO-Revision-Date: 2025-08-27 20:02+0000\n"
 "Last-Translator: \"David D.\" <dadu042@users.noreply.hosted.weblate.org>\n"
 "Language: fr_FR\n"
@@ -64,6 +64,9 @@ msgstr "%(event)s avec %(subjects)s"
 msgid "A Betty demonstration"
 msgstr ""
 
+msgid "A countable localizable string"
+msgstr ""
+
 msgid ""
 "A family history as told by <a "
 "href=\"https://betty.readthedocs.io\">Betty👵</a>"
@@ -74,10 +77,16 @@ msgstr ""
 msgid "A formal witness to an event."
 msgstr ""
 
+msgid "A localizable string"
+msgstr ""
+
 msgid "A person's presence at an event."
 msgstr ""
 
 msgid "A place number, such as a house or flat number."
+msgstr ""
+
+msgid "A plugin ID"
 msgstr ""
 
 msgid "A single file in a media display"
@@ -140,6 +149,9 @@ msgstr ""
 
 msgid "Appearances"
 msgstr "Caractéristiques"
+
+msgid "Application configuration"
+msgstr ""
 
 msgid "Assets directory"
 msgstr ""
@@ -332,6 +344,9 @@ msgstr ""
 msgid "City"
 msgstr ""
 
+msgid "Clean URLs"
+msgstr ""
+
 msgid "Clear all caches"
 msgstr ""
 
@@ -468,13 +483,24 @@ msgid "Cremations"
 msgstr ""
 
 #, python-brace-format
-msgid "Data has no {attribute} attribute."
+msgid "Data has no attribute {attribute}"
+msgstr ""
+
+#, python-brace-format
+msgid "Data has no index {index}"
+msgstr ""
+
+#, python-brace-format
+msgid "Data has no key \"{key}\""
 msgstr ""
 
 msgid "Death"
 msgstr "Décès"
 
 msgid "Deaths"
+msgstr ""
+
+msgid "Debugging mode"
 msgstr ""
 
 msgid "Department"
@@ -580,6 +606,12 @@ msgstr ""
 msgid "Entity type"
 msgstr "Type d'entité"
 
+msgid "Entity type configuration"
+msgstr ""
+
+msgid "Entity types"
+msgstr ""
+
 msgid "Event"
 msgstr "Evénement"
 
@@ -676,6 +708,9 @@ msgstr ""
 
 msgid "Generate a static site"
 msgstr "Générer un site statique"
+
+msgid "Generate list HTML page"
+msgstr ""
 
 msgid "Generating site..."
 msgstr ""
@@ -804,6 +839,9 @@ msgstr "Licence"
 msgid "Licenses"
 msgstr ""
 
+msgid "Lifetime threshold"
+msgstr ""
+
 msgid "Link"
 msgstr ""
 
@@ -853,6 +891,9 @@ msgstr ""
 msgid "Loading \"{file_path}\"..."
 msgstr ""
 
+msgid "Locale"
+msgstr ""
+
 msgid "Locale aliases must not contain slashes."
 msgstr ""
 
@@ -860,11 +901,17 @@ msgstr ""
 msgid "Locale {locale} is not known by your system."
 msgstr ""
 
+msgid "Locales"
+msgstr ""
+
 msgid "Localities"
 msgstr ""
 
 msgid "Locality"
 msgstr "Localité"
+
+msgid "Logo"
+msgstr ""
 
 msgid "MMMM"
 msgstr "MMMM"
@@ -877,6 +924,9 @@ msgstr "d MMMM y"
 
 msgid "MMMM, y"
 msgstr "MMMM y"
+
+msgid "Machine name"
+msgstr ""
 
 msgid "Man"
 msgstr ""
@@ -1081,6 +1131,9 @@ msgstr ""
 msgid "Plugins"
 msgstr ""
 
+msgid "Populate images"
+msgstr ""
+
 msgid "Positional arguments"
 msgstr ""
 
@@ -1138,6 +1191,9 @@ msgstr ""
 
 msgid "Project author"
 msgstr "Auteur du projet"
+
+msgid "Project configuration"
+msgstr ""
 
 msgid "Province"
 msgstr "Province"
@@ -1350,11 +1406,19 @@ msgstr "L’URL doit inclure un hôte."
 msgid "The URL must start with a scheme such as https:// or http://."
 msgstr "L’URL doit commencer par un schéma tel que https:// ou http://."
 
+msgid "The absolute, public URL at which the site will be published."
+msgstr ""
+
 #, python-brace-format
 msgid ""
 "The betty:privacy Gramps attribute must have a value of \"public\" or "
 "\"private\", but \"{privacy_value}\" was given for {entity_type} "
 "{entity_id} ({entity_label}), which was ignored."
+msgstr ""
+
+msgid ""
+"The number of years people are expected to live at most, e.g. after which"
+" they are presumed to have died."
 msgstr ""
 
 #, python-brace-format
@@ -1459,6 +1523,9 @@ msgstr ""
 msgid "Timeline"
 msgstr "Chronologie"
 
+msgid "Title"
+msgstr ""
+
 msgid "Toggle full screen"
 msgstr ""
 
@@ -1477,6 +1544,9 @@ msgid "Translations for {locale} initialized at {po_file_path}."
 msgstr ""
 
 msgid "Type"
+msgstr ""
+
+msgid "URL"
 msgstr ""
 
 msgid "Unauthorized"
@@ -1572,8 +1642,24 @@ msgid "Where do you want to save your project's configuration file?"
 msgstr "Où voulez-vous enregistrer le fichier de configuration de votre projet ?"
 
 msgid ""
+"Whether to download additional images found through Wikipedia links in "
+"the ancestry"
+msgstr ""
+
+msgid ""
+"Whether to output more detailed logs and disable optimizations that make "
+"debugging harder."
+msgstr ""
+
+msgid "Whether to use clean URLs: \"/path\" instead of \"/path/index.html\"."
+msgstr ""
+
+msgid ""
 "Which language should your project site be generated in? Enter a language"
 " code."
+msgstr ""
+
+msgid "Wiki extension configuration"
 msgstr ""
 
 msgid "Wikipedia contributors"

--- a/assets/locale/he/betty.po
+++ b/assets/locale/he/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-17 22:03+0000\n"
+"POT-Creation-Date: 2026-01-19 20:08+0000\n"
 "PO-Revision-Date: 2025-05-06 10:01+0000\n"
 "Last-Translator: Yaron Shahrabani <sh.yaron@gmail.com>\n"
 "Language: he\n"
@@ -66,6 +66,9 @@ msgstr "%(event)s עם %(subjects)s"
 msgid "A Betty demonstration"
 msgstr ""
 
+msgid "A countable localizable string"
+msgstr ""
+
 msgid ""
 "A family history as told by <a "
 "href=\"https://betty.readthedocs.io\">Betty👵</a>"
@@ -74,10 +77,16 @@ msgstr ""
 msgid "A formal witness to an event."
 msgstr ""
 
+msgid "A localizable string"
+msgstr ""
+
 msgid "A person's presence at an event."
 msgstr ""
 
 msgid "A place number, such as a house or flat number."
+msgstr ""
+
+msgid "A plugin ID"
 msgstr ""
 
 msgid "A single file in a media display"
@@ -139,6 +148,9 @@ msgid "Announcements of marriage"
 msgstr ""
 
 msgid "Appearances"
+msgstr ""
+
+msgid "Application configuration"
 msgstr ""
 
 msgid "Assets directory"
@@ -327,6 +339,9 @@ msgstr ""
 msgid "City"
 msgstr ""
 
+msgid "Clean URLs"
+msgstr ""
+
 msgid "Clear all caches"
 msgstr ""
 
@@ -461,13 +476,24 @@ msgid "Cremations"
 msgstr ""
 
 #, python-brace-format
-msgid "Data has no {attribute} attribute."
+msgid "Data has no attribute {attribute}"
+msgstr ""
+
+#, python-brace-format
+msgid "Data has no index {index}"
+msgstr ""
+
+#, python-brace-format
+msgid "Data has no key \"{key}\""
 msgstr ""
 
 msgid "Death"
 msgstr ""
 
 msgid "Deaths"
+msgstr ""
+
+msgid "Debugging mode"
 msgstr ""
 
 msgid "Department"
@@ -573,6 +599,12 @@ msgstr ""
 msgid "Entity type"
 msgstr ""
 
+msgid "Entity type configuration"
+msgstr ""
+
+msgid "Entity types"
+msgstr ""
+
 msgid "Event"
 msgstr ""
 
@@ -668,6 +700,9 @@ msgid "Genders"
 msgstr ""
 
 msgid "Generate a static site"
+msgstr ""
+
+msgid "Generate list HTML page"
 msgstr ""
 
 msgid "Generating site..."
@@ -793,6 +828,9 @@ msgstr ""
 msgid "Licenses"
 msgstr ""
 
+msgid "Lifetime threshold"
+msgstr ""
+
 msgid "Link"
 msgstr ""
 
@@ -842,6 +880,9 @@ msgstr ""
 msgid "Loading \"{file_path}\"..."
 msgstr ""
 
+msgid "Locale"
+msgstr ""
+
 msgid "Locale aliases must not contain slashes."
 msgstr ""
 
@@ -849,10 +890,16 @@ msgstr ""
 msgid "Locale {locale} is not known by your system."
 msgstr ""
 
+msgid "Locales"
+msgstr ""
+
 msgid "Localities"
 msgstr ""
 
 msgid "Locality"
+msgstr ""
+
+msgid "Logo"
 msgstr ""
 
 msgid "MMMM"
@@ -865,6 +912,9 @@ msgid "MMMM d, y"
 msgstr ""
 
 msgid "MMMM, y"
+msgstr ""
+
+msgid "Machine name"
 msgstr ""
 
 msgid "Man"
@@ -1070,6 +1120,9 @@ msgstr ""
 msgid "Plugins"
 msgstr ""
 
+msgid "Populate images"
+msgstr ""
+
 msgid "Positional arguments"
 msgstr ""
 
@@ -1126,6 +1179,9 @@ msgid ""
 msgstr ""
 
 msgid "Project author"
+msgstr ""
+
+msgid "Project configuration"
 msgstr ""
 
 msgid "Province"
@@ -1339,11 +1395,19 @@ msgstr ""
 msgid "The URL must start with a scheme such as https:// or http://."
 msgstr ""
 
+msgid "The absolute, public URL at which the site will be published."
+msgstr ""
+
 #, python-brace-format
 msgid ""
 "The betty:privacy Gramps attribute must have a value of \"public\" or "
 "\"private\", but \"{privacy_value}\" was given for {entity_type} "
 "{entity_id} ({entity_label}), which was ignored."
+msgstr ""
+
+msgid ""
+"The number of years people are expected to live at most, e.g. after which"
+" they are presumed to have died."
 msgstr ""
 
 #, python-brace-format
@@ -1446,6 +1510,9 @@ msgstr ""
 msgid "Timeline"
 msgstr ""
 
+msgid "Title"
+msgstr ""
+
 msgid "Toggle full screen"
 msgstr ""
 
@@ -1464,6 +1531,9 @@ msgid "Translations for {locale} initialized at {po_file_path}."
 msgstr ""
 
 msgid "Type"
+msgstr ""
+
+msgid "URL"
 msgstr ""
 
 msgid "Unauthorized"
@@ -1557,8 +1627,24 @@ msgid "Where do you want to save your project's configuration file?"
 msgstr ""
 
 msgid ""
+"Whether to download additional images found through Wikipedia links in "
+"the ancestry"
+msgstr ""
+
+msgid ""
+"Whether to output more detailed logs and disable optimizations that make "
+"debugging harder."
+msgstr ""
+
+msgid "Whether to use clean URLs: \"/path\" instead of \"/path/index.html\"."
+msgstr ""
+
+msgid ""
 "Which language should your project site be generated in? Enter a language"
 " code."
+msgstr ""
+
+msgid "Wiki extension configuration"
 msgstr ""
 
 msgid "Wikipedia contributors"

--- a/assets/locale/nl-NL/betty.po
+++ b/assets/locale/nl-NL/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-17 22:03+0000\n"
+"POT-Creation-Date: 2026-01-19 20:08+0000\n"
 "PO-Revision-Date: 2025-11-08 23:46+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: nl_NL\n"
@@ -68,6 +68,9 @@ msgstr "%(event)s met %(subjects)s"
 msgid "A Betty demonstration"
 msgstr ""
 
+msgid "A countable localizable string"
+msgstr ""
+
 msgid ""
 "A family history as told by <a "
 "href=\"https://betty.readthedocs.io\">Betty👵</a>"
@@ -78,10 +81,16 @@ msgstr ""
 msgid "A formal witness to an event."
 msgstr ""
 
+msgid "A localizable string"
+msgstr ""
+
 msgid "A person's presence at an event."
 msgstr ""
 
 msgid "A place number, such as a house or flat number."
+msgstr ""
+
+msgid "A plugin ID"
 msgstr ""
 
 msgid "A single file in a media display"
@@ -144,6 +153,9 @@ msgstr ""
 
 msgid "Appearances"
 msgstr "Verschijningen"
+
+msgid "Application configuration"
+msgstr ""
 
 msgid "Assets directory"
 msgstr ""
@@ -358,6 +370,9 @@ msgstr ""
 msgid "City"
 msgstr "Stad"
 
+msgid "Clean URLs"
+msgstr ""
+
 msgid "Clear all caches"
 msgstr "Leeg alle caches"
 
@@ -502,13 +517,24 @@ msgid "Cremations"
 msgstr ""
 
 #, python-brace-format
-msgid "Data has no {attribute} attribute."
+msgid "Data has no attribute {attribute}"
+msgstr ""
+
+#, python-brace-format
+msgid "Data has no index {index}"
+msgstr ""
+
+#, python-brace-format
+msgid "Data has no key \"{key}\""
 msgstr ""
 
 msgid "Death"
 msgstr "Overlijden"
 
 msgid "Deaths"
+msgstr ""
+
+msgid "Debugging mode"
 msgstr ""
 
 msgid "Department"
@@ -616,6 +642,12 @@ msgstr ""
 msgid "Entity type"
 msgstr "Entiteitstype"
 
+msgid "Entity type configuration"
+msgstr ""
+
+msgid "Entity types"
+msgstr ""
+
 msgid "Event"
 msgstr "Gebeurtenis"
 
@@ -712,6 +744,9 @@ msgstr ""
 
 msgid "Generate a static site"
 msgstr "Genereer een statische site"
+
+msgid "Generate list HTML page"
+msgstr ""
 
 msgid "Generating site..."
 msgstr ""
@@ -841,6 +876,9 @@ msgstr "Licentie"
 msgid "Licenses"
 msgstr ""
 
+msgid "Lifetime threshold"
+msgstr ""
+
 msgid "Link"
 msgstr ""
 
@@ -890,6 +928,9 @@ msgstr "{source_count} bronnen geladen."
 msgid "Loading \"{file_path}\"..."
 msgstr "\"{file_path}\" aan het laden..."
 
+msgid "Locale"
+msgstr ""
+
 msgid "Locale aliases must not contain slashes."
 msgstr "Taalregioaliassen mogen geen schuine streep bevatten."
 
@@ -897,11 +938,17 @@ msgstr "Taalregioaliassen mogen geen schuine streep bevatten."
 msgid "Locale {locale} is not known by your system."
 msgstr ""
 
+msgid "Locales"
+msgstr ""
+
 msgid "Localities"
 msgstr ""
 
 msgid "Locality"
 msgstr "Plaats"
+
+msgid "Logo"
+msgstr ""
 
 msgid "MMMM"
 msgstr "MMMM"
@@ -914,6 +961,9 @@ msgstr "d MMMM y"
 
 msgid "MMMM, y"
 msgstr "MMMM y"
+
+msgid "Machine name"
+msgstr ""
 
 msgid "Man"
 msgstr ""
@@ -1121,6 +1171,9 @@ msgstr ""
 msgid "Plugins"
 msgstr ""
 
+msgid "Populate images"
+msgstr ""
+
 msgid "Positional arguments"
 msgstr ""
 
@@ -1185,6 +1238,9 @@ msgstr ""
 
 msgid "Project author"
 msgstr "Projectauteur"
+
+msgid "Project configuration"
+msgstr ""
 
 msgid "Province"
 msgstr "Provincie"
@@ -1402,6 +1458,9 @@ msgstr "De URL moet een host bevatten."
 msgid "The URL must start with a scheme such as https:// or http://."
 msgstr "De URL moet beginnen met een protocol, zoals https:// of http://."
 
+msgid "The absolute, public URL at which the site will be published."
+msgstr ""
+
 #, python-brace-format
 msgid ""
 "The betty:privacy Gramps attribute must have a value of \"public\" or "
@@ -1411,6 +1470,11 @@ msgstr ""
 "Het betty:privacy Gramps-attribuut moet \"public\" of \"private\" zijn, "
 "maar {entity_type} {entity_id} ({entity_label}) bevat "
 "\"{privacy_value}\", en is daarom genegeerd."
+
+msgid ""
+"The number of years people are expected to live at most, e.g. after which"
+" they are presumed to have died."
+msgstr ""
 
 #, python-brace-format
 msgid ""
@@ -1512,6 +1576,9 @@ msgstr ""
 msgid "Timeline"
 msgstr "Tijdlijn"
 
+msgid "Title"
+msgstr ""
+
 msgid "Toggle full screen"
 msgstr "Schakel volledig scherm"
 
@@ -1530,6 +1597,9 @@ msgid "Translations for {locale} initialized at {po_file_path}."
 msgstr ""
 
 msgid "Type"
+msgstr ""
+
+msgid "URL"
 msgstr ""
 
 msgid "Unauthorized"
@@ -1625,8 +1695,24 @@ msgid "Where do you want to save your project's configuration file?"
 msgstr "Waar wil je je projectconfiguratiebestand opslaan?"
 
 msgid ""
+"Whether to download additional images found through Wikipedia links in "
+"the ancestry"
+msgstr ""
+
+msgid ""
+"Whether to output more detailed logs and disable optimizations that make "
+"debugging harder."
+msgstr ""
+
+msgid "Whether to use clean URLs: \"/path\" instead of \"/path/index.html\"."
+msgstr ""
+
+msgid ""
 "Which language should your project site be generated in? Enter a language"
 " code."
+msgstr ""
+
+msgid "Wiki extension configuration"
 msgstr ""
 
 msgid "Wikipedia contributors"

--- a/assets/locale/pt-BR/betty.po
+++ b/assets/locale/pt-BR/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-17 22:03+0000\n"
+"POT-Creation-Date: 2026-01-19 20:08+0000\n"
 "PO-Revision-Date: 2025-12-16 20:00+0000\n"
 "Last-Translator: Mateus Liberale Gomes <sergiogomes209403@gmail.com>\n"
 "Language: pt_BR\n"
@@ -68,6 +68,9 @@ msgstr "%(event)s com %(subjects)s"
 msgid "A Betty demonstration"
 msgstr ""
 
+msgid "A countable localizable string"
+msgstr ""
+
 msgid ""
 "A family history as told by <a "
 "href=\"https://betty.readthedocs.io\">Betty👵</a>"
@@ -78,10 +81,16 @@ msgstr ""
 msgid "A formal witness to an event."
 msgstr ""
 
+msgid "A localizable string"
+msgstr ""
+
 msgid "A person's presence at an event."
 msgstr ""
 
 msgid "A place number, such as a house or flat number."
+msgstr ""
+
+msgid "A plugin ID"
 msgstr ""
 
 msgid "A single file in a media display"
@@ -144,6 +153,9 @@ msgstr ""
 
 msgid "Appearances"
 msgstr "Aparências"
+
+msgid "Application configuration"
+msgstr ""
 
 msgid "Assets directory"
 msgstr ""
@@ -362,6 +374,9 @@ msgstr ""
 msgid "City"
 msgstr "Cidade"
 
+msgid "Clean URLs"
+msgstr ""
+
 msgid "Clear all caches"
 msgstr "Limpar todos os caches"
 
@@ -502,13 +517,24 @@ msgid "Cremations"
 msgstr ""
 
 #, python-brace-format
-msgid "Data has no {attribute} attribute."
+msgid "Data has no attribute {attribute}"
+msgstr ""
+
+#, python-brace-format
+msgid "Data has no index {index}"
+msgstr ""
+
+#, python-brace-format
+msgid "Data has no key \"{key}\""
 msgstr ""
 
 msgid "Death"
 msgstr ""
 
 msgid "Deaths"
+msgstr ""
+
+msgid "Debugging mode"
 msgstr ""
 
 msgid "Department"
@@ -614,6 +640,12 @@ msgstr ""
 msgid "Entity type"
 msgstr ""
 
+msgid "Entity type configuration"
+msgstr ""
+
+msgid "Entity types"
+msgstr ""
+
 msgid "Event"
 msgstr ""
 
@@ -709,6 +741,9 @@ msgid "Genders"
 msgstr ""
 
 msgid "Generate a static site"
+msgstr ""
+
+msgid "Generate list HTML page"
 msgstr ""
 
 msgid "Generating site..."
@@ -834,6 +869,9 @@ msgstr ""
 msgid "Licenses"
 msgstr ""
 
+msgid "Lifetime threshold"
+msgstr ""
+
 msgid "Link"
 msgstr ""
 
@@ -883,6 +921,9 @@ msgstr ""
 msgid "Loading \"{file_path}\"..."
 msgstr ""
 
+msgid "Locale"
+msgstr ""
+
 msgid "Locale aliases must not contain slashes."
 msgstr ""
 
@@ -890,10 +931,16 @@ msgstr ""
 msgid "Locale {locale} is not known by your system."
 msgstr ""
 
+msgid "Locales"
+msgstr ""
+
 msgid "Localities"
 msgstr ""
 
 msgid "Locality"
+msgstr ""
+
+msgid "Logo"
 msgstr ""
 
 msgid "MMMM"
@@ -906,6 +953,9 @@ msgid "MMMM d, y"
 msgstr ""
 
 msgid "MMMM, y"
+msgstr ""
+
+msgid "Machine name"
 msgstr ""
 
 msgid "Man"
@@ -1111,6 +1161,9 @@ msgstr ""
 msgid "Plugins"
 msgstr ""
 
+msgid "Populate images"
+msgstr ""
+
 msgid "Positional arguments"
 msgstr ""
 
@@ -1167,6 +1220,9 @@ msgid ""
 msgstr ""
 
 msgid "Project author"
+msgstr ""
+
+msgid "Project configuration"
 msgstr ""
 
 msgid "Province"
@@ -1380,11 +1436,19 @@ msgstr ""
 msgid "The URL must start with a scheme such as https:// or http://."
 msgstr ""
 
+msgid "The absolute, public URL at which the site will be published."
+msgstr ""
+
 #, python-brace-format
 msgid ""
 "The betty:privacy Gramps attribute must have a value of \"public\" or "
 "\"private\", but \"{privacy_value}\" was given for {entity_type} "
 "{entity_id} ({entity_label}), which was ignored."
+msgstr ""
+
+msgid ""
+"The number of years people are expected to live at most, e.g. after which"
+" they are presumed to have died."
 msgstr ""
 
 #, python-brace-format
@@ -1487,6 +1551,9 @@ msgstr ""
 msgid "Timeline"
 msgstr ""
 
+msgid "Title"
+msgstr ""
+
 msgid "Toggle full screen"
 msgstr ""
 
@@ -1505,6 +1572,9 @@ msgid "Translations for {locale} initialized at {po_file_path}."
 msgstr ""
 
 msgid "Type"
+msgstr ""
+
+msgid "URL"
 msgstr ""
 
 msgid "Unauthorized"
@@ -1598,8 +1668,24 @@ msgid "Where do you want to save your project's configuration file?"
 msgstr ""
 
 msgid ""
+"Whether to download additional images found through Wikipedia links in "
+"the ancestry"
+msgstr ""
+
+msgid ""
+"Whether to output more detailed logs and disable optimizations that make "
+"debugging harder."
+msgstr ""
+
+msgid "Whether to use clean URLs: \"/path\" instead of \"/path/index.html\"."
+msgstr ""
+
+msgid ""
 "Which language should your project site be generated in? Enter a language"
 " code."
+msgstr ""
+
+msgid "Wiki extension configuration"
 msgstr ""
 
 msgid "Wikipedia contributors"

--- a/assets/locale/ru-RU/betty.po
+++ b/assets/locale/ru-RU/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-17 22:03+0000\n"
+"POT-Creation-Date: 2026-01-19 20:08+0000\n"
 "PO-Revision-Date: 2025-12-08 19:00+0000\n"
 "Last-Translator: Artur Kalagov "
 "<artur.kalagov@users.noreply.hosted.weblate.org>\n"
@@ -70,6 +70,9 @@ msgstr "%(event)s с %(subjects)s"
 msgid "A Betty demonstration"
 msgstr ""
 
+msgid "A countable localizable string"
+msgstr ""
+
 msgid ""
 "A family history as told by <a "
 "href=\"https://betty.readthedocs.io\">Betty👵</a>"
@@ -80,10 +83,16 @@ msgstr ""
 msgid "A formal witness to an event."
 msgstr ""
 
+msgid "A localizable string"
+msgstr ""
+
 msgid "A person's presence at an event."
 msgstr ""
 
 msgid "A place number, such as a house or flat number."
+msgstr ""
+
+msgid "A plugin ID"
 msgstr ""
 
 msgid "A single file in a media display"
@@ -146,6 +155,9 @@ msgstr ""
 
 msgid "Appearances"
 msgstr "Источники"
+
+msgid "Application configuration"
+msgstr ""
 
 msgid "Assets directory"
 msgstr ""
@@ -362,6 +374,9 @@ msgstr ""
 msgid "City"
 msgstr "Город"
 
+msgid "Clean URLs"
+msgstr ""
+
 msgid "Clear all caches"
 msgstr "Очистить все кэши"
 
@@ -506,13 +521,24 @@ msgid "Cremations"
 msgstr ""
 
 #, python-brace-format
-msgid "Data has no {attribute} attribute."
+msgid "Data has no attribute {attribute}"
+msgstr ""
+
+#, python-brace-format
+msgid "Data has no index {index}"
+msgstr ""
+
+#, python-brace-format
+msgid "Data has no key \"{key}\""
 msgstr ""
 
 msgid "Death"
 msgstr "Смерть"
 
 msgid "Deaths"
+msgstr ""
+
+msgid "Debugging mode"
 msgstr ""
 
 msgid "Department"
@@ -620,6 +646,12 @@ msgstr ""
 msgid "Entity type"
 msgstr "Тип объекта"
 
+msgid "Entity type configuration"
+msgstr ""
+
+msgid "Entity types"
+msgstr ""
+
 msgid "Event"
 msgstr "Событие"
 
@@ -716,6 +748,9 @@ msgstr ""
 
 msgid "Generate a static site"
 msgstr "Создание статического сайта"
+
+msgid "Generate list HTML page"
+msgstr ""
 
 msgid "Generating site..."
 msgstr ""
@@ -843,6 +878,9 @@ msgstr "Лицензия"
 msgid "Licenses"
 msgstr ""
 
+msgid "Lifetime threshold"
+msgstr ""
+
 msgid "Link"
 msgstr ""
 
@@ -892,6 +930,9 @@ msgstr "Загружено {source_count} источников."
 msgid "Loading \"{file_path}\"..."
 msgstr "Загрузка \"{file_path}\"..."
 
+msgid "Locale"
+msgstr ""
+
 msgid "Locale aliases must not contain slashes."
 msgstr "Языковые псевдонимы не должны содержать символ \"/\"."
 
@@ -899,11 +940,17 @@ msgstr "Языковые псевдонимы не должны содержат
 msgid "Locale {locale} is not known by your system."
 msgstr ""
 
+msgid "Locales"
+msgstr ""
+
 msgid "Localities"
 msgstr ""
 
 msgid "Locality"
 msgstr "Местность"
+
+msgid "Logo"
+msgstr ""
 
 msgid "MMMM"
 msgstr "MMMM"
@@ -916,6 +963,9 @@ msgstr "d MMMM y г."
 
 msgid "MMMM, y"
 msgstr "MMMM y г."
+
+msgid "Machine name"
+msgstr ""
 
 msgid "Man"
 msgstr ""
@@ -1123,6 +1173,9 @@ msgstr ""
 msgid "Plugins"
 msgstr ""
 
+msgid "Populate images"
+msgstr ""
+
 msgid "Positional arguments"
 msgstr ""
 
@@ -1188,6 +1241,9 @@ msgstr ""
 
 msgid "Project author"
 msgstr "Автор проекта"
+
+msgid "Project configuration"
+msgstr ""
 
 msgid "Province"
 msgstr "Провинция"
@@ -1406,6 +1462,9 @@ msgstr "URL-адрес должен содержать имя хоста."
 msgid "The URL must start with a scheme such as https:// or http://."
 msgstr "URL-адрес должен начинаться с указания протокола https:// или http://."
 
+msgid "The absolute, public URL at which the site will be published."
+msgstr ""
+
 #, python-brace-format
 msgid ""
 "The betty:privacy Gramps attribute must have a value of \"public\" or "
@@ -1415,6 +1474,11 @@ msgstr ""
 "Атрибут Gramps betty:privacy должен иметь значение \"public\" или "
 "\"private\", но для {entity_type} {entity_id} ({entity_label}) было "
 "указано \"{privacy_value}\", которое было проигнорировано."
+
+msgid ""
+"The number of years people are expected to live at most, e.g. after which"
+" they are presumed to have died."
+msgstr ""
 
 #, python-brace-format
 msgid ""
@@ -1519,6 +1583,9 @@ msgstr ""
 msgid "Timeline"
 msgstr "Хронология"
 
+msgid "Title"
+msgstr ""
+
 msgid "Toggle full screen"
 msgstr "Переключить режим отображения"
 
@@ -1537,6 +1604,9 @@ msgid "Translations for {locale} initialized at {po_file_path}."
 msgstr ""
 
 msgid "Type"
+msgstr ""
+
+msgid "URL"
 msgstr ""
 
 msgid "Unauthorized"
@@ -1632,8 +1702,24 @@ msgid "Where do you want to save your project's configuration file?"
 msgstr "Где вы хотите сохранить конфигурационный файл вашего проекта?"
 
 msgid ""
+"Whether to download additional images found through Wikipedia links in "
+"the ancestry"
+msgstr ""
+
+msgid ""
+"Whether to output more detailed logs and disable optimizations that make "
+"debugging harder."
+msgstr ""
+
+msgid "Whether to use clean URLs: \"/path\" instead of \"/path/index.html\"."
+msgstr ""
+
+msgid ""
 "Which language should your project site be generated in? Enter a language"
 " code."
+msgstr ""
+
+msgid "Wiki extension configuration"
 msgstr ""
 
 msgid "Wikipedia contributors"

--- a/assets/locale/uk/betty.po
+++ b/assets/locale/uk/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty 0.4\n"
 "Report-Msgid-Bugs-To: illia@maier.page\n"
-"POT-Creation-Date: 2026-01-17 22:03+0000\n"
+"POT-Creation-Date: 2026-01-19 20:08+0000\n"
 "PO-Revision-Date: 2025-05-13 17:01+0000\n"
 "Last-Translator: Максим Горпиніч <maksimgorpinic4@gmail.com>\n"
 "Language: uk\n"
@@ -67,6 +67,9 @@ msgstr "%(event)s з %(subjects)s"
 msgid "A Betty demonstration"
 msgstr ""
 
+msgid "A countable localizable string"
+msgstr ""
+
 msgid ""
 "A family history as told by <a "
 "href=\"https://betty.readthedocs.io\">Betty👵</a>"
@@ -77,10 +80,16 @@ msgstr ""
 msgid "A formal witness to an event."
 msgstr ""
 
+msgid "A localizable string"
+msgstr ""
+
 msgid "A person's presence at an event."
 msgstr ""
 
 msgid "A place number, such as a house or flat number."
+msgstr ""
+
+msgid "A plugin ID"
 msgstr ""
 
 msgid "A single file in a media display"
@@ -143,6 +152,9 @@ msgstr ""
 
 msgid "Appearances"
 msgstr "Знайдено в"
+
+msgid "Application configuration"
+msgstr ""
 
 msgid "Assets directory"
 msgstr ""
@@ -357,6 +369,9 @@ msgstr ""
 msgid "City"
 msgstr "Місто"
 
+msgid "Clean URLs"
+msgstr ""
+
 msgid "Clear all caches"
 msgstr "Очистити всі кеші"
 
@@ -499,13 +514,24 @@ msgid "Cremations"
 msgstr ""
 
 #, python-brace-format
-msgid "Data has no {attribute} attribute."
+msgid "Data has no attribute {attribute}"
+msgstr ""
+
+#, python-brace-format
+msgid "Data has no index {index}"
+msgstr ""
+
+#, python-brace-format
+msgid "Data has no key \"{key}\""
 msgstr ""
 
 msgid "Death"
 msgstr "Смерть"
 
 msgid "Deaths"
+msgstr ""
+
+msgid "Debugging mode"
 msgstr ""
 
 msgid "Department"
@@ -613,6 +639,12 @@ msgstr ""
 msgid "Entity type"
 msgstr "Тип сутності"
 
+msgid "Entity type configuration"
+msgstr ""
+
+msgid "Entity types"
+msgstr ""
+
 msgid "Event"
 msgstr "Подія"
 
@@ -709,6 +741,9 @@ msgstr ""
 
 msgid "Generate a static site"
 msgstr "Згенерувати статичний сайт"
+
+msgid "Generate list HTML page"
+msgstr ""
 
 msgid "Generating site..."
 msgstr ""
@@ -835,6 +870,9 @@ msgstr "Ліцензія"
 msgid "Licenses"
 msgstr ""
 
+msgid "Lifetime threshold"
+msgstr ""
+
 msgid "Link"
 msgstr ""
 
@@ -884,6 +922,9 @@ msgstr "Завантажено {source_count} джерел."
 msgid "Loading \"{file_path}\"..."
 msgstr "Завантаження \"{file_path}\"..."
 
+msgid "Locale"
+msgstr ""
+
 msgid "Locale aliases must not contain slashes."
 msgstr "Аліаси локалей не повинні містити слешів."
 
@@ -891,11 +932,17 @@ msgstr "Аліаси локалей не повинні містити слеш�
 msgid "Locale {locale} is not known by your system."
 msgstr ""
 
+msgid "Locales"
+msgstr ""
+
 msgid "Localities"
 msgstr ""
 
 msgid "Locality"
 msgstr "Місцевість"
+
+msgid "Logo"
+msgstr ""
 
 msgid "MMMM"
 msgstr "MMMM"
@@ -908,6 +955,9 @@ msgstr "d MMMM y року"
 
 msgid "MMMM, y"
 msgstr "MMMM y року"
+
+msgid "Machine name"
+msgstr ""
 
 msgid "Man"
 msgstr ""
@@ -1115,6 +1165,9 @@ msgstr ""
 msgid "Plugins"
 msgstr ""
 
+msgid "Populate images"
+msgstr ""
+
 msgid "Positional arguments"
 msgstr ""
 
@@ -1180,6 +1233,9 @@ msgstr ""
 
 msgid "Project author"
 msgstr "Автор проєкту"
+
+msgid "Project configuration"
+msgstr ""
 
 msgid "Province"
 msgstr "Провінція"
@@ -1397,6 +1453,9 @@ msgstr "URL має містити хост."
 msgid "The URL must start with a scheme such as https:// or http://."
 msgstr "URL має починатися зі схеми, наприклад, https:// або http://."
 
+msgid "The absolute, public URL at which the site will be published."
+msgstr ""
+
 #, python-brace-format
 msgid ""
 "The betty:privacy Gramps attribute must have a value of \"public\" or "
@@ -1406,6 +1465,11 @@ msgstr ""
 "Атрибут betty:privacy у Gramps повинен мати значення \"public\" або "
 "\"private\", але для {entity_type} {entity_id} ({entity_label}) було "
 "задано \"{privacy_value}\", що було проігноровано."
+
+msgid ""
+"The number of years people are expected to live at most, e.g. after which"
+" they are presumed to have died."
+msgstr ""
 
 #, python-brace-format
 msgid ""
@@ -1510,6 +1574,9 @@ msgstr ""
 msgid "Timeline"
 msgstr "Хронологія"
 
+msgid "Title"
+msgstr ""
+
 msgid "Toggle full screen"
 msgstr "Перемкнути на весь екран"
 
@@ -1528,6 +1595,9 @@ msgid "Translations for {locale} initialized at {po_file_path}."
 msgstr ""
 
 msgid "Type"
+msgstr ""
+
+msgid "URL"
 msgstr ""
 
 msgid "Unauthorized"
@@ -1623,8 +1693,24 @@ msgid "Where do you want to save your project's configuration file?"
 msgstr "Де ви хочете зберегти файл конфігурації вашого проєкту?"
 
 msgid ""
+"Whether to download additional images found through Wikipedia links in "
+"the ancestry"
+msgstr ""
+
+msgid ""
+"Whether to output more detailed logs and disable optimizations that make "
+"debugging harder."
+msgstr ""
+
+msgid "Whether to use clean URLs: \"/path\" instead of \"/path/index.html\"."
+msgstr ""
+
+msgid ""
 "Which language should your project site be generated in? Enter a language"
 " code."
+msgstr ""
+
+msgid "Wiki extension configuration"
 msgstr ""
 
 msgid "Wikipedia contributors"

--- a/betty/app/__init__.py
+++ b/betty/app/__init__.py
@@ -147,7 +147,7 @@ class App(Configurable[AppConfiguration], ServiceLevel):
         Create a new application from the environment.
         """
         if config.CONFIGURATION_FILE_PATH.exists():
-            configuration = AppConfiguration.load(
+            configuration = AppConfiguration.data().load(
                 (await assert_load_file())(config.CONFIGURATION_FILE_PATH)
             )
         else:

--- a/betty/app/config.py
+++ b/betty/app/config.py
@@ -4,31 +4,50 @@ Provide application configuration.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Self, final
+from typing import final
 
-from typing_extensions import override
+from babel import Locale
 
-from betty.assertion import OptionalField, assert_locale, assert_record
-from betty.config import Configuration, Sample
+from betty.assertion import assert_locale
+from betty.data import DataDefinition, HasData, Sample
+from betty.data.aggregate.record import FieldDefinition
+from betty.data.aggregate.record.object import ObjectDefinition
+from betty.data.indicator.selector import Attr
 from betty.dirs import APP_CONFIG_DIRECTORY_PATH
 from betty.locale import DEFAULT_LOCALE, to_language_tag
-
-if TYPE_CHECKING:
-    from collections.abc import Iterable
-
-    from babel import Locale
-
-    from betty.portable import PortableData, PortableMapping
+from betty.locale.localizable.gettext import _
+from betty.portable import CallbackPorter
 
 CONFIGURATION_FILE_PATH = APP_CONFIG_DIRECTORY_PATH / "app.json"
 
 
 @final
-class AppConfiguration(Configuration):
+@ObjectDefinition(
+    label=_("Application configuration"),
+    fields=[
+        FieldDefinition(
+            Attr("locale"),
+            DataDefinition(
+                cls=Locale,
+                label=_("Locale"),
+                porter=CallbackPorter(assert_locale(), to_language_tag),
+                empty=lambda data: data is None,
+            ),
+            required=False,
+        ),
+    ],
+    samples=[
+        lambda: Sample(AppConfiguration(), label="Minimal", minimal=True),
+        lambda: Sample(
+            AppConfiguration(locale=DEFAULT_LOCALE), label="Full", full=True
+        ),
+    ],
+)
+class AppConfiguration(HasData):
     """
     Configuration for :py:class:`betty.app.App`.
 
-    .. configuration:: betty.app.config:AppConfiguration
+    .. has_data:: betty.app.config:AppConfiguration
     """
 
     def __init__(
@@ -36,7 +55,6 @@ class AppConfiguration(Configuration):
         *,
         locale: Locale | None = None,
     ):
-        super().__init__()
         self._locale: Locale | None = locale
 
     @property
@@ -49,26 +67,3 @@ class AppConfiguration(Configuration):
     @locale.setter
     def locale(self, locale: Locale | None) -> None:
         self._locale = locale
-
-    @override
-    @classmethod
-    def load(cls, portable: PortableData, /) -> Self:
-        return cls(**assert_record(OptionalField("locale", assert_locale()))(portable))
-
-    @override
-    def dump(self) -> PortableMapping:
-        if self.locale is None:
-            return {}
-        return {"locale": to_language_tag(self.locale)}
-
-    @override
-    def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, type(self)):
-            return NotImplemented
-        return self.locale == other.locale
-
-    @override
-    @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
-        yield Sample(cls(), label="Minimal", minimal=True)
-        yield Sample(cls(locale=DEFAULT_LOCALE), label="Full", full=True)

--- a/betty/collections.py
+++ b/betty/collections.py
@@ -1,0 +1,136 @@
+"""
+Collection data tpes.
+"""
+
+from collections.abc import Callable, Collection, Iterable, Iterator, MutableSequence
+from typing import Generic, TypeVar, final, overload
+
+from typing_extensions import override
+
+from betty.functools import passthrough
+
+_KeyT = TypeVar("_KeyT")
+_ValueT = TypeVar("_ValueT")
+_ResolvableKeyT = TypeVar("_ResolvableKeyT")
+_ResolvableValueT = TypeVar("_ResolvableValueT")
+
+
+class KeyedCollection(
+    Collection[_ValueT], Generic[_KeyT, _ValueT, _ResolvableKeyT, _ResolvableValueT]
+):
+    """
+    A collection of values, automatically keyed.
+    """
+
+    def __init__(
+        self,
+        values: Iterable[_ResolvableValueT],
+        *,
+        key: Callable[[_ValueT], _KeyT],
+        key_resolver: Callable[[_ResolvableKeyT | _KeyT], _KeyT] = passthrough,
+        value_resolver: Callable[[_ResolvableValueT | _KeyT], _ValueT] = passthrough,
+    ):
+        self._values = {}
+        for value in values:
+            value = value_resolver(value)
+            self._values[key(value)] = value
+        self._key = key
+        self._key_resolver = key_resolver
+        self._value_resolver = value_resolver
+
+    @override
+    def __len__(self) -> int:
+        return self._values.__len__()
+
+    @override
+    def __iter__(self) -> Iterator[_ValueT]:
+        yield from self._values.values()
+
+    @override
+    def __contains__(self, key: object) -> bool:
+        try:
+            return (
+                self._key_resolver(
+                    key,  # ty:ignore[invalid-argument-type]
+                )
+                in self._values
+            )
+        except Exception:
+            return False
+
+    def __getitem__(self, key: _ResolvableKeyT) -> _ValueT:
+        return self._values[self._key_resolver(key)]
+
+    def __delitem__(self, key: _ResolvableKeyT) -> None:
+        del self._values[self._key_resolver(key)]
+
+    def add(self, value: _ResolvableValueT) -> None:
+        """
+        Add a value to the collection.
+        """
+        value: _ValueT = self._value_resolver(value)
+        self._values[self._key(value)] = value
+
+
+@final
+class ResolvingMutableSequence(
+    MutableSequence[_ValueT], Generic[_ValueT, _ResolvableValueT]
+):
+    """
+    A sequence of values.
+    """
+
+    def __init__(
+        self,
+        decorated: MutableSequence[_ValueT],
+        resolver: Callable[[_ResolvableValueT | _ValueT], _ValueT],
+        /,
+    ):
+        self._decorated = decorated
+        self._resolver = resolver
+
+    @override
+    def insert(self, index: int, value: _ResolvableValueT | _ValueT) -> None:
+        self._decorated.insert(index, self._resolver(value))
+
+    @overload
+    def __getitem__(self, index: int) -> _ValueT:
+        pass
+
+    @overload
+    def __getitem__(self, index: slice) -> MutableSequence[_ValueT]:
+        pass
+
+    def __getitem__(self, index):
+        return self._decorated[index]
+
+    @overload
+    def __setitem__(self, index: int, value: _ResolvableValueT | _ValueT) -> None: ...
+
+    @overload
+    def __setitem__(
+        self, index: slice, value: Iterable[_ResolvableValueT | _ValueT]
+    ) -> None: ...
+
+    def __setitem__(self, index, value):
+        if isinstance(index, int):
+            self._decorated[index] = self._resolver(value)
+        else:
+            self._decorated[index] = map(self._resolver, value)
+
+    def __delitem__(self, index: int | slice) -> None:
+        del self._decorated[index]
+
+    def __len__(self):
+        return len(self._decorated)
+
+    def __contains__(self, value: object) -> bool:
+        try:
+            return (
+                self._resolver(
+                    value,  # ty:ignore[invalid-argument-type]
+                )
+                in self._decorated
+            )
+        except Exception:
+            return False

--- a/betty/config/__init__.py
+++ b/betty/config/__init__.py
@@ -9,15 +9,14 @@ from typing import TYPE_CHECKING, Any, Generic, Self
 
 from typing_extensions import TypeVar, override
 
-from betty.locale.localizable.ensure import ensure_localizable
+from betty.data import HasData
 from betty.portable import Portable, PortableData
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from betty.locale.localizable import Localizable, LocalizableLike
+    from betty.data import Sample
     from betty.service.level.factory import ServiceLevelTarget
-
 
 _PortableDataT = TypeVar("_PortableDataT", bound=PortableData, default=PortableData)
 
@@ -42,113 +41,27 @@ class Configuration(Portable, Generic[_PortableDataT]):
         return None
 
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:  # type: ignore[type-var]
+    def samples(cls) -> Iterable[Sample[Self]]:
         """
         Create samples for this configuration.
         """
         return ()
 
 
-_ConfigurationT = TypeVar("_ConfigurationT", bound=Configuration, default=Configuration)
+_HasDataT = TypeVar("_HasDataT", bound=HasData | Configuration)
 
 
-class Sample(Generic[_ConfigurationT]):
-    """
-    A configuration sample.
-
-    Samples are useful for generating documentation and tests.
-    """
-
-    def __init__(
-        self,
-        configuration: _ConfigurationT,
-        *,
-        label: LocalizableLike,
-        description: LocalizableLike | None = None,
-        minimal: bool = False,
-        full: bool = False,
-    ):
-        self._configuration = configuration
-        self._label = ensure_localizable(label)
-        self._description = ensure_localizable(description) if description else None
-        self._minimal = minimal
-        self._full = full
-
-    @property
-    def configuration(self) -> _ConfigurationT:
-        """
-        The sample configuration.
-        """
-        return self._configuration
-
-    @property
-    def label(self) -> Localizable:
-        """
-        The sample's human-readable short label.
-        """
-        return self._label
-
-    @property
-    def description(self) -> Localizable | None:
-        """
-        The sample's human-readable long description.
-        """
-        return self._description
-
-    @property
-    def minimal(self) -> bool:
-        """
-        Whether this is a minimal sample.
-        """
-        return self._minimal
-
-    @property
-    def full(self) -> bool:
-        """
-        Whether this is a full sample.
-        """
-        return self._full
-
-
-def get_minimal_sample(configuration: type[_ConfigurationT]) -> Sample[_ConfigurationT]:
-    """
-    Get a sample for a configuration type, preferably as minimal as possible.
-    """
-    samples = list(configuration.samples())
-    for sample in samples:
-        if sample.minimal:
-            return sample
-    for sample in samples:
-        if not sample.full:
-            return sample
-    return samples[0]
-
-
-def get_full_sample(configuration: type[_ConfigurationT]) -> Sample[_ConfigurationT]:
-    """
-    Get a sample for a configuration type, preferably as full as possible.
-    """
-    samples = list(configuration.samples())
-    for sample in samples:
-        if sample.full:
-            return sample
-    for sample in samples:
-        if not sample.minimal:
-            return sample
-    return samples[0]
-
-
-class Configurable(ABC, Generic[_ConfigurationT]):
+class Configurable(ABC, Generic[_HasDataT]):
     """
     Any configurable object.
     """
 
-    def __init__(self, *args: Any, configuration: _ConfigurationT, **kwargs: Any):
+    def __init__(self, *args: Any, configuration: _HasDataT, **kwargs: Any):
         super().__init__(*args, **kwargs)
         self._configuration = configuration
 
     @property
-    def configuration(self) -> _ConfigurationT:
+    def configuration(self) -> _HasDataT:
         """
         The object's configuration.
         """
@@ -156,7 +69,7 @@ class Configurable(ABC, Generic[_ConfigurationT]):
 
     @classmethod
     @abstractmethod
-    def configuration_cls(cls) -> type[_ConfigurationT]:
+    def configuration_cls(cls) -> type[_HasDataT]:
         """
         The object's configuration class.
         """

--- a/betty/config/color.py
+++ b/betty/config/color.py
@@ -10,7 +10,8 @@ from typing import TYPE_CHECKING, Any, Self
 from typing_extensions import override
 
 from betty.assertion import assert_str
-from betty.config import Configuration, Sample
+from betty.config import Configuration
+from betty.data import Sample
 from betty.exception import HumanFacingException
 from betty.locale.localizable.gettext import _
 
@@ -75,5 +76,5 @@ class ColorConfiguration(Configuration):
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         yield Sample(cls("#ff0000"), label="Default")

--- a/betty/config/factory.py
+++ b/betty/config/factory.py
@@ -5,9 +5,10 @@ Integrate the configuration and factory APIs.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Self, TypeVar
+from typing import TYPE_CHECKING, Self, TypeVar, cast
 
 from betty.config import Configurable, Configuration
+from betty.data import HasData
 from betty.exception import HumanFacingException
 from betty.factory import FactoryError
 from betty.importlib import fully_qualified_name
@@ -20,10 +21,10 @@ if TYPE_CHECKING:
 
 
 _T = TypeVar("_T")
-_ConfigurationT = TypeVar("_ConfigurationT", bound=Configuration)
+_HasDataT = TypeVar("_HasDataT", bound=HasData | Configuration)
 
 
-class ConfigurationDependentSelfFactory(Configurable[_ConfigurationT], ABC):
+class ConfigurationDependentSelfFactory(Configurable[_HasDataT], ABC):
     """
     Create factories that require configuration.
     """
@@ -31,7 +32,7 @@ class ConfigurationDependentSelfFactory(Configurable[_ConfigurationT], ABC):
     @classmethod
     @abstractmethod
     def new_for_configuration(
-        cls, configuration: _ConfigurationT
+        cls, configuration: _HasDataT
     ) -> ServiceLevelTarget[Self]:
         """
         Create a new factory for the given configuration.
@@ -43,8 +44,10 @@ class _HumanFacingFactoryError(FactoryError, HumanFacingException):
 
 
 def new_target(
-    target: ConfigurationDependentSelfFactory[Configuration] | ServiceLevelTarget[_T],
-    configuration: Configuration | PortableData | Void = Void(),  # noqa: B008
+    target: ConfigurationDependentSelfFactory[HasData]
+    | ConfigurationDependentSelfFactory[Configuration]
+    | ServiceLevelTarget[_T],
+    configuration: HasData | Configuration | PortableData | Void = Void(),  # noqa: B008
     /,
 ) -> ServiceLevelTarget[_T]:
     """
@@ -63,12 +66,18 @@ def new_target(
             raise FactoryError(
                 f"Cannot instantiate {fully_qualified_name(target)} with configuration because it does not subclass {fully_qualified_name(ConfigurationDependentSelfFactory)}."
             )
-        if isinstance(configuration, Configuration):
+        if isinstance(configuration, (HasData, Configuration)):
             if not isinstance(configuration, target.configuration_cls()):
                 raise FactoryError(
                     f"{fully_qualified_name(target)} required {fully_qualified_name(target.configuration_cls())}, but {fully_qualified_name(type(configuration))} was given."
                 )
         else:
-            configuration = target.configuration_cls().load(configuration)
+            configuration_cls = cast(
+                type[ConfigurationDependentSelfFactory], target
+            ).configuration_cls()
+            if issubclass(configuration_cls, HasData):
+                configuration = configuration_cls.data().load(configuration)
+            else:
+                configuration = configuration_cls.load(configuration)
         return target.new_for_configuration(configuration)  # ty:ignore[invalid-return-type, invalid-argument-type]
     return target  # ty:ignore[invalid-return-type]

--- a/betty/console/command/commands/config.py
+++ b/betty/console/command/commands/config.py
@@ -54,8 +54,9 @@ class Config(ServiceLevelDependentSelfFactory, Command):
 
     async def _command_function(self, *, locale: Locale) -> None:
         localizers = await self._app.localizers
-        updated_configuration = AppConfiguration()
-        updated_configuration.load(self._app.configuration.dump())
+        updated_configuration = AppConfiguration.data().load(
+            AppConfiguration.data().dump(self._app.configuration)
+        )
         updated_configuration.locale = locale
         self._app.user.localizer = localizers.get(locale)
         await self._app.user.message_information(
@@ -65,5 +66,6 @@ class Config(ServiceLevelDependentSelfFactory, Command):
         )
 
         await dump_file(
-            updated_configuration.dump(), app_config.CONFIGURATION_FILE_PATH
+            AppConfiguration.data().dump(updated_configuration),
+            app_config.CONFIGURATION_FILE_PATH,
         )

--- a/betty/console/project.py
+++ b/betty/console/project.py
@@ -124,4 +124,4 @@ async def _read_project_configuration_file(
                 configuration_file_path=str(configuration_file_path)
             ),
         )
-        return ProjectConfiguration.load(portable), configuration_file_path
+        return ProjectConfiguration.data().load(portable), configuration_file_path

--- a/betty/content_provider/content_providers.py
+++ b/betty/content_provider/content_providers.py
@@ -14,9 +14,10 @@ from betty.assertion import (
     assert_record,
     assert_str,
 )
-from betty.config import Configuration, Sample
+from betty.config import Configuration
 from betty.config.factory import ConfigurationDependentSelfFactory
 from betty.content_provider import ContentProvider, ContentProviderDefinition
+from betty.data import Sample
 from betty.locale.localizable.assertion import assert_load_localizable
 from betty.locale.localizable.attr import RequiredLocalizableAttr
 from betty.locale.localizable.gettext import _
@@ -87,7 +88,7 @@ class RenderConfiguration(Configuration):
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
 
         yield Sample(cls(DUMMY_LOCALIZABLE), label="Minimal")
@@ -280,7 +281,7 @@ class BoxConfiguration(Configuration):
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         yield Sample(cls([]), label="Minimal", minimal=True)
         yield Sample(
             cls(

--- a/betty/data/__init__.py
+++ b/betty/data/__init__.py
@@ -1,3 +1,251 @@
 """
-Data management.
+Describe, access, and manipulate arbitrary data.
 """
+
+from __future__ import annotations
+
+from functools import update_wrapper
+from typing import TYPE_CHECKING, Any, Generic, Self
+
+from typing_extensions import TypeVar
+
+from betty.importlib import fully_qualified_name
+from betty.locale.localizable.ensure import ensure_localizable
+from betty.portable import Portable, PortableData, PortablePorter, Porter
+from betty.portable.error import NotPortable
+from betty.service.hydrate import Hydratable
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+    from ty_extensions import Intersection
+
+    from betty.locale.localizable import Localizable, LocalizableLike
+    from betty.service.level import ServiceLevel
+
+_DataT = TypeVar("_DataT", default=Any)
+
+
+class DataDefinition(Generic[_DataT]):
+    """
+    A data definition.
+    """
+
+    def __init__(
+        self,
+        *,
+        cls: type[_DataT] | None = None,
+        label: LocalizableLike,
+        description: LocalizableLike | None = None,
+        porter: Porter[_DataT] | None = None,
+        fallback_porter: Porter[_DataT] | None = None,
+        samples: Iterable[Callable[[], Sample[_DataT]]] | None = None,
+        empty: Callable[[_DataT], bool] | None = None,
+    ):
+        self._cls: type[_DataT] | None = None
+        self._label = ensure_localizable(label)
+        self._description = (
+            None if description is None else ensure_localizable(description)
+        )
+        self._porter = porter
+        self._fallback_porter = fallback_porter
+        self._samples = () if samples is None else list(samples)
+        self._empty = empty
+        if cls is not None:
+            self._cls = cls
+
+    @property
+    def cls(self) -> type[_DataT]:
+        """
+        The data's Python type.
+        """
+        if self._cls is None:
+            raise ValueError("This definition was not yet used to decorate a class.")
+        assert self._cls is not None
+        return self._cls
+
+    @property
+    def porter(self) -> Porter[_DataT]:
+        """
+        The porter for the data.
+        """
+        if self._porter is None:
+            if issubclass(self.cls, Portable):
+                self._porter = PortablePorter(self.cls)
+            elif self._fallback_porter is not None:
+                self._porter = self._fallback_porter
+
+            else:
+                raise NotPortable(
+                    f"This definition does not have a porter. Either make the data class {fully_qualified_name(self.cls)} subclass {fully_qualified_name(Portable)}, or provide a porter when initializing the definition."
+                )
+        assert self._porter is not None
+        return self._porter
+
+    def __call__(self, cls: type[_DataT]) -> type[_DataT]:
+        """
+        Decorate a data class.
+
+        :raises ValueError: Raised if the definition was already used to decorate a class.
+        """
+        if self._cls is not None:
+            raise ValueError("This definition was already used to decorate a class.")
+        if not issubclass(cls, HasData):
+            raise ValueError(
+                f"Can only decorate classes that subclass {fully_qualified_name(HasData)}."
+            )
+        assert self._cls is None
+        cls.data = staticmethod(update_wrapper(lambda: self, cls.data))  # ty:ignore[invalid-assignment]
+        self._cls = cls
+        return cls
+
+    @property
+    def label(self) -> Localizable:
+        """
+        The human-readable data label.
+        """
+        return self._label
+
+    @property
+    def description(self) -> Localizable | None:
+        """
+        The human-readable long data description.
+        """
+        return self._description
+
+    @property
+    def samples(self) -> Iterable[Sample[_DataT]]:
+        """
+        Any samples for this data.
+        """
+        for sample in self._samples:
+            yield sample()
+
+    def load(self, portable: PortableData, /) -> _DataT:
+        """
+        Create a new data instance from portable.
+
+        :raises betty.exception.HumanFacingException: Raised if the portable data is invalid.
+        """
+        return self.porter.load(portable)
+
+    def dump(self, data: _DataT, /) -> PortableData:
+        """
+        Dump the data to portable data.
+        """
+        return self.porter.dump(data)
+
+    async def hydrate(self, data: _DataT, services: ServiceLevel, /) -> None:
+        """
+        Hydrate the data.
+
+        Hydration allows data definitions to require a :py:type:`betty.service.level.ServiceLevel` to perform tasks
+        such as validation or enhancing the data using information or functionality from the service level.
+        """
+        from betty.config import Configuration
+
+        if isinstance(data, Hydratable):
+            await data.hydrate(services)
+        if isinstance(data, Configuration):
+            assert services is not None
+            validator = data.validator
+            if validator is not None:
+                await services.new_target(validator)
+
+    def empty(self, data: _DataT, /) -> bool:
+        """
+        Check if the data can be considered 'empty'.
+        """
+        if self._empty is None:
+            return False
+        return self._empty(data)
+
+
+_DataDefinitionT = TypeVar(
+    "_DataDefinitionT", bound=DataDefinition, default=DataDefinition, covariant=True
+)
+
+
+class HasData(Generic[_DataDefinitionT]):
+    """
+    A class that defines data for its instances.
+    """
+
+    @classmethod
+    def data(cls) -> Intersection[_DataDefinitionT, DataDefinition[Self]]:
+        """
+        Define the data for instances of this class.
+        """
+        raise NotImplementedError(
+            f"{fully_qualified_name(cls)} was not decorated with a {fully_qualified_name(DataDefinition)} subclass."
+        )
+
+    def __eq__(self, other: Any) -> bool:
+        if type(self) is not type(other):
+            return NotImplemented
+        data = type(self).data()
+        return data.dump(self) == data.dump(other)
+
+
+class Sample(Generic[_DataT]):
+    """
+    A data sample.
+
+    Samples are useful for generating documentation and tests.
+    """
+
+    def __init__(
+        self,
+        data: _DataT,
+        *,
+        label: LocalizableLike,
+        description: LocalizableLike | None = None,
+        minimal: bool = False,
+        full: bool = False,
+    ):
+        self._data = data
+        self._label = ensure_localizable(label)
+        self._description = ensure_localizable(description) if description else None
+        self._minimal = minimal
+        self._full = full
+
+    @property
+    def data(self) -> _DataT:
+        """
+        The sample data.
+        """
+        return self._data
+
+    @property
+    def label(self) -> Localizable:
+        """
+        The sample's human-readable short label.
+        """
+        return self._label
+
+    @property
+    def description(self) -> Localizable | None:
+        """
+        The sample's human-readable long description.
+        """
+        return self._description
+
+    @property
+    def minimal(self) -> bool:
+        """
+        Whether this is a minimal sample.
+        """
+        return self._minimal
+
+    @property
+    def full(self) -> bool:
+        """
+        Whether this is a full sample.
+        """
+        return self._full
+
+
+class SampleNotFound(Exception):
+    """
+    Raised when a sample could not be found.
+    """

--- a/betty/data/aggregate/__init__.py
+++ b/betty/data/aggregate/__init__.py
@@ -1,0 +1,41 @@
+"""
+Aggregate data types.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
+
+from typing_extensions import override
+
+from betty.data import DataDefinition
+from betty.data.indicator.selector import Element
+from betty.exception import reraise_with_indicator
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from betty.service.level import ServiceLevel
+
+_DataT = TypeVar("_DataT")
+_ElementT = TypeVar("_ElementT", bound=Element[Any])
+
+
+class AggregateDefinition(DataDefinition[_DataT], ABC, Generic[_DataT, _ElementT]):
+    """
+    Define an aggregate data type, e.g. data that consists of other parts.
+    """
+
+    @abstractmethod
+    def elements(self, data: _DataT) -> Sequence[tuple[_ElementT, DataDefinition]]:
+        """
+        The selectors and definitions for all elements contained by the data.
+        """
+
+    @override
+    async def hydrate(self, data: _DataT, services: ServiceLevel, /) -> None:
+        for selector, element in self.elements(data):
+            with reraise_with_indicator(selector):
+                await element.hydrate(selector.get(data), services)
+        await super().hydrate(data, services)

--- a/betty/data/aggregate/collection/__init__.py
+++ b/betty/data/aggregate/collection/__init__.py
@@ -1,0 +1,50 @@
+"""
+Collection data types.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Collection
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from betty.data.aggregate import AggregateDefinition
+from betty.data.indicator.selector import Element
+
+if TYPE_CHECKING:
+    from betty.data import DataDefinition
+    from betty.locale.localizable import LocalizableLike
+    from betty.portable import Porter
+
+_CollectionT = TypeVar("_CollectionT", bound=Collection)
+_ElementT = TypeVar("_ElementT", bound=Element[Any])
+
+
+class CollectionDefinition(AggregateDefinition[_CollectionT, _ElementT]):
+    """
+    A homogenous collection data definition.
+    """
+
+    def __init__(
+        self,
+        *,
+        cls: type[_CollectionT] | None = None,
+        item: DataDefinition,
+        label: LocalizableLike,
+        description: LocalizableLike | None = None,
+        porter: Porter[_CollectionT] | None = None,
+    ):
+        super().__init__(
+            cls=cls,
+            label=label,
+            description=description,
+            porter=porter,
+            empty=lambda data: not len(data),
+        )
+        self._item = item
+
+    @property
+    def item(self) -> DataDefinition:
+        """
+        The definition of the items contained by this collection.
+        """
+        return self._item

--- a/betty/data/aggregate/collection/keyed.py
+++ b/betty/data/aggregate/collection/keyed.py
@@ -1,0 +1,79 @@
+"""
+Keyed collection data types.
+"""
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, TypeVar, final
+
+from typing_extensions import override
+
+from betty.assertion import assert_mapping, assert_sequence
+from betty.collections import KeyedCollection
+from betty.data import DataDefinition
+from betty.data.aggregate.collection import CollectionDefinition
+from betty.data.aggregate.record import RecordDefinition
+from betty.data.indicator.selector import Element, Key
+from betty.locale.localizable import LocalizableLike
+from betty.portable import CallbackPorter, PortableData
+
+if TYPE_CHECKING:
+    from ty_extensions import Intersection  # noqa: TC004
+
+
+_ValueT = TypeVar("_ValueT")
+_ElementT = TypeVar("_ElementT")
+_ElementTT = TypeVar("_ElementTT", bound=Element[Any])
+
+
+@final
+class KeyedCollectionDefinition(
+    CollectionDefinition[KeyedCollection[Any, _ValueT, Any, Any], Key]
+):
+    """
+    A definition for :py:class:`betty.collections.KeyedCollection`.
+    """
+
+    _item: RecordDefinition[_ValueT, Element[Any]]
+
+    def __init__(
+        self,
+        *,
+        item: RecordDefinition[_ValueT, _ElementTT],
+        key: "Intersection[_ElementTT, Element[_ElementT]]",
+        ordered: bool,
+        label: LocalizableLike,
+        description: LocalizableLike | None = None,
+    ):
+        super().__init__(
+            cls=KeyedCollection,
+            label=label,
+            description=description,
+            porter=CallbackPorter(self._load, self._dump),
+            item=item,
+        )
+        self._key = key
+        self._ordered = ordered
+
+    @override
+    def elements(
+        self, data: KeyedCollection[Any, _ValueT, Any, Any]
+    ) -> Sequence[tuple[Key, DataDefinition]]:
+        return [(Key(self._key.get(item_data)), self.item) for item_data in data]
+
+    def _load(
+        self, portable: PortableData, /
+    ) -> KeyedCollection[str, _ValueT, str, _ValueT]:
+        if self._ordered:
+            items = assert_sequence(self._item.load)(portable)
+        else:
+            items = [
+                self._item.load_key(portable_item, self._key, portable_key)
+                for portable_key, portable_item in assert_mapping()(portable).items()
+            ]
+
+        return KeyedCollection(items, key=self._key.get)
+
+    def _dump(self, data: KeyedCollection[str, _ValueT, str, _ValueT]) -> PortableData:
+        if self._ordered:
+            return [self._item.dump(value) for value in data]
+        return dict(self._item.dump_key(item_data, self._key) for item_data in data)

--- a/betty/data/aggregate/collection/mapping.py
+++ b/betty/data/aggregate/collection/mapping.py
@@ -1,0 +1,59 @@
+"""
+Key-value mapping data types.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, MutableMapping, Sequence
+from typing import TYPE_CHECKING, Any, TypeVar, final
+
+from typing_extensions import override
+
+from betty.data.aggregate.collection import CollectionDefinition
+from betty.data.indicator.selector import Key
+from betty.portable import CallbackPorter, PortableData
+
+if TYPE_CHECKING:
+    from betty.data import DataDefinition
+    from betty.locale.localizable import LocalizableLike
+
+_DataItemT = TypeVar("_DataItemT")
+_MutableMappingT = TypeVar("_MutableMappingT", bound=MutableMapping[str, Any])
+
+
+@final
+class MappingDefinition(CollectionDefinition[_MutableMappingT, Key]):
+    """
+    A key-value mapping data definition.
+    """
+
+    def __init__(
+        self,
+        *,
+        cls: type[_MutableMappingT],
+        item: DataDefinition[_DataItemT],
+        label: LocalizableLike,
+        description: LocalizableLike | None = None,
+        factory: Callable[[Mapping[str, _DataItemT]], _MutableMappingT] | None = None,
+    ):
+        super().__init__(
+            cls=cls,
+            item=item,
+            label=label,
+            description=description,
+            porter=CallbackPorter(self._load, self._dump),
+        )
+        self._factory = factory
+
+    @override
+    def elements(self, data: _MutableMappingT) -> Sequence[tuple[Key, DataDefinition]]:
+        return [(Key(key), self.item) for key, item_data in data.items()]
+
+    def _load(self, portable: PortableData, /) -> _MutableMappingT:
+        from betty.assertion import assert_mapping, assert_str
+
+        factory = self.cls if not self._factory else self._factory
+        return factory(assert_mapping(self._item.load, assert_str())(portable))
+
+    def _dump(self, data: _MutableMappingT) -> PortableData:
+        return {key: self._item.dump(item) for key, item in data.items()}

--- a/betty/data/aggregate/collection/sequence.py
+++ b/betty/data/aggregate/collection/sequence.py
@@ -1,0 +1,61 @@
+"""
+Sequence data types.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, MutableSequence, Sequence
+from typing import TYPE_CHECKING, Any, TypeVar, final
+
+from typing_extensions import override
+
+from betty.data.aggregate.collection import CollectionDefinition
+from betty.data.indicator.selector import Index
+from betty.portable import CallbackPorter, PortableData
+
+if TYPE_CHECKING:
+    from betty.data import DataDefinition
+    from betty.locale.localizable import LocalizableLike
+
+_DataItemT = TypeVar("_DataItemT")
+_MutableSequenceT = TypeVar("_MutableSequenceT", bound=MutableSequence[Any])
+
+
+@final
+class SequenceDefinition(CollectionDefinition[_MutableSequenceT, Index]):
+    """
+    A sequence data definition.
+    """
+
+    def __init__(
+        self,
+        *,
+        cls: type[_MutableSequenceT],
+        item: DataDefinition[_DataItemT],
+        label: LocalizableLike,
+        description: LocalizableLike | None = None,
+        factory: Callable[[Iterable[_DataItemT]], _MutableSequenceT] | None = None,
+    ):
+        super().__init__(
+            cls=cls,
+            item=item,
+            label=label,
+            description=description,
+            porter=CallbackPorter(self._load, self._dump),
+        )
+        self._factory = factory
+
+    @override
+    def elements(
+        self, data: _MutableSequenceT
+    ) -> Sequence[tuple[Index, DataDefinition]]:
+        return [(Index(index), self.item) for index, item_data in enumerate(data)]
+
+    def _load(self, portable: PortableData, /) -> _MutableSequenceT:
+        from betty.assertion import assert_sequence
+
+        factory = self.cls if not self._factory else self._factory
+        return factory(assert_sequence(self._item.load)(portable))
+
+    def _dump(self, data: _MutableSequenceT) -> PortableData:
+        return [self._item.dump(item) for item in data]

--- a/betty/data/aggregate/record/__init__.py
+++ b/betty/data/aggregate/record/__init__.py
@@ -1,0 +1,196 @@
+"""
+Record data types.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, final
+
+from typing_extensions import override
+
+from betty.assertion import OptionalField
+from betty.data import DataDefinition
+from betty.data.aggregate import AggregateDefinition
+from betty.data.indicator.selector import Element
+from betty.locale.localizable.ensure import ensure_localizable
+from betty.portable import Loader, PortableData, PortableMapping, Porter
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Sequence
+
+    from betty.data import HasData, Sample
+    from betty.locale.localizable import Localizable, LocalizableLike
+
+_DataT = TypeVar("_DataT")
+_ElementT = TypeVar("_ElementT", bound=Element[Any])
+
+
+@final
+class FieldDefinition(Generic[_ElementT, _DataT]):
+    """
+    A record field definition.
+    """
+
+    def __init__(
+        self,
+        selector: _ElementT,
+        data: DataDefinition[_DataT] | HasData[DataDefinition[_DataT]],
+        *,
+        label: LocalizableLike | None = None,
+        description: LocalizableLike | None = None,
+        required: bool = True,
+        empty: Callable[[_DataT], bool] | None = None,
+    ):
+        self._selector = selector
+        self._data = data if isinstance(data, DataDefinition) else data.data()
+        self._label = None if label is None else ensure_localizable(label)
+        self._description = (
+            None if description is None else ensure_localizable(description)
+        )
+        self._required = required
+        self._empty = empty
+
+    @property
+    def selector(self) -> Element:
+        """
+        The field selector.
+        """
+        return self._selector
+
+    @property
+    def data(self) -> DataDefinition:
+        """
+        The field's data definition.
+        """
+        return self._data
+
+    @property
+    def label(self) -> Localizable | None:
+        """
+        The human-readable field label.
+        """
+        return self._label
+
+    @property
+    def description(self) -> Localizable | None:
+        """
+        The human-readable long field description.
+        """
+        return self._description
+
+    @property
+    def required(self) -> bool:
+        """
+        Whether the field is required.
+        """
+        return self._required
+
+    def empty(self, data: _DataT) -> bool:
+        """
+        Check if the data can be considered 'empty'.
+        """
+        if self._empty is None:
+            return self.data.empty(data)
+        return self._empty(data)
+
+
+class _RecordPorter(Porter[_DataT]):
+    def __init__(
+        self,
+        loader: Loader[_DataT],
+        dumper: Callable[[_DataT], PortableMapping],
+        /,
+    ):
+        self._loader = loader
+        self._dumper = dumper
+
+    @override
+    def load(self, portable: PortableData) -> _DataT:
+        return self._loader(portable)
+
+    @override
+    def dump(self, data: _DataT) -> PortableMapping:
+        return self._dumper(data)
+
+
+class RecordDefinition(AggregateDefinition[_DataT, _ElementT]):
+    """
+    A record data definition.
+
+    Records have explicitly defined fields.
+    """
+
+    _porter: _RecordPorter[_DataT]
+
+    def __init__(
+        self,
+        *,
+        cls: type[_DataT] | None = None,
+        label: LocalizableLike,
+        fields: Sequence[FieldDefinition[_ElementT, Any]],
+        description: LocalizableLike | None = None,
+        samples: Iterable[Callable[[], Sample[_DataT]]] | None = None,
+        factory: Callable[..., _DataT] | None = None,
+    ):
+        super().__init__(
+            cls=cls,
+            label=label,
+            description=description,
+            samples=samples,
+            porter=_RecordPorter(self._load, self._dump),
+        )
+        self._factory = factory
+        self._fields = fields
+
+    @property
+    def fields(self) -> Sequence[FieldDefinition[_ElementT, Any]]:
+        """
+        The definitions of the fields contained by this record.
+        """
+        return self._fields
+
+    @override
+    def elements(self, data: _DataT) -> Sequence[tuple[_ElementT, DataDefinition]]:
+        return [(field.selector, field.data) for field in self.fields]  # ty:ignore[invalid-return-type]
+
+    def _load(self, portable: PortableData, /) -> _DataT:
+        from betty.assertion import RequiredField, assert_record
+
+        factory = self.cls if not self._factory else self._factory
+        return factory(
+            **assert_record(
+                *[
+                    (RequiredField if field.required else OptionalField)(
+                        field.selector.element, field.data.load
+                    )
+                    for field in self._fields
+                ]
+            )(portable)
+        )
+
+    def _dump(self, data: _DataT) -> PortableMapping:
+        portable = {}
+        for field in self.fields:
+            field_data = field.selector.get(data)
+            if not field.empty(field_data):
+                portable[field.selector.element] = field.data.dump(field_data)
+        return portable
+
+    def load_key(
+        self, portable: PortableData, key: _ElementT, portable_key: str, /
+    ) -> _DataT:
+        """
+        Create a new data instance from portable data and a portable primary key.
+
+        :raises betty.exception.HumanFacingException: Raised if the portable data is invalid.
+        """
+        return self._porter.load({**portable, key.element: portable_key})
+
+    def dump_key(self, data: _DataT, key: _ElementT, /) -> tuple[str, PortableData]:
+        """
+        Dump the data to portable data and a portable primary key.
+        """
+        portable = self._porter.dump(data)
+        portable_key = portable.pop(key.element)
+        assert isinstance(portable_key, str)
+        return portable_key, portable

--- a/betty/data/aggregate/record/mapping.py
+++ b/betty/data/aggregate/record/mapping.py
@@ -1,0 +1,23 @@
+"""
+Key-value mapping record data types.
+"""
+
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+from typing import Any, TypeVar, final
+
+from betty.data.aggregate.record import RecordDefinition
+from betty.data.indicator.selector import Key
+
+_MutableMappingT = TypeVar("_MutableMappingT", bound=MutableMapping[str, Any])
+
+
+@final
+class TypedMappingDefinition(RecordDefinition[_MutableMappingT, Key]):
+    """
+    A typed mapping definition.
+
+    Actual values do not have to be :py:class:`typing.TypedDict`. They can be any mapping, but like typed dicts, values
+    are limited to the defined elements.
+    """

--- a/betty/data/aggregate/record/object.py
+++ b/betty/data/aggregate/record/object.py
@@ -1,0 +1,18 @@
+"""
+Object data types.
+"""
+
+from __future__ import annotations
+
+from typing import TypeVar
+
+from betty.data.aggregate.record import RecordDefinition
+from betty.data.indicator.selector import Attr
+
+_DataT = TypeVar("_DataT")
+
+
+class ObjectDefinition(RecordDefinition[_DataT, Attr]):
+    """
+    An object definition.
+    """

--- a/betty/data/enum.py
+++ b/betty/data/enum.py
@@ -1,0 +1,39 @@
+"""
+Enumerated data types.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import TYPE_CHECKING, TypeVar, final
+
+from betty.data import DataDefinition
+from betty.portable import CallbackPorter
+
+if TYPE_CHECKING:
+    from betty.locale.localizable import LocalizableLike
+
+_EnumT = TypeVar("_EnumT", bound=Enum)
+
+
+@final
+class EnumDefinition(DataDefinition[_EnumT]):
+    """
+    An enum data definition.
+    """
+
+    def __init__(
+        self,
+        *,
+        cls: type[_EnumT],
+        label: LocalizableLike,
+        description: LocalizableLike | None = None,
+    ):
+        from betty.assertion import assert_enum
+
+        super().__init__(
+            cls=cls,
+            label=label,
+            description=description,
+            porter=CallbackPorter(assert_enum(cls), lambda enum: enum.value),
+        )

--- a/betty/data/indicator/__init__.py
+++ b/betty/data/indicator/__init__.py
@@ -26,6 +26,28 @@ class Indicator(ABC):
 
 
 @final
+class AnyIndex(Indicator):
+    """
+    A sequence item indicator.
+    """
+
+    @override
+    def format(self) -> str:
+        return "[]"
+
+
+@final
+class AnyKey(Indicator):
+    """
+    A mapping item indicator.
+    """
+
+    @override
+    def format(self) -> str:
+        return "{}"
+
+
+@final
 class Path(Indicator):
     """
     A file on disk.

--- a/betty/data/indicator/selector.py
+++ b/betty/data/indicator/selector.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from betty.assertion import Assertion
 
 _T = TypeVar("_T")
-_ItemT = TypeVar("_ItemT")
+_ElementT = TypeVar("_ElementT")
 
 
 class Selector(Indicator, ABC):
@@ -88,82 +88,90 @@ class Selectors(Selector):
         return data
 
 
-@final
-class Attr(Selector):
+class Element(Selector, Generic[_ElementT]):
     """
-    An object attribute indicator.
+    An aggregate element selector.
     """
 
-    def __init__(self, attr: str, /):
-        self._attr = attr
-
-    @override
-    def format(self) -> str:
-        return f".{self._attr}"
-
-    @override
-    def _get(self, data: Any, /) -> Any:
-        try:
-            return getattr(data, self._attr)
-        except AttributeError:
-            from betty.exception import HumanFacingException
-
-            raise HumanFacingException(
-                _("Data has no {attribute} attribute.").format(
-                    attribute=f".{self._attr}"
-                )
-            ) from None
-
-
-class _Item(Selector, Generic[_ItemT]):
-    def __init__(self, item: _ItemT, /):
-        self._item = item
+    def __init__(self, element: _ElementT, /):
+        self._element = element
 
     def __eq__(self, other: Any) -> bool:
         if type(other) is not type(self):
             return NotImplemented
-        return self._item == other._item
+        return self._element == other._element
 
     @property
-    def item(self) -> _ItemT:
+    def element(self) -> _ElementT:
         """
-        The lookup item.
+        The element.
         """
-        return self._item
+        return self._element
 
 
 @final
-class Index(_Item[int]):
+class Attr(Element[str]):
     """
-    A sequence index indicator.
+    An attribute selector.
     """
 
     @override
     def format(self) -> str:
-        return f"[{self._item}]"
+        return f".{self.element}"
 
     @override
     def _get(self, data: Any, /) -> Any:
-        from betty.assertion import assert_len, assert_sequence
+        try:
+            return getattr(data, self.element)
+        except AttributeError:
+            from betty.exception import HumanFacingException
 
-        assert_sequence()(data)
-        assert_len(minimum=self._item + 1)(data)
-        return data[self.item]
+            raise HumanFacingException(
+                _("Data has no attribute {attribute}").format(
+                    attribute=f".{self.element}"
+                )
+            ) from None
 
 
 @final
-class Key(_Item[str]):
+class Index(Element[int]):
     """
-    A mapping key indicator.
+    A sequence item selector.
     """
 
     @override
     def format(self) -> str:
-        return f'["{self._item}"]'
+        return f"[{self.element}]"
 
     @override
     def _get(self, data: Any, /) -> Any:
-        from betty.assertion import RequiredField, assert_record
+        try:
+            return data[self.element]
+        except (LookupError, TypeError):
+            from betty.exception import HumanFacingException
 
-        assert_record(RequiredField(self._item), allow_extra=True)(data)
-        return data[self.item]
+            raise HumanFacingException(
+                _("Data has no index {index}").format(index=f".{self.element}")
+            ) from None
+
+
+@final
+class Key(Element[str]):
+    """
+    A mapping key selector.
+    """
+
+    @override
+    def format(self) -> str:
+        return f'["{self.element}"]'
+
+    @override
+    def _get(self, data: Any, /) -> Any:
+        try:
+            return data[self.element]
+        except (LookupError, TypeError):
+            from betty.exception import HumanFacingException
+
+            raise HumanFacingException(
+                _('Data has no key "{key}"').format(key=f".{self.element}")
+            ) from None

--- a/betty/data/sample.py
+++ b/betty/data/sample.py
@@ -1,0 +1,80 @@
+"""
+Data sample helpers.
+"""
+
+from __future__ import annotations
+
+from typing import TypeVar, overload
+
+from betty.config import Configuration
+from betty.data import DataDefinition, HasData, Sample, SampleNotFound
+
+_DataT = TypeVar("_DataT")
+_HasDataT = TypeVar("_HasDataT", bound=HasData)
+_ConfigurationT = TypeVar("_ConfigurationT", bound=Configuration)
+
+
+@overload
+def get_minimal_sample(data: type[_HasDataT], /) -> Sample[_HasDataT]:
+    pass
+
+
+@overload
+def get_minimal_sample(data: DataDefinition[_DataT], /) -> Sample[_DataT]:
+    pass
+
+
+@overload
+def get_minimal_sample(data: type[_ConfigurationT], /) -> Sample[_ConfigurationT]:
+    pass
+
+
+def get_minimal_sample(data):
+    """
+    Get a sample for a data type, preferably as minimal as possible.
+    """
+    if isinstance(data, type) and issubclass(data, HasData):
+        data = data.data()
+    samples = list(data.samples if isinstance(data, DataDefinition) else data.samples())
+    for sample in samples:
+        if sample.minimal:
+            return sample
+    for sample in samples:
+        if not sample.full:
+            return sample
+    if samples:
+        return samples[0]
+    raise SampleNotFound
+
+
+@overload
+def get_full_sample(data: type[_HasDataT], /) -> Sample[_HasDataT]:
+    pass
+
+
+@overload
+def get_full_sample(data: DataDefinition[_DataT], /) -> Sample[_DataT]:
+    pass
+
+
+@overload
+def get_full_sample(data: type[_ConfigurationT], /) -> Sample[_ConfigurationT]:
+    pass
+
+
+def get_full_sample(data):
+    """
+    Get a sample for a data type, preferably as full as possible.
+    """
+    if isinstance(data, type) and issubclass(data, HasData):
+        data = data.data()
+    samples = list(data.samples if isinstance(data, DataDefinition) else data.samples())
+    for sample in samples:
+        if sample.full:
+            return sample
+    for sample in samples:
+        if not sample.minimal:
+            return sample
+    if samples:
+        return samples[0]
+    raise SampleNotFound

--- a/betty/data/simple.py
+++ b/betty/data/simple.py
@@ -1,0 +1,42 @@
+"""
+Simple (scalar) data types.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeVar
+
+from betty.data import DataDefinition
+from betty.functools import passthrough
+from betty.portable import CallbackPorter, Porter
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from betty.locale.localizable import LocalizableLike
+
+_DataT = TypeVar("_DataT")
+
+
+class SimpleDefinition(DataDefinition[_DataT]):
+    """
+    A simple (scalar) data definition.
+    """
+
+    def __init__(
+        self,
+        *,
+        cls: type[_DataT] | None = None,
+        label: LocalizableLike,
+        description: LocalizableLike | None = None,
+        porter: Porter[_DataT] | None = None,
+        empty: Callable[[_DataT], bool] | None = None,
+    ):
+        super().__init__(
+            cls=cls,
+            label=label,
+            description=description,
+            porter=porter,
+            empty=empty,
+            fallback_porter=CallbackPorter(passthrough, passthrough),
+        )

--- a/betty/documentation.py
+++ b/betty/documentation.py
@@ -2,6 +2,7 @@
 Provide the Documentation API.
 """
 
+import multiprocessing
 from asyncio import to_thread
 from contextlib import AsyncExitStack
 from pathlib import Path
@@ -45,8 +46,7 @@ async def _build(
         confdir=str(source_directory_path),
         doctreedir=str(cache_directory_path / ".doctrees"),
         outdir=str(output_directory_path),
-        # @todo
-        # parallel=multiprocessing.cpu_count(),
+        parallel=multiprocessing.cpu_count(),
         srcdir=str(source_directory_path),
         verbosity=9 if user.verbosity is Verbosity.MOST_VERBOSE else 0,
         warningiserror=True,

--- a/betty/locale/localizable/data.py
+++ b/betty/locale/localizable/data.py
@@ -1,0 +1,51 @@
+"""
+Localizable data.
+"""
+
+from __future__ import annotations
+
+from typing import TypeVar, final
+
+from betty.classtools import Singleton
+from betty.data import DataDefinition
+from betty.locale.localizable import CountableLocalizable, Localizable
+from betty.locale.localizable.gettext import _
+from betty.locale.localizable.portable import (
+    dump_countable_localizable,
+    dump_localizable,
+    load_countable_localizable,
+    load_localizable,
+)
+from betty.portable import CallbackPorter
+
+_DataT = TypeVar("_DataT")
+
+
+@final
+class LocalizableDefinition(DataDefinition[Localizable], Singleton):
+    """
+    The data definition for :py:class:`betty.locale.localizable.Localizable`.
+    """
+
+    def __init__(self):
+        super().__init__(
+            cls=Localizable,
+            label=_("A localizable string"),
+            porter=CallbackPorter(load_localizable, dump_localizable),
+        )
+
+
+@final
+class CountableLocalizableDefinition(DataDefinition[CountableLocalizable], Singleton):
+    """
+    The data definition for :py:class:`betty.locale.localizable.CountableLocalizable`.
+    """
+
+    def __init__(self):
+        super().__init__(
+            cls=CountableLocalizable,
+            label=_("A countable localizable string"),
+            porter=CallbackPorter(
+                load_countable_localizable, dump_countable_localizable
+            ),
+        )

--- a/betty/model/config.py
+++ b/betty/model/config.py
@@ -13,8 +13,9 @@ from betty.assertion import (
     assert_record,
     assert_str,
 )
-from betty.config import Configuration, Sample
+from betty.config import Configuration
 from betty.config.collections.sequence import ConfigurationSequence
+from betty.data import Sample
 from betty.data.indicator.selector import Index
 from betty.exception import reraise_with_indicator
 from betty.machine_name import MachineName, assert_machine_name
@@ -99,7 +100,7 @@ class EntityReference(Configuration):
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         from betty.ancestry.person import Person
 
         yield Sample(cls(Person, "123"), label="Default")
@@ -130,7 +131,7 @@ class EntityReferenceSequence(ConfigurationSequence[EntityReference]):
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         from betty.ancestry.person import Person
 
         yield Sample(cls(), label="Minimal", minimal=True)

--- a/betty/plugin/__init__.py
+++ b/betty/plugin/__init__.py
@@ -52,7 +52,7 @@ class PluginDefinition(Generic[_BaseClsCoT]):
         """
         The plugin type definition.
         """
-        raise Exception(
+        raise NotImplementedError(
             f"{fully_qualified_name(cls)} was not decorated with a {fully_qualified_name(PluginDefinition)} subclass."
         )
 
@@ -285,7 +285,7 @@ class Plugin(Generic[_PluginDefinitionCoT]):
         """
         The plugin definition.
         """
-        raise Exception(
+        raise NotImplementedError(
             f"{fully_qualified_name(cls)} was not decorated with a {fully_qualified_name(PluginDefinition)} subclass."
         )
 

--- a/betty/plugin/config/__init__.py
+++ b/betty/plugin/config/__init__.py
@@ -17,11 +17,13 @@ from betty.assertion import (
     assert_or,
     assert_record,
 )
-from betty.config import Configuration, Sample, get_full_sample
+from betty.config import Configuration
 from betty.config.collections import ConfigurationCollection, ConfigurationKey
 from betty.config.collections.mapping import ConfigurationMapping
 from betty.config.collections.sequence import ConfigurationSequence
 from betty.config.color import ColorConfiguration
+from betty.data import Sample
+from betty.data.sample import get_full_sample
 from betty.locale import DEFAULT_LOCALE
 from betty.locale.localizable.assertion import (
     assert_load_countable_localizable,
@@ -126,7 +128,7 @@ class PluginDefinitionConfiguration(Configuration):
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         yield Sample(cls(id="my-custom-plugin"), label="Default")
 
 
@@ -414,7 +416,7 @@ class PluginInstanceConfiguration(Configuration, Generic[_PluginDefinitionT, _Pl
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         from betty.project.extension.raspberry_mint import RaspberryMint
         from betty.project.extension.raspberry_mint.config import (
             RaspberryMintConfiguration,
@@ -465,7 +467,7 @@ class _PluginInstanceConfigurationCollection(
     def _item_cls(
         cls,
     ) -> type[PluginInstanceConfiguration[_PluginDefinitionT, _PluginT]]:
-        return PluginInstanceConfiguration[_PluginDefinitionT, _PluginT]
+        return PluginInstanceConfiguration  # ty:ignore[invalid-return-type]
 
 
 class PluginInstanceConfigurationMapping(
@@ -526,10 +528,10 @@ class PluginInstanceConfigurationMapping(
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         yield Sample(cls(), label="Minimal", minimal=True)
         yield Sample(
-            cls([get_full_sample(PluginInstanceConfiguration).configuration]),
+            cls([get_full_sample(PluginInstanceConfiguration).data]),
             label="Full",
             full=True,
         )
@@ -548,10 +550,10 @@ class PluginInstanceConfigurationSequence(
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         yield Sample(cls(), label="Minimal", minimal=True)
         yield Sample(
-            cls([get_full_sample(PluginInstanceConfiguration).configuration]),
+            cls([get_full_sample(PluginInstanceConfiguration).data]),
             label="Full",
             full=True,
         )
@@ -595,14 +597,8 @@ class PluginInstanceConfigurationSequenceSequence(
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         yield Sample(
-            cls(
-                [
-                    next(
-                        iter(PluginInstanceConfigurationSequence.samples())
-                    ).configuration
-                ]
-            ),
+            cls([next(iter(PluginInstanceConfigurationSequence.samples())).data]),
             label="Default",
         )

--- a/betty/plugin/data.py
+++ b/betty/plugin/data.py
@@ -1,0 +1,39 @@
+"""
+Data types for plugins.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, final
+
+from typing_extensions import override
+
+from betty.data import DataDefinition
+from betty.functools import passthrough
+from betty.locale.localizable.gettext import _
+from betty.machine_name import MachineName, assert_machine_name
+from betty.portable import CallbackPorter
+
+if TYPE_CHECKING:
+    from betty.plugin import PluginDefinition
+    from betty.service.level import ServiceLevel
+
+
+@final
+class PluginIdDefinition(DataDefinition[MachineName]):
+    """
+    Define data that represents a plugin ID.
+    """
+
+    def __init__(self, plugin_type: type[PluginDefinition]):
+        super().__init__(
+            cls=MachineName,
+            label=plugin_type.type().label,
+            description=_("A plugin ID"),
+            porter=CallbackPorter(assert_machine_name(), passthrough),
+        )
+        self._plugin_type = plugin_type
+
+    @override
+    async def hydrate(self, data: MachineName, services: ServiceLevel, /) -> None:
+        (await services.plugins(self._plugin_type)).get(data)

--- a/betty/portable/__init__.py
+++ b/betty/portable/__init__.py
@@ -8,9 +8,12 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import MutableMapping, MutableSequence
-from typing import Generic, Self, TypeAlias
+from typing import Generic, Protocol, Self, TypeAlias, final
 
-from typing_extensions import TypeVar
+from typing_extensions import TypeVar, override
+
+_DataT = TypeVar("_DataT")
+
 
 PortableData: TypeAlias = (
     bool
@@ -45,7 +48,7 @@ Keys are strings.
 """
 
 
-class Portable(ABC, Generic[_PortableDataT]):
+class Portable(ABC):
     """
     A class that can be dumped to and loaded from portable data.
     """
@@ -60,9 +63,94 @@ class Portable(ABC, Generic[_PortableDataT]):
         """
 
     @abstractmethod
-    def dump(self) -> _PortableDataT:
+    def dump(self) -> PortableData:
         """
         Produce a portable data dump of ``self``.
 
         :raises betty.portable.error.NotPortable: Raised if any part of the data is not portable.
         """
+
+
+_PortableT = TypeVar("_PortableT", bound=Portable)
+
+
+class Loader(Protocol[_DataT]):
+    """
+    A callable that can load portable data.
+    """
+
+    def __call__(self, portable: PortableData, /) -> _DataT:
+        """
+        Load the portable data.
+        """
+
+
+class Dumper(Protocol[_DataT]):
+    """
+    A callable that can dump to portable data.
+    """
+
+    def __call__(self, data: _DataT, /) -> PortableData:
+        """
+        Dump the portable data.
+        """
+
+
+class Porter(ABC, Generic[_DataT]):
+    """
+    An object capable of dumping and loading data to and from portable data.
+    """
+
+    @abstractmethod
+    def load(self, portable: PortableData, /) -> _DataT:
+        """
+        Load data from its portable form.
+        """
+
+    @abstractmethod
+    def dump(self, data: _DataT, /) -> PortableData:
+        """
+        Dump data to its portable form.
+        """
+
+
+@final
+class CallbackPorter(Porter[_DataT]):
+    """
+    Make data portable using a separate loader and dumper.
+    """
+
+    def __init__(
+        self,
+        loader: Loader[_DataT],
+        dumper: Dumper[_DataT],
+        /,
+    ):
+        self._loader = loader
+        self._dumper = dumper
+
+    @override
+    def load(self, portable: PortableData) -> _DataT:
+        return self._loader(portable)
+
+    @override
+    def dump(self, data: _DataT) -> PortableData:
+        return self._dumper(data)
+
+
+@final
+class PortablePorter(Porter[_PortableT]):
+    """
+    Expose a portable data type as a porter.
+    """
+
+    def __init__(self, cls: type[_PortableT]):
+        self._cls = cls
+
+    @override
+    def load(self, portable: PortableData) -> _PortableT:
+        return self._cls.load(portable)
+
+    @override
+    def dump(self, data: _PortableT) -> PortableData:
+        return data.dump()

--- a/betty/project/config.py
+++ b/betty/project/config.py
@@ -4,9 +4,8 @@ Provide project configuration.
 
 from __future__ import annotations
 
-from collections.abc import Collection, Iterable, MutableMapping
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Self, cast, final
+from typing import TYPE_CHECKING, Any, Self, final
 from urllib.parse import urlparse
 
 from babel import Locale
@@ -14,27 +13,32 @@ from typing_extensions import override
 
 from betty.ancestry.event_type import EventType, EventTypeDefinition
 from betty.ancestry.gender import Gender, GenderDefinition
+from betty.ancestry.person import Person
 from betty.ancestry.place_type import PlaceType, PlaceTypeDefinition
 from betty.ancestry.presence_role import PresenceRole, PresenceRoleDefinition
 from betty.assertion import (
     Field,
     OptionalField,
     RequiredField,
-    assert_bool,
-    assert_int,
+    assert_file_path,
     assert_locale,
-    assert_none,
     assert_number,
-    assert_or,
-    assert_path,
     assert_record,
     assert_str,
 )
-from betty.config import Configuration, Sample, get_full_sample
+from betty.collections import KeyedCollection
+from betty.config import Configuration
 from betty.config.collections.mapping import OrderedConfigurationMapping
 from betty.copyright_notice import CopyrightNotice, CopyrightNoticeDefinition
-from betty.data.indicator.selector import Key
-from betty.exception import HumanFacingException, reraise_with_indicator
+from betty.data import DataDefinition, HasData, Sample
+from betty.data.aggregate.collection.keyed import KeyedCollectionDefinition
+from betty.data.aggregate.record import FieldDefinition
+from betty.data.aggregate.record.object import ObjectDefinition
+from betty.data.indicator.selector import Attr
+from betty.data.sample import get_full_sample
+from betty.data.simple import SimpleDefinition
+from betty.dirs import ASSETS_DIRECTORY_PATH
+from betty.exception import HumanFacingException
 from betty.license import License, LicenseDefinition
 from betty.locale import DEFAULT_LOCALE, LocaleLike, ensure_locale, to_language_tag
 from betty.locale.localizable.assertion import assert_load_localizable
@@ -42,6 +46,7 @@ from betty.locale.localizable.attr import (
     OptionalLocalizableAttr,
     RequiredLocalizableAttr,
 )
+from betty.locale.localizable.data import LocalizableDefinition
 from betty.locale.localizable.ensure import ensure_localizable
 from betty.locale.localizable.gettext import _
 from betty.locale.localizable.portable import dump_localizable
@@ -52,21 +57,22 @@ from betty.plugin.config import (
     CountableHumanFacingPluginDefinitionConfiguration,
     HumanFacingPluginDefinitionConfiguration,
     PluginDefinitionConfigurationMapping,
-    PluginIdentifierKeyConfigurationMapping,
     PluginInstanceConfiguration,
     PluginInstanceConfigurationMapping,
 )
 from betty.plugin.config.ordered import OrderedPluginDefinitionConfiguration
+from betty.plugin.data import PluginIdDefinition
 from betty.plugin.resolve import ResolvableId, resolve_id
+from betty.portable import CallbackPorter
 from betty.project.extension import Extension, ExtensionDefinition
-from betty.service.level.factory import CallbackServiceLevelDependentFactory
+from betty.service.hydrate import Hydratable
 
 if TYPE_CHECKING:
+    from collections.abc import Collection, Iterable
+
     from betty.locale.localizable import Localizable, LocalizableLike
-    from betty.plugin.repository import PluginRepository
     from betty.portable import PortableData, PortableMapping
-    from betty.project import Project
-    from betty.service.level.factory import ServiceLevelTarget
+    from betty.service.level import ServiceLevel
 
 DEFAULT_LIFETIME_THRESHOLD = 123
 """
@@ -114,7 +120,7 @@ class ExtensionInstanceConfigurationMapping(
                 [
                     PluginInstanceConfiguration(
                         RaspberryMint,
-                        get_full_sample(RaspberryMintConfiguration).configuration,
+                        get_full_sample(RaspberryMintConfiguration).data,
                     )
                 ]  # ty:ignore[invalid-argument-type]
             ),
@@ -124,29 +130,51 @@ class ExtensionInstanceConfigurationMapping(
 
 
 @final
-class EntityTypeConfiguration(Configuration):
+@ObjectDefinition(
+    label=_("Entity type configuration"),
+    fields=[
+        FieldDefinition(Attr("entity_type"), PluginIdDefinition(EntityDefinition)),
+        FieldDefinition(
+            Attr("generate_html_list"),
+            SimpleDefinition(cls=bool, label=_("Generate list HTML page")),
+            required=False,
+        ),
+    ],
+    samples=[
+        lambda: Sample(
+            EntityTypeConfiguration(entity_type=Person), label="Minimal", minimal=True
+        ),
+        lambda: Sample(
+            EntityTypeConfiguration(entity_type=Person, generate_html_list=True),
+            label="Full",
+            full=True,
+        ),
+    ],
+)
+class EntityTypeConfiguration(
+    HasData[ObjectDefinition["EntityTypeConfiguration"]], Hydratable
+):
     """
     Configure a single entity type for a project.
 
-    .. configuration:: betty.project.config:EntityTypeConfiguration
+    .. has_data:: betty.project.config:EntityTypeConfiguration
     """
 
     def __init__(
         self,
-        entity_type: ResolvableId[EntityDefinition],
         *,
-        generate_html_list: bool = True,
+        entity_type: ResolvableId[EntityDefinition],
+        generate_html_list: bool = False,
     ):
-        super().__init__()
-        self._id = resolve_id(entity_type)
+        self._entity_type = resolve_id(entity_type)
         self.generate_html_list = generate_html_list
 
     @property
-    def id(self) -> MachineName:
+    def entity_type(self) -> MachineName:
         """
         The ID of the configured entity type.
         """
-        return self._id
+        return self._entity_type
 
     @property
     def generate_html_list(self) -> bool:
@@ -160,117 +188,14 @@ class EntityTypeConfiguration(Configuration):
         self._generate_html_list = generate_html_list
 
     @override
-    @classmethod
-    def load(cls, portable: PortableData, /) -> Self:
-        record = assert_record(
-            RequiredField("entity_type", assert_machine_name()),
-            OptionalField("generate_html_list", assert_bool),
-        )(portable)
-        return cls(
-            record["entity_type"],
-            generate_html_list=record.get("generate_html_list", True),
-        )
-
-    @override
-    def dump(self) -> PortableMapping:
-        return {
-            "entity_type": self.id,
-            "generate_html_list": self.generate_html_list,
-        }
-
-    @override
-    def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, type(self)):
-            return NotImplemented
-        return (self.id, self.generate_html_list) == (
-            other.id,
-            other.generate_html_list,
-        )
-
-    async def validate(
-        self, entity_type_repository: PluginRepository[EntityDefinition], /
-    ) -> None:
-        """
-        Validate the configuration.
-        """
-        entity_type = entity_type_repository[self.id]
+    async def hydrate(self, services: ServiceLevel, /) -> None:
+        entity_type = (await services.plugins(EntityDefinition)).get(self._entity_type)
         if self.generate_html_list and not entity_type.public_facing:
             raise HumanFacingException(
                 _(
                     "Cannot generate pages for {entity_type}, because it is not a public-facing entity type."
                 ).format(entity_type=entity_type.label)
             )
-
-    @override
-    @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
-        from betty.ancestry.person import Person
-
-        yield Sample(EntityTypeConfiguration(Person), label="Minimal", minimal=True)
-        yield Sample(
-            EntityTypeConfiguration(Person, generate_html_list=False),
-            label="Full",
-            full=True,
-        )
-
-
-@final
-class EntityTypeConfigurationMapping(
-    PluginIdentifierKeyConfigurationMapping[EntityDefinition, EntityTypeConfiguration]
-):
-    """
-    Configure the entity types for a project.
-
-    .. configuration:: betty.project.config:EntityTypeConfigurationMapping
-    """
-
-    @override
-    def _get_key(self, configuration: EntityTypeConfiguration, /) -> MachineName:
-        return configuration.id
-
-    @override
-    @classmethod
-    def _load_key(
-        cls, portable_item: PortableData, portable_key: str, /
-    ) -> PortableData:
-        assert isinstance(portable_item, MutableMapping)
-        portable_item["entity_type"] = portable_key  # ty:ignore[invalid-assignment]
-        return portable_item
-
-    @override
-    def _dump_key(self, portable_item: PortableData, /) -> tuple[PortableData, str]:
-        assert isinstance(portable_item, MutableMapping)
-        return portable_item, cast(
-            str,
-            portable_item.pop(
-                "entity_type",  # ty:ignore[invalid-argument-type]
-            ),
-        )
-
-    @override
-    @classmethod
-    def _item_cls(cls) -> type[EntityTypeConfiguration]:
-        return EntityTypeConfiguration
-
-    async def validate(
-        self, entity_type_repository: PluginRepository[EntityDefinition], /
-    ) -> None:
-        """
-        Validate the configuration.
-        """
-        for configuration in self.values():
-            with reraise_with_indicator(Key(configuration.id)):
-                await configuration.validate(entity_type_repository)
-
-    @override
-    @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
-        yield Sample(cls(), label="Minimal", minimal=True)
-        yield Sample(
-            cls([get_full_sample(EntityTypeConfiguration).configuration]),
-            label="Full",
-            full=True,
-        )
 
 
 @final
@@ -339,7 +264,7 @@ class LocaleConfiguration(Configuration):
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         yield Sample(cls(Locale("nl", "NL")), label="Minimal", minimal=True)
         yield Sample(cls(Locale("nl", "NL"), alias="nl"), label="Full", full=True)
 
@@ -403,10 +328,10 @@ class LocaleConfigurationMapping(
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         yield Sample(cls(), label="Minimal", minimal=True)
         yield Sample(
-            cls([get_full_sample(LocaleConfiguration).configuration]),
+            cls([get_full_sample(LocaleConfiguration).data]),
             label="Full",
             full=True,
         )
@@ -500,10 +425,10 @@ class CopyrightNoticePluginConfigurationMapping(
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         yield Sample(cls(), label="Minimal", minimal=True)
         yield Sample(
-            cls([get_full_sample(CopyrightNoticePluginConfiguration).configuration]),
+            cls([get_full_sample(CopyrightNoticePluginConfiguration).data]),
             label="Full",
             full=True,
         )
@@ -595,10 +520,10 @@ class LicensePluginConfigurationMapping(
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         yield Sample(cls(), label="Minimal", minimal=True)
         yield Sample(
-            cls([get_full_sample(LicensePluginConfiguration).configuration]),
+            cls([get_full_sample(LicensePluginConfiguration).data]),
             label="Full",
             full=True,
         )
@@ -669,10 +594,10 @@ class EventTypePluginConfigurationMapping(
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         yield Sample(cls(), label="Minimal", minimal=True)
         yield Sample(
-            cls([get_full_sample(EventTypePluginConfiguration).configuration]),
+            cls([get_full_sample(EventTypePluginConfiguration).data]),
             label="Full",
             full=True,
         )
@@ -740,10 +665,10 @@ class PlaceTypePluginConfigurationMapping(
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         yield Sample(cls(), label="Minimal", minimal=True)
         yield Sample(
-            cls([get_full_sample(PlaceTypePluginConfiguration).configuration]),
+            cls([get_full_sample(PlaceTypePluginConfiguration).data]),
             label="Full",
             full=True,
         )
@@ -811,10 +736,10 @@ class PresenceRolePluginConfigurationMapping(
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         yield Sample(cls(), label="Minimal", minimal=True)
         yield Sample(
-            cls([get_full_sample(PresenceRolePluginConfiguration).configuration]),
+            cls([get_full_sample(PresenceRolePluginConfiguration).data]),
             label="Full",
             full=True,
         )
@@ -880,208 +805,209 @@ class GenderPluginConfigurationMapping(
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         yield Sample(cls(), label="Minimal", minimal=True)
         yield Sample(
-            cls([get_full_sample(GenderPluginConfiguration).configuration]),
+            cls([get_full_sample(GenderPluginConfiguration).data]),
             label="Full",
             full=True,
         )
 
 
 @final
-class ProjectConfiguration(Configuration):
+@ObjectDefinition(
+    label=_("Project configuration"),
+    fields=[
+        FieldDefinition(
+            Attr("author"),
+            LocalizableDefinition(),
+            label=_("Author"),
+            required=False,
+            empty=lambda data: data is None,
+        ),
+        FieldDefinition(
+            Attr("clean_urls"),
+            SimpleDefinition(
+                cls=bool,
+                label=_("Clean URLs"),
+                description=_(
+                    'Whether to use clean URLs: "/path" instead of "/path/index.html".'
+                ),
+            ),
+            empty=lambda data: data is False,
+            required=False,
+        ),
+        FieldDefinition(
+            Attr("copyright_notice"),
+            DataDefinition(
+                cls=PluginInstanceConfiguration, label=_("Copyright notice")
+            ),
+            required=False,
+            empty=lambda data: data == ProjectConfiguration._default_copyright_notice(),
+        ),
+        FieldDefinition(
+            Attr("copyright_notices"),
+            DataDefinition(
+                cls=CopyrightNoticePluginConfigurationMapping,
+                label=_("Copyright notices"),
+            ),
+            empty=lambda data: not len(data),
+            required=False,
+        ),
+        FieldDefinition(
+            Attr("debug"),
+            SimpleDefinition(
+                cls=bool,
+                label=_("Debugging mode"),
+                description=_(
+                    "Whether to output more detailed logs and disable optimizations that make debugging harder."
+                ),
+            ),
+            empty=lambda data: data is False,
+            required=False,
+        ),
+        FieldDefinition(
+            Attr("entity_types"),
+            KeyedCollectionDefinition(
+                item=EntityTypeConfiguration.data(),
+                label=_("Entity types"),
+                key=Attr("entity_type"),
+                ordered=False,
+            ),
+            required=False,
+        ),
+        FieldDefinition(
+            Attr("event_types"),
+            DataDefinition(
+                cls=EventTypePluginConfigurationMapping, label=_("Event types")
+            ),
+            empty=lambda data: not len(data),
+            required=False,
+        ),
+        FieldDefinition(
+            Attr("extensions"),
+            DataDefinition(
+                cls=ExtensionInstanceConfigurationMapping, label=_("Extensions")
+            ),
+            empty=lambda data: not len(data),
+            required=False,
+        ),
+        FieldDefinition(
+            Attr("genders"),
+            DataDefinition(cls=GenderPluginConfigurationMapping, label=_("Genders")),
+            empty=lambda data: not len(data),
+            required=False,
+        ),
+        FieldDefinition(
+            Attr("license"),
+            DataDefinition(cls=PluginInstanceConfiguration, label=_("License")),
+            required=False,
+            empty=lambda data: data == ProjectConfiguration._default_license(),
+        ),
+        FieldDefinition(
+            Attr("licenses"),
+            DataDefinition(cls=LicensePluginConfigurationMapping, label=_("Licenses")),
+            empty=lambda data: not len(data),
+            required=False,
+        ),
+        FieldDefinition(
+            Attr("lifetime_threshold"),
+            SimpleDefinition(
+                cls=int,
+                label=_("Lifetime threshold"),
+                description=_(
+                    "The number of years people are expected to live at most, e.g. after which they are presumed to have died."
+                ),
+            ),
+            required=False,
+            empty=lambda data: data == DEFAULT_LIFETIME_THRESHOLD,
+        ),
+        FieldDefinition(
+            Attr("locales"),
+            DataDefinition(cls=LocaleConfigurationMapping, label=_("Locales")),
+            empty=lambda data: data == ProjectConfiguration._default_locales(),
+            required=False,
+        ),
+        FieldDefinition(
+            Attr("logo"),
+            SimpleDefinition(
+                cls=Path,
+                label=_("Logo"),
+                porter=CallbackPorter(assert_file_path(), str),
+            ),
+            required=False,
+            empty=lambda data: data is None,
+        ),
+        FieldDefinition(
+            Attr("name"),
+            SimpleDefinition(cls=str, label=_("Machine name")),
+            required=False,
+            empty=lambda data: data is None,
+        ),
+        FieldDefinition(
+            Attr("place_types"),
+            DataDefinition(
+                cls=PlaceTypePluginConfigurationMapping, label=_("Place types")
+            ),
+            empty=lambda data: not len(data),
+            required=False,
+        ),
+        FieldDefinition(
+            Attr("presence_roles"),
+            DataDefinition(
+                cls=PresenceRolePluginConfigurationMapping, label=_("Presence roles")
+            ),
+            empty=lambda data: not len(data),
+            required=False,
+        ),
+        FieldDefinition(Attr("title"), LocalizableDefinition(), label=_("Title")),
+        FieldDefinition(
+            Attr("url"),
+            SimpleDefinition(
+                cls=str,
+                label=_("URL"),
+                description=_(
+                    "The absolute, public URL at which the site will be published."
+                ),
+            ),
+        ),
+    ],
+    samples=[
+        lambda: Sample(
+            ProjectConfiguration(title="Betty", url="https://example.com"),
+            label="Minimal",
+            minimal=True,
+        ),
+        lambda: Sample(
+            ProjectConfiguration(
+                url="https://ancestry.example.com/betty",
+                debug=True,
+                clean_urls=True,
+                title="Betty's ancestry",
+                name="betty-ancestry",
+                author="Bart Feenstra",
+                logo=ASSETS_DIRECTORY_PATH / "public" / "static" / "betty-512x512.png",
+                lifetime_threshold=123,
+                locales=get_full_sample(LocaleConfigurationMapping).data,
+                entity_types=[get_full_sample(EntityTypeConfiguration).data],
+                event_types=get_full_sample(EventTypePluginConfigurationMapping).data,
+                extensions=get_full_sample(ExtensionInstanceConfigurationMapping).data,
+                genders=get_full_sample(GenderPluginConfigurationMapping).data,
+                place_types=get_full_sample(PlaceTypePluginConfigurationMapping).data,
+                presence_roles=get_full_sample(
+                    PresenceRolePluginConfigurationMapping
+                ).data,
+            ),
+            label="Full",
+            full=True,
+        ),
+    ],
+)
+class ProjectConfiguration(HasData):
     """
     Configuration for a :py:class:`betty.project.Project`.
 
-    .. configuration:: betty.project.config:ProjectConfiguration
-
-    ``url``
-    -------
-    :sup:`required`
-
-    The absolute, public URL at which the site will be published.
-
-    ``debug``
-    ---------
-    :sup:`optional`
-
-    ``true`` to output more detailed logs and disable optimizations that make debugging harder. Defaults to ``false``.
-
-    ``clean_urls``
-    --------------
-    :sup:`optional`
-
-    A boolean indicating whether to use clean URLs, e.g. ``/path`` instead of ``/path/index.html``. Defaults to ``false``.
-
-    ``title``
-    ---------
-    :sup:`optional`
-
-    The project's human-readable title. This can be a string or :py:class:`multiple translations <betty.locale.localizable.static.StaticTranslations>`.
-
-    ``name``
-    --------
-    :sup:`optional`
-
-    The project's machine name.
-
-    ``author``
-    ----------
-    :sup:`optional`
-
-    The project's author and copyright holder. This can be a string or :py:class:`multiple translations <betty.locale.localizable.static.StaticTranslations>`.
-
-    ``logo``
-    --------
-    :sup:`optional`
-
-    The path to your site's logo file. Defaults to the Betty logo.
-
-    ``lifetime_threshold``
-    ----------------------
-    :sup:`optional`
-
-    The number of years people are expected to live at most, e.g. after which they're presumed to have died.
-    :py:const:`Defaults to 123 years <betty.project.config.DEFAULT_LIFETIME_THRESHOLD>`.
-
-    ``locales``
-    -----------
-    :sup:`optional`
-
-    If no locales are specified, Betty defaults to US English (``en-US``).
-
-    Read more about :doc:`translations </usage/translation>`.
-
-    An array of locales, each of which is an object with the following keys:
-
-    ``locales[].locale``
-    ^^^^^^^^^^^^^^^^^^^^
-    :sup:`required`
-
-    An `IETF BCP 47 <https://tools.ietf.org/html/bcp47>`_ language tag.
-
-    ``locales[].alias``
-    ^^^^^^^^^^^^^^^^^^^
-    :sup:`optional`
-
-    A shorthand alias to use instead of the full language tag, such as when rendering URLs.
-
-    ``entity_types``
-    ----------------
-    :sup:`optional`
-
-    Keys are entity type (plugin) IDs, and values are objects containing the following keys:
-
-    ``entity_types{}.generate_html_list``
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    :sup:`optional`
-
-    Whether to generate the HTML page to list entities of this type. Defaults to ``false``.
-
-    ``event_types``
-    ---------------
-    :sup:`optional`
-
-    Keys are event type (plugin) IDs, and values are objects containing the following keys:
-
-    ``event_types{}.label``
-    ^^^^^^^^^^^^^^^^^^^^^^^
-    :sup:`required`
-
-    The event type's human-readable label. This can be a string or :py:class:`multiple translations <betty.locale.localizable.static.StaticTranslations>`.
-
-    ``event_types{}.description``
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    :sup:`optional`
-
-    The event type's human-readable long description. This can be a string or :py:class:`multiple translations <betty.locale.localizable.static.StaticTranslations>`.
-
-    ``event_types{}.comes_before``
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    :sup:`optional`
-
-    A collection of the IDs of other event types that this one comes before.
-
-    ``event_types{}.comes_after``
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    :sup:`optional`
-
-    A collection of the IDs of other event types that this one comes after.
-
-    ``genders``
-    -----------
-    :sup:`optional`
-
-    Keys are gender (plugin) IDs, and values are objects containing the following keys:
-
-    ``genders{}.label``
-    ^^^^^^^^^^^^^^^^^^^
-    :sup:`required`
-
-    The gender's human-readable label. This can be a string or :py:class:`multiple translations <betty.locale.localizable.static.StaticTranslations>`.
-
-    ``genders{}.description``
-    ^^^^^^^^^^^^^^^^^^^^^^^^^
-    :sup:`optional`
-
-    The gender's human-readable long description. This can be a string or :py:class:`multiple translations <betty.locale.localizable.static.StaticTranslations>`.
-
-    ``place_types``
-    ---------------
-    :sup:`optional`
-
-    Keys are place type (plugin) IDs, and values are objects containing the following keys:
-
-    ``place_types{}.label``
-    ^^^^^^^^^^^^^^^^^^^^^^^
-    :sup:`required`
-
-    The place type's human-readable label. This can be a string or :py:class:`multiple translations <betty.locale.localizable.static.StaticTranslations>`.
-
-    ``place_types{}.description``
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    :sup:`optional`
-
-    The place type's human-readable long description. This can be a string or :py:class:`multiple translations <betty.locale.localizable.static.StaticTranslations>`.
-
-    ``presence_roles``
-    ------------------
-    :sup:`optional`
-
-    Keys are presence role (plugin) IDs, and values are objects containing the following keys:
-
-    ``presence_roles{}.label``
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^
-    :sup:`required`
-
-    The presence role's human-readable label. This can be a string or :py:class:`multiple translations <betty.locale.localizable.static.StaticTranslations>`.
-
-    ``presence_roles{}.description``
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    :sup:`optional`
-
-    The presence role's human-readable long description. This can be a string or :py:class:`multiple translations <betty.locale.localizable.static.StaticTranslations>`.
-
-    ``extensions``
-    --------------
-    :sup:`optional`
-
-    The :py:class:`extensions <betty.project.extension.ExtensionDefinition>` to enable. Keys are extension names, and values
-    are objects containing the following keys, both of which may be omitted to quickly enable an extension using its default
-    configuration:
-
-    ``extensions{}.enabled``
-    ^^^^^^^^^^^^^^^^^^^^^^^^
-    :sup:`optional`
-
-    A boolean indicating whether the extension is enabled. Defaults to ``true``.
-
-    ``extensions{}.configuration``
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    :sup:`optional`
-
-    An object containing the extension's own configuration, if it provides any configuration options.
+    .. has_data:: betty.project.config:ProjectConfiguration
     """
 
     license: PluginInstanceConfiguration[LicenseDefinition, License]
@@ -1104,7 +1030,8 @@ class ProjectConfiguration(Configuration):
         url: str,
         clean_urls: bool = False,
         author: LocalizableLike | None = None,
-        entity_types: EntityTypeConfigurationMapping | None = None,
+        entity_types: Iterable[EntityTypeConfiguration | ResolvableId[EntityDefinition]]
+        | None = None,
         event_types: EventTypePluginConfigurationMapping | None = None,
         place_types: PlaceTypePluginConfigurationMapping | None = None,
         presence_roles: PresenceRolePluginConfigurationMapping | None = None,
@@ -1129,8 +1056,12 @@ class ProjectConfiguration(Configuration):
         self._clean_urls = clean_urls
         self.title = title
         self.author = author
-        self._entity_types = (
-            EntityTypeConfigurationMapping() if entity_types is None else entity_types
+        self._entity_types = KeyedCollection(
+            () if entity_types is None else entity_types,
+            key=lambda item: item.entity_type,
+            value_resolver=lambda data: data
+            if isinstance(data, EntityTypeConfiguration)
+            else EntityTypeConfiguration(entity_type=data),
         )
         self._event_types = (
             EventTypePluginConfigurationMapping()
@@ -1174,8 +1105,9 @@ class ProjectConfiguration(Configuration):
         self._lifetime_threshold = lifetime_threshold
         self._logo = logo
 
+    @classmethod
     def _default_copyright_notice(
-        self,
+        cls,
     ) -> PluginInstanceConfiguration[CopyrightNoticeDefinition, CopyrightNotice]:
         from betty.copyright_notice.copyright_notices import ProjectAuthor
 
@@ -1183,8 +1115,9 @@ class ProjectConfiguration(Configuration):
             ProjectAuthor
         )
 
+    @classmethod
     def _default_license(
-        self,
+        cls,
     ) -> PluginInstanceConfiguration[LicenseDefinition, License]:
         from betty.license.licenses import AllRightsReserved
 
@@ -1192,22 +1125,9 @@ class ProjectConfiguration(Configuration):
             AllRightsReserved
         )
 
-    def _default_locales(self) -> LocaleConfigurationMapping:
+    @classmethod
+    def _default_locales(cls) -> LocaleConfigurationMapping:
         return LocaleConfigurationMapping()
-
-    @override
-    @property
-    def validator(self) -> ServiceLevelTarget[None]:
-        from betty.project.factory import require_project
-
-        @require_project
-        async def _validate(project: Project) -> None:
-            with reraise_with_indicator(Key("entity_types")):
-                await self.entity_types.validate(
-                    await project.plugins(EntityDefinition)
-                )
-
-        return CallbackServiceLevelDependentFactory(_validate)
 
     @property
     def name(self) -> MachineName | None:
@@ -1281,7 +1201,14 @@ class ProjectConfiguration(Configuration):
         return self._locales
 
     @property
-    def entity_types(self) -> EntityTypeConfigurationMapping:
+    def entity_types(
+        self,
+    ) -> KeyedCollection[
+        MachineName,
+        EntityTypeConfiguration,
+        ResolvableId[EntityDefinition],
+        EntityTypeConfiguration | ResolvableId[EntityDefinition],
+    ]:
         """
         The available entity types.
         """
@@ -1383,160 +1310,3 @@ class ProjectConfiguration(Configuration):
         The gender plugins created by this project.
         """
         return self._genders
-
-    @override
-    @classmethod
-    def load(cls, portable: PortableData, /) -> Self:
-        return cls(
-            **assert_record(
-                OptionalField("name", assert_or(assert_str(), assert_none)),
-                RequiredField("url", assert_str()),
-                RequiredField("title", assert_load_localizable),
-                OptionalField("author", assert_load_localizable),
-                OptionalField("logo", assert_or(assert_path(), assert_none)),
-                OptionalField("clean_urls", assert_bool),
-                OptionalField("debug", assert_bool),
-                OptionalField("lifetime_threshold", assert_int()),
-                OptionalField("locales", LocaleConfigurationMapping.load),
-                OptionalField("extensions", ExtensionInstanceConfigurationMapping.load),
-                OptionalField("entity_types", EntityTypeConfigurationMapping.load),
-                OptionalField("copyright_notice", PluginInstanceConfiguration.load),
-                OptionalField(
-                    "copyright_notices", CopyrightNoticePluginConfigurationMapping.load
-                ),
-                OptionalField("license", PluginInstanceConfiguration.load),
-                OptionalField("licenses", LicensePluginConfigurationMapping.load),
-                OptionalField("event_types", EventTypePluginConfigurationMapping.load),
-                OptionalField("genders", GenderPluginConfigurationMapping.load),
-                OptionalField("place_types", PlaceTypePluginConfigurationMapping.load),
-                OptionalField(
-                    "presence_roles", PresenceRolePluginConfigurationMapping.load
-                ),
-            )(portable)
-        )
-
-    @override
-    def dump(self) -> PortableMapping:
-        portable: PortableMapping = {
-            "title": dump_localizable(self.title),
-            "url": self.url,
-        }
-        if self.author is not None:
-            portable["author"] = dump_localizable(self.author)
-        if self.clean_urls:
-            portable["clean_urls"] = self.clean_urls
-        if self.copyright_notice != self._default_copyright_notice():
-            portable["copyright_notice"] = self.copyright_notice.dump()
-        if self.copyright_notices:
-            portable["copyright_notices"] = self.copyright_notices.dump()
-        if self.debug:
-            portable["debug"] = self.debug
-        if self.entity_types:
-            portable["entity_types"] = self.entity_types.dump()
-        if self.event_types:
-            portable["event_types"] = self.event_types.dump()
-        if self.extensions:
-            portable["extensions"] = self.extensions.dump()
-        if self.genders:
-            portable["genders"] = self.genders.dump()
-        if self.license != self._default_license():
-            portable["license"] = self.license.dump()
-        if self.licenses:
-            portable["licenses"] = self.licenses.dump()
-        if self.lifetime_threshold != DEFAULT_LIFETIME_THRESHOLD:
-            portable["lifetime_threshold"] = self.lifetime_threshold
-        if self.locales != self._default_locales():
-            portable["locales"] = self.locales.dump()
-        if self.logo:
-            portable["logo"] = str(self.logo)
-        if self.name is not None:
-            portable["name"] = self.name
-        if self.place_types:
-            portable["place_types"] = self.place_types.dump()
-        if self.presence_roles:
-            portable["presence_roles"] = self.presence_roles.dump()
-        return portable
-
-    @override
-    def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, type(self)):
-            return NotImplemented
-        return (
-            self.title,
-            self.url,
-            self.author,
-            self.clean_urls,
-            self.copyright_notice,
-            self.copyright_notices,
-            self.debug,
-            self.entity_types,
-            self.event_types,
-            self.extensions,
-            self.genders,
-            self.license,
-            self.licenses,
-            self.lifetime_threshold,
-            self.locales,
-            self.logo,
-            self.name,
-            self.place_types,
-            self.presence_roles,
-        ) == (
-            other.title,
-            other.url,
-            other.author,
-            other.clean_urls,
-            other.copyright_notice,
-            other.copyright_notices,
-            other.debug,
-            other.entity_types,
-            other.event_types,
-            other.extensions,
-            other.genders,
-            other.license,
-            other.licenses,
-            other.lifetime_threshold,
-            other.locales,
-            other.logo,
-            other.name,
-            other.place_types,
-            other.presence_roles,
-        )
-
-    @override
-    @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
-        yield Sample(
-            cls(title="Betty", url="https://example.com"), label="Minimal", minimal=True
-        )
-        yield Sample(
-            cls(
-                url="https://ancestry.example.com/betty",
-                debug=True,
-                clean_urls=True,
-                title="Betty's ancestry",
-                name="betty-ancestry",
-                author="Bart Feenstra",
-                logo=Path("my-ancestry-logo.png"),
-                lifetime_threshold=123,
-                locales=get_full_sample(LocaleConfigurationMapping).configuration,
-                entity_types=get_full_sample(
-                    EntityTypeConfigurationMapping
-                ).configuration,
-                event_types=get_full_sample(
-                    EventTypePluginConfigurationMapping
-                ).configuration,
-                extensions=get_full_sample(
-                    ExtensionInstanceConfigurationMapping
-                ).configuration,
-                genders=get_full_sample(GenderPluginConfigurationMapping).configuration,
-                place_types=get_full_sample(
-                    PlaceTypePluginConfigurationMapping
-                ).configuration,
-                presence_roles=get_full_sample(
-                    PresenceRolePluginConfigurationMapping
-                ).configuration,
-            ),
-            label="Full",
-            full=True,
-        )

--- a/betty/project/extension/demo/project.py
+++ b/betty/project/extension/demo/project.py
@@ -23,8 +23,6 @@ from betty.plugin.config import (
 )
 from betty.project import Project
 from betty.project.config import (
-    EntityTypeConfiguration,
-    EntityTypeConfigurationMapping,
     ExtensionInstanceConfigurationMapping,
     LocaleConfiguration,
     LocaleConfigurationMapping,
@@ -217,14 +215,12 @@ async def create_project(app: App, project_directory_path: Path) -> Project:
                 ),
             ]  # ty:ignore[invalid-argument-type]
         ),
-        entity_types=EntityTypeConfigurationMapping(
-            [
-                EntityTypeConfiguration(Person),
-                EntityTypeConfiguration(Event),
-                EntityTypeConfiguration(Place),
-                EntityTypeConfiguration(Source),
-            ]
-        ),
+        entity_types=[
+            Person,
+            Event,
+            Place,
+            Source,
+        ],
         locales=LocaleConfigurationMapping(
             [
                 # The first configured locale is the project default.

--- a/betty/project/extension/gramps/config.py
+++ b/betty/project/extension/gramps/config.py
@@ -19,8 +19,10 @@ from betty.assertion import (
     assert_record,
     assert_str,
 )
-from betty.config import Configuration, Sample, get_full_sample
+from betty.config import Configuration
 from betty.config.collections.sequence import ConfigurationSequence
+from betty.data import Sample
+from betty.data.sample import get_full_sample
 from betty.exception import HumanFacingException
 from betty.gramps.loader import (
     DEFAULT_EVENT_TYPE_MAPPING,
@@ -111,7 +113,7 @@ class PluginMapping(Configuration, Generic[_PluginDefinitionT, _PluginT]):
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         yield Sample(cls(), label="Minimal", minimal=True)
         yield Sample(
             cls({"GrampsType": PluginInstanceConfiguration("my-betty-type")}),
@@ -258,7 +260,7 @@ class FamilyTreeConfiguration(Configuration):
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         yield Sample(cls("my-gramps-family-tree"), label="Minimal")
 
 
@@ -276,10 +278,10 @@ class FamilyTreeConfigurationSequence(ConfigurationSequence[FamilyTreeConfigurat
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         yield Sample(cls(), label="Minimal", minimal=True)
         yield Sample(
-            cls([get_full_sample(FamilyTreeConfiguration).configuration]),
+            cls([get_full_sample(FamilyTreeConfiguration).data]),
             label="Full",
             full=True,
         )
@@ -421,7 +423,7 @@ class GrampsConfiguration(Configuration):
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         yield Sample(cls(), label="Minimal")
         yield Sample(
             cls(executable=Path("gramps.exe")), label="A custom Gramps executable"

--- a/betty/project/extension/raspberry_mint/assets/templates/header.html.j2
+++ b/betty/project/extension/raspberry_mint/assets/templates/header.html.j2
@@ -1,7 +1,7 @@
 {% cache 'raspberry-mint-template-header--before:' ~ document.localizer.locale %}
     {% set ns = namespace(primary_navigation_links = {}) %}
-    {% for entity_type_configuration in project.configuration.entity_types.values() | selectattr('generate_html_list') %}
-        {% set entity_type = app.plugins('entity')[entity_type_configuration.id] %}
+    {% for entity_type_configuration in project.configuration.entity_types | selectattr('generate_html_list') %}
+        {% set entity_type = app.plugins('entity')[entity_type_configuration.entity_type] %}
         {% set entity_type_label -%}
             {% if entity_type.id == 'event' %}
                 {% trans %}Timeline{% endtrans %}

--- a/betty/project/extension/raspberry_mint/config/__init__.py
+++ b/betty/project/extension/raspberry_mint/config/__init__.py
@@ -9,10 +9,12 @@ from typing import TYPE_CHECKING, Any, Self, final
 from typing_extensions import override
 
 from betty.assertion import OptionalField, assert_record
-from betty.config import Configuration, Sample, get_full_sample, get_minimal_sample
+from betty.config import Configuration
 from betty.config.color import ColorConfiguration
+from betty.data import Sample
 from betty.data.indicator import Path
 from betty.data.indicator.selector import Key
+from betty.data.sample import get_full_sample, get_minimal_sample
 from betty.exception import reraise_with_indicator
 from betty.project.extension.theme.config import RegionalContentConfiguration
 from betty.project.factory import require_project
@@ -196,21 +198,17 @@ class RaspberryMintConfiguration(Configuration):
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         yield Sample(cls(), label="Minimal", minimal=True)
         yield Sample(
             cls(
-                primary_color=get_minimal_sample(ColorConfiguration).configuration,
-                secondary_color=get_minimal_sample(ColorConfiguration).configuration,
-                tertiary_color=get_minimal_sample(ColorConfiguration).configuration,
+                primary_color=get_minimal_sample(ColorConfiguration).data,
+                secondary_color=get_minimal_sample(ColorConfiguration).data,
+                tertiary_color=get_minimal_sample(ColorConfiguration).data,
             ),
             label="Custom colors",
         )
         yield Sample(
-            cls(
-                regional_content=get_full_sample(
-                    RegionalContentConfiguration
-                ).configuration,
-            ),
+            cls(regional_content=get_full_sample(RegionalContentConfiguration).data),
             label="Regional content",
         )

--- a/betty/project/extension/raspberry_mint/content_provider.py
+++ b/betty/project/extension/raspberry_mint/content_provider.py
@@ -21,10 +21,11 @@ from betty.assertion import (
     assert_record,
     assert_sequence,
 )
-from betty.config import Configuration, Sample
+from betty.config import Configuration
 from betty.config.factory import ConfigurationDependentSelfFactory
 from betty.content_provider import ContentProvider, ContentProviderDefinition
 from betty.content_provider.content_providers import Template
+from betty.data import Sample
 from betty.locale.localizable.assertion import assert_load_localizable
 from betty.locale.localizable.attr import RequiredLocalizableAttr
 from betty.locale.localizable.ensure import ensure_localizable
@@ -158,7 +159,7 @@ class SectionConfiguration(Configuration):
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
 
         yield Sample(
@@ -383,7 +384,7 @@ class ColorStyleConfiguration(Configuration):
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         from betty.content_provider.content_providers import Render, RenderConfiguration
 
         yield Sample(
@@ -546,7 +547,7 @@ class PresencesConfiguration(Configuration):
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         from betty.ancestry.presence_role.presence_roles import Subject
 
         yield Sample(cls(), label="Minimal")
@@ -730,7 +731,7 @@ class ColumnsConfiguration(Configuration):
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         from betty.content_provider.content_providers import Render, RenderConfiguration
 
         yield Sample(

--- a/betty/project/extension/theme/config.py
+++ b/betty/project/extension/theme/config.py
@@ -10,8 +10,9 @@ from typing import TYPE_CHECKING, Any, Self, final
 from typing_extensions import override
 
 from betty.assertion import assert_len, assert_mapping, assert_str
-from betty.config import Configuration, Sample
+from betty.config import Configuration
 from betty.content_provider import ContentProvider, ContentProviderDefinition
+from betty.data import Sample
 from betty.data.indicator.selector import Key
 from betty.exception import HumanFacingException, reraise_with_indicator
 from betty.locale.localizable.gettext import _
@@ -128,7 +129,7 @@ class RegionalContentConfiguration(Configuration):
 
     @override
     @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
+    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
         from betty.content_provider.content_providers import Render, RenderConfiguration
 
         yield Sample(

--- a/betty/project/extension/wiki/config.py
+++ b/betty/project/extension/wiki/config.py
@@ -2,35 +2,48 @@
 Configuration for the Wikipedia extension.
 """
 
-from collections.abc import Iterable
-from typing import Any, Self
+from typing import final
 
-from typing_extensions import override
+from betty.data import HasData, Sample
+from betty.data.aggregate.record import FieldDefinition
+from betty.data.aggregate.record.object import ObjectDefinition
+from betty.data.indicator.selector import Attr
+from betty.data.simple import SimpleDefinition
+from betty.locale.localizable.gettext import _
 
-from betty.assertion import (
-    OptionalField,
-    assert_bool,
-    assert_record,
+
+@final
+@ObjectDefinition(
+    label=_("Wiki extension configuration"),
+    fields=[
+        FieldDefinition(
+            Attr("populate_images"),
+            SimpleDefinition(
+                cls=bool,
+                label=_("Populate images"),
+                description=_(
+                    "Whether to download additional images found through Wikipedia links in the ancestry"
+                ),
+                empty=lambda data: data is True,
+            ),
+            required=False,
+        )
+    ],
+    samples=[
+        lambda: Sample(WikiConfiguration(), label="Minimal", minimal=True),
+        lambda: Sample(
+            WikiConfiguration(populate_images=False), label="Full", full=True
+        ),
+    ],
 )
-from betty.config import Configuration, Sample
-from betty.portable import PortableData, PortableMapping
-
-
-class WikiConfiguration(Configuration):
+class WikiConfiguration(HasData):
     """
     Configuration for the :py:class:`betty.project.extension.wiki.Wiki` extension.
 
-    .. configuration:: betty.project.extension.wiki.config:WikiConfiguration
-
-    ``populate_images``
-    ^^^^^^^^^^^^^^^^^^^
-    :sup:`optional`
-
-    A boolean indicating whether to download images from the Wikipedia links in the ancestry. Defaults to ``true``.
+    .. has_data:: betty.project.extension.wiki.config:WikiConfiguration
     """
 
     def __init__(self, *, populate_images: bool = True):
-        super().__init__()
         self._populate_images = populate_images
 
     @property
@@ -43,27 +56,3 @@ class WikiConfiguration(Configuration):
     @populate_images.setter
     def populate_images(self, populate_images: bool) -> None:
         self._populate_images = populate_images
-
-    @override
-    @classmethod
-    def load(cls, portable: PortableData, /) -> Self:
-        return cls(
-            **assert_record(OptionalField("populate_images", assert_bool))(portable)
-        )
-
-    @override
-    def dump(self) -> PortableMapping:
-        return {
-            "populate_images": self.populate_images,
-        }
-
-    @override
-    def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, type(self)):
-            return NotImplemented
-        return self.populate_images == other.populate_images
-
-    @override
-    @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:
-        yield Sample(cls(), label="Default")

--- a/betty/project/generate/jobs.py
+++ b/betty/project/generate/jobs.py
@@ -526,7 +526,7 @@ class GenerateEntityTypesHtml(Job[ProjectContext]):
                 for entity_type in await project.plugins(EntityDefinition)
                 if entity_type.public_facing
                 and (
-                    entity_type in project.configuration.entity_types
+                    entity_type.id in project.configuration.entity_types
                     and project.configuration.entity_types[
                         entity_type.id
                     ].generate_html_list

--- a/betty/project/new.py
+++ b/betty/project/new.py
@@ -16,7 +16,6 @@ from betty.plugin.config import PluginInstanceConfiguration
 from betty.portable.file import dump_file
 from betty.project.config import (
     EntityTypeConfiguration,
-    EntityTypeConfigurationMapping,
     ExtensionInstanceConfigurationMapping,
     LocaleConfiguration,
     LocaleConfigurationMapping,
@@ -154,20 +153,18 @@ async def new(app: App) -> None:
     configuration = ProjectConfiguration(
         author=author,
         locales=locales,
-        entity_types=EntityTypeConfigurationMapping(
-            [
-                EntityTypeConfiguration(Person, generate_html_list=True),
-                EntityTypeConfiguration(Event, generate_html_list=True),
-                EntityTypeConfiguration(Place, generate_html_list=True),
-                EntityTypeConfiguration(Source, generate_html_list=True),
-            ]
-        ),
+        entity_types=[
+            EntityTypeConfiguration(entity_type=Person, generate_html_list=True),
+            EntityTypeConfiguration(entity_type=Event, generate_html_list=True),
+            EntityTypeConfiguration(entity_type=Place, generate_html_list=True),
+            EntityTypeConfiguration(entity_type=Source, generate_html_list=True),
+        ],
         extensions=ExtensionInstanceConfigurationMapping(extensions),
         name=name,
         title=title,
         url=url,
     )
-    await dump_file(configuration.dump(), configuration_file_path)
+    await dump_file(configuration.data().dump(configuration), configuration_file_path)
     await app.user.message_information(
         _("Saved your project to {configuration_file}.").format(
             configuration_file=str(configuration_file_path)

--- a/betty/service/container.py
+++ b/betty/service/container.py
@@ -25,7 +25,7 @@ from typing import (
 from typing_extensions import override
 
 from betty.concurrent import AsynchronizedLock, Lock
-from betty.config import Configurable
+from betty.config import Configurable, Configuration
 from betty.requirement import Requirement
 from betty.service import ServiceError
 from betty.service.bootstrap import Bootstrapped, Shutdownable, ShutdownStack
@@ -71,9 +71,16 @@ class ServiceContainer(Bootstrapped, Shutdownable):
 
     async def _bootstrap(self) -> None:
         if isinstance(self, Configurable):
-            validator_factory = self.configuration.validator
-            if validator_factory is not None:
-                await self._new_target(validator_factory)
+            configuration = self.configuration
+            if isinstance(configuration, Configuration):
+                validator_factory = configuration.validator
+                if validator_factory is not None:
+                    await self._new_target(validator_factory)
+            else:
+                await configuration.data().hydrate(  # ty:ignore[unresolved-attribute]
+                    configuration,
+                    self,
+                )
 
     @classmethod
     def _service_managers(cls) -> Iterable[ServiceManager[Self, Any, Any]]:

--- a/betty/service/hydrate.py
+++ b/betty/service/hydrate.py
@@ -1,0 +1,26 @@
+"""
+The hydration API.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from betty.service.level import ServiceLevel
+
+
+class Hydratable(ABC):
+    """
+    An object that can be hydrated from a service level.
+    """
+
+    @abstractmethod
+    async def hydrate(self, services: ServiceLevel, /) -> None:
+        """
+        Hydrate the object.
+
+        Hydration allows data definitions to require a :py:type:`betty.service.level.ServiceLevel` to perform tasks
+        such as validation or enhancing the data using information or functionality from the service level.
+        """

--- a/betty/sphinx/extension/betty.py
+++ b/betty/sphinx/extension/betty.py
@@ -18,6 +18,8 @@ from typing_extensions import override
 
 from betty.app import App
 from betty.config import Configurable, Configuration
+from betty.data import HasData
+from betty.data.aggregate.record import RecordDefinition
 from betty.functools import Result
 from betty.importlib import import_any
 from betty.locale.localize import DEFAULT_LOCALIZER
@@ -347,7 +349,7 @@ class _ConfigurationDirective(SphinxDirective):
 .. tab-set::
 
 """
-            portable = sample.configuration.dump()
+            portable = sample.data.dump()
             for serializer in serializers:
                 serialized = serializer.dump(portable)
                 example_content += f"""
@@ -365,11 +367,102 @@ class _ConfigurationDirective(SphinxDirective):
         )
 
 
+class _HasDataDirective(SphinxDirective):
+    required_arguments = 1
+
+    @override
+    def run(self) -> list[nodes.Node]:
+        # Right-strip periods to avoid D400 and D415 violations.
+        cls_name = self.arguments[0].rstrip(".")
+        cls = import_any(cls_name)
+        assert issubclass(cls, HasData)
+        data = cls.data()
+        content = ""
+
+        if isinstance(data, RecordDefinition) and data.fields:
+            content += """
+Data
+====
+"""
+            for field in sorted(
+                data.fields,
+                key=lambda field: (not field.required, field.selector.element),
+            ):
+                primary_label = field.data.label if field.label is None else field.label
+                content += f"""
+                
+``{field.selector.element}`` :sup:`{"required" if field.required else "optional"}`
+
+    **{primary_label.localize(DEFAULT_LOCALIZER)}**
+"""
+                primary_description = (
+                    field.data.description
+                    if field.description is None
+                    else field.description
+                )
+                if primary_description is not None:
+                    content += f"""
+    {primary_description.localize(DEFAULT_LOCALIZER)}
+"""
+                content += f"""
+
+    Value: :py:class:`{field.data.cls.__name__} <{field.data.cls.__module__}.{field.data.cls.__qualname__}>`
+"""
+                if field.label is not None:
+                    content += f"""
+    *{field.data.label.localize(DEFAULT_LOCALIZER)}*
+"""
+                if field.description is not None and field.data.description is not None:
+                    content += f"""
+    *{field.data.description.localize(DEFAULT_LOCALIZER)}*
+"""
+
+        samples = list(data.samples)
+        if samples:
+            examples_label = "Examples" if len(samples) > 1 else "Example"
+            content += f"""
+{examples_label}
+{"".join(["=" * len(examples_label)])}
+
+"""
+            serializers = _to_thread(lambda: run(_get_serializers()))
+            for sample in samples:
+                example_content = ""
+                if len(samples) > 1:
+                    example_label = sample.label.localize(DEFAULT_LOCALIZER)
+                    example_content += f"""
+{example_label}
+{"".join(["-" * len(example_label)])}
+"""
+                example_content += """
+.. tab-set::
+
+"""
+                portable = data.dump(sample.data)
+                for serializer in serializers:
+                    serialized = serializer.dump(portable)
+                    example_content += f"""
+   .. tab-item:: {serializer.plugin().label.localize(DEFAULT_LOCALIZER)}
+
+      .. code-block:: {serializer.plugin().id}
+
+{indent(serialized, " " * 10)}
+"""
+                content += example_content
+
+        return nested_parse_to_nodes(
+            self.state,
+            content,
+            offset=self.content_offset,
+        )
+
+
 def setup(app: Sphinx) -> ExtensionMetadata:
     """
     Implement Sphinx's extension setup.
     """
     app.add_directive("configuration", _ConfigurationDirective)
+    app.add_directive("has_data", _HasDataDirective)
     app.add_directive("plugin", _PluginDirective)
     app.add_directive("plugin_type", _PluginTypeDirective)
     app.add_directive("plugin_types", _PluginTypesDirective)

--- a/betty/test_utils/config/__init__.py
+++ b/betty/test_utils/config/__init__.py
@@ -16,7 +16,10 @@ from betty.assertion import (
     assert_str,
 )
 from betty.config import Configurable, Configuration
+from betty.data import HasData
+from betty.data.aggregate.record.object import ObjectDefinition
 from betty.importlib import fully_qualified_name
+from betty.locale.localizable.plain import Plain
 from betty.locale.localize import DEFAULT_LOCALIZER
 from betty.portable import PortableData
 
@@ -38,7 +41,7 @@ class ConfigurationTestBase(Generic[_ConfigurationT]):
             return
         docstring = self.sut_cls.__doc__
         assert docstring, (
-            f"{fully_qualified_name(self.sut_cls)}.samples() does not have a docstring."
+            f"{fully_qualified_name(self.sut_cls)} does not have a docstring."
         )
         directive = f".. configuration:: {fully_qualified_name(self.sut_cls)}"
         assert directive in docstring, (
@@ -78,7 +81,7 @@ class ConfigurationTestBase(Generic[_ConfigurationT]):
         samples = list(self.sut_cls.samples())
         for sample in samples:
             with subtests.test(str(sample.label.localize(DEFAULT_LOCALIZER))):
-                assert sample.configuration != other
+                assert sample.data != other
 
     def test___eq____with_samples(self, subtests: pytest.Subtests) -> None:
         """
@@ -87,13 +90,13 @@ class ConfigurationTestBase(Generic[_ConfigurationT]):
         samples = list(self.sut_cls.samples())
         for sample in samples:
             with subtests.test(str(sample.label.localize(DEFAULT_LOCALIZER))):
-                assert sample.configuration == sample.configuration, (
+                assert sample.data == sample.data, (
                     f'Failed asserting that {fully_qualified_name(self.sut_cls)} sample "{sample.label.localize(DEFAULT_LOCALIZER)}" instance is equal to itself.'
                 )
                 for other_sample in samples:
                     if other_sample is sample:
                         continue
-                    assert sample.configuration != other_sample.configuration, (
+                    assert sample.data != other_sample.data, (
                         f'Failed asserting that {fully_qualified_name(self.sut_cls)} sample "{sample.label.localize(DEFAULT_LOCALIZER)}" instance is not equal to sample "{sample.label.localize(DEFAULT_LOCALIZER)}".'
                     )
 
@@ -104,17 +107,21 @@ class ConfigurationTestBase(Generic[_ConfigurationT]):
         samples = list(self.sut_cls.samples())
         for sample in samples:
             with subtests.test(str(sample.label.localize(DEFAULT_LOCALIZER))):
-                portable = sample.configuration.dump()
+                portable = sample.data.dump()
                 assert portable == self.sut_cls.load(portable).dump(), (
                     f'Failed asserting that {fully_qualified_name(self.sut_cls)}.load() and {fully_qualified_name(self.sut_cls)}.dump() do not change the data for sample "{sample.label.localize(DEFAULT_LOCALIZER)}".'
                 )
                 for other_sample in samples:
                     if other_sample is sample:
                         continue
-                    assert portable != other_sample.configuration.dump()
+                    assert portable != other_sample.data.dump()
 
 
-class DummyConfiguration(Configuration):
+@ObjectDefinition(
+    label=Plain("Dummy configuration"),
+    fields=[],
+)
+class DummyConfiguration(Configuration, HasData):
     """
     A dummy :py:class:`betty.config.Configuration` implementation.
     """

--- a/betty/test_utils/data.py
+++ b/betty/test_utils/data.py
@@ -1,0 +1,111 @@
+"""
+Test utilities for :py:mod:`betty.data`.
+"""
+
+from typing import Any, Generic, TypeVar
+
+import pytest
+
+from betty.data import HasData
+from betty.importlib import fully_qualified_name
+from betty.locale.localize import DEFAULT_LOCALIZER
+
+_HasDataT = TypeVar("_HasDataT", bound=HasData, covariant=True)
+
+
+class HasDataTestBase(Generic[_HasDataT]):
+    """
+    A base class for testing :py:class:`betty.data.HasData` subclasses.
+    """
+
+    sut_cls: type[_HasDataT]
+    """
+    The system under test.
+    """
+
+    def test_data(self) -> None:
+        """
+        Tests :py:meth:`betty.data.HasData.data` implementations.
+        """
+        self.sut_cls.data()
+
+    def test_cls_docstring(self) -> None:
+        """
+        Test the class's docstring.
+        """
+        docstring = self.sut_cls.__doc__
+        assert docstring, "Failed asserting that the class has a docstring"
+        directive = f".. has_data:: {fully_qualified_name(self.sut_cls)}"
+        assert directive in docstring, (
+            f"Failed to find `{directive}` in the class's docstring"
+        )
+
+    def test_data__samples__should_provide_at_least_one(self) -> None:
+        """
+        Tests that the data definition provides at least one sample.
+        """
+        assert len(list(self.sut_cls.data().samples)), (
+            "Failed asserting that at least one sample is provided"
+        )
+
+    def test_data__porter__with_samples(self, subtests: pytest.Subtests) -> None:
+        """
+        Tests that the data definition can consistently dump and load its samples.
+        """
+        samples = list(self.sut_cls.data().samples)
+        for sample in samples:
+            with subtests.test(str(sample.label.localize(DEFAULT_LOCALIZER))):
+                portable = self.sut_cls.data().dump(sample.data)
+                assert portable == self.sut_cls.data().dump(
+                    self.sut_cls.data().load(portable)
+                ), (
+                    f'Failed asserting that repeatedly loading and dumping sample "{sample.label.localize(DEFAULT_LOCALIZER)}" keeps producing the same portable data'
+                )
+                for other_sample in samples:
+                    if other_sample is sample:
+                        continue
+                    assert portable != self.sut_cls.data().dump(other_sample.data), (
+                        f'Failed asserting that sample "{sample.label.localize(DEFAULT_LOCALIZER)}" instance is not equal to sample "{other_sample.label.localize(DEFAULT_LOCALIZER)}"'
+                    )
+
+    @pytest.mark.parametrize(
+        "other",
+        [
+            object,
+            object(),
+            True,
+            False,
+            None,
+            123,
+            "abc",
+            [],
+            {},
+        ],
+    )
+    def test___eq____with_non_has_data_other(
+        self, other: Any, subtests: pytest.Subtests
+    ) -> None:
+        """
+        Tests :py:meth:`object.__eq__` implementations with values that do not subclass :py:class:`betty.data.HasData`.
+        """
+        samples = list(self.sut_cls.data().samples)
+        for sample in samples:
+            with subtests.test(str(sample.label.localize(DEFAULT_LOCALIZER))):
+                assert sample.data != other
+
+    def test___eq____with_samples(self, subtests: pytest.Subtests) -> None:
+        """
+        Tests :py:meth:`object.__eq__` implementations with the data definition's samples.
+        """
+        samples = list(self.sut_cls.data().samples)
+        for sample in samples:
+            with subtests.test(str(sample.label.localize(DEFAULT_LOCALIZER))):
+                assert sample.data == sample.data, (
+                    f'Failed asserting that sample "{sample.label.localize(DEFAULT_LOCALIZER)}" instance is equal to itself'
+                )
+                for other_sample in samples:
+                    if other_sample is sample:
+                        continue
+                    assert sample.data != other_sample.data, (
+                        f'Failed asserting that sample "{sample.label.localize(DEFAULT_LOCALIZER)}" instance is not equal to sample "{other_sample.label.localize(DEFAULT_LOCALIZER)}"'
+                    )

--- a/betty/tests/app/test_config.py
+++ b/betty/tests/app/test_config.py
@@ -1,15 +1,10 @@
-from typing import TYPE_CHECKING
-
 from babel import Locale
 
 from betty.app.config import AppConfiguration
-from betty.test_utils.config import ConfigurationTestBase
-
-if TYPE_CHECKING:
-    from betty.portable import PortableMapping
+from betty.test_utils.data import HasDataTestBase
 
 
-class TestAppConfiguration(ConfigurationTestBase[AppConfiguration]):
+class TestAppConfiguration(HasDataTestBase[AppConfiguration]):
     sut_cls = AppConfiguration
 
     def test___init____minimal_locale(self) -> None:
@@ -26,25 +21,3 @@ class TestAppConfiguration(ConfigurationTestBase[AppConfiguration]):
         locale = Locale("nl", "NL")
         sut.locale = locale
         assert sut.locale is locale
-
-    def test_load__minimal(self) -> None:
-        sut = AppConfiguration()
-        portable: PortableMapping = {}
-        sut.load(portable)
-
-    def test_load__with_locale(self) -> None:
-        locale = "nl"
-        portable: PortableMapping = {"locale": locale}
-        sut = AppConfiguration.load(portable)
-        assert sut.locale == Locale(locale)
-
-    def test_dump__minimal(self) -> None:
-        sut = AppConfiguration()
-        actual = sut.dump()
-        assert actual == {}
-
-    def test_dump__with_locale(self) -> None:
-        locale = "nl"
-        sut = AppConfiguration(locale=Locale(locale))
-        actual = sut.dump()
-        assert actual == {"locale": locale}

--- a/betty/tests/config/test___init__.py
+++ b/betty/tests/config/test___init__.py
@@ -3,11 +3,9 @@ from typing import Self
 from typing_extensions import override
 
 from betty.assertion import assert_int
-from betty.config import Configurable, Configuration, Sample
-from betty.locale.localizable.plain import Plain
+from betty.config import Configurable, Configuration
 from betty.portable import PortableData
 from betty.test_utils.config import DummyConfiguration
-from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
 
 
 class TestConfiguration:
@@ -24,33 +22,6 @@ class TestConfiguration:
         @override
         def dump(self) -> PortableData:
             return self.value
-
-
-class TestSample:
-    def test_configuration(self) -> None:
-        configuration = DummyConfiguration()
-        sut = Sample(configuration, label=DUMMY_LOCALIZABLE)
-        assert sut.configuration is configuration
-
-    def test_label(self) -> None:
-        label = Plain("-")
-        sut = Sample(DummyConfiguration(), label=label)
-        assert sut.label is label
-
-    def test_description(self) -> None:
-        description = Plain("-")
-        sut = Sample(
-            DummyConfiguration(), label=DUMMY_LOCALIZABLE, description=description
-        )
-        assert sut.description is description
-
-    def test_minimal(self) -> None:
-        sut = Sample(DummyConfiguration(), label=DUMMY_LOCALIZABLE, minimal=True)
-        assert sut.minimal
-
-    def test_full(self) -> None:
-        sut = Sample(DummyConfiguration(), label=DUMMY_LOCALIZABLE, full=True)
-        assert sut.full
 
 
 class TestConfigurable:

--- a/betty/tests/console/command/commands/test_about.py
+++ b/betty/tests/console/command/commands/test_about.py
@@ -40,7 +40,8 @@ class TestAbout(CommandTestBase):
             Project.new_isolated(app) as project,
         ):
             await dump_file(
-                project.configuration.dump(), project.configuration_file_path
+                project.configuration.data().dump(project.configuration),
+                project.configuration_file_path,
             )
             result = await run(
                 app,

--- a/betty/tests/console/command/commands/test_config.py
+++ b/betty/tests/console/command/commands/test_config.py
@@ -44,7 +44,7 @@ class TestConfig(CommandTestBase):
             "--locale",
             locale,
         )
-        configuration = AppConfiguration.load(
+        configuration = AppConfiguration.data().load(
             (await assert_load_file())(configuration_file_path)
         )
         assert configuration.locale == Locale(locale)

--- a/betty/tests/console/command/commands/test_generate.py
+++ b/betty/tests/console/command/commands/test_generate.py
@@ -35,7 +35,8 @@ class TestGenerate(CommandTestBase):
 
         async with Project.new_isolated(isolated_app) as project:
             await dump_file(
-                project.configuration.dump(), project.configuration_file_path
+                project.configuration.data().dump(project.configuration),
+                project.configuration_file_path,
             )
             await run(
                 isolated_app,

--- a/betty/tests/console/command/commands/test_new_translation.py
+++ b/betty/tests/console/command/commands/test_new_translation.py
@@ -34,7 +34,8 @@ class TestNewTranslation(CommandTestBase):
     ) -> None:
         async with Project.new_isolated(isolated_app) as project, project:
             await dump_file(
-                project.configuration.dump(), project.configuration_file_path
+                project.configuration.data().dump(project.configuration),
+                project.configuration_file_path,
             )
             locale = "nl"
             m_new_translation = mocker.patch(

--- a/betty/tests/console/command/commands/test_serve.py
+++ b/betty/tests/console/command/commands/test_serve.py
@@ -33,7 +33,8 @@ class TestServe(CommandTestBase):
         mocker.patch("betty.serve.BuiltinProjectServer", new=NoOpProjectServer)
         async with Project.new_isolated(isolated_app) as project:
             await dump_file(
-                project.configuration.dump(), project.configuration_file_path
+                project.configuration.data().dump(project.configuration),
+                project.configuration_file_path,
             )
             await makedirs(project.www_directory_path)
 

--- a/betty/tests/console/command/commands/test_update_translations.py
+++ b/betty/tests/console/command/commands/test_update_translations.py
@@ -37,7 +37,8 @@ class TestUpdateTranslations(CommandTestBase):
         )
         async with Project.new_isolated(isolated_app) as project, project:
             await dump_file(
-                project.configuration.dump(), project.configuration_file_path
+                project.configuration.data().dump(project.configuration),
+                project.configuration_file_path,
             )
             await run(
                 isolated_app,
@@ -57,7 +58,8 @@ class TestUpdateTranslations(CommandTestBase):
         )
         async with Project.new_isolated(isolated_app) as project, project:
             await dump_file(
-                project.configuration.dump(), project.configuration_file_path
+                project.configuration.data().dump(project.configuration),
+                project.configuration_file_path,
             )
             await run(
                 isolated_app,
@@ -82,7 +84,8 @@ class TestUpdateTranslations(CommandTestBase):
         )
         async with Project.new_isolated(isolated_app) as project, project:
             await dump_file(
-                project.configuration.dump(), project.configuration_file_path
+                project.configuration.data().dump(project.configuration),
+                project.configuration_file_path,
             )
             await run(
                 isolated_app,

--- a/betty/tests/console/test___init__.py
+++ b/betty/tests/console/test___init__.py
@@ -141,7 +141,8 @@ class TestVerbosity:
         with CommandDefinition.type().override_discovery(StaticDiscovery(_NoOpCommand)):
             async with Project.new_isolated(isolated_app) as project:
                 await dump_file(
-                    project.configuration.dump(), project.configuration_file_path
+                    project.configuration.data().dump(project.configuration),
+                    project.configuration_file_path,
                 )
                 args = ["no-op"]
                 if verbosity is not None:

--- a/betty/tests/coverage/test_coverage.py
+++ b/betty/tests/coverage/test_coverage.py
@@ -130,8 +130,6 @@ _BASELINE: Mapping[str, _ModuleIgnore] = {
             "load": MissingReason.ABSTRACT,
             "validator": MissingReason.STATIC_CONTENT_ONLY,
         },
-        "get_full_sample": MissingReason.SHOULD_BE_COVERED,
-        "get_minimal_sample": MissingReason.SHOULD_BE_COVERED,
     },
     "betty/config/collections/__init__.py": MissingReason.ABSTRACT,
     "betty/config/factory.py": {
@@ -164,8 +162,23 @@ _BASELINE: Mapping[str, _ModuleIgnore] = {
         },
         "ServiceInitializedError": MissingReason.ABSTRACT,
     },
+    "betty/service/hydrate.py": {
+        "Hydratable": MissingReason.ABSTRACT,
+    },
     "betty/service/level/__init__.py": MissingReason.ABSTRACT,
     "betty/service/level/factory.py": MissingReason.ABSTRACT,
+    "betty/data/__init__.py": {
+        "HasData": MissingReason.ABSTRACT,
+        "SampleNotFound": MissingReason.STATIC_CONTENT_ONLY,
+    },
+    "betty/data/aggregate/__init__.py": {
+        "AggregateDefinition": {
+            "elements": MissingReason.ABSTRACT,
+        },
+    },
+    "betty/data/aggregate/collection/__init__.py": {
+        "CollectionDefinition": MissingReason.ABSTRACT,
+    },
     "betty/data/indicator/__init__.py": {
         "Indicator": MissingReason.ABSTRACT,
     },
@@ -409,7 +422,10 @@ _BASELINE: Mapping[str, _ModuleIgnore] = {
         "PluginDefinitionConfigurationMapping": MissingReason.SHOULD_BE_COVERED,
     },
     "betty/portable/__init__.py": {
+        "Dumper": MissingReason.ABSTRACT,
+        "Loader": MissingReason.ABSTRACT,
         "Portable": MissingReason.ABSTRACT,
+        "Porter": MissingReason.ABSTRACT,
     },
     "betty/portable/error.py": {
         "NotPortable": MissingReason.STATIC_CONTENT_ONLY,

--- a/betty/tests/data/aggregate/collection/test_keyed.py
+++ b/betty/tests/data/aggregate/collection/test_keyed.py
@@ -1,0 +1,81 @@
+from collections.abc import Sequence
+
+from betty.collections import KeyedCollection
+from betty.data.aggregate.collection.keyed import KeyedCollectionDefinition
+from betty.data.aggregate.record import FieldDefinition
+from betty.data.aggregate.record.mapping import TypedMappingDefinition
+from betty.data.indicator.selector import Key
+from betty.data.simple import SimpleDefinition
+from betty.portable import PortableData
+from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
+
+
+class TestKeyedCollectionDefinition:
+    _item = TypedMappingDefinition[dict[str, str]](
+        cls=dict,
+        label=DUMMY_LOCALIZABLE,
+        fields=[
+            FieldDefinition(
+                Key("key"), SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE)
+            ),
+            FieldDefinition(
+                Key("other_element"), SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE)
+            ),
+        ],
+    )
+    _sut_unordered = KeyedCollectionDefinition[dict[str, str]](
+        item=_item,
+        key=Key("key"),
+        ordered=False,
+        label=DUMMY_LOCALIZABLE,
+    )
+    _sut_ordered = KeyedCollectionDefinition[dict[str, str]](
+        item=_item,
+        key=Key("key"),
+        ordered=True,
+        label=DUMMY_LOCALIZABLE,
+    )
+    _portable_unordered: PortableData = {
+        "my_first_key": {
+            "other_element": "my_first_other_element",
+        }
+    }
+    _portable_ordered: PortableData = [
+        {
+            "key": "my_first_key",
+            "other_element": "my_first_other_element",
+        }
+    ]
+    _values: Sequence[dict[str, str]] = [
+        {
+            "key": "my_first_key",
+            "other_element": "my_first_other_element",
+        }
+    ]
+
+    def test_elements(self) -> None:
+        assert list(
+            self._sut_ordered.elements(
+                KeyedCollection(self._values, key=lambda value: value["key"])
+            )
+        ) == [(Key("my_first_key"), self._item)]
+
+    def test_load__unordered(self) -> None:
+        data = self._sut_unordered.load(self._portable_unordered)
+        assert isinstance(data, KeyedCollection)
+        assert data["my_first_key"]["key"] == "my_first_key"
+        assert data["my_first_key"]["other_element"] == "my_first_other_element"
+
+    def test_load__ordered(self) -> None:
+        data = self._sut_ordered.load(self._portable_ordered)
+        assert isinstance(data, KeyedCollection)
+        assert data["my_first_key"]["key"] == "my_first_key"
+        assert data["my_first_key"]["other_element"] == "my_first_other_element"
+
+    def test_dump__unordered(self) -> None:
+        data = KeyedCollection(self._values, key=lambda value: value["key"])
+        assert self._sut_unordered.dump(data) == self._portable_unordered
+
+    def test_dump__ordered(self) -> None:
+        data = KeyedCollection(self._values, key=lambda value: value["key"])
+        assert self._sut_ordered.dump(data) == self._portable_ordered

--- a/betty/tests/data/aggregate/collection/test_mapping.py
+++ b/betty/tests/data/aggregate/collection/test_mapping.py
@@ -1,0 +1,91 @@
+import pytest
+
+from betty.data import DataDefinition
+from betty.data.aggregate.collection.mapping import MappingDefinition
+from betty.data.indicator.selector import Key
+from betty.data.simple import SimpleDefinition
+from betty.portable.error import NotPortable
+from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
+
+
+class TestMappingDefinition:
+    def test_elements(self) -> None:
+        item = SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE)
+        sut = MappingDefinition[dict[str, str]](
+            cls=dict[str, str],
+            item=item,
+            label=DUMMY_LOCALIZABLE,
+        )
+        assert sut.item is item
+        assert list(sut.elements({"key": "value"})) == [(Key("key"), item)]
+
+    def test_item(self) -> None:
+        item = SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE)
+        sut = MappingDefinition[dict[str, str]](
+            cls=dict[str, str],
+            item=item,
+            label=DUMMY_LOCALIZABLE,
+        )
+        assert sut.item is item
+
+    def test_load__without_items(self) -> None:
+        sut = MappingDefinition[dict[str, str]](
+            cls=dict[str, str],
+            item=SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+            label=DUMMY_LOCALIZABLE,
+        )
+        assert sut.load({}) == {}
+
+    def test_load__with_items(self) -> None:
+        sut = MappingDefinition[dict[str, str]](
+            cls=dict[str, str],
+            item=SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+            label=DUMMY_LOCALIZABLE,
+        )
+        assert sut.load({"hello": "Hello, world!"}) == {"hello": "Hello, world!"}
+
+    def test_load__with_factory(self) -> None:
+        class FactoryDict(dict[str, str]):
+            pass
+
+        sut = MappingDefinition[dict[str, str]](
+            cls=dict[str, str],
+            item=SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+            label=DUMMY_LOCALIZABLE,
+            factory=FactoryDict,
+        )
+        assert isinstance(sut.load({}), FactoryDict)
+
+    def test_load__with_item_not_loadable(self) -> None:
+        sut = MappingDefinition[dict[str, str]](
+            cls=dict[str, str],
+            item=DataDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+            label=DUMMY_LOCALIZABLE,
+        )
+        with pytest.raises(NotPortable):
+            sut.load({"hello": "Hello, world!"})
+
+    def test_dump__without_items(self) -> None:
+        sut = MappingDefinition[dict[str, str]](
+            cls=dict[str, str],
+            item=SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+            label=DUMMY_LOCALIZABLE,
+        )
+        assert sut.dump({}) == {}
+
+    def test_dump__with_items(self) -> None:
+        sut = MappingDefinition[dict[str, str]](
+            cls=dict[str, str],
+            item=SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+            label=DUMMY_LOCALIZABLE,
+        )
+        assert sut.dump({"hello": "Hello, world!"}) == {"hello": "Hello, world!"}
+
+    def test_dump__with_item_not_dumpable(self) -> None:
+        sut = MappingDefinition[dict[str, str]](
+            cls=dict[str, str],
+            item=DataDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+            label=DUMMY_LOCALIZABLE,
+        )
+        with pytest.raises(NotPortable):
+            sut.dump({"hello": "Hello, world!"})

--- a/betty/tests/data/aggregate/collection/test_sequence.py
+++ b/betty/tests/data/aggregate/collection/test_sequence.py
@@ -1,0 +1,80 @@
+import pytest
+
+from betty.data import DataDefinition
+from betty.data.aggregate.collection.sequence import SequenceDefinition
+from betty.data.simple import SimpleDefinition
+from betty.portable.error import NotPortable
+from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
+
+
+class TestSequenceDefinition:
+    def test_elements__should_contain_exactly_one_element(self) -> None:
+        item = SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE)
+        sut = SequenceDefinition[list[str]](
+            cls=list[str],
+            item=item,
+            label=DUMMY_LOCALIZABLE,
+        )
+        assert sut.item is item
+
+    def test_load__without_items(self) -> None:
+        sut = SequenceDefinition[list[str]](
+            cls=list[str],
+            item=SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+            label=DUMMY_LOCALIZABLE,
+        )
+        assert sut.load([]) == []
+
+    def test_load__with_items(self) -> None:
+        sut = SequenceDefinition[list[str]](
+            cls=list[str],
+            item=SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+            label=DUMMY_LOCALIZABLE,
+        )
+        assert sut.load(["Hello, world!"]) == ["Hello, world!"]
+
+    def test_load__with_factory(self) -> None:
+        class FactoryList(list[str]):
+            pass
+
+        sut = SequenceDefinition[list[str]](
+            cls=list[str],
+            item=SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+            label=DUMMY_LOCALIZABLE,
+            factory=FactoryList,
+        )
+        assert isinstance(sut.load([]), FactoryList)
+
+    def test_load__with_item_not_loadable(self) -> None:
+        sut = SequenceDefinition[list[str]](
+            cls=list[str],
+            item=DataDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+            label=DUMMY_LOCALIZABLE,
+        )
+        with pytest.raises(NotPortable):
+            sut.load(["Hello, world!"])
+
+    def test_dump__without_items(self) -> None:
+        sut = SequenceDefinition[list[str]](
+            cls=list[str],
+            item=SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+            label=DUMMY_LOCALIZABLE,
+        )
+        assert sut.dump([]) == []
+
+    def test_dump__with_items(self) -> None:
+        sut = SequenceDefinition[list[str]](
+            cls=list[str],
+            item=SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+            label=DUMMY_LOCALIZABLE,
+        )
+        assert sut.dump(["Hello, world!"]) == ["Hello, world!"]
+
+    def test_dump__with_item_not_dumpable(self) -> None:
+        sut = SequenceDefinition[list[str]](
+            cls=list[str],
+            item=DataDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+            label=DUMMY_LOCALIZABLE,
+        )
+        with pytest.raises(NotPortable):
+            sut.dump(["Hello, world!"])

--- a/betty/tests/data/aggregate/record/test___init__.py
+++ b/betty/tests/data/aggregate/record/test___init__.py
@@ -1,0 +1,223 @@
+import pytest
+
+from betty.data import DataDefinition
+from betty.data.aggregate.record import FieldDefinition, RecordDefinition
+from betty.data.indicator.selector import Attr, Key
+from betty.data.simple import SimpleDefinition
+from betty.exception import HumanFacingException
+from betty.locale.localizable.plain import Plain
+from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
+
+
+class TestFieldDefinition:
+    def test_selector(self) -> None:
+        selector = Key("my_first_key")
+        sut = FieldDefinition(selector, DataDefinition(label=DUMMY_LOCALIZABLE))
+        assert sut.selector is selector
+
+    def test_data(self) -> None:
+        data = DataDefinition(label=DUMMY_LOCALIZABLE)
+        sut = FieldDefinition(Key("_"), data)
+        assert sut.data is data
+
+    def test_label__with_label(self) -> None:
+        label = Plain("-")
+        sut = FieldDefinition(
+            Key("_"), DataDefinition(label=DUMMY_LOCALIZABLE), label=label
+        )
+        assert sut.label is label
+
+    def test_description__without_description(self) -> None:
+        sut = FieldDefinition(Key("_"), DataDefinition(label=DUMMY_LOCALIZABLE))
+        assert sut.description is None
+
+    def test_description__with_description(self) -> None:
+        description = Plain("-")
+        sut = FieldDefinition(
+            Key("_"), DataDefinition(label=DUMMY_LOCALIZABLE), description=description
+        )
+        assert sut.description is description
+
+    def test_required(self) -> None:
+        sut = FieldDefinition(
+            Key("_"), DataDefinition(label=DUMMY_LOCALIZABLE), required=False
+        )
+        assert not sut.required
+
+    def test_empty__without_callback(self) -> None:
+        sut = FieldDefinition(Key("_"), DataDefinition(label=DUMMY_LOCALIZABLE))
+        assert not sut.empty(object())
+
+    def test_empty__with_field_callback(self) -> None:
+        sut = FieldDefinition(
+            Key("_"), DataDefinition(label=DUMMY_LOCALIZABLE), empty=lambda _: True
+        )
+        assert sut.empty(object())
+
+    def test_empty__with_data_callback(self) -> None:
+        sut = FieldDefinition(
+            Key("_"), DataDefinition(label=DUMMY_LOCALIZABLE, empty=lambda _: True)
+        )
+        assert sut.empty(object())
+
+
+class RecordDefinitionTestRecord:
+    def __init__(self, my_first_element: str | None = None):
+        self.my_first_element = my_first_element
+
+
+class RecordDefinitionTestFactoryRecord(RecordDefinitionTestRecord):
+    pass
+
+
+class TestRecordDefinition:
+    def test_fields(self) -> None:
+        element = FieldDefinition(
+            Attr("my_first_element"), SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE)
+        )
+        sut = RecordDefinition[RecordDefinitionTestRecord, Attr](
+            cls=RecordDefinitionTestRecord,
+            label=DUMMY_LOCALIZABLE,
+            fields=[element],
+        )
+        assert list(sut.fields) == [element]
+
+    def test_elements(self) -> None:
+        selector = Attr("my_first_element")
+        element = SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE)
+        field = FieldDefinition(selector, element)
+        sut = RecordDefinition[RecordDefinitionTestRecord, Attr](
+            cls=RecordDefinitionTestRecord,
+            label=DUMMY_LOCALIZABLE,
+            fields=[field],
+        )
+        assert list(sut.elements(RecordDefinitionTestRecord())) == [(selector, element)]
+
+    def test_load__required_with_value(self) -> None:
+        field_name = "my_first_element"
+        sut = RecordDefinition[RecordDefinitionTestRecord, Attr](
+            cls=RecordDefinitionTestRecord,
+            label=DUMMY_LOCALIZABLE,
+            fields=[
+                FieldDefinition(
+                    Attr(field_name),
+                    SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+                ),
+            ],
+        )
+        value = "Hello, world!"
+        data = sut.load({field_name: value})
+        assert data.my_first_element == value
+
+    def test_load__required_without_value(self) -> None:
+        field_name = "my_first_element"
+        sut = RecordDefinition[RecordDefinitionTestRecord, Attr](
+            cls=RecordDefinitionTestRecord,
+            label=DUMMY_LOCALIZABLE,
+            fields=[
+                FieldDefinition(
+                    Attr(field_name),
+                    SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+                ),
+            ],
+        )
+        with pytest.raises(HumanFacingException):
+            sut.load({})
+
+    def test_load__optional_with_value(self) -> None:
+        field_name = "my_first_element"
+        sut = RecordDefinition[RecordDefinitionTestRecord, Attr](
+            cls=RecordDefinitionTestRecord,
+            label=DUMMY_LOCALIZABLE,
+            fields=[
+                FieldDefinition(
+                    Attr(field_name),
+                    SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+                    required=False,
+                ),
+            ],
+        )
+        value = "Hello, world!"
+        data = sut.load({field_name: value})
+        assert data.my_first_element == value
+
+    def test_load__optional_without_value(self) -> None:
+        field_name = "my_first_element"
+        sut = RecordDefinition[RecordDefinitionTestRecord, Attr](
+            cls=RecordDefinitionTestRecord,
+            label=DUMMY_LOCALIZABLE,
+            fields=[
+                FieldDefinition(
+                    Attr(field_name),
+                    SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+                    required=False,
+                ),
+            ],
+        )
+        sut.load({})
+
+    def test_load__with_factory(self) -> None:
+        field_name = "my_first_element"
+        sut = RecordDefinition[RecordDefinitionTestRecord, Attr](
+            cls=RecordDefinitionTestRecord,
+            label=DUMMY_LOCALIZABLE,
+            fields=[
+                FieldDefinition(
+                    Attr(field_name),
+                    SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+                ),
+            ],
+            factory=RecordDefinitionTestFactoryRecord,
+        )
+        value = "Hello, world!"
+        data = sut.load({field_name: value})
+        assert isinstance(data, RecordDefinitionTestFactoryRecord)
+        assert data.my_first_element == value
+
+    def test_dump(self) -> None:
+        field_name = "my_first_element"
+        sut = RecordDefinition[RecordDefinitionTestRecord, Attr](
+            cls=RecordDefinitionTestRecord,
+            label=DUMMY_LOCALIZABLE,
+            fields=[
+                FieldDefinition(
+                    Attr(field_name),
+                    SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+                ),
+            ],
+        )
+        value = "Hello, world!"
+        data = RecordDefinitionTestRecord(value)
+        assert sut.dump(data) == {field_name: value}
+
+    def test_load_key(self) -> None:
+        field_name = "my_first_element"
+        sut = RecordDefinition[RecordDefinitionTestRecord, Attr](
+            cls=RecordDefinitionTestRecord,
+            label=DUMMY_LOCALIZABLE,
+            fields=[
+                FieldDefinition(
+                    Attr(field_name),
+                    SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+                ),
+            ],
+        )
+        value = "Hello, world!"
+        data = sut.load_key({}, Attr(field_name), value)
+        assert data.my_first_element == value
+
+    def test_dump_key(self) -> None:
+        field_name = "my_first_element"
+        sut = RecordDefinition[RecordDefinitionTestRecord, Attr](
+            cls=RecordDefinitionTestRecord,
+            label=DUMMY_LOCALIZABLE,
+            fields=[
+                FieldDefinition(
+                    Attr(field_name),
+                    SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+                ),
+            ],
+        )
+        value = "Hello, world!"
+        data = RecordDefinitionTestRecord(value)
+        assert sut.dump_key(data, Attr(field_name)) == (value, {})

--- a/betty/tests/data/aggregate/record/test_mapping.py
+++ b/betty/tests/data/aggregate/record/test_mapping.py
@@ -1,0 +1,67 @@
+from betty.data.aggregate.record import FieldDefinition
+from betty.data.aggregate.record.mapping import TypedMappingDefinition
+from betty.data.indicator.selector import Key
+from betty.data.simple import SimpleDefinition
+from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
+
+
+class TestTypedMappingDefinition:
+    def test_elements(self) -> None:
+        element = FieldDefinition(
+            Key("my_first_element"), SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE)
+        )
+        sut = TypedMappingDefinition[dict[str, str]](
+            cls=dict,
+            label=DUMMY_LOCALIZABLE,
+            fields=[element],
+        )
+        assert list(sut.fields) == [element]
+
+    def test_load(self) -> None:
+        field_name = "my_first_element"
+        sut = TypedMappingDefinition[dict[str, str]](
+            cls=dict,
+            label=DUMMY_LOCALIZABLE,
+            fields=[
+                FieldDefinition(
+                    Key(field_name),
+                    SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+                ),
+            ],
+        )
+        value = "Hello, world!"
+        data = sut.load({field_name: value})
+        assert data["my_first_element"] == value
+
+    def test_load__with_factory(self) -> None:
+        class FactoryDict(dict[str, str]):
+            pass
+
+        sut = TypedMappingDefinition[dict[str, str]](
+            cls=dict,
+            label=DUMMY_LOCALIZABLE,
+            fields=[
+                FieldDefinition(
+                    Key("my_first_element"),
+                    SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+                ),
+            ],
+            factory=FactoryDict,
+        )
+        assert isinstance(sut.load({"my_first_element": "Hello, world!"}), FactoryDict)
+
+    def test_dump(self) -> None:
+        field_name = "my_first_element"
+        sut = TypedMappingDefinition[dict[str, str]](
+            cls=dict,
+            label=DUMMY_LOCALIZABLE,
+            fields=[
+                FieldDefinition(
+                    Key(field_name),
+                    SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+                ),
+            ],
+        )
+        value = "Hello, world!"
+        data = {field_name: value}
+        assert sut.dump(data) == {field_name: value}

--- a/betty/tests/data/aggregate/record/test_object.py
+++ b/betty/tests/data/aggregate/record/test_object.py
@@ -1,0 +1,76 @@
+from betty.data.aggregate.record import FieldDefinition
+from betty.data.aggregate.record.object import ObjectDefinition
+from betty.data.indicator.selector import Attr
+from betty.data.simple import SimpleDefinition
+from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
+
+
+class ObjectDefinitionTestObject:
+    def __init__(self, my_first_element: str):
+        self.my_first_element = my_first_element
+
+
+class ObjectDefinitionTestFactoryObject(ObjectDefinitionTestObject):
+    pass
+
+
+class TestObjectDefinition:
+    def test_elements(self) -> None:
+        element = FieldDefinition(
+            Attr("my_first_element"), SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE)
+        )
+        sut = ObjectDefinition[ObjectDefinitionTestObject](
+            cls=ObjectDefinitionTestObject,
+            label=DUMMY_LOCALIZABLE,
+            fields=[element],
+        )
+        assert list(sut.fields) == [element]
+
+    def test_load(self) -> None:
+        field_name = "my_first_element"
+        sut = ObjectDefinition[ObjectDefinitionTestObject](
+            cls=ObjectDefinitionTestObject,
+            label=DUMMY_LOCALIZABLE,
+            fields=[
+                FieldDefinition(
+                    Attr(field_name),
+                    SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+                ),
+            ],
+        )
+        value = "Hello, world!"
+        data = sut.load({field_name: value})
+        assert data.my_first_element == value
+
+    def test_load__with_factory(self) -> None:
+        sut = ObjectDefinition[ObjectDefinitionTestObject](
+            cls=ObjectDefinitionTestObject,
+            label=DUMMY_LOCALIZABLE,
+            fields=[
+                FieldDefinition(
+                    Attr("my_first_element"),
+                    SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+                ),
+            ],
+            factory=ObjectDefinitionTestFactoryObject,
+        )
+        assert isinstance(
+            sut.load({"my_first_element": "Hello, world!"}),
+            ObjectDefinitionTestFactoryObject,
+        )
+
+    def test_dump(self) -> None:
+        field_name = "my_first_element"
+        sut = ObjectDefinition[ObjectDefinitionTestObject](
+            cls=ObjectDefinitionTestObject,
+            label=DUMMY_LOCALIZABLE,
+            fields=[
+                FieldDefinition(
+                    Attr(field_name),
+                    SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE),
+                ),
+            ],
+        )
+        value = "Hello, world!"
+        data = ObjectDefinitionTestObject(value)
+        assert sut.dump(data) == {field_name: value}

--- a/betty/tests/data/aggregate/test___init__.py
+++ b/betty/tests/data/aggregate/test___init__.py
@@ -1,0 +1,35 @@
+from collections.abc import Sequence
+from unittest.mock import AsyncMock
+
+from typing_extensions import override
+
+from betty.data import DataDefinition
+from betty.data.aggregate import AggregateDefinition
+from betty.data.indicator.selector import Key
+from betty.service.level.universal import universe
+from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
+
+
+class TestAggregateDefinition:
+    async def test_hydrate(self) -> None:
+        m_element = AsyncMock(spec=DataDefinition)
+
+        class _Sut(AggregateDefinition[dict[str, object], Key]):
+            def __init__(self):
+                super().__init__(cls=dict[str, object], label=DUMMY_LOCALIZABLE)
+
+            @override
+            def elements(
+                self, data: dict[str, object]
+            ) -> Sequence[tuple[Key, DataDefinition]]:
+                return [
+                    (
+                        Key("key"),
+                        m_element,
+                    )
+                ]
+
+        element_data = object()
+        sut = _Sut()
+        await sut.hydrate({"key": element_data}, universe)
+        m_element.hydrate.assert_awaited_once_with(element_data, universe)

--- a/betty/tests/data/indicator/test___init__.py
+++ b/betty/tests/data/indicator/test___init__.py
@@ -1,6 +1,16 @@
 import pathlib
 
-from betty.data.indicator import Path, Url
+from betty.data.indicator import AnyIndex, AnyKey, Path, Url
+
+
+class TestAnyIndex:
+    def test_format(self) -> None:
+        assert AnyIndex().format()
+
+
+class TestAnyKey:
+    def test_format(self) -> None:
+        assert AnyKey().format()
 
 
 class TestPath:

--- a/betty/tests/data/indicator/test_selector.py
+++ b/betty/tests/data/indicator/test_selector.py
@@ -5,7 +5,7 @@ import pytest
 from typing_extensions import override
 
 from betty.data.indicator import Indicator
-from betty.data.indicator.selector import Attr, Index, Key, Selector, Selectors
+from betty.data.indicator.selector import Attr, Element, Index, Key, Selector, Selectors
 from betty.exception import HumanFacingException
 
 
@@ -16,6 +16,9 @@ class DummyIndicator(Indicator):
 
 
 class TestAttr:
+    def test_element(self) -> None:
+        assert Attr("my_first_attr").element == "my_first_attr"
+
     def test_format(self) -> None:
         assert Attr("attr").format() == ".attr"
 
@@ -145,3 +148,31 @@ class TestSelectors:
         with pytest.raises(HumanFacingException) as exc_info:
             Selectors(*selectors).get([[], []])
         assert list(exc_info.value.indicators) == [inner_selector, outer_selector]
+
+
+class ElementTestElement(Element[Any]):
+    @override
+    def _get(self, data: Any, /) -> Any:
+        raise NotImplementedError
+
+    @override
+    def format(self) -> str:
+        raise NotImplementedError
+
+
+class TestElement:
+    def test_element(self) -> None:
+        element = "my_first_element"
+        sut = ElementTestElement(element)
+        assert sut.element == element
+
+    @pytest.mark.parametrize(
+        ("expected", "one", "other"),
+        [
+            (True, ElementTestElement(1), ElementTestElement(1)),
+            (False, ElementTestElement(1), ElementTestElement(2)),
+            (False, ElementTestElement(1), ElementTestElement("1")),
+        ],
+    )
+    def test___eq__(self, expected: bool, one: Element, other: Element) -> None:
+        assert (one == other) is expected

--- a/betty/tests/data/test___init__.py
+++ b/betty/tests/data/test___init__.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from typing import Self
+
+import pytest
+from typing_extensions import override
+
+from betty.assertion import assert_str
+from betty.data import (
+    DataDefinition,
+    HasData,
+    Sample,
+)
+from betty.locale.localizable.plain import Plain
+from betty.portable import CallbackPorter, Portable, PortableData
+from betty.portable.error import NotPortable
+from betty.service.level.universal import universe
+from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
+
+
+class TestSample:
+    def test_data(self) -> None:
+        data = object()
+        sut = Sample(data, label=DUMMY_LOCALIZABLE)
+        assert sut.data is data
+
+    def test_label(self) -> None:
+        label = Plain("-")
+        sut = Sample(object(), label=label)
+        assert sut.label is label
+
+    def test_description(self) -> None:
+        description = Plain("-")
+        sut = Sample(object(), label=DUMMY_LOCALIZABLE, description=description)
+        assert sut.description is description
+
+    def test_minimal(self) -> None:
+        sut = Sample(object(), label=DUMMY_LOCALIZABLE, minimal=True)
+        assert sut.minimal
+
+    def test_full(self) -> None:
+        sut = Sample(object(), label=DUMMY_LOCALIZABLE, full=True)
+        assert sut.full
+
+
+class DataDefinitionTestData(Portable, HasData):
+    def __init__(self, value: str):
+        self.value = value
+
+    @override
+    @classmethod
+    def load(cls, portable: PortableData, /) -> Self:
+        return cls(assert_str()(portable))
+
+    @override
+    def dump(self) -> PortableData:
+        return self.value
+
+
+class TestDataDefinition:
+    def test_cls(self) -> None:
+        sut = DataDefinition(cls=object, label=DUMMY_LOCALIZABLE)
+        assert sut.cls is object
+
+    def test___call__(self) -> None:
+        sut = DataDefinition[DataDefinitionTestData](label=DUMMY_LOCALIZABLE)
+        sut(DataDefinitionTestData)
+        assert sut.cls is DataDefinitionTestData
+
+    def test_label(self) -> None:
+        label = Plain("-")
+        sut = DataDefinition(cls=object, label=label)
+        assert sut.label is label
+
+    def test_description(self) -> None:
+        description = Plain("-")
+        sut = DataDefinition(
+            cls=object, label=DUMMY_LOCALIZABLE, description=description
+        )
+        assert sut.description is description
+
+    def test_porter__without_porter(self) -> None:
+        sut = DataDefinition(cls=object, label=DUMMY_LOCALIZABLE)
+        with pytest.raises(NotPortable):
+            sut.porter  # noqa: B018
+
+    def test_porter__with_porter(self) -> None:
+        porter = CallbackPorter(lambda _: None, lambda _: None)
+        sut = DataDefinition(cls=object, label=DUMMY_LOCALIZABLE, porter=porter)
+        assert sut.porter is porter
+
+    def test_porter__with_portable(self) -> None:
+        sut = DataDefinition(cls=DataDefinitionTestData, label=DUMMY_LOCALIZABLE)
+        sut.porter  # noqa: B018
+
+    def test_samples(self) -> None:
+        sample = Sample(object(), label=DUMMY_LOCALIZABLE)
+        sut = DataDefinition(
+            cls=object, label=DUMMY_LOCALIZABLE, samples=[lambda: sample]
+        )
+        assert list(sut.samples) == [sample]
+
+    def test_load__with_porter(self) -> None:
+        sut = DataDefinition(
+            cls=object,
+            label=DUMMY_LOCALIZABLE,
+            porter=CallbackPorter(lambda _: "loader", lambda _: None),
+        )
+        assert sut.load(None) == "loader"
+
+    def test_load__with_portable(self) -> None:
+        sut = DataDefinition(cls=DataDefinitionTestData, label=DUMMY_LOCALIZABLE)
+        value = "Hello, world!"
+        assert sut.load(value).value == value
+
+    def test_load__should_error(self) -> None:
+        sut = DataDefinition(cls=object, label=DUMMY_LOCALIZABLE)
+        with pytest.raises(NotPortable):
+            sut.load(None)
+
+    def test_dump__with_porter(self) -> None:
+        sut = DataDefinition(
+            cls=object,
+            label=DUMMY_LOCALIZABLE,
+            porter=CallbackPorter(lambda _: None, lambda _: "dumper"),
+        )
+        assert sut.dump(None) == "dumper"
+
+    def test_dump__with_portable(self) -> None:
+        sut = DataDefinition(cls=DataDefinitionTestData, label=DUMMY_LOCALIZABLE)
+        value = "Hello, world!"
+        assert sut.dump(DataDefinitionTestData(value)) == value
+
+    def test_dump__should_error(self) -> None:
+        sut = DataDefinition(cls=object, label=DUMMY_LOCALIZABLE)
+        with pytest.raises(NotPortable):
+            sut.dump(None)
+
+    def test_empty__fallback(self) -> None:
+        sut = DataDefinition(cls=object, label=DUMMY_LOCALIZABLE)
+        assert not sut.empty(object())
+
+    def test_empty__callback(self) -> None:
+        sut = DataDefinition(
+            cls=object, label=DUMMY_LOCALIZABLE, empty=lambda data: True
+        )
+        assert sut.empty(object())
+
+    async def test_hydrate(self) -> None:
+        sut = DataDefinition(cls=object, label=DUMMY_LOCALIZABLE)
+        await sut.hydrate(object(), universe)

--- a/betty/tests/data/test_enum.py
+++ b/betty/tests/data/test_enum.py
@@ -1,0 +1,24 @@
+from enum import Enum
+
+from betty.data.enum import EnumDefinition
+from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
+
+
+class EnumDefinitionTestEnum(Enum):
+    HELLO_WORLD = "Hello, World!"
+
+
+class TestEnumDefinition:
+    def test_load(self) -> None:
+        sut = EnumDefinition(cls=EnumDefinitionTestEnum, label=DUMMY_LOCALIZABLE)
+        assert (
+            sut.load(EnumDefinitionTestEnum.HELLO_WORLD.value)
+            is EnumDefinitionTestEnum.HELLO_WORLD
+        )
+
+    def test_dump(self) -> None:
+        sut = EnumDefinition(cls=EnumDefinitionTestEnum, label=DUMMY_LOCALIZABLE)
+        assert (
+            sut.dump(EnumDefinitionTestEnum.HELLO_WORLD)
+            == EnumDefinitionTestEnum.HELLO_WORLD.value
+        )

--- a/betty/tests/data/test_sample.py
+++ b/betty/tests/data/test_sample.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from betty.data import DataDefinition, Sample, SampleNotFound
+from betty.data.sample import get_full_sample, get_minimal_sample
+from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
+
+if TYPE_CHECKING:
+    from betty.config import Configuration
+
+
+_sample_full = Sample(object(), label=DUMMY_LOCALIZABLE, full=True)
+_sample_undetermined = Sample(object(), label=DUMMY_LOCALIZABLE)
+_sample_minimal = Sample(object(), label=DUMMY_LOCALIZABLE, minimal=True)
+
+
+@pytest.mark.parametrize(
+    ("expected", "data"),
+    [
+        (
+            _sample_full,
+            DataDefinition(
+                cls=object, label=DUMMY_LOCALIZABLE, samples=[lambda: _sample_full]
+            ),
+        ),
+        (
+            _sample_full,
+            DataDefinition(
+                cls=object,
+                label=DUMMY_LOCALIZABLE,
+                samples=[lambda: _sample_undetermined, lambda: _sample_full],
+            ),
+        ),
+        (
+            _sample_full,
+            DataDefinition(
+                cls=object,
+                label=DUMMY_LOCALIZABLE,
+                samples=[lambda: _sample_minimal, lambda: _sample_full],
+            ),
+        ),
+        (
+            _sample_undetermined,
+            DataDefinition(
+                cls=object,
+                label=DUMMY_LOCALIZABLE,
+                samples=[lambda: _sample_undetermined],
+            ),
+        ),
+        (
+            _sample_undetermined,
+            DataDefinition(
+                cls=object,
+                label=DUMMY_LOCALIZABLE,
+                samples=[lambda: _sample_minimal, lambda: _sample_undetermined],
+            ),
+        ),
+        (
+            _sample_minimal,
+            DataDefinition(
+                cls=object, label=DUMMY_LOCALIZABLE, samples=[lambda: _sample_minimal]
+            ),
+        ),
+    ],
+)
+def test_get_full_sample(
+    expected: Sample[object], data: DataDefinition[object] | type[Configuration]
+) -> None:
+    assert get_full_sample(data) is expected
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        DataDefinition(cls=object, label=DUMMY_LOCALIZABLE),
+    ],
+)
+def test_get_full_sample__without_samples(
+    data: DataDefinition[object] | type[Configuration],
+) -> None:
+    with pytest.raises(SampleNotFound):
+        get_full_sample(data)
+
+
+@pytest.mark.parametrize(
+    ("expected", "data"),
+    [
+        (
+            _sample_minimal,
+            DataDefinition(
+                cls=object, label=DUMMY_LOCALIZABLE, samples=[lambda: _sample_minimal]
+            ),
+        ),
+        (
+            _sample_minimal,
+            DataDefinition(
+                cls=object,
+                label=DUMMY_LOCALIZABLE,
+                samples=[lambda: _sample_undetermined, lambda: _sample_minimal],
+            ),
+        ),
+        (
+            _sample_minimal,
+            DataDefinition(
+                cls=object,
+                label=DUMMY_LOCALIZABLE,
+                samples=[lambda: _sample_full, lambda: _sample_minimal],
+            ),
+        ),
+        (
+            _sample_undetermined,
+            DataDefinition(
+                cls=object,
+                label=DUMMY_LOCALIZABLE,
+                samples=[lambda: _sample_undetermined],
+            ),
+        ),
+        (
+            _sample_undetermined,
+            DataDefinition(
+                cls=object,
+                label=DUMMY_LOCALIZABLE,
+                samples=[lambda: _sample_full, lambda: _sample_undetermined],
+            ),
+        ),
+        (
+            _sample_full,
+            DataDefinition(
+                cls=object, label=DUMMY_LOCALIZABLE, samples=[lambda: _sample_full]
+            ),
+        ),
+    ],
+)
+def test_get_minimal_sample(
+    expected: Sample[object], data: DataDefinition[object] | type[Configuration]
+) -> None:
+    assert get_minimal_sample(data) is expected
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        DataDefinition(cls=object, label=DUMMY_LOCALIZABLE),
+    ],
+)
+def test_get_minimal_sample__without_samples(
+    data: DataDefinition[object] | type[Configuration],
+) -> None:
+    with pytest.raises(SampleNotFound):
+        get_minimal_sample(data)

--- a/betty/tests/data/test_simple.py
+++ b/betty/tests/data/test_simple.py
@@ -1,0 +1,14 @@
+from betty.data.simple import SimpleDefinition
+from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
+
+
+class TestSimpleDefinition:
+    def test_load(self) -> None:
+        sut = SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE)
+        value = "Hello, world!"
+        assert sut.load(value) == value
+
+    def test_dump(self) -> None:
+        sut = SimpleDefinition(cls=str, label=DUMMY_LOCALIZABLE)
+        value = "Hello, world!"
+        assert sut.dump(value) == value

--- a/betty/tests/locale/localizable/test_data.py
+++ b/betty/tests/locale/localizable/test_data.py
@@ -1,0 +1,135 @@
+import pytest
+from typing_extensions import override
+
+from betty.exception import HumanFacingException
+from betty.locale import DEFAULT_LOCALE_TAG
+from betty.locale.error import UnknownLocale
+from betty.locale.localizable import CountableLocalizable, Localizable, LocalizableCount
+from betty.locale.localizable.data import (
+    CountableLocalizableDefinition,
+    LocalizableDefinition,
+)
+from betty.locale.localizable.error import InvalidPluralTag, MissingPluralTag
+from betty.locale.localizable.markup import Paragraph
+from betty.locale.localizable.plain import Plain
+from betty.locale.localizable.static import (
+    CountableStaticTranslations,
+    StaticTranslations,
+)
+from betty.locale.localize import DEFAULT_LOCALIZER
+from betty.portable.error import NotPortable
+from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
+
+
+class TestLocalizableDefinition:
+    def test_load__without_translations_should_error(self) -> None:
+        with pytest.raises(HumanFacingException):
+            LocalizableDefinition().load({})
+
+    def test_load__with_single_undetermined_translation(self) -> None:
+        localizable = "Hello, world!"
+        assert (
+            LocalizableDefinition().load(localizable).localize(DEFAULT_LOCALIZER)
+            == localizable
+        )
+
+    def test_dump__with_plain_text(self) -> None:
+        localizable = "Hello, world!"
+        assert LocalizableDefinition().dump(Plain(localizable)) == localizable
+
+    def test_dump__with_static_translations_single_undetermined(self) -> None:
+        localizable = "Hello, world!"
+        assert (
+            LocalizableDefinition().dump(StaticTranslations(localizable)) == localizable
+        )
+
+    def test_dump__with_static_translations(self) -> None:
+        localizable = {
+            DEFAULT_LOCALE_TAG: "Hello, world!",
+            "nl-NL": "Hallo, wereld!",
+        }
+
+        assert (
+            LocalizableDefinition().dump(StaticTranslations(localizable)) == localizable
+        )
+
+    def test_dump__with_unsupported_localizable(self) -> None:
+        with pytest.raises(NotPortable):
+            LocalizableDefinition().dump(Paragraph("Hello, world!"))
+
+
+class _NotDumpableCountableLocalizable(CountableLocalizable):
+    @override
+    def count(self, count: LocalizableCount, /) -> Localizable:
+        return DUMMY_LOCALIZABLE
+
+
+class TestCountableLocalizableDefinition:
+    def test_load_countable_localizable(self) -> None:
+        loaded = CountableLocalizableDefinition().load(
+            {
+                DEFAULT_LOCALE_TAG: {
+                    "one": "{count} thing",
+                    "other": "{count} things",
+                },
+            }
+        )
+        assert loaded.count(1).localize(DEFAULT_LOCALIZER) == "1 thing"
+
+    def test_load_countable_localizable__without_locales(self) -> None:
+        with pytest.raises(HumanFacingException):
+            CountableLocalizableDefinition().load({})
+
+    def test_load_countable_localizable__with_unknown_locale(self) -> None:
+        with pytest.raises(UnknownLocale):
+            CountableLocalizableDefinition().load(
+                {
+                    "unknownlocale": {},
+                }
+            )
+
+    def test_load_countable_localizable__with_missing_plural_tag(self) -> None:
+        with pytest.raises(MissingPluralTag):
+            CountableLocalizableDefinition().load(
+                {
+                    DEFAULT_LOCALE_TAG: {},
+                }
+            )
+
+    def test_load_countable_localizable__wth_invalid_plural_tag(self) -> None:
+        with pytest.raises(InvalidPluralTag):
+            CountableLocalizableDefinition().load(
+                {
+                    DEFAULT_LOCALE_TAG: {
+                        "one": "{count}",
+                        "other": "{count}",
+                        "invalid": "{count}",
+                    },
+                }
+            )
+
+    def test_dump_countable_localizable(self) -> None:
+        assert CountableLocalizableDefinition().dump(
+            CountableStaticTranslations(
+                {
+                    DEFAULT_LOCALE_TAG: {
+                        "one": "{count} thing",
+                        "other": "{count} things",
+                    }
+                }
+            )
+        ) == {
+            DEFAULT_LOCALE_TAG: {
+                "one": "{count} thing",
+                "other": "{count} things",
+            }
+        }
+
+    class _NotDumpableCountableLocalizable(CountableLocalizable):
+        @override
+        def count(self, count: LocalizableCount, /) -> Localizable:
+            return DUMMY_LOCALIZABLE
+
+    def test_dump_countable_localizable__with_unsupported_localizable(self) -> None:
+        with pytest.raises(NotPortable):
+            CountableLocalizableDefinition().dump(_NotDumpableCountableLocalizable())

--- a/betty/tests/plugin/test_data.py
+++ b/betty/tests/plugin/test_data.py
@@ -1,0 +1,33 @@
+import pytest
+
+from betty.machine_name import InvalidMachineName
+from betty.plugin.data import PluginIdDefinition
+from betty.plugin.error import PluginNotFound
+from betty.service.level.universal import universe
+from betty.test_utils.plugin import DummyPluginDefinition, DummyPluginOne
+
+
+class TestPluginIdDefinition:
+    def test_load__without_valid_machine_name(self) -> None:
+        sut = PluginIdDefinition(DummyPluginDefinition)
+        with pytest.raises(InvalidMachineName):
+            sut.load("invalid_machine_name")
+
+    def test_load__with_valid_machine_name(self) -> None:
+        plugin_id = DummyPluginOne.plugin().id
+        sut = PluginIdDefinition(DummyPluginDefinition)
+        assert sut.load(plugin_id) == plugin_id
+
+    def test_dump(self) -> None:
+        plugin_id = DummyPluginOne.plugin().id
+        sut = PluginIdDefinition(DummyPluginDefinition)
+        assert sut.dump(plugin_id) == plugin_id
+
+    async def test_hydrate(self) -> None:
+        sut = PluginIdDefinition(DummyPluginDefinition)
+        await sut.hydrate(DummyPluginOne.plugin().id, universe)
+
+    async def test_hydrate__plugin_not_found(self) -> None:
+        sut = PluginIdDefinition(DummyPluginDefinition)
+        with pytest.raises(PluginNotFound):
+            await sut.hydrate("non-existent-plugin-id", universe)

--- a/betty/tests/portable/test___init__.py
+++ b/betty/tests/portable/test___init__.py
@@ -1,0 +1,42 @@
+from typing import Self
+
+from typing_extensions import override
+
+from betty.assertion import assert_str
+from betty.portable import CallbackPorter, Portable, PortableData, PortablePorter
+
+
+class TestCallbackPorter:
+    def test_load(self) -> None:
+        sut = CallbackPorter(lambda _: "loaded", lambda _: "dumped")
+        assert sut.load(None) == "loaded"
+
+    def test_dump(self) -> None:
+        sut = CallbackPorter(lambda _: "loaded", lambda _: "dumped")
+        assert sut.dump(None) == "dumped"
+
+
+class PortablePorterTestPortable(Portable):
+    def __init__(self, value: str):
+        self.value = value
+
+    @override
+    @classmethod
+    def load(cls, serialized: PortableData, /) -> Self:
+        return cls(assert_str()(serialized))
+
+    @override
+    def dump(self) -> PortableData:
+        return self.value
+
+
+class TestPortablePorter:
+    def test_load(self) -> None:
+        sut = PortablePorter(PortablePorterTestPortable)
+        value = "Hello, world!"
+        assert sut.load(value).value == value
+
+    def test_dump(self) -> None:
+        sut = PortablePorter(PortablePorterTestPortable)
+        value = "Hello, world!"
+        assert sut.dump(PortablePorterTestPortable(value)) == value

--- a/betty/tests/project/extension/raspberry_mint/test___init__.py
+++ b/betty/tests/project/extension/raspberry_mint/test___init__.py
@@ -59,8 +59,10 @@ class TestRaspberryMint(
         ):
             async with Project.new_isolated(isolated_app) as project:
                 project.configuration.extensions.enable(RaspberryMint)
-                project.configuration.entity_types.replace(
-                    EntityTypeConfiguration(DummyEntityOne, generate_html_list=True)
+                project.configuration.entity_types.add(
+                    EntityTypeConfiguration(
+                        entity_type=DummyEntityOne, generate_html_list=True
+                    )
                 )
                 async with project:
                     await generate(project)

--- a/betty/tests/project/extension/wiki/test_config.py
+++ b/betty/tests/project/extension/wiki/test_config.py
@@ -1,55 +1,6 @@
-from typing import TYPE_CHECKING, Any
-
-import pytest
-
-from betty.exception import HumanFacingException
 from betty.project.extension.wiki.config import WikiConfiguration
-from betty.test_utils.config import ConfigurationTestBase
-
-if TYPE_CHECKING:
-    from collections.abc import Mapping
-
-    from betty.portable import PortableData
+from betty.test_utils.data import HasDataTestBase
 
 
-class TestWikiConfiguration(ConfigurationTestBase[WikiConfiguration]):
+class TestWikiConfiguration(HasDataTestBase[WikiConfiguration]):
     sut_cls = WikiConfiguration
-
-    async def test_load__with_minimal_configuration(self) -> None:
-        portable: Mapping[str, Any] = {}
-        WikiConfiguration.load(portable)
-
-    async def test_load__without_dict_should_error(self) -> None:
-        with pytest.raises(HumanFacingException):
-            WikiConfiguration.load(None)
-
-    @pytest.mark.parametrize(
-        "populate_images",
-        [
-            True,
-            False,
-        ],
-    )
-    async def test_load__with_populate_images(
-        self, populate_images: bool | None
-    ) -> None:
-        portable: PortableData = {
-            "populate_images": populate_images,
-        }
-        sut = WikiConfiguration.load(portable)
-        assert sut.populate_images == populate_images
-
-    async def test_dump__with_minimal_configuration(self) -> None:
-        sut = WikiConfiguration()
-        expected = {
-            "populate_images": True,
-        }
-        assert sut.dump() == expected
-
-    async def test_dump__with_populate_images(self) -> None:
-        sut = WikiConfiguration()
-        sut.populate_images = False
-        expected = {
-            "populate_images": False,
-        }
-        assert sut.dump() == expected

--- a/betty/tests/project/generate/test_jobs.py
+++ b/betty/tests/project/generate/test_jobs.py
@@ -56,8 +56,10 @@ class TestGenerateEntityTypesHtml:
     )
     async def test_do(self, entity_type: type[Entity], isolated_app: App) -> None:
         async with Project.new_isolated(isolated_app) as project:
-            project.configuration.entity_types.append(
-                EntityTypeConfiguration(entity_type, generate_html_list=True)
+            project.configuration.entity_types.add(
+                EntityTypeConfiguration(
+                    entity_type=entity_type, generate_html_list=True
+                )
             )
             async with project:
                 await do(ProjectContext(project), GenerateEntityTypesHtml())
@@ -68,8 +70,8 @@ class TestGenerateEntityTypesHtml:
 
     async def test_do__with_pager(self, isolated_app: App) -> None:
         async with Project.new_isolated(isolated_app) as project:
-            project.configuration.entity_types.append(
-                EntityTypeConfiguration(Place, generate_html_list=True)
+            project.configuration.entity_types.add(
+                EntityTypeConfiguration(entity_type=Place, generate_html_list=True)
             )
             place_one = Place(id="P1")
             place_two = Place(id="P2")

--- a/betty/tests/project/test_config.py
+++ b/betty/tests/project/test_config.py
@@ -12,23 +12,21 @@ from betty.ancestry.gender import GenderDefinition
 from betty.ancestry.place_type import PlaceTypeDefinition
 from betty.ancestry.presence_role import PresenceRoleDefinition
 from betty.copyright_notice import CopyrightNotice, CopyrightNoticeDefinition
+from betty.dirs import ASSETS_DIRECTORY_PATH
 from betty.exception import HumanFacingException
 from betty.license import License, LicenseDefinition
 from betty.locale import DEFAULT_LOCALE, DEFAULT_LOCALE_TAG, LocaleLike
 from betty.locale.localizable.plain import Plain
 from betty.locale.localize import DEFAULT_LOCALIZER
 from betty.machine_name import MachineName
-from betty.model import Entity, EntityDefinition
+from betty.model import EntityDefinition
 from betty.plugin.config import PluginInstanceConfiguration
 from betty.plugin.discovery.static import StaticDiscovery
-from betty.plugin.repository.static import StaticPluginRepository
 from betty.plugin.resolve import ResolvableId
-from betty.project import Project
 from betty.project.config import (
     CopyrightNoticePluginConfiguration,
     CopyrightNoticePluginConfigurationMapping,
     EntityTypeConfiguration,
-    EntityTypeConfigurationMapping,
     EventTypePluginConfiguration,
     EventTypePluginConfigurationMapping,
     ExtensionInstanceConfigurationMapping,
@@ -45,11 +43,13 @@ from betty.project.config import (
     ProjectConfiguration,
 )
 from betty.project.extension import Extension, ExtensionDefinition
+from betty.service.level.universal import universe
 from betty.test_utils.config import ConfigurationTestBase, DummyConfiguration
 from betty.test_utils.config.collections import (
     ConfigurationCollectionTestBaseNewSut,
 )
 from betty.test_utils.config.collections.mapping import ConfigurationMappingTestBase
+from betty.test_utils.data import HasDataTestBase
 from betty.test_utils.locale.localizable import (
     DUMMY_COUNTABLE_LOCALIZABLE,
     DUMMY_LOCALIZABLE,
@@ -63,7 +63,6 @@ from betty.test_utils.project.extension import (
 from betty.typing import Void
 
 if TYPE_CHECKING:
-    from betty.app import App
     from betty.portable import PortableData, PortableMapping
     from betty.test_utils.config.collections import (
         ConfigurationCollectionTestBaseSutConfigurationKeys,
@@ -358,18 +357,18 @@ class TestExtensionInstanceConfigurationMapping(
         assert DummyExtensionOne.plugin() in sut
 
 
-class TestEntityTypeConfiguration(ConfigurationTestBase[EntityTypeConfiguration]):
+class TestEntityTypeConfiguration(HasDataTestBase[EntityTypeConfiguration]):
     sut_cls = EntityTypeConfiguration
 
-    async def test_id__with___init___entity_type(self) -> None:
+    async def test_entity_type__with___init___entity_type(self) -> None:
         entity_type = DummyEntityOne
-        sut = EntityTypeConfiguration(entity_type)
-        assert sut.id == entity_type.plugin().id
+        sut = EntityTypeConfiguration(entity_type=entity_type)
+        assert sut.entity_type == entity_type.plugin().id
 
-    async def test_id__with___init___entity_type_id(self) -> None:
+    async def test_entity_type__with___init___entity_type_id(self) -> None:
         entity_type_id = DummyEntityOne.plugin().id
-        sut = EntityTypeConfiguration(entity_type_id)
-        assert sut.id == entity_type_id
+        sut = EntityTypeConfiguration(entity_type=entity_type_id)
+        assert sut.entity_type == entity_type_id
 
     @pytest.mark.parametrize(
         "generate_html_list,",
@@ -379,160 +378,23 @@ class TestEntityTypeConfiguration(ConfigurationTestBase[EntityTypeConfiguration]
         ],
     )
     async def test_generate_html_list(self, generate_html_list: bool) -> None:
-        sut = EntityTypeConfiguration(DummyEntityOne)
+        sut = EntityTypeConfiguration(entity_type=DummyEntityOne)
         sut.generate_html_list = generate_html_list
         assert sut.generate_html_list == generate_html_list
 
-    async def test_load__with_empty_configuration(self) -> None:
-        portable: PortableData = {}
-        with pytest.raises(HumanFacingException):
-            EntityTypeConfiguration.load(portable)
-
-    def test_load__with_minimal_configuration(self) -> None:
-        portable: PortableData = {
-            "entity_type": DummyEntityOne.plugin().id,
-        }
-        EntityTypeConfiguration.load(portable)
-
-    @pytest.mark.parametrize(
-        "generate_html_list,",
-        [
-            True,
-            False,
-        ],
-    )
-    def test_load__with_generate_html_list(self, generate_html_list: bool) -> None:
-        portable: PortableData = {
-            "entity_type": DummyEntityOne.plugin().id,
-            "generate_html_list": generate_html_list,
-        }
-        sut = EntityTypeConfiguration.load(portable)
-        assert sut.generate_html_list == generate_html_list
-
-    async def test_dump__with_minimal_configuration(self) -> None:
-        sut = EntityTypeConfiguration(DummyEntityOne)
-        expected = {
-            "entity_type": DummyEntityOne.plugin().id,
-            "generate_html_list": True,
-        }
-        assert sut.dump() == expected
-
-    async def test_dump__with_generate_html_list(self) -> None:
-        sut = EntityTypeConfiguration(DummyEntityOne, generate_html_list=False)
-        expected = {
-            "entity_type": DummyEntityOne.plugin().id,
-            "generate_html_list": False,
-        }
-        assert sut.dump() == expected
-
-    async def test_validate__with_generate_html_list_with_non_public_facing_entity_type_should_error(
+    async def test_hydrate__with_generate_html_list_with_non_public_facing_entity_type_should_error(
         self,
     ) -> None:
-        sut = EntityTypeConfiguration(DummyNonPublicFacingEntityOne)
-        with pytest.raises(HumanFacingException):
-            await sut.validate(
-                StaticPluginRepository(EntityDefinition, DummyNonPublicFacingEntityOne)
-            )
-
-
-@EntityDefinition(
-    "zero",
-    label=DUMMY_LOCALIZABLE,
-    label_plural=DUMMY_LOCALIZABLE,
-    label_countable=DUMMY_COUNTABLE_LOCALIZABLE,
-)
-class EntityTypeConfigurationMappingTestEntity0(Entity):
-    pass
-
-
-@EntityDefinition(
-    "one",
-    label=DUMMY_LOCALIZABLE,
-    label_plural=DUMMY_LOCALIZABLE,
-    label_countable=DUMMY_COUNTABLE_LOCALIZABLE,
-)
-class EntityTypeConfigurationMappingTestEntity1(Entity):
-    pass
-
-
-@EntityDefinition(
-    "two",
-    label=DUMMY_LOCALIZABLE,
-    label_plural=DUMMY_LOCALIZABLE,
-    label_countable=DUMMY_COUNTABLE_LOCALIZABLE,
-)
-class EntityTypeConfigurationMappingTestEntity2(Entity):
-    pass
-
-
-@EntityDefinition(
-    "three",
-    label=DUMMY_LOCALIZABLE,
-    label_plural=DUMMY_LOCALIZABLE,
-    label_countable=DUMMY_COUNTABLE_LOCALIZABLE,
-)
-class EntityTypeConfigurationMappingTestEntity3(Entity):
-    pass
-
-
-class TestEntityTypeConfigurationMapping(
-    ConfigurationMappingTestBase[
-        EntityTypeConfigurationMapping,
-        MachineName,
-        ResolvableId[EntityDefinition],
-        EntityTypeConfiguration,
-    ]
-):
-    sut_cls = EntityTypeConfigurationMapping
-
-    @override
-    @pytest.fixture
-    def sut_configuration_keys(
-        self,
-    ) -> ConfigurationCollectionTestBaseSutConfigurationKeys[MachineName]:
-        return (
-            EntityTypeConfigurationMappingTestEntity0.plugin().id,
-            EntityTypeConfigurationMappingTestEntity1.plugin().id,
-            EntityTypeConfigurationMappingTestEntity2.plugin().id,
-            EntityTypeConfigurationMappingTestEntity3.plugin().id,
+        sut = EntityTypeConfiguration(
+            entity_type=DummyNonPublicFacingEntityOne, generate_html_list=True
         )
-
-    @override
-    @pytest.fixture
-    def new_sut(
-        self,
-    ) -> ConfigurationCollectionTestBaseNewSut[
-        EntityTypeConfiguration, MachineName, ResolvableId[EntityDefinition]
-    ]:
-        return EntityTypeConfigurationMapping
-
-    @override
-    @pytest.fixture
-    def sut_configurations(
-        self,
-        sut_configuration_keys: ConfigurationCollectionTestBaseSutConfigurationKeys[
-            MachineName
-        ],
-    ) -> ConfigurationCollectionTestBaseSutConfigurations[EntityTypeConfiguration]:
-        return (
-            EntityTypeConfiguration(sut_configuration_keys[0]),
-            EntityTypeConfiguration(sut_configuration_keys[1]),
-            EntityTypeConfiguration(sut_configuration_keys[2]),
-            EntityTypeConfiguration(sut_configuration_keys[3]),
-        )
-
-    async def test_validate__with_item_error_should_error(self) -> None:
-        sut = EntityTypeConfigurationMapping(
-            [
-                EntityTypeConfiguration(
-                    DummyNonPublicFacingEntityOne, generate_html_list=True
-                )
-            ]
-        )
-        with pytest.raises(HumanFacingException):
-            await sut.validate(
-                StaticPluginRepository(EntityDefinition, DummyNonPublicFacingEntityOne)
-            )
+        with (
+            pytest.raises(HumanFacingException),
+            EntityDefinition.type().override_discovery(
+                StaticDiscovery(DummyNonPublicFacingEntityOne)
+            ),
+        ):
+            await sut.hydrate(universe)
 
 
 class TestCopyrightNoticePluginConfigurationMapping(
@@ -893,28 +755,8 @@ class TestGenderPluginConfigurationMapping(
         return GenderPluginConfigurationMapping
 
 
-class TestProjectConfiguration(ConfigurationTestBase[ProjectConfiguration]):
+class TestProjectConfiguration(HasDataTestBase[ProjectConfiguration]):
     sut_cls = ProjectConfiguration
-
-    async def test_validator__should_validate_entity_type_configuration(
-        self, isolated_app: App
-    ) -> None:
-        sut = ProjectConfiguration(title="Betty", url="https://example.com")
-        sut.entity_types.replace(
-            EntityTypeConfiguration(
-                DummyNonPublicFacingEntityOne.plugin(), generate_html_list=True
-            )
-        )
-        with EntityDefinition.type().override_discovery(
-            StaticDiscovery(DummyNonPublicFacingEntityOne)
-        ):
-            async with Project.new_isolated(isolated_app) as project:
-                async with project:
-                    with pytest.raises(HumanFacingException) as exc_info:
-                        await project.new_target(sut.validator)
-        assert 'data["entity_types"]["dummy-non-public-facing-one"]' in str(
-            exc_info.value
-        )
 
     async def test_lifetime_threshold(self) -> None:
         sut = ProjectConfiguration(title="Betty", url="https://example.com")
@@ -1052,33 +894,43 @@ class TestProjectConfiguration(ConfigurationTestBase[ProjectConfiguration]):
         assert sut.genders is sut.genders
 
     async def test_load__should_load_minimal(self) -> None:
-        portable = ProjectConfiguration(title="Betty", url="https://example.com").dump()
-        sut = ProjectConfiguration.load(portable)
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(title="Betty", url="https://example.com")
+        )
+        sut = ProjectConfiguration.data().load(portable)
         assert sut.url == portable["url"]
 
     async def test_load__should_load_name(self) -> None:
         name = "my-first-betty-site"
-        portable = ProjectConfiguration(title="Betty", url="https://example.com").dump()
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(title="Betty", url="https://example.com")
+        )
         portable["name"] = name
-        sut = ProjectConfiguration.load(portable)
+        sut = ProjectConfiguration.data().load(portable)
         assert sut.name == name
 
     async def test_load__should_load_title(self) -> None:
         title = "My first Betty site"
-        portable = ProjectConfiguration(title="Betty", url="https://example.com").dump()
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(title="Betty", url="https://example.com")
+        )
         portable["title"] = title
-        sut = ProjectConfiguration.load(portable)
+        sut = ProjectConfiguration.data().load(portable)
         assert sut.title.localize(DEFAULT_LOCALIZER) == title
 
     async def test_load__should_load_copyright_notice(self) -> None:
-        portable = ProjectConfiguration(title="Betty", url="https://example.com").dump()
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(title="Betty", url="https://example.com")
+        )
         copyright_notice_id = "my-first-copyright-notice"
         portable["copyright_notice"] = copyright_notice_id
-        sut = ProjectConfiguration.load(portable)
+        sut = ProjectConfiguration.data().load(portable)
         assert sut.copyright_notice.id == copyright_notice_id
 
     async def test_load__should_load_copyright_notices(self) -> None:
-        portable = ProjectConfiguration(title="Betty", url="https://example.com").dump()
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(title="Betty", url="https://example.com")
+        )
         copyright_notice_id = "my-first-copyright-notice"
         copyright_notice_label = "My First Copyright Notice"
         portable["copyright_notices"] = {
@@ -1088,21 +940,25 @@ class TestProjectConfiguration(ConfigurationTestBase[ProjectConfiguration]):
                 "text": "My First Copyright Notice is the best copyright notice.",
             }
         }
-        sut = ProjectConfiguration.load(portable)
+        sut = ProjectConfiguration.data().load(portable)
         assert (
             sut.copyright_notices[copyright_notice_id].label.localize(DEFAULT_LOCALIZER)
             == copyright_notice_label
         )
 
     async def test_load__should_load_license(self) -> None:
-        portable = ProjectConfiguration(title="Betty", url="https://example.com").dump()
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(title="Betty", url="https://example.com")
+        )
         license_id = "my-first-license"
         portable["license"] = license_id
-        sut = ProjectConfiguration.load(portable)
+        sut = ProjectConfiguration.data().load(portable)
         assert sut.license.id == license_id
 
     async def test_load__should_load_licenses(self) -> None:
-        portable = ProjectConfiguration(title="Betty", url="https://example.com").dump()
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(title="Betty", url="https://example.com")
+        )
         license_id = "my-first-license"
         license_label = "My First License"
         portable["licenses"] = {
@@ -1112,40 +968,48 @@ class TestProjectConfiguration(ConfigurationTestBase[ProjectConfiguration]):
                 "text": "My First License is the best license.",
             }
         }
-        sut = ProjectConfiguration.load(portable)
+        sut = ProjectConfiguration.data().load(portable)
         assert (
             sut.licenses[license_id].label.localize(DEFAULT_LOCALIZER) == license_label
         )
 
     async def test_load__should_load_author(self) -> None:
         author = "Bart"
-        portable = ProjectConfiguration(title="Betty", url="https://example.com").dump()
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(title="Betty", url="https://example.com")
+        )
         portable["author"] = author
-        sut = ProjectConfiguration.load(portable)
+        sut = ProjectConfiguration.data().load(portable)
         assert sut.author is not None
         assert sut.author.localize(DEFAULT_LOCALIZER) == author
 
     async def test_load__should_load_logo(self) -> None:
-        logo = Path("logo.png")
-        portable = ProjectConfiguration(title="Betty", url="https://example.com").dump()
+        logo = ASSETS_DIRECTORY_PATH / "public" / "static" / "betty-512x512.png"
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(title="Betty", url="https://example.com")
+        )
         portable["logo"] = str(logo)
-        sut = ProjectConfiguration.load(portable)
+        sut = ProjectConfiguration.data().load(portable)
         assert sut.logo == logo
 
     async def test_load__should_load_locale_locale(self) -> None:
         locale = "nl-NL"
-        portable = ProjectConfiguration(title="Betty", url="https://example.com").dump()
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(title="Betty", url="https://example.com")
+        )
         portable["locales"] = [{"locale": locale}]
-        sut = ProjectConfiguration.load(portable)
+        sut = ProjectConfiguration.data().load(portable)
         assert len(sut.locales) == 1
         assert locale in sut.locales
 
     async def test_load__should_load_locale_alias(self) -> None:
         locale = "nl-NL"
         alias = "nl"
-        portable = ProjectConfiguration(title="Betty", url="https://example.com").dump()
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(title="Betty", url="https://example.com")
+        )
         portable["locales"] = [{"locale": locale, "alias": alias}]
-        sut = ProjectConfiguration.load(portable)
+        sut = ProjectConfiguration.data().load(portable)
         assert len(sut.locales) == 1
         assert locale in sut.locales
         actual = sut.locales[locale]
@@ -1153,9 +1017,11 @@ class TestProjectConfiguration(ConfigurationTestBase[ProjectConfiguration]):
 
     async def test_load__should_clean_urls(self) -> None:
         clean_urls = True
-        portable = ProjectConfiguration(title="Betty", url="https://example.com").dump()
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(title="Betty", url="https://example.com")
+        )
         portable["clean_urls"] = clean_urls
-        sut = ProjectConfiguration.load(portable)
+        sut = ProjectConfiguration.data().load(portable)
         assert sut.clean_urls == clean_urls
 
     @pytest.mark.parametrize(
@@ -1166,29 +1032,35 @@ class TestProjectConfiguration(ConfigurationTestBase[ProjectConfiguration]):
         ],
     )
     async def test_load__should_load_debug(self, debug: bool) -> None:
-        portable = ProjectConfiguration(title="Betty", url="https://example.com").dump()
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(title="Betty", url="https://example.com")
+        )
         portable["debug"] = debug
-        sut = ProjectConfiguration.load(portable)
+        sut = ProjectConfiguration.data().load(portable)
         assert sut.debug == debug
 
     async def test_load__should_load_extension(self) -> None:
-        portable = ProjectConfiguration(title="Betty", url="https://example.com").dump()
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(title="Betty", url="https://example.com")
+        )
         portable["extensions"] = {
             DummyExtensionOne.plugin().id: {},
         }
-        sut = ProjectConfiguration.load(portable)
+        sut = ProjectConfiguration.data().load(portable)
         actual = sut.extensions[DummyExtensionOne.plugin()]
         assert isinstance(actual.configuration, Void)
 
     async def test_load__extension_with_invalid_configuration_should_raise_error(
         self,
     ) -> None:
-        portable = ProjectConfiguration(title="Betty", url="https://example.com").dump()
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(title="Betty", url="https://example.com")
+        )
         portable["extensions"] = {
             DummyConfigurableExtension.plugin().id: 1337,
         }
         with pytest.raises(HumanFacingException):
-            ProjectConfiguration.load(portable)
+            ProjectConfiguration.data().load(portable)
 
     @pytest.mark.parametrize(
         ("expected", "event_types_configuration"),
@@ -1227,11 +1099,13 @@ class TestProjectConfiguration(ConfigurationTestBase[ProjectConfiguration]):
         expected: PortableMapping,
         event_types_configuration: PortableMapping,
     ) -> None:
-        portable = ProjectConfiguration(title="Betty", url="https://example.com").dump()
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(title="Betty", url="https://example.com")
+        )
         portable["event_types"] = event_types_configuration
-        sut = ProjectConfiguration.load(portable)
+        sut = ProjectConfiguration.data().load(portable)
         if event_types_configuration:
-            assert sut.dump()["event_types"] == expected
+            assert ProjectConfiguration.data().dump(sut)["event_types"] == expected
 
     @pytest.mark.parametrize(
         ("expected", "place_types_configuration"),
@@ -1270,11 +1144,13 @@ class TestProjectConfiguration(ConfigurationTestBase[ProjectConfiguration]):
         expected: PortableMapping,
         place_types_configuration: PortableMapping,
     ) -> None:
-        portable = ProjectConfiguration(title="Betty", url="https://example.com").dump()
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(title="Betty", url="https://example.com")
+        )
         portable["place_types"] = place_types_configuration
-        sut = ProjectConfiguration.load(portable)
+        sut = ProjectConfiguration.data().load(portable)
         if place_types_configuration:
-            assert sut.dump()["place_types"] == expected
+            assert ProjectConfiguration.data().dump(sut)["place_types"] == expected
 
     @pytest.mark.parametrize(
         ("expected", "presence_roles_configuration"),
@@ -1313,11 +1189,13 @@ class TestProjectConfiguration(ConfigurationTestBase[ProjectConfiguration]):
         expected: PortableMapping,
         presence_roles_configuration: PortableMapping,
     ) -> None:
-        portable = ProjectConfiguration(title="Betty", url="https://example.com").dump()
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(title="Betty", url="https://example.com")
+        )
         portable["presence_roles"] = presence_roles_configuration
-        sut = ProjectConfiguration.load(portable)
+        sut = ProjectConfiguration.data().load(portable)
         if presence_roles_configuration:
-            assert sut.dump()["presence_roles"] == expected
+            assert ProjectConfiguration.data().dump(sut)["presence_roles"] == expected
 
     @pytest.mark.parametrize(
         ("expected", "genders_configuration"),
@@ -1356,58 +1234,66 @@ class TestProjectConfiguration(ConfigurationTestBase[ProjectConfiguration]):
         expected: PortableMapping,
         genders_configuration: PortableMapping,
     ) -> None:
-        portable = ProjectConfiguration(title="Betty", url="https://example.com").dump()
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(title="Betty", url="https://example.com")
+        )
         portable["genders"] = genders_configuration
-        sut = ProjectConfiguration.load(portable)
+        sut = ProjectConfiguration.data().load(portable)
         if genders_configuration:
-            assert sut.dump()["genders"] == expected
+            assert ProjectConfiguration.data().dump(sut)["genders"] == expected
 
     async def test_load__should_error_if_invalid_config(self) -> None:
         portable: PortableData = {}
         with pytest.raises(HumanFacingException):
-            ProjectConfiguration.load(portable)
+            ProjectConfiguration.data().load(portable)
 
     async def test_dump__should_dump_minimal(self) -> None:
         sut = ProjectConfiguration(title="Betty", url="https://example.com")
-        assert sut.dump() == {
+        assert ProjectConfiguration.data().dump(sut) == {
             "title": "Betty",
             "url": "https://example.com",
         }
 
     async def test_dump__should_dump_title(self) -> None:
         title = "My first Betty site"
-        portable = ProjectConfiguration(title=title, url="https://example.com").dump()
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(title=title, url="https://example.com")
+        )
         assert portable["title"] == title
 
     async def test_dump__should_dump_name(self) -> None:
         name = "my-first-betty-site"
-        portable = ProjectConfiguration(
-            name=name, title="Betty", url="https://example.com"
-        ).dump()
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(name=name, title="Betty", url="https://example.com")
+        )
         assert portable["name"] == name
 
     async def test_dump__should_dump_author(self) -> None:
         author = "Bart"
-        portable = ProjectConfiguration(
-            author=author, title="Betty", url="https://example.com"
-        ).dump()
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(
+                author=author, title="Betty", url="https://example.com"
+            )
+        )
         assert portable["author"] == author
 
     async def test_dump__should_dumpo_logo(self) -> None:
         logo = Path("logo.png")
-        portable = ProjectConfiguration(
-            logo=logo, title="Betty", url="https://example.com"
-        ).dump()
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(logo=logo, title="Betty", url="https://example.com")
+        )
         assert portable["logo"] == str(logo)
 
     async def test_dump__should_dump_locale_locale(self) -> None:
         locale = "nl-NL"
         locale_configuration = LocaleConfiguration(locale)
-        portable = ProjectConfiguration(
-            locales=LocaleConfigurationMapping([locale_configuration]),
-            title="Betty",
-            url="https://example.com",
-        ).dump()
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(
+                locales=LocaleConfigurationMapping([locale_configuration]),
+                title="Betty",
+                url="https://example.com",
+            )
+        )
         assert portable["locales"] == [
             {
                 "locale": locale,
@@ -1421,26 +1307,30 @@ class TestProjectConfiguration(ConfigurationTestBase[ProjectConfiguration]):
             locale,
             alias=alias,
         )
-        portable = ProjectConfiguration(
-            locales=LocaleConfigurationMapping([locale_configuration]),
-            title="Betty",
-            url="https://example.com",
-        ).dump()
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(
+                locales=LocaleConfigurationMapping([locale_configuration]),
+                title="Betty",
+                url="https://example.com",
+            )
+        )
         assert portable["locales"] == [
             {"locale": locale, "alias": alias},
         ]
 
     async def test_dump__should_dump_clean_urls(self) -> None:
         clean_urls = True
-        portable = ProjectConfiguration(
-            clean_urls=clean_urls, title="Betty", url="https://example.com"
-        ).dump()
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(
+                clean_urls=clean_urls, title="Betty", url="https://example.com"
+            )
+        )
         assert portable["clean_urls"] == clean_urls
 
     async def test_dump__should_dump_debug(self) -> None:
-        portable = ProjectConfiguration(
-            debug=True, title="Betty", url="https://example.com"
-        ).dump()
+        portable = ProjectConfiguration.data().dump(
+            ProjectConfiguration(debug=True, title="Betty", url="https://example.com")
+        )
         assert portable["debug"]
 
     async def test_dump__should_dump_one_extension_with_configuration(self) -> None:
@@ -1451,7 +1341,7 @@ class TestProjectConfiguration(ConfigurationTestBase[ProjectConfiguration]):
                 DummyConfigurableExtension.plugin(), DummyConfiguration(value)
             )
         )
-        portable = sut.dump()
+        portable = ProjectConfiguration.data().dump(sut)
         expected = {
             DummyConfigurableExtension.plugin().id: {
                 "configuration": {
@@ -1464,7 +1354,7 @@ class TestProjectConfiguration(ConfigurationTestBase[ProjectConfiguration]):
     async def test_dump__should_dump_one_extension_without_configuration(self) -> None:
         sut = ProjectConfiguration(title="Betty", url="https://example.com")
         sut.extensions.enable(_DummyNonConfigurableExtension)
-        portable = sut.dump()
+        portable = ProjectConfiguration.data().dump(sut)
         expected: PortableData = {_DummyNonConfigurableExtension.plugin().id: {}}
         assert portable["extensions"] == expected
 
@@ -1478,7 +1368,7 @@ class TestProjectConfiguration(ConfigurationTestBase[ProjectConfiguration]):
                 label_countable=DUMMY_COUNTABLE_LOCALIZABLE,
             )
         )
-        portable = sut.dump()
+        portable = ProjectConfiguration.data().dump(sut)
         expected: PortableMapping = {
             "foo": {
                 "label": "Foo",
@@ -1503,7 +1393,7 @@ class TestProjectConfiguration(ConfigurationTestBase[ProjectConfiguration]):
                 label_countable=DUMMY_COUNTABLE_LOCALIZABLE,
             )
         )
-        portable = sut.dump()
+        portable = ProjectConfiguration.data().dump(sut)
         expected: PortableMapping = {
             "foo": {
                 "label": "Foo",
@@ -1528,7 +1418,7 @@ class TestProjectConfiguration(ConfigurationTestBase[ProjectConfiguration]):
                 label_countable=DUMMY_COUNTABLE_LOCALIZABLE,
             ),
         )
-        portable = sut.dump()
+        portable = ProjectConfiguration.data().dump(sut)
         expected: PortableMapping = {
             "foo": {
                 "label": "Foo",
@@ -1553,7 +1443,7 @@ class TestProjectConfiguration(ConfigurationTestBase[ProjectConfiguration]):
                 label_countable=DUMMY_COUNTABLE_LOCALIZABLE,
             )
         )
-        portable = sut.dump()
+        portable = ProjectConfiguration.data().dump(sut)
         expected: PortableMapping = {
             "foo": {
                 "label": "Foo",
@@ -1577,7 +1467,10 @@ class TestProjectConfiguration(ConfigurationTestBase[ProjectConfiguration]):
             title="Betty",
             url="https://example.com",
         )
-        assert sut.dump()["copyright_notice"] == copyright_notice_configuration.id
+        assert (
+            ProjectConfiguration.data().dump(sut)["copyright_notice"]
+            == copyright_notice_configuration.id
+        )
 
     async def test_dump__should_dump_copyright_notices(self) -> None:
         sut = ProjectConfiguration(title="Betty", url="https://example.com")
@@ -1595,7 +1488,7 @@ class TestProjectConfiguration(ConfigurationTestBase[ProjectConfiguration]):
                 text=copyright_notice_text,
             )
         )
-        assert sut.dump()["copyright_notices"] == {
+        assert ProjectConfiguration.data().dump(sut)["copyright_notices"] == {
             copyright_notice_id: {
                 "label": copyright_notice_label,
                 "summary": copyright_notice_summary,
@@ -1610,7 +1503,9 @@ class TestProjectConfiguration(ConfigurationTestBase[ProjectConfiguration]):
         sut = ProjectConfiguration(
             license=license_configuration, title="Betty", url="https://example.com"
         )
-        assert sut.dump()["license"] == license_configuration.id
+        assert (
+            ProjectConfiguration.data().dump(sut)["license"] == license_configuration.id
+        )
 
     async def test_dump__should_dump_licenses(self) -> None:
         sut = ProjectConfiguration(title="Betty", url="https://example.com")
@@ -1626,7 +1521,7 @@ class TestProjectConfiguration(ConfigurationTestBase[ProjectConfiguration]):
                 text=license_text,
             )
         )
-        assert sut.dump()["licenses"] == {
+        assert ProjectConfiguration.data().dump(sut)["licenses"] == {
             license_id: {
                 "label": license_label,
                 "summary": license_summary,

--- a/betty/tests/project/test_new.py
+++ b/betty/tests/project/test_new.py
@@ -18,7 +18,7 @@ from betty.typing import Void
 
 
 async def _assert_new(configuration_file_path: Path) -> ProjectConfiguration:
-    return ProjectConfiguration.load(
+    return ProjectConfiguration.data().load(
         (await assert_load_file())(configuration_file_path)
     )
 

--- a/betty/tests/test_collections.py
+++ b/betty/tests/test_collections.py
@@ -1,0 +1,112 @@
+from typing import Any
+
+from betty.collections import KeyedCollection, ResolvingMutableSequence
+from betty.functools import passthrough
+
+
+class TestKeyedCollection:
+    def test___contains__(self) -> None:
+        sut = KeyedCollection(["one"], key=lambda value: value.upper())
+        assert "ONE" in sut
+
+    def test___contains____with_resolved_key(self) -> None:
+        sut = KeyedCollection[str, str, bool, str](
+            ["True"], key=passthrough, key_resolver=str
+        )
+        assert True in sut
+
+    def test___contains____with_invalid_value(self) -> None:
+        sut = KeyedCollection[str, str, bool, str](
+            ["True"], key=passthrough, key_resolver=str
+        )
+        assert object() not in sut
+
+    def test___getitem__(self) -> None:
+        sut = KeyedCollection(["one"], key=lambda value: value.upper())
+        assert sut["ONE"] == "one"
+
+    def test___getitem____with_resolved_key(self) -> None:
+        sut = KeyedCollection[str, str, bool, str](
+            ["True"], key=passthrough, key_resolver=str
+        )
+        assert sut[True] == "True"
+
+    def test___delitem__(self) -> None:
+        sut = KeyedCollection(["one"], key=lambda value: value.upper())
+        del sut["ONE"]
+
+    def test___delitem____with_resolved_key(self) -> None:
+        sut = KeyedCollection[str, str, bool, str](
+            ["True"], key=passthrough, key_resolver=str
+        )
+        del sut[True]
+
+    def test___iter__(self) -> None:
+        sut = KeyedCollection(["one"], key=lambda value: value.upper())
+        assert list(iter(sut)) == ["one"]
+
+    def test___len__(self) -> None:
+        sut = KeyedCollection(["one"], key=lambda value: value.upper())
+        assert len(sut) == 1
+
+    def test_add__with_new_key(self) -> None:
+        sut = KeyedCollection[str, str, str, str]([], key=lambda value: value.upper())
+        sut.add("one")
+        assert sut["ONE"] == "one"
+
+    def test_add__with_existing_key(self) -> None:
+        sut = KeyedCollection(["one"], key=lambda value: value.upper())
+        sut.add("ONE")
+        assert sut["ONE"] == "ONE"
+
+    def test_add__with_resolved_value(self) -> None:
+        sut = KeyedCollection[str, str, str, bool](
+            [], key=passthrough, value_resolver=str
+        )
+        sut.add(True)
+        assert sut["True"] == "True"
+
+
+class TestResolvingMutableSequence:
+    def test_insert(self) -> None:
+        decorated = []
+        sut = ResolvingMutableSequence(decorated, str)
+        sut.insert(3, True)
+        assert decorated == ["True"]
+
+    def test___getitem__(self) -> None:
+        sut = ResolvingMutableSequence(["True"], str)
+        assert sut[0] == "True"
+
+    def test___setitem____with_index(self) -> None:
+        decorated = ["True"]
+        sut = ResolvingMutableSequence(decorated, str)
+        sut[0] = False
+        assert decorated[0] == "False"
+
+    def test___setitem____with_slice(self) -> None:
+        decorated = ["True", "True", "True"]
+        sut = ResolvingMutableSequence(decorated, str)
+        sut[1:3] = [False, False]
+        assert decorated == ["True", "False", "False"]
+
+    def test___delitem__(self) -> None:
+        decorated = ["one"]
+        sut = ResolvingMutableSequence(decorated, passthrough)
+        del sut[0]
+        assert not decorated
+
+    def test___len__(self) -> None:
+        sut = ResolvingMutableSequence(["one"], passthrough)
+        assert len(sut) == 1
+
+    def test___contains__(self) -> None:
+        sut = ResolvingMutableSequence(["True"], str)
+        assert True in sut
+
+    def test___contains____with_invalid_value(self) -> None:
+        def _resolver(value: Any) -> Any:
+            raise Exception
+
+        sut = ResolvingMutableSequence([], _resolver)
+        assert object() not in sut


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/3449

## Follow-ups
- expand the has_data Sphinx directive to recursively render data elements. Do this for simple as well as aggregate root data.
- Allow mixin classes for **records** to declare their own field that can automatically be found by the subclass that is the actual record data.
- For a project's extension configuration, replace the `enable()` method with the ability to add a plain resolvable plugin identifier that is expanded to a `PluginInstanceConfiguration` internally. Do this for locale configurations as well. Add this as resolvers on `KeyedCollection`. Also add `KeyedPluginInstanceConfigurationCollection`.
- Refactor `PluginInstanceConfigurationSequence*` to be regular sequences with value resolvers. Add a `ResolvingMutableSequence` which decorates another sequence but resolves values before passing them on.
- Keep `LocaleConfigurationMapping`, but rename it and refactor it onto `KeyedCollection` to add the default value behavior.
- Model plugins (entities, event types, etc) are also `HasData`. Should plugin and plugin type definitions subclass `DataDefinition`? We can override `data()` automatically like we do with `plugin()`. We should probably make the relevant plugin classes subclass `HasData` now and provide a default implementation without element. We can then gradually expand in the future without breaking anything.
- Fix `@todo`s
- Remove configuration collections 
- Remove `Configuration`
- Remove all `config.py` files
- Remove the Sphinx directives for configuration
- Generate samples automatically.
- Improve samples. Add `Samples` and put the functionality to get minimal and full samples on there. Merge `minimal` and `full` into a new `SampleSize` where the items have numerical values that we can sort on. Add a third option 'intermediate` which is the default for any sample.
- https://github.com/bartfeenstra/betty/issues/3217