### PR TITLE
Revert "Use pytest-xdist"

### DIFF
--- a/bin/test-pytest.py
+++ b/bin/test-pytest.py
@@ -11,7 +11,7 @@ print("Running pytest...")  # noqa: T201
 
 check_call(["coverage", "erase"])
 check_call(
-    ["coverage", "run", "--module", "pytest", "-n", "auto", *sys.argv[1:]],
+    ["coverage", "run", "--module", "pytest", *sys.argv[1:]],
     env={
         **environ,
         "COVERAGE_PROCESS_START": path.join(getcwd(), ".coveragerc"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -266,7 +266,6 @@ test = [
     'pytest-asyncio ~= 1.0',
     'pytest-mock ~= 3.14',
     'pytest-playwright-asyncio ~= 0.7.0',
-    'pytest-xdist ~= 3.8',
     'requests ~= 2.32',
     'ruff ~= 0.14.0',
     'types-aiofiles ~= 25.1',


### PR DESCRIPTION
Reverts bartfeenstra/betty#3451

We've got too many random multiprocessing-related errors during test builds.