### PR TITLE
Allow selectors to set and delete data

### DIFF
--- a/assets/locale/ar/betty.po
+++ b/assets/locale/ar/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-23 09:00+0000\n"
+"POT-Creation-Date: 2026-01-25 00:31+0000\n"
 "PO-Revision-Date: 2024-11-30 19:00+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: ar\n"
@@ -487,18 +487,6 @@ msgid "Cremation"
 msgstr ""
 
 msgid "Cremations"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no attribute {attribute}"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no index {index}"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no key \"{key}\""
 msgstr ""
 
 msgid "Death"

--- a/assets/locale/betty.pot
+++ b/assets/locale/betty.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-23 09:00+0000\n"
+"POT-Creation-Date: 2026-01-25 00:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -483,18 +483,6 @@ msgid "Cremation"
 msgstr ""
 
 msgid "Cremations"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no attribute {attribute}"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no index {index}"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no key \"{key}\""
 msgstr ""
 
 msgid "Death"

--- a/assets/locale/de-DE/betty.po
+++ b/assets/locale/de-DE/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-23 09:00+0000\n"
+"POT-Creation-Date: 2026-01-25 00:31+0000\n"
 "PO-Revision-Date: 2025-03-28 20:02+0000\n"
 "Last-Translator: Ettore Atalan <atalanttore@googlemail.com>\n"
 "Language: de_DE\n"
@@ -508,18 +508,6 @@ msgid "Cremation"
 msgstr "Feuerbestattung"
 
 msgid "Cremations"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no attribute {attribute}"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no index {index}"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no key \"{key}\""
 msgstr ""
 
 msgid "Death"

--- a/assets/locale/en-GB/betty.po
+++ b/assets/locale/en-GB/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-23 09:00+0000\n"
+"POT-Creation-Date: 2026-01-25 00:31+0000\n"
 "PO-Revision-Date: 2025-12-29 14:25+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: en_GB\n"
@@ -522,18 +522,6 @@ msgid "Cremation"
 msgstr "Cremation"
 
 msgid "Cremations"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no attribute {attribute}"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no index {index}"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no key \"{key}\""
 msgstr ""
 
 msgid "Death"

--- a/assets/locale/es-ES/betty.po
+++ b/assets/locale/es-ES/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-23 09:00+0000\n"
+"POT-Creation-Date: 2026-01-25 00:31+0000\n"
 "PO-Revision-Date: 2025-12-29 14:48+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: es_ES\n"
@@ -490,18 +490,6 @@ msgid "Cremation"
 msgstr "Cremación"
 
 msgid "Cremations"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no attribute {attribute}"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no index {index}"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no key \"{key}\""
 msgstr ""
 
 msgid "Death"

--- a/assets/locale/fr-FR/betty.po
+++ b/assets/locale/fr-FR/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-23 09:00+0000\n"
+"POT-Creation-Date: 2026-01-25 00:31+0000\n"
 "PO-Revision-Date: 2025-08-27 20:02+0000\n"
 "Last-Translator: \"David D.\" <dadu042@users.noreply.hosted.weblate.org>\n"
 "Language: fr_FR\n"
@@ -495,18 +495,6 @@ msgid "Cremation"
 msgstr "Crémation"
 
 msgid "Cremations"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no attribute {attribute}"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no index {index}"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no key \"{key}\""
 msgstr ""
 
 msgid "Death"

--- a/assets/locale/he/betty.po
+++ b/assets/locale/he/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-23 09:00+0000\n"
+"POT-Creation-Date: 2026-01-25 00:31+0000\n"
 "PO-Revision-Date: 2025-05-06 10:01+0000\n"
 "Last-Translator: Yaron Shahrabani <sh.yaron@gmail.com>\n"
 "Language: he\n"
@@ -488,18 +488,6 @@ msgid "Cremation"
 msgstr ""
 
 msgid "Cremations"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no attribute {attribute}"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no index {index}"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no key \"{key}\""
 msgstr ""
 
 msgid "Death"

--- a/assets/locale/nl-NL/betty.po
+++ b/assets/locale/nl-NL/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-23 09:00+0000\n"
+"POT-Creation-Date: 2026-01-25 00:31+0000\n"
 "PO-Revision-Date: 2025-11-08 23:46+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: nl_NL\n"
@@ -529,18 +529,6 @@ msgid "Cremation"
 msgstr "Crematie"
 
 msgid "Cremations"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no attribute {attribute}"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no index {index}"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no key \"{key}\""
 msgstr ""
 
 msgid "Death"

--- a/assets/locale/pt-BR/betty.po
+++ b/assets/locale/pt-BR/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-23 09:00+0000\n"
+"POT-Creation-Date: 2026-01-25 00:31+0000\n"
 "PO-Revision-Date: 2025-12-16 20:00+0000\n"
 "Last-Translator: Mateus Liberale Gomes <sergiogomes209403@gmail.com>\n"
 "Language: pt_BR\n"
@@ -529,18 +529,6 @@ msgid "Cremation"
 msgstr ""
 
 msgid "Cremations"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no attribute {attribute}"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no index {index}"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no key \"{key}\""
 msgstr ""
 
 msgid "Death"

--- a/assets/locale/ru-RU/betty.po
+++ b/assets/locale/ru-RU/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-23 09:00+0000\n"
+"POT-Creation-Date: 2026-01-25 00:31+0000\n"
 "PO-Revision-Date: 2025-12-08 19:00+0000\n"
 "Last-Translator: Artur Kalagov "
 "<artur.kalagov@users.noreply.hosted.weblate.org>\n"
@@ -533,18 +533,6 @@ msgid "Cremation"
 msgstr "Кремация"
 
 msgid "Cremations"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no attribute {attribute}"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no index {index}"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no key \"{key}\""
 msgstr ""
 
 msgid "Death"

--- a/assets/locale/uk/betty.po
+++ b/assets/locale/uk/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty 0.4\n"
 "Report-Msgid-Bugs-To: illia@maier.page\n"
-"POT-Creation-Date: 2026-01-23 09:00+0000\n"
+"POT-Creation-Date: 2026-01-25 00:31+0000\n"
 "PO-Revision-Date: 2025-05-13 17:01+0000\n"
 "Last-Translator: Максим Горпиніч <maksimgorpinic4@gmail.com>\n"
 "Language: uk\n"
@@ -526,18 +526,6 @@ msgid "Cremation"
 msgstr "Кремація"
 
 msgid "Cremations"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no attribute {attribute}"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no index {index}"
-msgstr ""
-
-#, python-brace-format
-msgid "Data has no key \"{key}\""
 msgstr ""
 
 msgid "Death"

--- a/betty/data/indicator/selector.py
+++ b/betty/data/indicator/selector.py
@@ -5,15 +5,15 @@ Data selectors.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Generic, final
 
 from typing_extensions import TypeVar, override
 
 from betty.data.indicator import Indicator
-from betty.locale.localizable.gettext import _
 
 if TYPE_CHECKING:
-    from collections.abc import MutableSequence, Sequence
+    from collections.abc import Iterator, MutableSequence, Sequence
 
     from betty.assertion import Assertion
 
@@ -21,21 +21,69 @@ _T = TypeVar("_T")
 _ElementT = TypeVar("_ElementT")
 
 
+@final
+class SelectorError(ValueError):
+    """
+    Raise when a selector cannot access its element on the given data.
+    """
+
+    def __init__(self, selector: Selector, /):
+        super().__init__(f"Cannot access {selector.format()}")
+
+
 class Selector(Indicator, ABC):
     """
     Indicate and interact with aggregate data.
     """
 
+    @contextmanager
+    def _catch(self) -> Iterator[None]:
+        try:
+            yield
+        except Exception as error:
+            raise SelectorError(self) from error
+
     @final
     def get(self, data: Any, assertion: Assertion[Any, _T] | None = None, /) -> _T:
         """
         Get the value for this selector.
+
+        :raises SelectorError: raised if the selected element cannot be accessed.
         """
-        data = self._get(data)
+        with self._catch():
+            data = self._get(data)
         return assertion(data) if assertion else data
 
     @abstractmethod
     def _get(self, data: Any, /) -> Any:
+        pass
+
+    @final
+    def set(self, data: Any, value: Any, /) -> None:
+        """
+        Set the value for this selector.
+
+        :raises SelectorError: raised if the selected element cannot be accessed.
+        """
+        with self._catch():
+            self._set(data, value)
+
+    @abstractmethod
+    def _set(self, data: Any, value: Any, /) -> None:
+        pass
+
+    @final
+    def delete(self, data: Any, /) -> None:
+        """
+        Delete the element for this selector.
+
+        :raises SelectorError: raised if the selected element cannot be accessed.
+        """
+        with self._catch():
+            self._delete(data)
+
+    @abstractmethod
+    def _delete(self, data: Any, /) -> None:
         pass
 
 
@@ -77,15 +125,21 @@ class Selectors(Selector):
 
     @override
     def _get(self, data: Any, /) -> Any:
-        from betty.exception import HumanFacingException
-
-        for index, selector in enumerate(self._selectors):
-            try:
-                data = selector.get(data)
-            except HumanFacingException as error:
-                error.with_indicator(*reversed(self._selectors[0 : index + 1]))
-                raise
+        for selector in self._selectors:
+            data = selector.get(data)
         return data
+
+    @override
+    def _set(self, data: Any, value: Any, /) -> None:
+        for selector in self._selectors[:-1]:
+            data = selector.get(data)
+        self._selectors[-1].set(data, value)
+
+    @override
+    def _delete(self, data: Any, /) -> None:
+        for selector in self._selectors[:-1]:
+            data = selector.get(data)
+        self._selectors[-1].delete(data)
 
 
 class Element(Selector, Generic[_ElementT]):
@@ -123,14 +177,16 @@ class Attr(Element[str]):
     def _get(self, data: Any, /) -> Any:
         try:
             return getattr(data, self.element)
-        except AttributeError:
-            from betty.exception import HumanFacingException
+        except AttributeError as error:
+            raise SelectorError(self) from error
 
-            raise HumanFacingException(
-                _("Data has no attribute {attribute}").format(
-                    attribute=f".{self.element}"
-                )
-            ) from None
+    @override
+    def _set(self, data: Any, value: Any, /) -> None:
+        setattr(data, self.element, value)
+
+    @override
+    def _delete(self, data: Any, /) -> None:
+        delattr(data, self.element)
 
 
 @final
@@ -145,14 +201,15 @@ class Index(Element[int]):
 
     @override
     def _get(self, data: Any, /) -> Any:
-        try:
-            return data[self.element]
-        except (LookupError, TypeError):
-            from betty.exception import HumanFacingException
+        return data[self.element]
 
-            raise HumanFacingException(
-                _("Data has no index {index}").format(index=f".{self.element}")
-            ) from None
+    @override
+    def _set(self, data: Any, value: Any, /) -> None:
+        data[self.element] = value
+
+    @override
+    def _delete(self, data: Any, /) -> None:
+        del data[self.element]
 
 
 @final
@@ -167,11 +224,12 @@ class Key(Element[str]):
 
     @override
     def _get(self, data: Any, /) -> Any:
-        try:
-            return data[self.element]
-        except (LookupError, TypeError):
-            from betty.exception import HumanFacingException
+        return data[self.element]
 
-            raise HumanFacingException(
-                _('Data has no key "{key}"').format(key=f".{self.element}")
-            ) from None
+    @override
+    def _set(self, data: Any, value: Any, /) -> None:
+        data[self.element] = value
+
+    @override
+    def _delete(self, data: Any, /) -> None:
+        del data[self.element]

--- a/betty/tests/data/indicator/test_selector.py
+++ b/betty/tests/data/indicator/test_selector.py
@@ -5,8 +5,15 @@ import pytest
 from typing_extensions import override
 
 from betty.data.indicator import Indicator
-from betty.data.indicator.selector import Attr, Element, Index, Key, Selector, Selectors
-from betty.exception import HumanFacingException
+from betty.data.indicator.selector import (
+    Attr,
+    Element,
+    Index,
+    Key,
+    Selector,
+    SelectorError,
+    Selectors,
+)
 
 
 class DummyIndicator(Indicator):
@@ -24,21 +31,29 @@ class TestAttr:
 
     def test_get(self) -> None:
         class _Data:
-            my_first_attr = "my-first-value"
+            def __init__(self):
+                self.my_first_attr = "my-first-value"
 
         assert Attr("my_first_attr").get(_Data()) == "my-first-value"
 
-    @pytest.mark.parametrize(
-        "data",
-        [
-            [],
-            {},
-            object(),
-        ],
-    )
-    def test_get__with_error(self, data: Any) -> None:
-        with pytest.raises(HumanFacingException):
-            Attr("my_first_attr").get(data)
+    def test_set(self) -> None:
+        class _Data:
+            def __init__(self):
+                self.my_first_attr = "my-first-value"
+
+        data = _Data()
+        Attr("my_first_attr").set(data, "my-second-value")
+        assert data.my_first_attr == "my-second-value"
+
+    def test_delete(self) -> None:
+        class _Data:
+            def __init__(self):
+                self.my_first_attr = "my-first-value"
+
+        data = _Data()
+        Attr("my_first_attr").delete(data)
+        with pytest.raises(AttributeError):
+            assert data.my_first_attr
 
 
 class TestIndex:
@@ -48,17 +63,15 @@ class TestIndex:
     def test_get(self) -> None:
         assert Index(0).get(["my-first-value"]) == "my-first-value"
 
-    @pytest.mark.parametrize(
-        "data",
-        [
-            [],
-            {},
-            object(),
-        ],
-    )
-    def test_get__with_error(self, data: Any) -> None:
-        with pytest.raises(HumanFacingException):
-            Index(0).get(data)
+    def test_set(self) -> None:
+        data = ["my-first-value"]
+        Index(0).set(data, "my-second-value")
+        assert data[0] == "my-second-value"
+
+    def test_delete(self) -> None:
+        data = ["my-first-value"]
+        Index(0).delete(data)
+        assert data == []
 
 
 class TestKey:
@@ -71,20 +84,17 @@ class TestKey:
             == "my-first-value"
         )
 
-    @pytest.mark.parametrize(
-        "data",
-        [
-            {},
-            {
-                "my_second_key": "my-second-value",
-            },
-            [],
-            object(),
-        ],
-    )
-    def test_get__with_error(self, data: Any) -> None:
-        with pytest.raises(HumanFacingException):
-            Key("my_first_key").get(data)
+    def test_set(self) -> None:
+        data = {"my_first_key": "my-first-value"}
+        Key("my_first_key").set(data, "my-second-value")
+        assert data["my_first_key"] == "my-second-value"
+
+    def test_delete(self) -> None:
+        data = {"my_first_key": "my-first-value"}
+        Key("my_first_key").delete(
+            data,
+        )
+        assert data == {}
 
 
 class TestSelectors:
@@ -141,18 +151,28 @@ class TestSelectors:
             == "my-first-value"
         )
 
-    def test_get__with_error(self) -> None:
-        outer_selector = Index(1)
-        inner_selector = Index(0)
-        selectors = [outer_selector, inner_selector]
-        with pytest.raises(HumanFacingException) as exc_info:
-            Selectors(*selectors).get([[], []])
-        assert list(exc_info.value.indicators) == [inner_selector, outer_selector]
+    def test_set(self) -> None:
+        data = [[], ["my-first-value"]]
+        Selectors(Index(1), Index(0)).set(data, "my-second-value")
+        assert data[1][0] == "my-second-value"
+
+    def test_delete(self) -> None:
+        data = [[], ["my-first-value"]]
+        Selectors(Index(1), Index(0)).delete(data)
+        assert data[1] == []
 
 
 class ElementTestElement(Element[Any]):
     @override
     def _get(self, data: Any, /) -> Any:
+        raise NotImplementedError
+
+    @override
+    def _set(self, data: Any, value: Any, /) -> None:
+        raise NotImplementedError
+
+    @override
+    def _delete(self, data: Any, /) -> None:
         raise NotImplementedError
 
     @override
@@ -176,3 +196,8 @@ class TestElement:
     )
     def test___eq__(self, expected: bool, one: Element, other: Element) -> None:
         assert (one == other) is expected
+
+
+class TestSelectorError:
+    def test(self) -> None:
+        assert "[0]" in str(SelectorError(Index(0)))

--- a/betty/wiki/client.py
+++ b/betty/wiki/client.py
@@ -17,7 +17,7 @@ from geopy import Point
 
 from betty.assertion import assert_float, assert_mapping, assert_str
 from betty.data.indicator import Url
-from betty.data.indicator.selector import Index, Key, Selectors
+from betty.data.indicator.selector import Index, Key, SelectorError, Selectors
 from betty.exception import HumanFacingException, reraise_with_indicator
 from betty.hashid import hashid
 from betty.locale.localizable.gettext import _
@@ -92,6 +92,8 @@ class Client:
             yield
         except HumanFacingException as error:
             raise ClientError(error) from error
+        except SelectorError as error:
+            raise ClientError(str(error)) from error
 
     @asynccontextmanager
     async def _get(self, url: str) -> AsyncIterator[ClientResponse]:


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/3575. Any GUI can get any selectors it needs from data definitions, and use those to mutate data.