### PR TITLE
Refactor `SectionConfiguration` to data definitions

### DIFF
--- a/betty/content_provider/content_providers.py
+++ b/betty/content_provider/content_providers.py
@@ -289,7 +289,7 @@ class BoxConfiguration(Configuration):
                     PluginInstanceConfiguration(
                         Render, RenderConfiguration("Hello, world!")
                     )
-                ],  # ty:ignore[invalid-argument-type]
+                ],
                 min_height="100px",
                 max_height="1000px",
                 height="500px",

--- a/betty/plugin/config/__init__.py
+++ b/betty/plugin/config/__init__.py
@@ -21,7 +21,7 @@ from betty.config import Configuration
 from betty.config.collections import ConfigurationCollection, ConfigurationKey
 from betty.config.collections.mapping import ConfigurationMapping
 from betty.config.collections.sequence import ConfigurationSequence
-from betty.data import Sample
+from betty.data import HasData, Sample
 from betty.data.sample import get_full_sample
 from betty.locale import DEFAULT_LOCALE
 from betty.locale.localizable.assertion import (
@@ -360,7 +360,7 @@ class PluginInstanceConfiguration(Configuration, Generic[_PluginDefinitionT, _Pl
     def __init__(
         self,
         id: ResolvableId[_PluginDefinitionT],  # noqa: A002
-        configuration: Configuration | PortableData | Void = Void(),  # noqa: B008
+        configuration: HasData | Configuration | PortableData | Void = Void(),  # noqa: B008
         /,
     ):
         super().__init__()
@@ -381,7 +381,7 @@ class PluginInstanceConfiguration(Configuration, Generic[_PluginDefinitionT, _Pl
         return self._id
 
     @property
-    def configuration(self) -> Configuration | PortableData | Void:
+    def configuration(self) -> HasData | Configuration | PortableData | Void:
         """
         Get the plugin's own configuration.
         """

--- a/betty/plugin/config/__init__.py
+++ b/betty/plugin/config/__init__.py
@@ -21,8 +21,10 @@ from betty.config import Configuration
 from betty.config.collections import ConfigurationCollection, ConfigurationKey
 from betty.config.collections.mapping import ConfigurationMapping
 from betty.config.collections.sequence import ConfigurationSequence
-from betty.config.color import ColorConfiguration
 from betty.data import Sample
+from betty.data.aggregate.record import FieldDefinition
+from betty.data.aggregate.record.object import ObjectDefinition
+from betty.data.indicator.selector import Attr
 from betty.data.sample import get_full_sample
 from betty.locale import DEFAULT_LOCALE
 from betty.locale.localizable.assertion import (
@@ -38,6 +40,7 @@ from betty.locale.localizable.ensure import (
     ensure_countable_localizable,
     ensure_localizable,
 )
+from betty.locale.localizable.gettext import _
 from betty.locale.localizable.portable import (
     dump_countable_localizable,
     dump_localizable,
@@ -45,6 +48,7 @@ from betty.locale.localizable.portable import (
 from betty.locale.localizable.static import CountableStaticTranslations
 from betty.machine_name import MachineName, assert_machine_name
 from betty.plugin import Plugin, PluginDefinition
+from betty.plugin.data import PluginIdDefinition
 from betty.plugin.resolve import ResolvableId, resolve_id
 from betty.typing import Void
 
@@ -352,11 +356,10 @@ class PluginDefinitionConfigurationMapping(
         return portable_item, cast(str, portable_item.pop("id"))  # ty:ignore[invalid-argument-type]
 
 
+@final
 class PluginInstanceConfiguration(Configuration, Generic[_PluginDefinitionT, _PluginT]):
     """
     Configure a single plugin instance.
-
-    .. configuration:: betty.plugin.config:PluginInstanceConfiguration
     """
 
     def __init__(
@@ -414,26 +417,22 @@ class PluginInstanceConfiguration(Configuration, Generic[_PluginDefinitionT, _Pl
             else configuration,
         }
 
-    @override
-    @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
-        from betty.project.extension.raspberry_mint import RaspberryMint
-        from betty.project.extension.raspberry_mint.config import (
-            RaspberryMintConfiguration,
-        )
 
-        yield Sample(
-            cls(RaspberryMint),
-            label="Minimal",
-            minimal=True,
-        )
-        yield Sample(
-            cls(
-                RaspberryMint,
-                RaspberryMintConfiguration(primary_color=ColorConfiguration("#ff0000")),
+@final
+class PluginInstanceConfigurationDefinition(ObjectDefinition):
+    """
+    Define :py:class:`betty.plugin.config.PluginInstanceConfiguration`.
+    """
+
+    def __init__(self, plugin_type: type[PluginDefinition], /):
+        super().__init__(
+            cls=PluginInstanceConfiguration,
+            label=_("{plugin_type} configuration").format(
+                plugin_type=plugin_type.type().label
             ),
-            label="Full",
-            full=True,
+            fields=[
+                FieldDefinition(Attr("id"), PluginIdDefinition(plugin_type)),
+            ],
         )
 
 
@@ -459,7 +458,7 @@ class _PluginInstanceConfigurationCollection(
         /,
     ):
         if isinstance(configurations, PluginInstanceConfiguration):
-            configurations = [configurations]  # ty:ignore[invalid-assignment]
+            configurations = [configurations]
         super().__init__(configurations)
 
     @override

--- a/betty/plugin/config/__init__.py
+++ b/betty/plugin/config/__init__.py
@@ -22,9 +22,6 @@ from betty.config.collections import ConfigurationCollection, ConfigurationKey
 from betty.config.collections.mapping import ConfigurationMapping
 from betty.config.collections.sequence import ConfigurationSequence
 from betty.data import Sample
-from betty.data.aggregate.record import FieldDefinition
-from betty.data.aggregate.record.object import ObjectDefinition
-from betty.data.indicator.selector import Attr
 from betty.data.sample import get_full_sample
 from betty.locale import DEFAULT_LOCALE
 from betty.locale.localizable.assertion import (
@@ -40,7 +37,6 @@ from betty.locale.localizable.ensure import (
     ensure_countable_localizable,
     ensure_localizable,
 )
-from betty.locale.localizable.gettext import _
 from betty.locale.localizable.portable import (
     dump_countable_localizable,
     dump_localizable,
@@ -48,7 +44,6 @@ from betty.locale.localizable.portable import (
 from betty.locale.localizable.static import CountableStaticTranslations
 from betty.machine_name import MachineName, assert_machine_name
 from betty.plugin import Plugin, PluginDefinition
-from betty.plugin.data import PluginIdDefinition
 from betty.plugin.resolve import ResolvableId, resolve_id
 from betty.typing import Void
 
@@ -416,24 +411,6 @@ class PluginInstanceConfiguration(Configuration, Generic[_PluginDefinitionT, _Pl
             if isinstance(configuration, Configuration)
             else configuration,
         }
-
-
-@final
-class PluginInstanceConfigurationDefinition(ObjectDefinition):
-    """
-    Define :py:class:`betty.plugin.config.PluginInstanceConfiguration`.
-    """
-
-    def __init__(self, plugin_type: type[PluginDefinition], /):
-        super().__init__(
-            cls=PluginInstanceConfiguration,
-            label=_("{plugin_type} configuration").format(
-                plugin_type=plugin_type.type().label
-            ),
-            fields=[
-                FieldDefinition(Attr("id"), PluginIdDefinition(plugin_type)),
-            ],
-        )
 
 
 ShorthandPluginInstanceConfigurationSequence: TypeAlias = (

--- a/betty/plugin/data.py
+++ b/betty/plugin/data.py
@@ -57,6 +57,9 @@ class PluginInstanceConfigurationDefinition(ObjectDefinition):
             ),
             fields=[
                 FieldDefinition(Attr("id"), PluginIdDefinition(plugin_type)),
-                FieldDefinition(Attr("configuration"), DataDefinition(cls=object, label=_("Plugin configuration"))),
+                FieldDefinition(
+                    Attr("configuration"),
+                    DataDefinition(cls=object, label=_("Plugin configuration")),
+                ),
             ],
         )

--- a/betty/plugin/data.py
+++ b/betty/plugin/data.py
@@ -9,9 +9,13 @@ from typing import TYPE_CHECKING, final
 from typing_extensions import override
 
 from betty.data import DataDefinition
+from betty.data.aggregate.record import FieldDefinition
+from betty.data.aggregate.record.object import ObjectDefinition
+from betty.data.indicator.selector import Attr
 from betty.functools import passthrough
 from betty.locale.localizable.gettext import _
 from betty.machine_name import MachineName, assert_machine_name
+from betty.plugin.config import PluginInstanceConfiguration
 from betty.portable import CallbackPorter
 
 if TYPE_CHECKING:
@@ -37,3 +41,22 @@ class PluginIdDefinition(DataDefinition[MachineName]):
     @override
     async def hydrate(self, data: MachineName, services: ServiceLevel, /) -> None:
         (await services.plugins(self._plugin_type)).get(data)
+
+
+@final
+class PluginInstanceConfigurationDefinition(ObjectDefinition):
+    """
+    Define :py:class:`betty.plugin.config.PluginInstanceConfiguration`.
+    """
+
+    def __init__(self, plugin_type: type[PluginDefinition], /):
+        super().__init__(
+            cls=PluginInstanceConfiguration,
+            label=_("{plugin_type} configuration").format(
+                plugin_type=plugin_type.type().label
+            ),
+            fields=[
+                FieldDefinition(Attr("id"), PluginIdDefinition(plugin_type)),
+                FieldDefinition(Attr("configuration"), DataDefinition(cls=object, label=_("Plugin configuration"))),
+            ],
+        )

--- a/betty/project/config.py
+++ b/betty/project/config.py
@@ -58,11 +58,10 @@ from betty.plugin.config import (
     HumanFacingPluginDefinitionConfiguration,
     PluginDefinitionConfigurationMapping,
     PluginInstanceConfiguration,
-    PluginInstanceConfigurationDefinition,
     PluginInstanceConfigurationMapping,
 )
 from betty.plugin.config.ordered import OrderedPluginDefinitionConfiguration
-from betty.plugin.data import PluginIdDefinition
+from betty.plugin.data import PluginIdDefinition, PluginInstanceConfigurationDefinition
 from betty.plugin.resolve import ResolvableId, resolve_id
 from betty.portable import CallbackPorter
 from betty.project.extension import Extension, ExtensionDefinition

--- a/betty/project/config.py
+++ b/betty/project/config.py
@@ -58,6 +58,7 @@ from betty.plugin.config import (
     HumanFacingPluginDefinitionConfiguration,
     PluginDefinitionConfigurationMapping,
     PluginInstanceConfiguration,
+    PluginInstanceConfigurationDefinition,
     PluginInstanceConfigurationMapping,
 )
 from betty.plugin.config.ordered import OrderedPluginDefinitionConfiguration
@@ -112,8 +113,7 @@ class ExtensionInstanceConfigurationMapping(
 
         yield Sample(cls(), label="Minimal", minimal=True)
         yield Sample(
-            cls([PluginInstanceConfiguration(RaspberryMint)]),  # ty:ignore[invalid-argument-type]
-            label="Expanded",
+            cls([PluginInstanceConfiguration(RaspberryMint)]), label="Expanded"
         )
         yield Sample(
             cls(
@@ -122,7 +122,7 @@ class ExtensionInstanceConfigurationMapping(
                         RaspberryMint,
                         get_full_sample(RaspberryMintConfiguration).data,
                     )
-                ]  # ty:ignore[invalid-argument-type]
+                ]
             ),
             label="Full",
             full=True,
@@ -839,9 +839,7 @@ class GenderPluginConfigurationMapping(
         ),
         FieldDefinition(
             Attr("copyright_notice"),
-            DataDefinition(
-                cls=PluginInstanceConfiguration, label=_("Copyright notice")
-            ),
+            PluginInstanceConfigurationDefinition(CopyrightNoticeDefinition),
             required=False,
             empty=lambda data: data == ProjectConfiguration._default_copyright_notice(),
         ),
@@ -900,7 +898,7 @@ class GenderPluginConfigurationMapping(
         ),
         FieldDefinition(
             Attr("license"),
-            DataDefinition(cls=PluginInstanceConfiguration, label=_("License")),
+            PluginInstanceConfigurationDefinition(LicenseDefinition),
             required=False,
             empty=lambda data: data == ProjectConfiguration._default_license(),
         ),

--- a/betty/project/extension/demo/project.py
+++ b/betty/project/extension/demo/project.py
@@ -209,11 +209,11 @@ async def create_project(app: App, project_directory_path: Path) -> Project:
                                         ),
                                     ),
                                 ],
-                            }  # ty:ignore[invalid-argument-type]
+                            }
                         ),
                     ),
                 ),
-            ]  # ty:ignore[invalid-argument-type]
+            ]
         ),
         entity_types=[
             Person,

--- a/betty/project/extension/raspberry_mint/config/default.py
+++ b/betty/project/extension/raspberry_mint/config/default.py
@@ -250,6 +250,6 @@ def regional_content(
                         name="external-links",
                     ),
                 ),
-            ]  # ty:ignore[invalid-argument-type]
+            ]
         ),
     }

--- a/betty/project/extension/raspberry_mint/content_provider.py
+++ b/betty/project/extension/raspberry_mint/content_provider.py
@@ -13,7 +13,6 @@ from betty.ancestry.presence_role import PresenceRoleDefinition
 from betty.assertion import (
     OptionalField,
     RequiredField,
-    assert_bool,
     assert_enum,
     assert_int,
     assert_mapping,
@@ -21,16 +20,21 @@ from betty.assertion import (
     assert_record,
     assert_sequence,
 )
+from betty.collections import ResolvingMutableSequence
 from betty.config import Configuration
 from betty.config.factory import ConfigurationDependentSelfFactory
 from betty.content_provider import ContentProvider, ContentProviderDefinition
 from betty.content_provider.content_providers import Template
-from betty.data import Sample
-from betty.locale.localizable.assertion import assert_load_localizable
+from betty.data import DataDefinition, HasData, Sample
+from betty.data.aggregate.collection.sequence import SequenceDefinition
+from betty.data.aggregate.record import FieldDefinition
+from betty.data.aggregate.record.object import ObjectDefinition
+from betty.data.indicator.selector import Attr
+from betty.functools import passthrough
 from betty.locale.localizable.attr import RequiredLocalizableAttr
+from betty.locale.localizable.data import LocalizableDefinition
 from betty.locale.localizable.ensure import ensure_localizable
 from betty.locale.localizable.gettext import _
-from betty.locale.localizable.portable import dump_localizable
 from betty.machine_name import MachineName, assert_machine_name
 from betty.model import EntityDefinition
 from betty.model.config import EntityReference
@@ -43,6 +47,7 @@ from betty.plugin.config import (
     ShorthandPluginInstanceConfigurationSequenceSequence,
 )
 from betty.plugin.resolve import resolve_id
+from betty.portable import CallbackPorter
 from betty.project.extension.raspberry_mint import (
     Breakpoint,
     JustifyContent,
@@ -55,6 +60,7 @@ from betty.service.level.factory import (
     CallbackServiceLevelDependentFactory,
     ServiceLevelDependentSelfFactory,
 )
+from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
 from betty.typing import private
 
 if TYPE_CHECKING:
@@ -83,11 +89,60 @@ class _Base(HasRequirement, Plugin[ContentProviderDefinition]):
         )
 
 
-class SectionConfiguration(Configuration):
+@final
+@ObjectDefinition(
+    label=_("Section configuration"),
+    fields=[
+        FieldDefinition(
+            Attr("name"),
+            DataDefinition(
+                cls=str,
+                label=_("Name"),
+                porter=CallbackPorter(assert_machine_name(), passthrough),
+            ),
+            empty=lambda data: data is None,
+            required=False,
+        ),
+        FieldDefinition(
+            Attr("heading"),
+            LocalizableDefinition(),
+            label=_("Heading"),
+        ),
+        FieldDefinition(
+            Attr("visually_hide_heading"),
+            DataDefinition(cls=bool, label=_("Visually hide heading")),
+            required=False,
+            empty=lambda data: data is False,
+        ),
+        FieldDefinition(
+            Attr("content"),
+            SequenceDefinition(
+                cls=ResolvingMutableSequence,
+                item=DataDefinition(
+                    cls=PluginInstanceConfiguration,
+                    label=_("Content provider configuration"),
+                ),
+                label=_("Content"),
+            ),
+            empty=lambda data: not len(data),
+        ),
+    ],
+    samples=[
+        lambda: Sample(
+            SectionConfiguration(
+                PluginInstanceConfiguration("my-first-content"),  # ty:ignore[invalid-argument-type]
+                heading=DUMMY_LOCALIZABLE,
+            ),
+            label="Minimal",
+            minimal=True,
+        ),
+    ],
+)
+class SectionConfiguration(HasData):
     """
     Configuration for :py:class:`betty.project.extension.raspberry_mint.content_provider.Section`.
 
-    .. configuration:: betty.project.extension.raspberry_mint.content_provider:SectionConfiguration
+    .. has_data:: betty.project.extension.raspberry_mint.content_provider:SectionConfiguration
     """
 
     heading = RequiredLocalizableAttr()
@@ -104,72 +159,29 @@ class SectionConfiguration(Configuration):
     ):
         super().__init__()
         self.heading = ensure_localizable(heading)
-        self._content = PluginInstanceConfigurationSequence(content)  # ty:ignore[invalid-argument-type]
+        self._content = ResolvingMutableSequence(
+            [],
+            lambda data: data
+            if isinstance(data, PluginInstanceConfiguration)
+            else PluginInstanceConfiguration(data),
+        )
+        self._content.extend(
+            [content] if isinstance(content, PluginInstanceConfiguration) else content
+        )
         self.name = name
         self.visually_hide_heading = visually_hide_heading
 
     @property
     def content(
         self,
-    ) -> PluginInstanceConfigurationSequence[
-        ContentProviderDefinition, ContentProvider
+    ) -> ResolvingMutableSequence[
+        PluginInstanceConfiguration[ContentProviderDefinition, ContentProvider],
+        PluginInstanceConfiguration[ContentProviderDefinition, ContentProvider],
     ]:
         """
         The content within this section.
         """
-        return self._content  # ty:ignore[invalid-return-type]
-
-    @override
-    @classmethod
-    def load(cls, portable: PortableData, /) -> Self:
-        return cls(
-            **assert_record(
-                OptionalField("name", assert_machine_name()),
-                RequiredField("heading", assert_load_localizable),
-                RequiredField("content", PluginInstanceConfigurationSequence.load),
-                OptionalField(
-                    "visually_hide_heading",
-                    assert_bool,
-                ),
-            )(portable)
-        )
-
-    @override
-    def dump(self) -> PortableData:
-        portable = {
-            "heading": dump_localizable(self.heading),
-            "content": self.content.dump(),
-        }
-        if self.name:
-            portable["name"] = self.name
-        if self.visually_hide_heading:
-            portable["visually_hide_heading"] = True
-        return portable
-
-    @override
-    def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, type(self)):
-            return NotImplemented
-        return (self.heading, self.content, self.name, self.visually_hide_heading) == (
-            other.heading,
-            other.content,
-            other.name,
-            other.visually_hide_heading,
-        )
-
-    @override
-    @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
-        from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
-
-        yield Sample(
-            cls(
-                PluginInstanceConfiguration("my-first-content"),  # ty:ignore[invalid-argument-type]
-                heading=DUMMY_LOCALIZABLE,
-            ),
-            label="Minimal",
-            minimal=True,
-        )
+        return self._content
 
 
 @ContentProviderDefinition("raspberry-mint-section", label=_("Section"))

--- a/betty/project/extension/raspberry_mint/content_provider.py
+++ b/betty/project/extension/raspberry_mint/content_provider.py
@@ -394,7 +394,7 @@ class ColorStyleConfiguration(Configuration):
                     PluginInstanceConfiguration(
                         Render, RenderConfiguration("Hello, world!")
                     )
-                ],  # ty:ignore[invalid-argument-type]
+                ],
             ),
             label="Default",
         )

--- a/betty/test_utils/config/factory.py
+++ b/betty/test_utils/config/factory.py
@@ -9,15 +9,16 @@ import pytest
 from betty.app import App
 from betty.config import Configuration
 from betty.config.factory import ConfigurationDependentSelfFactory
+from betty.data import HasData
 from betty.factory import FactoryError
 from betty.project import Project
 from betty.requirement import HasRequirement, Requirement
 from betty.service.level.universal import universe
 
-_ConfigurationT = TypeVar("_ConfigurationT", bound=Configuration)
+_HasDataT = TypeVar("_HasDataT", bound=HasData | Configuration)
 
 
-class ConfigurationDependentSelfFactoryTestBase(Generic[_ConfigurationT]):
+class ConfigurationDependentSelfFactoryTestBase(Generic[_HasDataT]):
     """
     A base class for testing :py:class:`betty.config.factory.ConfigurationDependentSelfFactory` implementations.
     """
@@ -25,7 +26,7 @@ class ConfigurationDependentSelfFactoryTestBase(Generic[_ConfigurationT]):
     @pytest.fixture
     def configuration_dependent_self_factory_sut(
         self,
-    ) -> type[ConfigurationDependentSelfFactory[_ConfigurationT]]:
+    ) -> type[ConfigurationDependentSelfFactory[_HasDataT]]:
         """
         Provide the system(s) under test.
         """
@@ -34,7 +35,7 @@ class ConfigurationDependentSelfFactoryTestBase(Generic[_ConfigurationT]):
     @pytest.fixture
     def configuration_dependent_self_factory_sut_configuration(
         self,
-    ) -> _ConfigurationT:
+    ) -> _HasDataT:
         """
         Provide the system(s) under test.
         """
@@ -43,9 +44,9 @@ class ConfigurationDependentSelfFactoryTestBase(Generic[_ConfigurationT]):
     async def test_new_for_configuration__with_global(
         self,
         configuration_dependent_self_factory_sut: type[
-            ConfigurationDependentSelfFactory[_ConfigurationT]
+            ConfigurationDependentSelfFactory[_HasDataT]
         ],
-        configuration_dependent_self_factory_sut_configuration: _ConfigurationT,
+        configuration_dependent_self_factory_sut_configuration: _HasDataT,
     ) -> None:
         """
         Tests :py:meth:`betty.config.factory.ConfigurationDependentSelfFactory.new_for_configuration` implementations.
@@ -75,9 +76,9 @@ class ConfigurationDependentSelfFactoryTestBase(Generic[_ConfigurationT]):
     async def test_new_for_configuration__with_app(
         self,
         configuration_dependent_self_factory_sut: type[
-            ConfigurationDependentSelfFactory[_ConfigurationT]
+            ConfigurationDependentSelfFactory[_HasDataT]
         ],
-        configuration_dependent_self_factory_sut_configuration: _ConfigurationT,
+        configuration_dependent_self_factory_sut_configuration: _HasDataT,
         isolated_app: App,
     ) -> None:
         """
@@ -105,9 +106,9 @@ class ConfigurationDependentSelfFactoryTestBase(Generic[_ConfigurationT]):
     async def test_new_for_configuration__with_project(
         self,
         configuration_dependent_self_factory_sut: type[
-            ConfigurationDependentSelfFactory[_ConfigurationT]
+            ConfigurationDependentSelfFactory[_HasDataT]
         ],
-        configuration_dependent_self_factory_sut_configuration: _ConfigurationT,
+        configuration_dependent_self_factory_sut_configuration: _HasDataT,
         isolated_app: App,
     ) -> None:
         """

--- a/betty/tests/plugin/test_data.py
+++ b/betty/tests/plugin/test_data.py
@@ -32,5 +32,6 @@ class TestPluginIdDefinition:
         with pytest.raises(PluginNotFound):
             await sut.hydrate("non-existent-plugin-id", universe)
 
+
 class TestPluginInstanceConfigurationDefinition:
     pass

--- a/betty/tests/plugin/test_data.py
+++ b/betty/tests/plugin/test_data.py
@@ -31,3 +31,6 @@ class TestPluginIdDefinition:
         sut = PluginIdDefinition(DummyPluginDefinition)
         with pytest.raises(PluginNotFound):
             await sut.hydrate("non-existent-plugin-id", universe)
+
+class TestPluginInstanceConfigurationDefinition:
+    pass

--- a/betty/tests/project/extension/raspberry_mint/assets/test_index.py
+++ b/betty/tests/project/extension/raspberry_mint/assets/test_index.py
@@ -44,7 +44,7 @@ async def test_regional_content_front_page_summary(
                                     RenderConfiguration("Hello, world!"),
                                 ),
                             ]
-                        }  # ty:ignore[invalid-argument-type]
+                        }
                     )
                 ),
             )
@@ -74,7 +74,7 @@ async def test_regional_content_front_page_content(
                                     RenderConfiguration("Hello, world!"),
                                 ),
                             ]
-                        }  # ty:ignore[invalid-argument-type]
+                        }
                     )
                 ),
             )

--- a/betty/tests/project/extension/raspberry_mint/test_content_provider.py
+++ b/betty/tests/project/extension/raspberry_mint/test_content_provider.py
@@ -1054,7 +1054,7 @@ class TestColumns(ContentProviderTestBase):
                                     RenderConfiguration(DUMMY_LOCALIZABLE),
                                 ),
                             ],
-                        ],  # ty:ignore[invalid-argument-type]
+                        ],
                         width=[8, 4],
                     ),
                     jinja2_environment=await project.jinja2_environment,
@@ -1085,7 +1085,7 @@ class TestColumns(ContentProviderTestBase):
                                     RenderConfiguration(DUMMY_LOCALIZABLE),
                                 ),
                             ],
-                        ],  # ty:ignore[invalid-argument-type]
+                        ],
                         width={Breakpoint.XS: [8, 4], Breakpoint.LG: [7, 5]},
                     ),
                     jinja2_environment=await project.jinja2_environment,

--- a/betty/tests/project/extension/raspberry_mint/test_content_provider.py
+++ b/betty/tests/project/extension/raspberry_mint/test_content_provider.py
@@ -71,6 +71,7 @@ from betty.test_utils.content_provider import (
     ContentProviderTestBase,
     NoOpContentProvider,
 )
+from betty.test_utils.data import HasDataTestBase
 from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
 from betty.test_utils.model import DummyEntityOne
 
@@ -117,7 +118,7 @@ class TestEntityCard(
         assert entity.public_id in provided_content
 
 
-class TestSectionConfiguration(ConfigurationTestBase[SectionConfiguration]):
+class TestSectionConfiguration(HasDataTestBase[SectionConfiguration]):
     sut_cls = SectionConfiguration
 
     def test_content(self) -> None:
@@ -146,7 +147,7 @@ class TestSectionConfiguration(ConfigurationTestBase[SectionConfiguration]):
         assert sut.name == "my-first-section"
 
     def test_load__minimal(self) -> None:
-        sut = SectionConfiguration.load(
+        sut = SectionConfiguration.data().load(
             {
                 "heading": "My First Section",
                 "content": ["my-first-content"],
@@ -156,7 +157,7 @@ class TestSectionConfiguration(ConfigurationTestBase[SectionConfiguration]):
         assert sut.content[0].id == "my-first-content"
 
     def test_load__with_name(self) -> None:
-        sut = SectionConfiguration.load(
+        sut = SectionConfiguration.data().load(
             {
                 "name": "my-first-section",
                 "heading": "My First Section",
@@ -167,7 +168,7 @@ class TestSectionConfiguration(ConfigurationTestBase[SectionConfiguration]):
 
     def test_load__without_heading(self) -> None:
         with pytest.raises(HumanFacingException):
-            SectionConfiguration.load(
+            SectionConfiguration.data().load(
                 {
                     "name": "my-first-section",
                     "content": ["my-first-content"],
@@ -176,7 +177,7 @@ class TestSectionConfiguration(ConfigurationTestBase[SectionConfiguration]):
 
     def test_load__without_content(self) -> None:
         with pytest.raises(HumanFacingException):
-            SectionConfiguration.load(
+            SectionConfiguration.data().load(
                 {
                     "name": "my-first-section",
                     "heading": "My First Section",
@@ -189,7 +190,7 @@ class TestSectionConfiguration(ConfigurationTestBase[SectionConfiguration]):
             name="my-first-section",
             heading="My First Section",
         )
-        assert sut.dump() == {
+        assert SectionConfiguration.data().dump(sut) == {
             "name": "my-first-section",
             "heading": "My First Section",
             "content": [
@@ -203,7 +204,7 @@ class TestSectionConfiguration(ConfigurationTestBase[SectionConfiguration]):
             name="my-first-section",
             heading="My First Section",
         )
-        assert sut.dump() == {
+        assert SectionConfiguration.data().dump(sut) == {
             "name": "my-first-section",
             "heading": "My First Section",
             "content": [
@@ -230,7 +231,7 @@ class TestSection(
         return Section
 
     @override
-    @pytest.fixture(params=SectionConfiguration.samples())
+    @pytest.fixture(params=SectionConfiguration.data().samples)
     def configuration_dependent_self_factory_sut_configuration(
         self, request: pytest.FixtureRequest
     ) -> SectionConfiguration:

--- a/betty/tests/project/extension/theme/test_config.py
+++ b/betty/tests/project/extension/theme/test_config.py
@@ -67,7 +67,7 @@ class TestRegionalContentConfiguration(
                 "non-existent-region": [
                     PluginInstanceConfiguration("my-first-plugin"),
                 ]
-            }  # ty:ignore[invalid-argument-type]
+            }
         )
         with pytest.raises(HumanFacingException):
             sut.validate([])


### PR DESCRIPTION
## To do
- Remove the plugin instance confguration code as I accidentally forked this branch off there instead of 0.5.x
- Add a reusable solution for sequences of content providers, with useful labels and descriptions, because this pattern is used about a dozen times.