### PR TITLE
Use `__set_name__()` to automatically set entity association attribute names

### DIFF
--- a/betty/ancestry/citation.py
+++ b/betty/ancestry/citation.py
@@ -53,8 +53,6 @@ class Citation(HasDate, HasFileReferences, HasPrivacy, HasLinks):
     """
 
     facts = BidirectionalToManyMultipleTypes["Citation", "HasCitations"](
-        "betty.ancestry.citation:Citation",
-        "facts",
         "betty.ancestry.has_citations:HasCitations",
         "citations",
         title="Facts",
@@ -65,8 +63,6 @@ class Citation(HasDate, HasFileReferences, HasPrivacy, HasLinks):
     """
 
     source = BidirectionalToOne["Citation", Source](
-        "betty.ancestry.citation:Citation",
-        "source",
         "betty.ancestry.source:Source",
         "citations",
         title="Source",

--- a/betty/ancestry/enclosure.py
+++ b/betty/ancestry/enclosure.py
@@ -30,10 +30,8 @@ class Enclosure(HasDate, HasCitations, Entity):
     """
 
     encloser = BidirectionalToOne["Enclosure", "Place"](
-        "betty.ancestry.enclosure:Enclosure",
-        "encloser",
         "betty.ancestry.place:Place",
-        "enclosee",
+        "enclosees",
         title="Encloser",
         description="The place that encloses or contains the enclosee",
     )
@@ -42,10 +40,8 @@ class Enclosure(HasDate, HasCitations, Entity):
     """
 
     enclosee = BidirectionalToOne["Enclosure", "Place"](
-        "betty.ancestry.enclosure:Enclosure",
-        "enclosee",
         "betty.ancestry.place:Place",
-        "encloser",
+        "enclosers",
         title="Enclosee",
         description="The place that is enclosed or contained by the encloser",
     )

--- a/betty/ancestry/event.py
+++ b/betty/ancestry/event.py
@@ -75,8 +75,6 @@ class Event(
     """
 
     place = BidirectionalToZeroOrOne["Event", Place](
-        "betty.ancestry.event:Event",
-        "place",
         "betty.ancestry.place:Place",
         "events",
         title="Place",
@@ -86,8 +84,6 @@ class Event(
     The place the event happened.
     """
     presences = BidirectionalToManySingleType["Event", Presence](
-        "betty.ancestry.event:Event",
-        "presences",
         "betty.ancestry.presence:Presence",
         "event",
         title="Presences",

--- a/betty/ancestry/file.py
+++ b/betty/ancestry/file.py
@@ -58,8 +58,6 @@ class File(
     """
 
     referees = BidirectionalToManyMultipleTypes["File", "FileReference"](
-        "betty.ancestry.file:File",
-        "referees",
         "betty.ancestry.file_reference:FileReference",
         "file",
         title="Referees",

--- a/betty/ancestry/file_reference.py
+++ b/betty/ancestry/file_reference.py
@@ -30,8 +30,6 @@ class FileReference(Entity):
     """
 
     referee = BidirectionalToOne["FileReference", "HasFileReferences"](
-        "betty.ancestry.file_reference:FileReference",
-        "referee",
         "betty.ancestry.has_file_references:HasFileReferences",
         "file_references",
         title="Referee",
@@ -42,8 +40,6 @@ class FileReference(Entity):
     """
 
     file = BidirectionalToOne["FileReference", File](
-        "betty.ancestry.file_reference:FileReference",
-        "file",
         "betty.ancestry.file:File",
         "referees",
         title="File",

--- a/betty/ancestry/has_citations.py
+++ b/betty/ancestry/has_citations.py
@@ -19,8 +19,6 @@ class HasCitations(Entity):
     """
 
     citations = BidirectionalToManySingleType["HasCitations", "Citation"](
-        "betty.ancestry.has_citations:HasCitations",
-        "citations",
         "betty.ancestry.citation:Citation",
         "facts",
         title="Citations",

--- a/betty/ancestry/has_file_references.py
+++ b/betty/ancestry/has_file_references.py
@@ -21,8 +21,6 @@ class HasFileReferences(Entity):
     file_references = BidirectionalToManySingleType[
         "HasFileReferences", "FileReference"
     ](
-        "betty.ancestry.has_file_references:HasFileReferences",
-        "file_references",
         "betty.ancestry.file_reference:FileReference",
         "referee",
         title="File references",

--- a/betty/ancestry/has_links.py
+++ b/betty/ancestry/has_links.py
@@ -19,8 +19,6 @@ class HasLinks(Entity):
     """
 
     links = BidirectionalToManySingleType["HasLinks", "Link"](
-        "betty.ancestry.has_links:HasLinks",
-        "links",
         "betty.ancestry.link:Link",
         "owner",
         title="Links",

--- a/betty/ancestry/has_notes.py
+++ b/betty/ancestry/has_notes.py
@@ -17,8 +17,6 @@ class HasNotes(Entity):
     """
 
     notes = BidirectionalToManySingleType["HasNotes", Note](
-        "betty.ancestry.has_notes:HasNotes",
-        "notes",
         "betty.ancestry.note:Note",
         "entity",
         title="Notes",

--- a/betty/ancestry/link.py
+++ b/betty/ancestry/link.py
@@ -53,8 +53,6 @@ class Link(HasMediaType, HasDescription, HasPrivacy, Entity):
     """
 
     owner = BidirectionalToZeroOrOne["Link", "HasLinks"](
-        "betty.ancestry.link:Link",
-        "owner",
         "betty.ancestry.has_links:HasLinks",
         "links",
         title="Owner",

--- a/betty/ancestry/note.py
+++ b/betty/ancestry/note.py
@@ -44,8 +44,6 @@ class Note(HasPrivacy, HasLinks, HasMediaType):
     """
 
     entity = BidirectionalToZeroOrOne["Note", "HasNotes"](
-        "betty.ancestry.note:Note",
-        "entity",
         "betty.ancestry.has_notes:HasNotes",
         "notes",
         title="Entity",

--- a/betty/ancestry/person.py
+++ b/betty/ancestry/person.py
@@ -53,8 +53,6 @@ class Person(HasFileReferences, HasCitations, HasNotes, HasLinks, HasPrivacy):
 
     parents = BidirectionalToManySingleType["Person", "Person"](
         "betty.ancestry.person:Person",
-        "parents",
-        "betty.ancestry.person:Person",
         "children",
         title="Parents",
     )
@@ -64,8 +62,6 @@ class Person(HasFileReferences, HasCitations, HasNotes, HasLinks, HasPrivacy):
 
     children = BidirectionalToManySingleType["Person", "Person"](
         "betty.ancestry.person:Person",
-        "children",
-        "betty.ancestry.person:Person",
         "parents",
         title="Children",
     )
@@ -74,8 +70,6 @@ class Person(HasFileReferences, HasCitations, HasNotes, HasLinks, HasPrivacy):
     """
 
     presences = BidirectionalToManySingleType["Person", "Presence"](
-        "betty.ancestry.person:Person",
-        "presences",
         "betty.ancestry.presence:Presence",
         "person",
         title="Presences",
@@ -87,8 +81,6 @@ class Person(HasFileReferences, HasCitations, HasNotes, HasLinks, HasPrivacy):
     """
 
     names = BidirectionalToManySingleType["Person", "PersonName"](
-        "betty.ancestry.person:Person",
-        "names",
         "betty.ancestry.person_name:PersonName",
         "person",
         title="Names",

--- a/betty/ancestry/person_name.py
+++ b/betty/ancestry/person_name.py
@@ -40,8 +40,6 @@ class PersonName(HasLocale, HasCitations, HasPrivacy, Entity):
     """
 
     person = BidirectionalToOne["PersonName", "Person"](
-        "betty.ancestry.person_name:PersonName",
-        "person",
         "betty.ancestry.person:Person",
         "names",
         title="Person",

--- a/betty/ancestry/place.py
+++ b/betty/ancestry/place.py
@@ -50,8 +50,6 @@ class Place(HasLinks, HasFileReferences, HasNotes, HasPrivacy):
     """
 
     events = BidirectionalToManySingleType["Place", "Event"](
-        "betty.ancestry.place:Place",
-        "events",
         "betty.ancestry.event:Event",
         "place",
         title="Events",
@@ -62,8 +60,6 @@ class Place(HasLinks, HasFileReferences, HasNotes, HasPrivacy):
     """
 
     enclosers = BidirectionalToManySingleType["Place", "Enclosure"](
-        "betty.ancestry.place:Place",
-        "encloser",
         "betty.ancestry.enclosure:Enclosure",
         "enclosee",
         title="Enclosers",
@@ -75,8 +71,6 @@ class Place(HasLinks, HasFileReferences, HasNotes, HasPrivacy):
     """
 
     enclosees = BidirectionalToManySingleType["Place", "Enclosure"](
-        "betty.ancestry.place:Place",
-        "enclosee",
         "betty.ancestry.enclosure:Enclosure",
         "encloser",
         title="Enclosees",

--- a/betty/ancestry/presence.py
+++ b/betty/ancestry/presence.py
@@ -40,8 +40,6 @@ class Presence(HasPrivacy, Entity):
     """
 
     person = BidirectionalToOne["Presence", "Person"](
-        "betty.ancestry.presence:Presence",
-        "person",
         "betty.ancestry.person:Person",
         "presences",
         title="Person",
@@ -51,8 +49,6 @@ class Presence(HasPrivacy, Entity):
     """
 
     event = BidirectionalToOne["Presence", "Event"](
-        "betty.ancestry.presence:Presence",
-        "event",
         "betty.ancestry.event:Event",
         "presences",
         title="Event",

--- a/betty/ancestry/source.py
+++ b/betty/ancestry/source.py
@@ -68,8 +68,6 @@ class Source(HasDate, HasFileReferences, HasNotes, HasLinks, HasPrivacy, Entity)
 
     contained_by = BidirectionalToZeroOrOne["Source", "Source"](
         "betty.ancestry.source:Source",
-        "contained_by",
-        "betty.ancestry.source:Source",
         "contains",
         title="Contained by",
         description="Another source this source may be contained by",
@@ -80,8 +78,6 @@ class Source(HasDate, HasFileReferences, HasNotes, HasLinks, HasPrivacy, Entity)
 
     contains = BidirectionalToManySingleType["Source", "Source"](
         "betty.ancestry.source:Source",
-        "contains",
-        "betty.ancestry.source:Source",
         "contained_by",
         title="Contains",
         description="Other sources this source may contain",
@@ -91,8 +87,6 @@ class Source(HasDate, HasFileReferences, HasNotes, HasLinks, HasPrivacy, Entity)
     """
 
     citations = BidirectionalToManySingleType["Source", "Citation"](
-        "betty.ancestry.source:Source",
-        "citations",
         "betty.ancestry.citation:Citation",
         "source",
         title="Citations",

--- a/betty/model/association.py
+++ b/betty/model/association.py
@@ -22,7 +22,7 @@ from urllib.parse import quote
 
 from typing_extensions import override
 
-from betty.importlib import import_any
+from betty.importlib import fully_qualified_name, import_any
 from betty.json.linked_data import LinkedDataDumpableProvider
 from betty.json.schema import Array, Null, OneOf, Schema
 from betty.model import Entity, persistent_id
@@ -64,7 +64,7 @@ class AssociationRequired(RuntimeError):
 
     def __init__(self, association: _Association[_OwnerT, Any], owner: _OwnerT, /):
         super().__init__(
-            f"Association {association._owner_type_name}.{association.owner_attr_name} is required, but missing for {owner}."
+            f"Association {fully_qualified_name(association.owner_type)}.{association.owner_attr_name} is required, but missing for {owner}."
         )
 
 
@@ -138,23 +138,27 @@ class TemporaryToManyResolver(
 
 
 class _Association(LinkedDataDumpableProvider[_OwnerT], Generic[_OwnerT, _AssociateT]):
+    _owner_type: type[_OwnerT]
+    _owner_attr_name: str
+    _internal_owner_attr_name: str
+
     def __init__(
         self,
-        owner_type_name: str,
-        owner_attr_name: str,
         associate_type_name: str,
         *,
         title: str | None = None,
         description: str | None = None,
         linked_data_embedded: bool = False,
     ):
-        self._owner_type_name = owner_type_name
-        self._owner_attr_name = owner_attr_name
-        self._internal_owner_attr_name = f"_{owner_attr_name}"
         self._associate_type_name = associate_type_name
         self._linked_data_embedded = linked_data_embedded
         self._title = title
         self._description = description
+
+    def __set_name__(self, owner: type[_OwnerT], name: str) -> None:
+        self._owner_type = owner
+        self._owner_attr_name = name
+        self._internal_owner_attr_name = f"_{name}"
         AssociationRegistry._register(self)
 
     @override
@@ -162,7 +166,7 @@ class _Association(LinkedDataDumpableProvider[_OwnerT], Generic[_OwnerT, _Associ
         return hash(
             (
                 type(self),
-                self._owner_type_name,
+                self._owner_type,
                 self._owner_attr_name,
                 self._associate_type_name,
                 self._linked_data_embedded,
@@ -178,10 +182,7 @@ class _Association(LinkedDataDumpableProvider[_OwnerT], Generic[_OwnerT, _Associ
 
         This may be an abstract class.
         """
-        return cast(
-            "type[_OwnerT]",
-            import_any(self._owner_type_name),
-        )
+        return self._owner_type
 
     @property
     def owner_attr_name(self) -> str:
@@ -455,8 +456,6 @@ class _BidirectionalAssociation(
 ):
     def __init__(
         self,
-        owner_type_name: str,
-        owner_attr_name: str,
         associate_type_name: str,
         associate_attr_name: str,
         *,
@@ -466,8 +465,6 @@ class _BidirectionalAssociation(
     ):
         self._associate_attr_name = associate_attr_name
         super().__init__(
-            owner_type_name,
-            owner_attr_name,
             associate_type_name,
             title=title,
             description=description,
@@ -704,7 +701,7 @@ class AssociationRegistry:
             if association.owner_attr_name == owner_attr_name:
                 return association
         raise ValueError(
-            f"No association exists for {owner if isinstance(owner, type) else owner.__class__}.{owner_attr_name}."
+            f"No association exists for {fully_qualified_name(owner if isinstance(owner, type) else type(owner))}.{owner_attr_name}."
         )
 
     @classmethod

--- a/betty/tests/ancestry/test___init__.py
+++ b/betty/tests/ancestry/test___init__.py
@@ -38,8 +38,6 @@ class _TestAncestry_OneToOne_Left(Entity):
     one_right = BidirectionalToZeroOrOne[
         "_TestAncestry_OneToOne_Left", "_TestAncestry_OneToOne_Right"
     ](
-        "betty.tests.ancestry.test___init__:_TestAncestry_OneToOne_Left",
-        "one_right",
         "betty.tests.ancestry.test___init__:_TestAncestry_OneToOne_Right",
         "one_left",
     )
@@ -55,8 +53,6 @@ class _TestAncestry_OneToOne_Right(Entity):
     one_left = BidirectionalToZeroOrOne[
         "_TestAncestry_OneToOne_Right", _TestAncestry_OneToOne_Left
     ](
-        "betty.tests.ancestry.test___init__:_TestAncestry_OneToOne_Right",
-        "one_left",
         "betty.tests.ancestry.test___init__:_TestAncestry_OneToOne_Left",
         "one_right",
     )

--- a/betty/tests/model/test_association.py
+++ b/betty/tests/model/test_association.py
@@ -74,21 +74,13 @@ class TestAssociationRegistry:
         base_associate = UnidirectionalToZeroOrOne[
             "TestAssociationRegistry._OwnerBase",
             "TestAssociationRegistry._Associate",
-        ](
-            "betty.tests.model.test_association:TestAssociationRegistry._OwnerBase",
-            "base_associate",
-            "betty.tests.model.test_association:TestAssociationRegistry._Associate",
-        )
+        ]("betty.tests.model.test_association:TestAssociationRegistry._Associate")
 
     class _Owner(_OwnerBase):
         associate = UnidirectionalToZeroOrOne[
             "TestAssociationRegistry._Owner",
             "TestAssociationRegistry._Associate",
-        ](
-            "betty.tests.model.test_association:TestAssociationRegistry._Owner",
-            "associate",
-            "betty.tests.model.test_association:TestAssociationRegistry._Associate",
-        )
+        ]("betty.tests.model.test_association:TestAssociationRegistry._Associate")
 
     class _Associate(Entity):
         pass
@@ -187,8 +179,6 @@ class TestUnidirectionalToZeroOrOne:
             "TestUnidirectionalToZeroOrOne._Owner",
             "TestUnidirectionalToZeroOrOne._Associate",
         ](
-            "betty.tests.model.test_association:TestUnidirectionalToZeroOrOne._Owner",
-            "associate",
             "betty.tests.model.test_association:TestUnidirectionalToZeroOrOne._Associate",
         )
 
@@ -209,8 +199,6 @@ class TestUnidirectionalToZeroOrOne:
             "TestUnidirectionalToZeroOrOne._OwnerEmbedded",
             "TestUnidirectionalToZeroOrOne._Associate",
         ](
-            "betty.tests.model.test_association:TestUnidirectionalToZeroOrOne._OwnerEmbedded",
-            "associate",
             "betty.tests.model.test_association:TestUnidirectionalToZeroOrOne._Associate",
             linked_data_embedded=True,
         )
@@ -234,9 +222,7 @@ class TestUnidirectionalToZeroOrOne:
             "TestUnidirectionalToZeroOrOne._OwnerWithNonPublicFacingAssociate",
             "TestUnidirectionalToZeroOrOne._NonPublicFacingAssociate",
         ](
-            "betty.tests.model.test_association:TestUnidirectionalToZeroOrOne._OwnerWithNonPublicFacingAssociate",
-            "associate",
-            "betty.tests.model.test_association:TestUnidirectionalToZeroOrOne._NonPublicFacingAssociate",
+            "betty.tests.model.test_association:TestUnidirectionalToZeroOrOne._NonPublicFacingAssociate"
         )
 
     @EntityDefinition(
@@ -381,8 +367,6 @@ class TestBidirectionalToZeroOrOne:
             "TestBidirectionalToZeroOrOne._Owner",
             "TestBidirectionalToZeroOrOne._Associate",
         ](
-            "betty.tests.model.test_association:TestBidirectionalToZeroOrOne._Owner",
-            "associate",
             "betty.tests.model.test_association:TestBidirectionalToZeroOrOne._Associate",
             "owner",
         )
@@ -405,8 +389,6 @@ class TestBidirectionalToZeroOrOne:
             "TestBidirectionalToZeroOrOne._OwnerEmbedded",
             "TestBidirectionalToZeroOrOne._Associate",
         ](
-            "betty.tests.model.test_association:TestBidirectionalToZeroOrOne._OwnerEmbedded",
-            "associate",
             "betty.tests.model.test_association:TestBidirectionalToZeroOrOne._Associate",
             "owner",
             linked_data_embedded=True,
@@ -431,8 +413,6 @@ class TestBidirectionalToZeroOrOne:
             "TestBidirectionalToZeroOrOne._OwnerWithNonPublicFacingAssociate",
             "TestBidirectionalToZeroOrOne._NonPublicFacingAssociate",
         ](
-            "betty.tests.model.test_association:TestBidirectionalToZeroOrOne._OwnerWithNonPublicFacingAssociate",
-            "associate",
             "betty.tests.model.test_association:TestBidirectionalToZeroOrOne._NonPublicFacingAssociate",
             "owner",
         )
@@ -448,8 +428,6 @@ class TestBidirectionalToZeroOrOne:
             "TestBidirectionalToZeroOrOne._Associate",
             "TestBidirectionalToZeroOrOne._Owner",
         ](
-            "betty.tests.model.test_association:TestBidirectionalToZeroOrOne._Associate",
-            "owner",
             "betty.tests.model.test_association:TestBidirectionalToZeroOrOne._Owner",
             "associate",
         )
@@ -466,8 +444,6 @@ class TestBidirectionalToZeroOrOne:
             "TestBidirectionalToZeroOrOne._NonPublicFacingAssociate",
             "TestBidirectionalToZeroOrOne._OwnerWithNonPublicFacingAssociate",
         ](
-            "betty.tests.model.test_association:TestBidirectionalToZeroOrOne._NonPublicFacingAssociate",
-            "owner",
             "betty.tests.model.test_association:TestBidirectionalToZeroOrOne._OwnerWithNonPublicFacingAssociate",
             "associate",
         )
@@ -597,8 +573,6 @@ class TestUnidirectionalToOne:
         associate = UnidirectionalToOne[
             "TestUnidirectionalToOne._Owner", "TestUnidirectionalToOne._Associate"
         ](
-            "betty.tests.model.test_association:TestUnidirectionalToOne._Owner",
-            "associate",
             "betty.tests.model.test_association:TestUnidirectionalToOne._Associate",
         )
 
@@ -617,8 +591,6 @@ class TestUnidirectionalToOne:
             "TestUnidirectionalToOne._OwnerEmbedded",
             "TestUnidirectionalToOne._Associate",
         ](
-            "betty.tests.model.test_association:TestUnidirectionalToOne._OwnerEmbedded",
-            "associate",
             "betty.tests.model.test_association:TestUnidirectionalToOne._Associate",
             linked_data_embedded=True,
         )
@@ -640,9 +612,7 @@ class TestUnidirectionalToOne:
             "TestUnidirectionalToOne._OwnerWithNonPublicFacingAssociate",
             "TestUnidirectionalToOne._NonPublicFacingAssociate",
         ](
-            "betty.tests.model.test_association:TestUnidirectionalToOne._OwnerWithNonPublicFacingAssociate",
-            "associate",
-            "betty.tests.model.test_association:TestUnidirectionalToOne._NonPublicFacingAssociate",
+            "betty.tests.model.test_association:TestUnidirectionalToOne._NonPublicFacingAssociate"
         )
 
     @EntityDefinition(
@@ -744,8 +714,6 @@ class TestBidirectionalToOne:
         associate = BidirectionalToOne[
             "TestBidirectionalToOne._Owner", "TestBidirectionalToOne._Associate"
         ](
-            "betty.tests.model.test_association:TestBidirectionalToOne._Owner",
-            "associate",
             "betty.tests.model.test_association:TestBidirectionalToOne._Associate",
             "owner",
         )
@@ -760,8 +728,6 @@ class TestBidirectionalToOne:
         owner = BidirectionalToZeroOrOne[
             "TestBidirectionalToOne._Associate", "TestBidirectionalToOne._Owner"
         ](
-            "betty.tests.model.test_association:TestBidirectionalToOne._Associate",
-            "owner",
             "betty.tests.model.test_association:TestBidirectionalToOne._Owner",
             "associate",
         )
@@ -781,8 +747,6 @@ class TestBidirectionalToOne:
             "TestBidirectionalToOne._OwnerEmbedded",
             "TestBidirectionalToOne._AssociateEmbedded",
         ](
-            "betty.tests.model.test_association:TestBidirectionalToOne._OwnerEmbedded",
-            "associate",
             "betty.tests.model.test_association:TestBidirectionalToOne._AssociateEmbedded",
             "owner",
             linked_data_embedded=True,
@@ -799,8 +763,6 @@ class TestBidirectionalToOne:
             "TestBidirectionalToOne._AssociateEmbedded",
             "TestBidirectionalToOne._OwnerEmbedded",
         ](
-            "betty.tests.model.test_association:TestBidirectionalToOne._AssociateEmbedded",
-            "owner",
             "betty.tests.model.test_association:TestBidirectionalToOne._OwnerEmbedded",
             "associate",
         )
@@ -820,8 +782,6 @@ class TestBidirectionalToOne:
             "TestBidirectionalToOne._OwnerWithNonPublicFacingAssociate",
             "TestBidirectionalToOne._NonPublicFacingAssociate",
         ](
-            "betty.tests.model.test_association:TestBidirectionalToOne._OwnerWithNonPublicFacingAssociate",
-            "associate",
             "betty.tests.model.test_association:TestBidirectionalToOne._NonPublicFacingAssociate",
             "owner",
         )
@@ -838,8 +798,6 @@ class TestBidirectionalToOne:
             "TestBidirectionalToOne._NonPublicFacingAssociate",
             "TestBidirectionalToOne._OwnerWithNonPublicFacingAssociate",
         ](
-            "betty.tests.model.test_association:TestBidirectionalToOne._NonPublicFacingAssociate",
-            "owner",
             "betty.tests.model.test_association:TestBidirectionalToOne._OwnerWithNonPublicFacingAssociate",
             "associate",
         )
@@ -921,9 +879,7 @@ class TestUnidirectionalToManySingleType:
             "TestUnidirectionalToManySingleType._Owner",
             "TestUnidirectionalToManySingleType._Associate",
         ](
-            "betty.tests.model.test_association:TestUnidirectionalToManySingleType._Owner",
-            "associates",
-            "betty.tests.model.test_association:TestUnidirectionalToManySingleType._Associate",
+            "betty.tests.model.test_association:TestUnidirectionalToManySingleType._Associate"
         )
 
     @EntityDefinition(
@@ -937,8 +893,6 @@ class TestUnidirectionalToManySingleType:
             "TestUnidirectionalToManySingleType._OwnerEmbedded",
             "TestUnidirectionalToManySingleType._Associate",
         ](
-            "betty.tests.model.test_association:TestUnidirectionalToManySingleType._OwnerEmbedded",
-            "associates",
             "betty.tests.model.test_association:TestUnidirectionalToManySingleType._Associate",
             linked_data_embedded=True,
         )
@@ -1036,71 +990,52 @@ class TestUnidirectionalToManySingleType:
             assert actual == expected
 
 
-class _TestUnidirectionalToManyMultipleTypesOwner(Entity):
-    pass
-
-
-class _TestUnidirectionalToManyMultipleTypesTargetMixin(Entity):
-    owner = UnidirectionalToZeroOrOne[
-        "_TestUnidirectionalToManyMultipleTypesTargetMixin",
-        _TestUnidirectionalToManyMultipleTypesOwner,
-    ](
-        f"{__name__}:_TestUnidirectionalToManyMultipleTypesTargetMixin",
-        "owner",
-        f"{__name__}:{_TestUnidirectionalToManyMultipleTypesOwner.__name__}",
-        title="Owner",
-    )
-
-
-@EntityDefinition(
-    "one",
-    label=DUMMY_LOCALIZABLE,
-    label_plural=DUMMY_LOCALIZABLE,
-    label_countable=DUMMY_COUNTABLE_LOCALIZABLE,
-)
-class _TestUnidirectionalToManyMultipleTypesAssociateOne(
-    _TestUnidirectionalToManyMultipleTypesTargetMixin, Entity
-):
-    pass
-
-
-@EntityDefinition(
-    "two",
-    label=DUMMY_LOCALIZABLE,
-    label_plural=DUMMY_LOCALIZABLE,
-    label_countable=DUMMY_COUNTABLE_LOCALIZABLE,
-)
-class _TestUnidirectionalToManyMultipleTypesAssociateTwo(
-    _TestUnidirectionalToManyMultipleTypesTargetMixin, Entity
-):
-    pass
-
-
-class _TestUnidirectionalToManyMultipleTypesAssociateUnknown(Entity):
-    pass
-
-
 class TestUnidirectionalToManyMultipleTypes:
-    async def test_support_multiple_types(self) -> None:
-        sut = UnidirectionalToManyMultipleTypes[
-            _TestUnidirectionalToManyMultipleTypesOwner,
-            _TestUnidirectionalToManyMultipleTypesTargetMixin,
+    class _Owner(Entity):
+        associates = UnidirectionalToManyMultipleTypes[
+            "TestUnidirectionalToManyMultipleTypes._Owner",
+            "TestUnidirectionalToManyMultipleTypes._TargetMixin",
         ](
-            f"{_TestUnidirectionalToManyMultipleTypesOwner.__module__}:{_TestUnidirectionalToManyMultipleTypesOwner.__name__}",
-            "associates",
-            f"{_TestUnidirectionalToManyMultipleTypesTargetMixin.__module__}:{_TestUnidirectionalToManyMultipleTypesTargetMixin.__name__}",
+            "betty.tests.model.test_association:TestUnidirectionalToManyMultipleTypes._TargetMixin"
         )
 
-        owner = _TestUnidirectionalToManyMultipleTypesOwner()
-        associates = sut.__get__(owner, type(owner))
+    class _TargetMixin(Entity):
+        owner = UnidirectionalToZeroOrOne[
+            "TestUnidirectionalToManyMultipleTypes._TargetMixin",
+            "TestUnidirectionalToManyMultipleTypes._Owner",
+        ](
+            "betty.tests.model.test_association:TestUnidirectionalToManyMultipleTypes._Owner",
+            title="Owner",
+        )
 
-        associate_one = _TestUnidirectionalToManyMultipleTypesAssociateOne()
-        associate_two = _TestUnidirectionalToManyMultipleTypesAssociateTwo()
-        associates.add(associate_one, associate_two)
-        associates_one = associates[_TestUnidirectionalToManyMultipleTypesAssociateOne]
+    @EntityDefinition(
+        "one",
+        label=DUMMY_LOCALIZABLE,
+        label_plural=DUMMY_LOCALIZABLE,
+        label_countable=DUMMY_COUNTABLE_LOCALIZABLE,
+    )
+    class _AssociateOne(_TargetMixin):
+        pass
+
+    @EntityDefinition(
+        "two",
+        label=DUMMY_LOCALIZABLE,
+        label_plural=DUMMY_LOCALIZABLE,
+        label_countable=DUMMY_COUNTABLE_LOCALIZABLE,
+    )
+    class _AssociateTwo(_TargetMixin):
+        pass
+
+    async def test_support_multiple_types(self) -> None:
+        owner = self._Owner()
+
+        associate_one = self._AssociateOne()
+        associate_two = self._AssociateTwo()
+        owner.associates.add(associate_one, associate_two)
+        associates_one = owner.associates[self._AssociateOne]
         assert associate_one in associates_one
         assert associate_two not in associates_one
-        associates_two = associates[_TestUnidirectionalToManyMultipleTypesAssociateTwo]
+        associates_two = owner.associates[self._AssociateTwo]
         assert associate_one not in associates_two
         assert associate_two in associates_two
 
@@ -1117,8 +1052,6 @@ class TestBidirectionalToManySingleType:
             "TestBidirectionalToManySingleType._Owner",
             "TestBidirectionalToManySingleType._Associate",
         ](
-            "betty.tests.model.test_association:TestBidirectionalToManySingleType._Owner",
-            "associates",
             "betty.tests.model.test_association:TestBidirectionalToManySingleType._Associate",
             "owner",
         )
@@ -1134,8 +1067,6 @@ class TestBidirectionalToManySingleType:
             "TestBidirectionalToManySingleType._Associate",
             "TestBidirectionalToManySingleType._Owner",
         ](
-            "betty.tests.model.test_association:TestBidirectionalToManySingleType._Associate",
-            "owner",
             "betty.tests.model.test_association:TestBidirectionalToManySingleType._Owner",
             "associates",
         )
@@ -1151,8 +1082,6 @@ class TestBidirectionalToManySingleType:
             "TestBidirectionalToManySingleType._OwnerEmbedded",
             "TestBidirectionalToManySingleType._AssociateEmbedded",
         ](
-            "betty.tests.model.test_association:TestBidirectionalToManySingleType._OwnerEmbedded",
-            "associates",
             "betty.tests.model.test_association:TestBidirectionalToManySingleType._AssociateEmbedded",
             "owner",
             linked_data_embedded=True,
@@ -1169,8 +1098,6 @@ class TestBidirectionalToManySingleType:
             "TestBidirectionalToManySingleType._AssociateEmbedded",
             "TestBidirectionalToManySingleType._OwnerEmbedded",
         ](
-            "betty.tests.model.test_association:TestBidirectionalToManySingleType._AssociateEmbedded",
-            "owner",
             "betty.tests.model.test_association:TestBidirectionalToManySingleType._OwnerEmbedded",
             "associates",
         )
@@ -1196,8 +1123,6 @@ class TestBidirectionalToManySingleType:
             "TestBidirectionalToManySingleType._OwnerWithNonPublicFacingAssociate",
             "TestBidirectionalToManySingleType._NonPublicFacingAssociate",
         ](
-            "betty.tests.model.test_association:TestBidirectionalToManySingleType._OwnerWithNonPublicFacingAssociate",
-            "associates",
             "betty.tests.model.test_association:TestBidirectionalToManySingleType._NonPublicFacingAssociate",
             "owner",
         )
@@ -1214,8 +1139,6 @@ class TestBidirectionalToManySingleType:
             "TestBidirectionalToManySingleType._NonPublicFacingAssociate",
             "TestBidirectionalToManySingleType._OwnerWithNonPublicFacingAssociate",
         ](
-            "betty.tests.model.test_association:TestBidirectionalToManySingleType._NonPublicFacingAssociate",
-            "owner",
             "betty.tests.model.test_association:TestBidirectionalToManySingleType._OwnerWithNonPublicFacingAssociate",
             "associates",
         )
@@ -1332,73 +1255,54 @@ class TestBidirectionalToManySingleType:
             assert actual == expected
 
 
-class _TestBidirectionalToManyMultipleTypesOwner(Entity):
-    pass
-
-
-class _TestBidirectionalToManyMultipleTypesTargetMixin(Entity):
-    owner = BidirectionalToZeroOrOne[
-        "_TestBidirectionalToManyMultipleTypesTargetMixin",
-        _TestBidirectionalToManyMultipleTypesOwner,
-    ](
-        f"{__name__}:_TestBidirectionalToManyMultipleTypesTargetMixin",
-        "owner",
-        f"{__name__}:{_TestBidirectionalToManyMultipleTypesOwner.__name__}",
-        "associates",
-        title="Owner",
-    )
-
-
-@EntityDefinition(
-    "one",
-    label=DUMMY_LOCALIZABLE,
-    label_plural=DUMMY_LOCALIZABLE,
-    label_countable=DUMMY_COUNTABLE_LOCALIZABLE,
-)
-class _TestBidirectionalToManyMultipleTypesAssociateOne(
-    _TestBidirectionalToManyMultipleTypesTargetMixin, Entity
-):
-    pass
-
-
-@EntityDefinition(
-    "two",
-    label=DUMMY_LOCALIZABLE,
-    label_plural=DUMMY_LOCALIZABLE,
-    label_countable=DUMMY_COUNTABLE_LOCALIZABLE,
-)
-class _TestBidirectionalToManyMultipleTypesAssociateTwo(
-    _TestBidirectionalToManyMultipleTypesTargetMixin, Entity
-):
-    pass
-
-
-class _TestBidirectionalToManyMultipleTypesAssociateUnknown(Entity):
-    pass
-
-
 class TestBidirectionalToManyMultipleTypes:
-    async def test_support_multiple_types(self) -> None:
-        sut = BidirectionalToManyMultipleTypes[
-            _TestBidirectionalToManyMultipleTypesOwner,
-            _TestBidirectionalToManyMultipleTypesTargetMixin,
+    class _Owner(Entity):
+        associates = BidirectionalToManyMultipleTypes[
+            "TestBidirectionalToManyMultipleTypes._Owner",
+            "TestBidirectionalToManyMultipleTypes._TargetMixin",
         ](
-            f"{_TestBidirectionalToManyMultipleTypesOwner.__module__}:{_TestBidirectionalToManyMultipleTypesOwner.__name__}",
-            "associates",
-            f"{_TestBidirectionalToManyMultipleTypesTargetMixin.__module__}:{_TestBidirectionalToManyMultipleTypesTargetMixin.__name__}",
+            "betty.tests.model.test_association:TestBidirectionalToManyMultipleTypes._TargetMixin",
             "owner",
         )
 
-        owner = _TestBidirectionalToManyMultipleTypesOwner()
-        associates = sut.__get__(owner, type(owner))
+    class _TargetMixin(Entity):
+        owner = BidirectionalToZeroOrOne[
+            "TestBidirectionalToManyMultipleTypes._TargetMixin",
+            "TestBidirectionalToManyMultipleTypes._Owner",
+        ](
+            "betty.tests.model.test_association:TestBidirectionalToManyMultipleTypes._Owner",
+            "associates",
+            title="Owner",
+        )
 
-        associate_one = _TestBidirectionalToManyMultipleTypesAssociateOne()
-        associate_two = _TestBidirectionalToManyMultipleTypesAssociateTwo()
-        associates.add(associate_one, associate_two)
-        associates_one = associates[_TestBidirectionalToManyMultipleTypesAssociateOne]
+    @EntityDefinition(
+        "one",
+        label=DUMMY_LOCALIZABLE,
+        label_plural=DUMMY_LOCALIZABLE,
+        label_countable=DUMMY_COUNTABLE_LOCALIZABLE,
+    )
+    class _AssociateOne(_TargetMixin):
+        pass
+
+    @EntityDefinition(
+        "two",
+        label=DUMMY_LOCALIZABLE,
+        label_plural=DUMMY_LOCALIZABLE,
+        label_countable=DUMMY_COUNTABLE_LOCALIZABLE,
+    )
+    class _AssociateTwo(_TargetMixin):
+        pass
+
+    async def test_support_multiple_types(self) -> None:
+        owner = self._Owner()
+
+        associate_one = self._AssociateOne()
+        associate_two = self._AssociateTwo()
+        owner.associates.add(associate_one, associate_two)
+        associates_one = owner.associates[self._AssociateOne]
         assert associate_one in associates_one
         assert associate_two not in associates_one
-        associates_two = associates[_TestBidirectionalToManyMultipleTypesAssociateTwo]
+        associates_two = owner.associates[self._AssociateTwo]
         assert associate_one not in associates_two
         assert associate_two in associates_two
 
@@ -1407,11 +1311,7 @@ class TestAssociationRequired:
     class _Owner(Entity):
         associate = UnidirectionalToOne[
             "TestAssociationRequired._Owner", "TestAssociationRequired._Associate"
-        ](
-            "betty.tests.model.test_association:TestAssociationRequired._Owner",
-            "associate",
-            "betty.tests.model.test_association:TestAssociationRequired._Associate",
-        )
+        ]("betty.tests.model.test_association:TestAssociationRequired._Associate")
 
     class _Associate(Entity):
         pass


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/3528