### PR TITLE
Remove `EntityReferenceSequence`

### DIFF
--- a/betty/model/config.py
+++ b/betty/model/config.py
@@ -14,10 +14,7 @@ from betty.assertion import (
     assert_str,
 )
 from betty.config import Configuration
-from betty.config.collections.sequence import ConfigurationSequence
 from betty.data import Sample
-from betty.data.indicator.selector import Index
-from betty.exception import reraise_with_indicator
 from betty.machine_name import MachineName, assert_machine_name
 from betty.plugin.assertion import assert_plugin
 from betty.plugin.resolve import ResolvableId, resolve_id
@@ -104,35 +101,3 @@ class EntityReference(Configuration):
         from betty.ancestry.person import Person
 
         yield Sample(cls(Person, "123"), label="Default")
-
-
-@final
-class EntityReferenceSequence(ConfigurationSequence[EntityReference]):
-    """
-    Configuration for a sequence of references to entities from the project's ancestry.
-
-    .. configuration:: betty.model.config:EntityReferenceSequence
-    """
-
-    @override
-    @classmethod
-    def _item_cls(cls) -> type[EntityReference]:
-        return EntityReference
-
-    async def validate(
-        self, entity_type_repository: PluginRepository[EntityDefinition], /
-    ) -> None:
-        """
-        Validate the configuration.
-        """
-        for index, reference in enumerate(self):
-            with reraise_with_indicator(Index(index)):
-                await reference.validate(entity_type_repository)
-
-    @override
-    @classmethod
-    def samples(cls) -> Iterable[Sample[Self]]:  # ty:ignore[invalid-method-override]
-        from betty.ancestry.person import Person
-
-        yield Sample(cls(), label="Minimal", minimal=True)
-        yield Sample(cls([EntityReference(Person, "123")]), label="Expanded", full=True)

--- a/betty/tests/model/test_config.py
+++ b/betty/tests/model/test_config.py
@@ -1,28 +1,15 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
-from typing_extensions import override
 
 from betty.exception import HumanFacingException
 from betty.model import EntityDefinition
-from betty.model.config import EntityReference, EntityReferenceSequence
+from betty.model.config import EntityReference
 from betty.plugin.repository.static import StaticPluginRepository
 from betty.test_utils.config import ConfigurationTestBase
-from betty.test_utils.config.collections.sequence import ConfigurationSequenceTestBase
 from betty.test_utils.model import (
-    DummyEntityFour,
     DummyEntityOne,
-    DummyEntityThree,
-    DummyEntityTwo,
 )
-
-if TYPE_CHECKING:
-    from betty.test_utils.config.collections import (
-        ConfigurationCollectionTestBaseNewSut,
-        ConfigurationCollectionTestBaseSutConfigurations,
-    )
 
 
 class TestEntityReference(ConfigurationTestBase[EntityReference]):
@@ -80,39 +67,5 @@ class TestEntityReference(ConfigurationTestBase[EntityReference]):
 
     async def test_validate(self) -> None:
         sut = EntityReference("betty.non_existent.Entity", "id")
-        with pytest.raises(HumanFacingException):
-            await sut.validate(StaticPluginRepository(EntityDefinition))
-
-
-class TestEntityReferenceSequence(
-    ConfigurationSequenceTestBase[EntityReferenceSequence, EntityReference]
-):
-    sut_cls = EntityReferenceSequence
-
-    @override
-    @pytest.fixture
-    def new_sut(
-        self,
-    ) -> ConfigurationCollectionTestBaseNewSut[EntityReference, int, int]:
-        return EntityReferenceSequence
-
-    @override
-    @pytest.fixture
-    def sut_configurations(
-        self,
-    ) -> ConfigurationCollectionTestBaseSutConfigurations[EntityReference]:
-        return (
-            EntityReference(DummyEntityOne, "ONE"),
-            EntityReference(DummyEntityTwo, "TWO"),
-            EntityReference(DummyEntityThree, "THREE"),
-            EntityReference(DummyEntityFour, "FOUR"),
-        )
-
-    async def test_validate__with_invalid_item(
-        self,
-    ) -> None:
-        sut = EntityReferenceSequence(
-            [EntityReference("betty.non_existent.Entity", "123")]
-        )
         with pytest.raises(HumanFacingException):
             await sut.validate(StaticPluginRepository(EntityDefinition))


### PR DESCRIPTION
Remove `EntityReferenceSequence`, because it is unused and won't be used anymore now we use defined data.