### PR TITLE
Support classless plugins

### DIFF
--- a/betty/ancestry/event_type/__init__.py
+++ b/betty/ancestry/event_type/__init__.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, final
 from betty.definition.human_facing import CountableHumanFacingDefinition
 from betty.locale.localizable.gettext import _, ngettext
 from betty.plugin import Plugin, PluginTypeDefinition
+from betty.plugin.cls import PluginClsDefinition
 from betty.plugin.discovery.entry_point import EntryPointDiscovery
 from betty.plugin.discovery.project import ProjectDiscovery
 from betty.plugin.ordered import OrderedPluginDefinition
@@ -60,7 +61,9 @@ class ShouldExistEventType(EventType, ABC):
     ],
 )
 class EventTypeDefinition(
-    CountableHumanFacingDefinition, OrderedPluginDefinition[EventType]
+    CountableHumanFacingDefinition,
+    OrderedPluginDefinition,
+    PluginClsDefinition[EventType],
 ):
     """
     .. plugin_type:: event-type.

--- a/betty/ancestry/gender/__init__.py
+++ b/betty/ancestry/gender/__init__.py
@@ -8,7 +8,8 @@ from typing import final
 
 from betty.definition.human_facing import CountableHumanFacingDefinition
 from betty.locale.localizable.gettext import _, ngettext
-from betty.plugin import Plugin, PluginDefinition, PluginTypeDefinition
+from betty.plugin import Plugin, PluginTypeDefinition
+from betty.plugin.cls import PluginClsDefinition
 from betty.plugin.discovery.entry_point import EntryPointDiscovery
 from betty.plugin.discovery.project import ProjectDiscovery
 
@@ -35,7 +36,7 @@ class Gender(Plugin["GenderDefinition"]):
         ),
     ],
 )
-class GenderDefinition(CountableHumanFacingDefinition, PluginDefinition[Gender]):
+class GenderDefinition(CountableHumanFacingDefinition, PluginClsDefinition[Gender]):
     """
     .. plugin_type:: gender.
 

--- a/betty/ancestry/place_type/__init__.py
+++ b/betty/ancestry/place_type/__init__.py
@@ -8,7 +8,8 @@ from typing import final
 
 from betty.definition.human_facing import CountableHumanFacingDefinition
 from betty.locale.localizable.gettext import _, ngettext
-from betty.plugin import Plugin, PluginDefinition, PluginTypeDefinition
+from betty.plugin import Plugin, PluginTypeDefinition
+from betty.plugin.cls import PluginClsDefinition
 from betty.plugin.discovery.entry_point import EntryPointDiscovery
 from betty.plugin.discovery.project import ProjectDiscovery
 
@@ -35,7 +36,9 @@ class PlaceType(Plugin["PlaceTypeDefinition"]):
         ),
     ],
 )
-class PlaceTypeDefinition(CountableHumanFacingDefinition, PluginDefinition[PlaceType]):
+class PlaceTypeDefinition(
+    CountableHumanFacingDefinition, PluginClsDefinition[PlaceType]
+):
     """
     .. plugin_type:: place-type.
     """

--- a/betty/ancestry/presence_role/__init__.py
+++ b/betty/ancestry/presence_role/__init__.py
@@ -8,7 +8,8 @@ from typing import final
 
 from betty.definition.human_facing import CountableHumanFacingDefinition
 from betty.locale.localizable.gettext import _, ngettext
-from betty.plugin import Plugin, PluginDefinition, PluginTypeDefinition
+from betty.plugin import Plugin, PluginTypeDefinition
+from betty.plugin.cls import PluginClsDefinition
 from betty.plugin.discovery.entry_point import EntryPointDiscovery
 from betty.plugin.discovery.project import ProjectDiscovery
 
@@ -36,7 +37,7 @@ class PresenceRole(Plugin["PresenceRoleDefinition"]):
     ],
 )
 class PresenceRoleDefinition(
-    CountableHumanFacingDefinition, PluginDefinition[PresenceRole]
+    CountableHumanFacingDefinition, PluginClsDefinition[PresenceRole]
 ):
     """
     .. plugin_type:: presence-role.

--- a/betty/console/command/__init__.py
+++ b/betty/console/command/__init__.py
@@ -11,7 +11,8 @@ from typing import TYPE_CHECKING, TypeAlias, final
 from betty import about
 from betty.definition.human_facing import HumanFacingDefinition
 from betty.locale.localizable.gettext import _, ngettext
-from betty.plugin import Plugin, PluginDefinition, PluginTypeDefinition
+from betty.plugin import Plugin, PluginTypeDefinition
+from betty.plugin.cls import PluginClsDefinition
 from betty.plugin.discovery.entry_point import EntryPointDiscovery
 
 if TYPE_CHECKING:
@@ -43,7 +44,7 @@ class Command(Plugin["CommandDefinition"]):
     label_countable=ngettext("{count} command", "{count} commands"),
     discovery=EntryPointDiscovery("betty.command"),
 )
-class CommandDefinition(HumanFacingDefinition, PluginDefinition[Command]):
+class CommandDefinition(HumanFacingDefinition, PluginClsDefinition[Command]):
     """
     .. plugin_type:: command.
     """

--- a/betty/content_provider/__init__.py
+++ b/betty/content_provider/__init__.py
@@ -9,7 +9,8 @@ from typing import TYPE_CHECKING, final
 
 from betty.definition.human_facing import HumanFacingDefinition
 from betty.locale.localizable.gettext import _, ngettext
-from betty.plugin import Plugin, PluginDefinition, PluginTypeDefinition
+from betty.plugin import Plugin, PluginTypeDefinition
+from betty.plugin.cls import PluginClsDefinition
 from betty.plugin.discovery.entry_point import EntryPointDiscovery
 
 if TYPE_CHECKING:
@@ -37,7 +38,7 @@ class ContentProvider(ABC, Plugin["ContentProviderDefinition"]):
     discovery=EntryPointDiscovery("betty.content_provider"),
 )
 class ContentProviderDefinition(
-    HumanFacingDefinition, PluginDefinition[ContentProvider]
+    HumanFacingDefinition, PluginClsDefinition[ContentProvider]
 ):
     """
     .. plugin_type:: content-provider.

--- a/betty/copyright_notice/__init__.py
+++ b/betty/copyright_notice/__init__.py
@@ -9,7 +9,8 @@ from typing import TYPE_CHECKING, final
 
 from betty.definition.human_facing import HumanFacingDefinition
 from betty.locale.localizable.gettext import _, ngettext
-from betty.plugin import Plugin, PluginDefinition, PluginTypeDefinition
+from betty.plugin import Plugin, PluginTypeDefinition
+from betty.plugin.cls import PluginClsDefinition
 from betty.plugin.discovery.entry_point import EntryPointDiscovery
 from betty.plugin.discovery.project import ProjectDiscovery
 
@@ -63,7 +64,7 @@ class CopyrightNotice(Plugin["CopyrightNoticeDefinition"]):
     ],
 )
 class CopyrightNoticeDefinition(
-    HumanFacingDefinition, PluginDefinition[CopyrightNotice]
+    HumanFacingDefinition, PluginClsDefinition[CopyrightNotice]
 ):
     """
     .. plugin_type:: copyright-notice.

--- a/betty/document.py
+++ b/betty/document.py
@@ -29,7 +29,7 @@ from typing_extensions import override
 from betty.json.linked_data import LinkedDataDumpable
 from betty.locale.localize import DEFAULT_LOCALIZER, Localizer
 from betty.media_type.media_types import HTML
-from betty.plugin.resolve import ResolvableId, resolve_id
+from betty.plugin.resolve import ResolvableClsId, resolve_id
 from betty.portable import PortableMapping
 
 if TYPE_CHECKING:
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from betty.job import Context as JobContext
     from betty.locale.localizable import Localizable
     from betty.machine_name import MachineName
-    from betty.model import Entity
+    from betty.model import Entity, EntityDefinition
     from betty.project import Project
 
 DocumentVars: TypeAlias = Mapping[str, Any]
@@ -318,7 +318,9 @@ class EntityContexts:
         for entity in entities:
             self._contexts[entity.plugin().id] = entity
 
-    def __getitem__(self, entity_type: ResolvableId) -> Entity | None:
+    def __getitem__(
+        self, entity_type: ResolvableClsId[EntityDefinition]
+    ) -> Entity | None:
         return self._contexts[resolve_id(entity_type)]
 
     def __call__(self, *entities: Entity) -> EntityContexts:

--- a/betty/extension/__init__.py
+++ b/betty/extension/__init__.py
@@ -9,6 +9,7 @@ from typing_extensions import override
 from betty.definition.human_facing import HumanFacingDefinition
 from betty.locale.localizable.gettext import _, ngettext
 from betty.plugin import Plugin, PluginTypeDefinition
+from betty.plugin.cls import PluginClsDefinition
 from betty.plugin.dependent import DependentPluginDefinition
 from betty.plugin.discovery.entry_point import EntryPointDiscovery
 from betty.service.container import ServiceContainer
@@ -60,7 +61,9 @@ class Extension(ServiceContainer, Plugin["ExtensionDefinition"]):
     label_countable=ngettext("{count} extension", "{count} extensions"),
     discovery=EntryPointDiscovery("betty.extension"),
 )
-class ExtensionDefinition(HumanFacingDefinition, DependentPluginDefinition[Extension]):
+class ExtensionDefinition(
+    HumanFacingDefinition, DependentPluginDefinition, PluginClsDefinition[Extension]
+):
     """
     .. plugin_type:: extension.
 

--- a/betty/extension/gramps/config.py
+++ b/betty/extension/gramps/config.py
@@ -33,7 +33,7 @@ from betty.gramps.loader import (
 )
 from betty.locale.localizable.gettext import _
 from betty.pathlib import FilePathDefinition
-from betty.plugin import Plugin, PluginDefinition
+from betty.plugin import Plugin, PluginClsDefinition
 from betty.plugin.config import (
     PluginConfiguration,
     ResolvablePluginConfiguration,
@@ -49,23 +49,23 @@ if TYPE_CHECKING:
     from betty.ancestry.presence_role import PresenceRole
     from betty.locale.localizable import ResolvableLocalizable
 _PluginT = TypeVar("_PluginT", bound=Plugin, default=Plugin)
-_PluginDefinitionT = TypeVar(
-    "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
+_PluginClsDefinitionT = TypeVar(
+    "_PluginClsDefinitionT", bound=PluginClsDefinition, default=PluginClsDefinition
 )
 
 
 class _PluginMappingProperty(
     MappingProperty[
-        MutableMapping[str, PluginConfiguration[_PluginDefinitionT, _PluginT]],
-        Mapping[str, ResolvablePluginConfiguration[_PluginDefinitionT, _PluginT]],
+        MutableMapping[str, PluginConfiguration[_PluginClsDefinitionT, _PluginT]],
+        Mapping[str, ResolvablePluginConfiguration[_PluginClsDefinitionT, _PluginT]],
     ]
 ):
     def __init__(
         self,
-        plugin_type: type[_PluginDefinitionT],
+        plugin_type: type[_PluginClsDefinitionT],
         gramps_label: ResolvableLocalizable,
         default: Mapping[
-            str, ResolvablePluginConfiguration[_PluginDefinitionT, _PluginT]
+            str, ResolvablePluginConfiguration[_PluginClsDefinitionT, _PluginT]
         ],
     ):
         super().__init__(

--- a/betty/http_client/rate_limit.py
+++ b/betty/http_client/rate_limit.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, final
 from betty.concurrent import AsynchronizedLock, RateLimiter
 from betty.locale.localizable.gettext import _, ngettext
 from betty.plugin import Plugin, PluginTypeDefinition
+from betty.plugin.cls import PluginClsDefinition
 from betty.plugin.discovery.entry_point import EntryPointDiscovery
 from betty.plugin.ordered import OrderedPluginDefinition
 from betty.typing import threadsafe
@@ -98,7 +99,7 @@ class RateLimit(Plugin["RateLimitDefinition"]):
     ),
     discovery=EntryPointDiscovery("betty.http_rate_limit"),
 )
-class RateLimitDefinition(OrderedPluginDefinition[RateLimit]):
+class RateLimitDefinition(OrderedPluginDefinition, PluginClsDefinition[RateLimit]):
     """
     .. plugin_type:: http-rate-limit.
     """

--- a/betty/license/__init__.py
+++ b/betty/license/__init__.py
@@ -9,7 +9,8 @@ from typing import TYPE_CHECKING, final
 
 from betty.definition.human_facing import HumanFacingDefinition
 from betty.locale.localizable.gettext import _, ngettext
-from betty.plugin import Plugin, PluginDefinition, PluginTypeDefinition
+from betty.plugin import Plugin, PluginTypeDefinition
+from betty.plugin.cls import PluginClsDefinition
 from betty.plugin.discovery.entry_point import EntryPointDiscovery
 from betty.plugin.discovery.project import ProjectDiscovery
 
@@ -62,7 +63,7 @@ class License(Plugin["LicenseDefinition"]):
         ),
     ],
 )
-class LicenseDefinition(HumanFacingDefinition, PluginDefinition[License]):
+class LicenseDefinition(HumanFacingDefinition, PluginClsDefinition[License]):
     """
     .. plugin_type:: license.
     """

--- a/betty/model/__init__.py
+++ b/betty/model/__init__.py
@@ -16,7 +16,8 @@ from betty.json.linked_data import (
 from betty.json.schema import JsonSchemaReference, String
 from betty.locale.localizable.gettext import _, ngettext
 from betty.locale.localize import DEFAULT_LOCALIZER
-from betty.plugin import Plugin, PluginDefinition, PluginTypeDefinition
+from betty.plugin import Plugin, PluginTypeDefinition
+from betty.plugin.cls import PluginClsDefinition
 from betty.plugin.discovery.entry_point import EntryPointDiscovery
 from betty.string import kebab_case_to_lower_camel_case
 
@@ -147,7 +148,7 @@ class Entity(LinkedDataDumpableWithSchemaJsonLdObject, Plugin["EntityDefinition"
     ),
     discovery=EntryPointDiscovery("betty.entity_type"),
 )
-class EntityDefinition(CountableHumanFacingDefinition, PluginDefinition[Entity]):
+class EntityDefinition(CountableHumanFacingDefinition, PluginClsDefinition[Entity]):
     """
     .. plugin_type:: entity.
     """

--- a/betty/plugin/__init__.py
+++ b/betty/plugin/__init__.py
@@ -91,7 +91,6 @@ _PluginDefinitionCoT = TypeVar(
     default=PluginDefinition,
     covariant=True,
 )
-# @todo covariant?
 _PluginClsDefinitionT = TypeVar(
     "_PluginClsDefinitionT", bound=PluginClsDefinition, default=PluginClsDefinition
 )

--- a/betty/plugin/__init__.py
+++ b/betty/plugin/__init__.py
@@ -19,9 +19,9 @@ from betty.definition.human_facing import CountableHumanFacingDefinition
 from betty.importlib import fully_qualified_name
 from betty.locale.localizable.gettext import _
 from betty.machine_name import InvalidMachineName, MachineName, validate_machine_name
+from betty.plugin.cls import PluginClsDefinition
 
 if TYPE_CHECKING:
-    import builtins
     from collections.abc import Collection, Iterator, Mapping, MutableSequence
 
     from betty.locale.localizable import (
@@ -32,10 +32,7 @@ if TYPE_CHECKING:
     from betty.plugin.discovery import PluginDiscovery
 
 
-_BaseClsCoT = TypeVar("_BaseClsCoT", default=object, covariant=True)
-
-
-class PluginDefinition(ClsDefinition[_BaseClsCoT], Generic[_BaseClsCoT]):
+class PluginDefinition:
     """
     A plugin definition.
     """
@@ -47,7 +44,7 @@ class PluginDefinition(ClsDefinition[_BaseClsCoT], Generic[_BaseClsCoT]):
         self._id = plugin_id
 
     @classmethod
-    def type(cls) -> PluginTypeDefinition[_BaseClsCoT, Self]:
+    def type(cls) -> PluginTypeDefinition[Self]:
         """
         The plugin type definition.
         """
@@ -66,11 +63,6 @@ class PluginDefinition(ClsDefinition[_BaseClsCoT], Generic[_BaseClsCoT]):
         - Different plugin repositories **MAY** each have a plugin with the same ID.
         """
         return self._id
-
-    @override
-    def _set_cls(self, cls: builtins.type[_BaseClsCoT]) -> None:
-        super()._set_cls(cls)
-        cls.plugin = staticmethod(update_wrapper(lambda: self, cls.plugin))  # ty:ignore[unresolved-attribute]
 
     @property
     def reference_label(self) -> Localizable:
@@ -99,13 +91,15 @@ _PluginDefinitionCoT = TypeVar(
     default=PluginDefinition,
     covariant=True,
 )
+# @todo covariant?
+_PluginClsDefinitionT = TypeVar(
+    "_PluginClsDefinitionT", bound=PluginClsDefinition, default=PluginClsDefinition
+)
 
 
 @final
 class PluginTypeDefinition(
-    CountableHumanFacingDefinition,
-    ClsDefinition[_PluginDefinitionT],
-    Generic[_BaseClsCoT, _PluginDefinitionT],
+    CountableHumanFacingDefinition, ClsDefinition[_PluginDefinitionT]
 ):
     """
     A plugin type definition.
@@ -198,7 +192,7 @@ class PluginTypeDefinition(
         return self._defined_discovery != self._active_discovery
 
 
-class Plugin(Generic[_PluginDefinitionCoT]):
+class Plugin(Generic[_PluginClsDefinitionT]):
     """
     A plugin class.
 
@@ -207,7 +201,7 @@ class Plugin(Generic[_PluginDefinitionCoT]):
     """
 
     @classmethod
-    def plugin(cls) -> _PluginDefinitionCoT:
+    def plugin(cls) -> _PluginClsDefinitionT:
         """
         The plugin definition.
         """

--- a/betty/plugin/cls.py
+++ b/betty/plugin/cls.py
@@ -1,0 +1,25 @@
+"""
+Classed plugins.
+"""
+
+from __future__ import annotations
+
+from functools import update_wrapper
+
+from typing_extensions import TypeVar, override
+
+from betty.definition.cls import ClsDefinition
+from betty.plugin import Plugin, PluginDefinition
+
+_PluginT = TypeVar("_PluginT", default=Plugin)
+
+
+class PluginClsDefinition(PluginDefinition, ClsDefinition[_PluginT]):
+    """
+    A classed plugin definition.
+    """
+
+    @override
+    def _set_cls(self, cls: type[_PluginT]) -> None:
+        super()._set_cls(cls)
+        cls.plugin = staticmethod(update_wrapper(lambda: self, cls.plugin))  # ty:ignore[unresolved-attribute]

--- a/betty/plugin/cls.py
+++ b/betty/plugin/cls.py
@@ -11,15 +11,15 @@ from typing_extensions import TypeVar, override
 from betty.definition.cls import ClsDefinition
 from betty.plugin import Plugin, PluginDefinition
 
-_PluginT = TypeVar("_PluginT", default=Plugin)
+_PluginCoT = TypeVar("_PluginCoT", default=Plugin, covariant=True)
 
 
-class PluginClsDefinition(PluginDefinition, ClsDefinition[_PluginT]):
+class PluginClsDefinition(PluginDefinition, ClsDefinition[_PluginCoT]):
     """
     A classed plugin definition.
     """
 
     @override
-    def _set_cls(self, cls: type[_PluginT]) -> None:
+    def _set_cls(self, cls: type[_PluginCoT]) -> None:
         super()._set_cls(cls)
         cls.plugin = staticmethod(update_wrapper(lambda: self, cls.plugin))  # ty:ignore[unresolved-attribute]

--- a/betty/plugin/config/__init__.py
+++ b/betty/plugin/config/__init__.py
@@ -28,11 +28,13 @@ from betty.locale.localizable.property import (
     LocalizableProperty,
 )
 from betty.machine_name import MachineName, MachineNameDefinition, assert_machine_name
-from betty.plugin import Plugin, PluginDefinition
+from betty.plugin import Plugin, PluginClsDefinition, PluginDefinition
 from betty.plugin.resolve import ResolvableId, resolve_definition, resolve_id
 from betty.typing import Void
 
 if TYPE_CHECKING:
+    from ty_extensions import Intersection
+
     from betty.locale.localizable import CountableLocalizableLike, ResolvableLocalizable
     from betty.portable import PortableData
     from betty.service.level import ServiceLevel
@@ -41,6 +43,9 @@ _T = TypeVar("_T")
 _PluginT = TypeVar("_PluginT", bound=Plugin, default=Plugin)
 _PluginDefinitionT = TypeVar(
     "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
+)
+_PluginClsDefinitionT = TypeVar(
+    "_PluginClsDefinitionT", bound=PluginClsDefinition, default=PluginClsDefinition
 )
 
 
@@ -126,7 +131,9 @@ class CountableHumanFacingPluginDefinitionConfiguration(
 
 
 @final
-class PluginConfiguration(PortableRecord[Attr], Generic[_PluginDefinitionT, _PluginT]):
+class PluginConfiguration(
+    PortableRecord[Attr], Generic[_PluginClsDefinitionT, _PluginT]
+):
     """
     Configure a single plugin instance.
 
@@ -135,7 +142,7 @@ class PluginConfiguration(PortableRecord[Attr], Generic[_PluginDefinitionT, _Plu
 
     def __init__(
         self,
-        id: ResolvableId[_PluginDefinitionT],  # noqa: A002
+        id: ResolvableId[_PluginClsDefinitionT],  # noqa: A002
         configuration: Data | PortableData | Void = Void(),  # noqa: B008
         /,
     ):
@@ -203,7 +210,12 @@ class PluginConfiguration(PortableRecord[Attr], Generic[_PluginDefinitionT, _Plu
         }
 
     async def new_plugin(
-        self, services: ServiceLevel, plugin_type: type[_PluginDefinitionT], /
+        self,
+        services: ServiceLevel,
+        plugin_type: type[
+            Intersection[_PluginClsDefinitionT, PluginClsDefinition[_PluginT]]
+        ],
+        /,
     ) -> _PluginT:
         """
         Create a new instance of the configured plugin.
@@ -214,13 +226,16 @@ class PluginConfiguration(PortableRecord[Attr], Generic[_PluginDefinitionT, _Plu
 
 
 ResolvablePluginConfiguration: TypeAlias = (
-    ResolvableId[_PluginDefinitionT] | PluginConfiguration[_PluginDefinitionT, _PluginT]
+    ResolvableId[_PluginClsDefinitionT]
+    | PluginConfiguration[_PluginClsDefinitionT, _PluginT]
 )
 
 
 def resolve_plugin_configuration(
-    plugin_configuration: ResolvablePluginConfiguration[_PluginDefinitionT, _PluginT],
-) -> PluginConfiguration[_PluginDefinitionT, _PluginT]:
+    plugin_configuration: ResolvablePluginConfiguration[
+        _PluginClsDefinitionT, _PluginT
+    ],
+) -> PluginConfiguration[_PluginClsDefinitionT, _PluginT]:
     """
     Resolve a value to a plugin configuration.
     """
@@ -228,20 +243,20 @@ def resolve_plugin_configuration(
         return plugin_configuration
     if isinstance(plugin_configuration, str):
         return PluginConfiguration(plugin_configuration)
-    return PluginConfiguration(resolve_definition(plugin_configuration).id)  # ty:ignore[invalid-argument-type]
+    return PluginConfiguration(resolve_definition(plugin_configuration).id)
 
 
 ResolvablePluginConfigurationSequence: TypeAlias = (
-    ResolvablePluginConfiguration[_PluginDefinitionT, _PluginT]
-    | Iterable[ResolvablePluginConfiguration[_PluginDefinitionT, _PluginT]]
+    ResolvablePluginConfiguration[_PluginClsDefinitionT, _PluginT]
+    | Iterable[ResolvablePluginConfiguration[_PluginClsDefinitionT, _PluginT]]
 )
 
 
 def resolve_plugin_configuration_sequence(
     plugin_configurations: ResolvablePluginConfigurationSequence[
-        _PluginDefinitionT, _PluginT
+        _PluginClsDefinitionT, _PluginT
     ],
-) -> MutableSequence[PluginConfiguration[_PluginDefinitionT, _PluginT]]:
+) -> MutableSequence[PluginConfiguration[_PluginClsDefinitionT, _PluginT]]:
     """
     Resolve a value to a sequence of plugin configurations.
     """
@@ -252,15 +267,15 @@ def resolve_plugin_configuration_sequence(
         or isinstance(plugin_configurations, type)
         and issubclass(plugin_configurations, Plugin)
     ):
-        return [resolve_plugin_configuration(plugin_configurations)]  # ty:ignore[invalid-argument-type]
+        return [resolve_plugin_configuration(plugin_configurations)]
     return list(map(resolve_plugin_configuration, plugin_configurations))  # ty:ignore[invalid-argument-type]
 
 
 def resolve_plugin_configuration_mapping(
     plugin_configurations: Mapping[
-        _T, ResolvablePluginConfiguration[_PluginDefinitionT, _PluginT]
+        _T, ResolvablePluginConfiguration[_PluginClsDefinitionT, _PluginT]
     ],
-) -> MutableMapping[_T, PluginConfiguration[_PluginDefinitionT, _PluginT]]:
+) -> MutableMapping[_T, PluginConfiguration[_PluginClsDefinitionT, _PluginT]]:
     """
     Resolve a value to a mapping of plugin configurations.
     """

--- a/betty/plugin/config/__init__.py
+++ b/betty/plugin/config/__init__.py
@@ -29,7 +29,12 @@ from betty.locale.localizable.property import (
 )
 from betty.machine_name import MachineName, MachineNameDefinition, assert_machine_name
 from betty.plugin import Plugin, PluginClsDefinition, PluginDefinition
-from betty.plugin.resolve import ResolvableId, resolve_definition, resolve_id
+from betty.plugin.resolve import (
+    ResolvableClsId,
+    ResolvableId,
+    resolve_definition,
+    resolve_id,
+)
 from betty.typing import Void
 
 if TYPE_CHECKING:
@@ -40,7 +45,7 @@ if TYPE_CHECKING:
     from betty.service.level import ServiceLevel
 
 _T = TypeVar("_T")
-_PluginT = TypeVar("_PluginT", bound=Plugin, default=Plugin)
+_PluginCoT = TypeVar("_PluginCoT", bound=Plugin, default=Plugin, covariant=True)
 _PluginDefinitionT = TypeVar(
     "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
 )
@@ -132,7 +137,7 @@ class CountableHumanFacingPluginDefinitionConfiguration(
 
 @final
 class PluginConfiguration(
-    PortableRecord[Attr], Generic[_PluginClsDefinitionT, _PluginT]
+    PortableRecord[Attr], Generic[_PluginClsDefinitionT, _PluginCoT]
 ):
     """
     Configure a single plugin instance.
@@ -142,7 +147,7 @@ class PluginConfiguration(
 
     def __init__(
         self,
-        id: ResolvableId[_PluginClsDefinitionT],  # noqa: A002
+        id: ResolvableClsId[_PluginClsDefinitionT],  # noqa: A002
         configuration: Data | PortableData | Void = Void(),  # noqa: B008
         /,
     ):
@@ -213,10 +218,10 @@ class PluginConfiguration(
         self,
         services: ServiceLevel,
         plugin_type: type[
-            Intersection[_PluginClsDefinitionT, PluginClsDefinition[_PluginT]]
+            Intersection[_PluginClsDefinitionT, PluginClsDefinition[_PluginCoT]]
         ],
         /,
-    ) -> _PluginT:
+    ) -> _PluginCoT:
         """
         Create a new instance of the configured plugin.
         """
@@ -227,15 +232,15 @@ class PluginConfiguration(
 
 ResolvablePluginConfiguration: TypeAlias = (
     ResolvableId[_PluginClsDefinitionT]
-    | PluginConfiguration[_PluginClsDefinitionT, _PluginT]
+    | PluginConfiguration[_PluginClsDefinitionT, _PluginCoT]
 )
 
 
 def resolve_plugin_configuration(
     plugin_configuration: ResolvablePluginConfiguration[
-        _PluginClsDefinitionT, _PluginT
+        _PluginClsDefinitionT, _PluginCoT
     ],
-) -> PluginConfiguration[_PluginClsDefinitionT, _PluginT]:
+) -> PluginConfiguration[_PluginClsDefinitionT, _PluginCoT]:
     """
     Resolve a value to a plugin configuration.
     """
@@ -247,16 +252,16 @@ def resolve_plugin_configuration(
 
 
 ResolvablePluginConfigurationSequence: TypeAlias = (
-    ResolvablePluginConfiguration[_PluginClsDefinitionT, _PluginT]
-    | Iterable[ResolvablePluginConfiguration[_PluginClsDefinitionT, _PluginT]]
+    ResolvablePluginConfiguration[_PluginClsDefinitionT, _PluginCoT]
+    | Iterable[ResolvablePluginConfiguration[_PluginClsDefinitionT, _PluginCoT]]
 )
 
 
 def resolve_plugin_configuration_sequence(
     plugin_configurations: ResolvablePluginConfigurationSequence[
-        _PluginClsDefinitionT, _PluginT
+        _PluginClsDefinitionT, _PluginCoT
     ],
-) -> MutableSequence[PluginConfiguration[_PluginClsDefinitionT, _PluginT]]:
+) -> MutableSequence[PluginConfiguration[_PluginClsDefinitionT, _PluginCoT]]:
     """
     Resolve a value to a sequence of plugin configurations.
     """
@@ -273,9 +278,9 @@ def resolve_plugin_configuration_sequence(
 
 def resolve_plugin_configuration_mapping(
     plugin_configurations: Mapping[
-        _T, ResolvablePluginConfiguration[_PluginClsDefinitionT, _PluginT]
+        _T, ResolvablePluginConfiguration[_PluginClsDefinitionT, _PluginCoT]
     ],
-) -> MutableMapping[_T, PluginConfiguration[_PluginClsDefinitionT, _PluginT]]:
+) -> MutableMapping[_T, PluginConfiguration[_PluginClsDefinitionT, _PluginCoT]]:
     """
     Resolve a value to a mapping of plugin configurations.
     """

--- a/betty/plugin/config/property.py
+++ b/betty/plugin/config/property.py
@@ -15,7 +15,7 @@ from betty.data.aggregate.record.object.property import (
     SequenceProperty,
 )
 from betty.data.indicator.selector import Attr
-from betty.plugin import Plugin, PluginDefinition
+from betty.plugin import Plugin, PluginClsDefinition, PluginDefinition
 from betty.plugin.config import (
     PluginConfiguration,
     PluginDefinitionConfiguration,
@@ -33,16 +33,19 @@ _PluginT = TypeVar("_PluginT", bound=Plugin, default=Plugin)
 _PluginDefinitionT = TypeVar(
     "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
 )
+_PluginClsDefinitionT = TypeVar(
+    "_PluginClsDefinitionT", bound=PluginClsDefinition, default=PluginClsDefinition
+)
 
 
 @final
 class PluginConfigurationSequenceProperty(
     SequenceProperty[
         ResolvingMutableSequence[
-            PluginConfiguration[_PluginDefinitionT, _PluginT],
-            ResolvablePluginConfiguration[_PluginDefinitionT, _PluginT],
+            PluginConfiguration[_PluginClsDefinitionT, _PluginT],
+            ResolvablePluginConfiguration[_PluginClsDefinitionT, _PluginT],
         ],
-        ResolvablePluginConfigurationSequence[_PluginDefinitionT, _PluginT],
+        ResolvablePluginConfigurationSequence[_PluginClsDefinitionT, _PluginT],
     ]
 ):
     """
@@ -51,7 +54,7 @@ class PluginConfigurationSequenceProperty(
 
     def __init__(
         self,
-        plugin_type: type[_PluginDefinitionT],
+        plugin_type: type[_PluginClsDefinitionT],
         *,
         label: ResolvableLocalizable | None = None,
         description: ResolvableLocalizable | None = None,

--- a/betty/plugin/dependent.py
+++ b/betty/plugin/dependent.py
@@ -19,10 +19,7 @@ if TYPE_CHECKING:
     from betty.plugin.repository import PluginRepository
 
 
-_BaseClsCoT = TypeVar("_BaseClsCoT", default=object, covariant=True)
-
-
-class DependentPluginDefinition(OrderedPluginDefinition[_BaseClsCoT]):
+class DependentPluginDefinition(OrderedPluginDefinition):
     """
     A definition of a plugin that can declare its dependency on other plugins.
     """

--- a/betty/plugin/error.py
+++ b/betty/plugin/error.py
@@ -4,7 +4,7 @@ Generic plugin API errors.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, final
+from typing import TYPE_CHECKING, final
 
 from typing_extensions import TypeVar
 
@@ -48,7 +48,7 @@ class PluginNotFound(PluginUnavailable):
 
     def __init__(
         self,
-        plugin_type: PluginTypeDefinition[Any, _PluginDefinitionT],
+        plugin_type: PluginTypeDefinition[_PluginDefinitionT],
         plugin_not_found: MachineName,
         available_plugins: Sequence[ResolvableId[_PluginDefinitionT]],
         /,

--- a/betty/plugin/ordered.py
+++ b/betty/plugin/ordered.py
@@ -20,13 +20,12 @@ if TYPE_CHECKING:
     from betty.plugin.repository import PluginRepository
 
 
-_BaseClsCoT = TypeVar("_BaseClsCoT", default=object, covariant=True)
 _PluginDefinitionT = TypeVar(
     "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
 )
 
 
-class OrderedPluginDefinition(PluginDefinition[_BaseClsCoT]):
+class OrderedPluginDefinition(PluginDefinition):
     """
     A definition of plugin that can declare its order with respect to other plugins.
     """

--- a/betty/plugin/resolve.py
+++ b/betty/plugin/resolve.py
@@ -4,7 +4,7 @@ Tools to resolve wide varieties of generic plugin API types to specific types or
 
 from __future__ import annotations
 
-from typing import TypeAlias
+from typing import TypeAlias, overload
 
 from typing_extensions import TypeVar
 
@@ -18,25 +18,49 @@ _PluginClsDefinitionT = TypeVar(
     "_PluginClsDefinitionT", bound=PluginClsDefinition, default=PluginClsDefinition
 )
 
-ResolvableDefinition: TypeAlias = _PluginDefinitionT | type[Plugin[_PluginDefinitionT]]
+ResolvableDefinition: TypeAlias = PluginDefinition | type[Plugin]
 """
 Use :py:func:`betty.plugin.resolve.resolve_definition` to resolve this to a :py:class:`betty.plugin.PluginDefinition`
 """
 
-ResolvableId: TypeAlias = MachineName | ResolvableDefinition[_PluginDefinitionT]
+ResolvableClsDefinition: TypeAlias = (
+    _PluginClsDefinitionT | type[Plugin[_PluginClsDefinitionT]]
+)
+"""
+Use :py:func:`betty.plugin.resolve.resolve_definition` to resolve this to a :py:class:`betty.plugin.PluginDefinition`
+"""
+
+ResolvableId: TypeAlias = MachineName | ResolvableDefinition
+"""
+Use :py:func:`betty.plugin.resolve.resolve_id` to resolve this to a plugin ID.
+"""
+
+ResolvableClsId: TypeAlias = (
+    MachineName | ResolvableClsDefinition[_PluginClsDefinitionT]
+)
 """
 Use :py:func:`betty.plugin.resolve.resolve_id` to resolve this to a plugin ID.
 """
 
 
+@overload
 def resolve_definition(
-    definition: ResolvableDefinition[_PluginDefinitionT], /
-) -> _PluginDefinitionT:
+    definition: ResolvableClsDefinition[_PluginClsDefinitionT], /
+) -> _PluginClsDefinitionT:
+    pass
+
+
+@overload
+def resolve_definition(definition: ResolvableDefinition, /) -> PluginDefinition:
+    pass
+
+
+def resolve_definition(definition):
     """
     Resolve a plugin definition.
     """
-    if isinstance(definition, PluginClsDefinition):
-        return definition  # ty:ignore[invalid-return-type]
+    if isinstance(definition, PluginDefinition):
+        return definition
     return definition.plugin()
 
 

--- a/betty/plugin/resolve.py
+++ b/betty/plugin/resolve.py
@@ -9,10 +9,13 @@ from typing import TypeAlias
 from typing_extensions import TypeVar
 
 from betty.machine_name import MachineName
-from betty.plugin import Plugin, PluginDefinition
+from betty.plugin import Plugin, PluginClsDefinition, PluginDefinition
 
 _PluginDefinitionT = TypeVar(
     "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
+)
+_PluginClsDefinitionT = TypeVar(
+    "_PluginClsDefinitionT", bound=PluginClsDefinition, default=PluginClsDefinition
 )
 
 ResolvableDefinition: TypeAlias = _PluginDefinitionT | type[Plugin[_PluginDefinitionT]]
@@ -32,7 +35,7 @@ def resolve_definition(
     """
     Resolve a plugin definition.
     """
-    if isinstance(definition, PluginDefinition):
+    if isinstance(definition, PluginClsDefinition):
         return definition  # ty:ignore[invalid-return-type]
     return definition.plugin()
 

--- a/betty/plugin/schema.py
+++ b/betty/plugin/schema.py
@@ -4,34 +4,33 @@ Access discovered plugins.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Generic, final
+from typing import TYPE_CHECKING, final
 
 from typing_extensions import TypeVar
 
 from betty.json.schema import Enum
 from betty.locale.localize import DEFAULT_LOCALIZER
-from betty.plugin import Plugin, PluginDefinition, PluginTypeDefinition
+from betty.plugin import PluginDefinition, PluginTypeDefinition
 from betty.string import kebab_case_to_lower_camel_case
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-_PluginT = TypeVar("_PluginT", bound=Plugin, default=Plugin)
 _PluginDefinitionT = TypeVar(
     "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
 )
 
 
 @final
-class PluginIdSchema(Enum, Generic[_PluginDefinitionT, _PluginT]):
+class PluginIdSchema(Enum):
     """
     The JSON schema for the IDs of the plugins in this repository.
     """
 
     def __init__(
         self,
-        plugin_type: PluginTypeDefinition[_PluginT, _PluginDefinitionT],
-        plugins: Iterable[PluginDefinition[_PluginT]],
+        plugin_type: PluginTypeDefinition[_PluginDefinitionT],
+        plugins: Iterable[_PluginDefinitionT],
         /,
     ):
         label = plugin_type.label.localize(DEFAULT_LOCALIZER)

--- a/betty/render/__init__.py
+++ b/betty/render/__init__.py
@@ -10,7 +10,8 @@ from typing import TYPE_CHECKING, final
 from betty.definition.human_facing import HumanFacingDefinition
 from betty.html import plain_text_to_html
 from betty.locale.localizable.gettext import _, ngettext
-from betty.plugin import Plugin, PluginDefinition, PluginTypeDefinition
+from betty.plugin import Plugin, PluginTypeDefinition
+from betty.plugin.cls import PluginClsDefinition
 from betty.plugin.discovery.entry_point import EntryPointDiscovery
 
 if TYPE_CHECKING:
@@ -44,7 +45,7 @@ class Renderer(ABC, Plugin["RendererDefinition"]):
     label_countable=ngettext("{count} renderer", "{count} renderers"),
     discovery=EntryPointDiscovery("betty.renderer"),
 )
-class RendererDefinition(HumanFacingDefinition, PluginDefinition[Renderer]):
+class RendererDefinition(HumanFacingDefinition, PluginClsDefinition[Renderer]):
     """
     .. plugin_type:: renderer.
     """

--- a/betty/serde/__init__.py
+++ b/betty/serde/__init__.py
@@ -12,7 +12,8 @@ from betty.exception import HumanFacingException
 from betty.locale.localizable.gettext import _, ngettext
 from betty.locale.localizable.markup import AnyEnumeration
 from betty.locale.localizable.plain import Plain
-from betty.plugin import Plugin, PluginDefinition, PluginTypeDefinition
+from betty.plugin import Plugin, PluginTypeDefinition
+from betty.plugin.cls import PluginClsDefinition
 from betty.plugin.discovery.entry_point import EntryPointDiscovery
 
 if TYPE_CHECKING:
@@ -64,7 +65,7 @@ class Serializer(ABC, Plugin["SerializerDefinition"]):
     label_countable=ngettext("{count} serializer", "{count} serializers"),
     discovery=EntryPointDiscovery("betty.serializer"),
 )
-class SerializerDefinition(HumanFacingDefinition, PluginDefinition[Serializer]):
+class SerializerDefinition(HumanFacingDefinition, PluginClsDefinition[Serializer]):
     """
     .. plugin_type:: serializer.
     """

--- a/betty/sphinx/extension/betty.py
+++ b/betty/sphinx/extension/betty.py
@@ -25,6 +25,7 @@ from betty.functools import Result
 from betty.importlib import import_any
 from betty.locale.localize import DEFAULT_LOCALIZER
 from betty.plugin import plugin_types
+from betty.plugin.cls import PluginClsDefinition
 from betty.plugin.dependent import DependentPluginDefinition
 from betty.plugin.ordered import OrderedPluginDefinition
 from betty.project import Project
@@ -144,11 +145,6 @@ class _PluginDirective(SphinxDirective):
     def _build_metadata(
         self, plugin: PluginDefinition, plugins: PluginRepository[PluginDefinition]
     ) -> list[nodes.Node]:
-        cls = plugin.cls
-        if issubclass(cls, Configurable):
-            configuration_content = f":py:class:`{cls.configuration_cls().__name__} <{cls.configuration_cls().__module__}.{cls.configuration_cls().__qualname__}>`"
-        else:
-            configuration_content = "*not configurable*"
         content = f"""
 .. list-table::
    :widths: 20 10
@@ -156,6 +152,14 @@ class _PluginDirective(SphinxDirective):
 
    * - Plugin ID
      - ``{plugin.id}``
+"""
+        if isinstance(plugin, PluginClsDefinition):
+            cls = plugin.cls
+            if issubclass(cls, Configurable):
+                configuration_content = f":py:class:`{cls.configuration_cls().__name__} <{cls.configuration_cls().__module__}.{cls.configuration_cls().__qualname__}>`"
+            else:
+                configuration_content = "*not configurable*"
+            content = f"""
    * - Class
      - :py:class:`{plugin.cls.__name__} <{plugin.cls.__module__}.{plugin.cls.__qualname__}>`
    * - Configuration
@@ -197,6 +201,7 @@ class _PluginDirective(SphinxDirective):
         contents = [
             f":py:class:`{plugin.id} <{plugin.cls.__module__}.{plugin.cls.__qualname__}>`"
             for plugin in sorted(plugins, key=lambda plugin: plugin.id)
+            if isinstance(plugin, PluginClsDefinition)
         ]
         if not contents:
             return ""
@@ -275,9 +280,10 @@ class _PluginTypeDirective(SphinxDirective):
     def _build_builtin_plugin_definition(
         self, plugin: PluginDefinition
     ) -> tuple[NodesLike, NodesLike]:
-        term_nodes, _ = self.parse_inline(
-            f"{plugin.id} (:py:class:`{plugin.cls.__name__} <{plugin.cls.__module__}.{plugin.cls.__qualname__}>`)"
-        )
+        term = plugin.id
+        if isinstance(plugin, PluginClsDefinition):
+            term += f" (:py:class:`{plugin.cls.__name__} <{plugin.cls.__module__}.{plugin.cls.__qualname__}>`)"
+        term_nodes, _ = self.parse_inline(term)
         definition_nodes: MutableSequence[nodes.Node] | None = None
         if isinstance(plugin, HumanFacingDefinition):
             definition_nodes = [nodes.Text(plugin.label.localize(DEFAULT_LOCALIZER))]

--- a/betty/test_utils/documentation.py
+++ b/betty/test_utils/documentation.py
@@ -9,6 +9,7 @@ import pytest
 from betty.app import App
 from betty.importlib import fully_qualified_name
 from betty.plugin import PluginDefinition, plugin_types
+from betty.plugin.cls import PluginClsDefinition
 from betty.project import Project
 
 
@@ -48,12 +49,11 @@ class PluginDocumentationTestBase:
         )
 
     def _test_plugin(self, plugin: PluginDefinition) -> None:
-        if not self._match_module(plugin.cls):
-            return
         if plugin.id.startswith("-"):
             return
-        docstring = plugin.cls.__doc__ or ""
-        directive = f".. plugin:: {plugin.type().id}:{plugin.id}"
-        assert directive in docstring, (
-            f'Failed to find the "{directive}" directive in the docstring for {fully_qualified_name(plugin.cls)}'
-        )
+        if isinstance(plugin, PluginClsDefinition) and self._match_module(plugin.cls):
+            docstring = plugin.cls.__doc__ or ""
+            directive = f".. plugin:: {plugin.type().id}:{plugin.id}"
+            assert directive in docstring, (
+                f'Failed to find the "{directive}" directive in the docstring for {fully_qualified_name(plugin.cls)}'
+            )

--- a/betty/test_utils/plugin/__init__.py
+++ b/betty/test_utils/plugin/__init__.py
@@ -11,16 +11,11 @@ import pytest
 from betty.locale.localize import DEFAULT_LOCALIZER
 from betty.machine_name import assert_machine_name
 from betty.plugin import Plugin, PluginDefinition, PluginTypeDefinition
+from betty.plugin.cls import PluginClsDefinition
 from betty.plugin.discovery.callback import CallbackDiscovery
 from betty.test_utils.locale.localizable import DUMMY_COUNTABLE_LOCALIZABLE
 
 _PluginT = TypeVar("_PluginT", bound=Plugin)
-
-
-def _assert_cls_is_public(cls: type) -> None:
-    assert not cls.__name__.startswith("_"), (
-        f"Failed asserting that plugin class {cls} is public (its name must not start with an underscore)"
-    )
 
 
 class PluginTestBase(Generic[_PluginT]):
@@ -85,12 +80,6 @@ class PluginDefinitionTestBase:
         """
         assert_machine_name()(sut.id)
 
-    def test_cls(self, sut: PluginDefinition) -> None:
-        """
-        Tests the :py:attr:`betty.plugin.PluginDefinition.cls` value.
-        """
-        _assert_cls_is_public(sut.cls)
-
 
 class DummyPlugin(Plugin["DummyPluginDefinition"]):
     """
@@ -112,7 +101,7 @@ class DummyPlugin(Plugin["DummyPluginDefinition"]):
         ]
     ),
 )
-class DummyPluginDefinition(PluginDefinition[DummyPlugin]):
+class DummyPluginDefinition(PluginClsDefinition[DummyPlugin]):
     """
     A definition of a dummy plugin.
     """

--- a/betty/test_utils/plugin/config.py
+++ b/betty/test_utils/plugin/config.py
@@ -8,7 +8,8 @@ from typing import TYPE_CHECKING, Self, final
 
 from typing_extensions import override
 
-from betty.plugin import Plugin, PluginDefinition, PluginTypeDefinition
+from betty.plugin import Plugin, PluginTypeDefinition
+from betty.plugin.cls import PluginClsDefinition
 from betty.plugin.discovery.callback import CallbackDiscovery
 from betty.test_utils.config import DummyConfigurable
 from betty.test_utils.data import DummyData
@@ -49,7 +50,7 @@ class ConfigurableDummyPlugin(
         ]
     ),
 )
-class ConfigurableDummyPluginDefinition(PluginDefinition[ConfigurableDummyPlugin]):
+class ConfigurableDummyPluginDefinition(PluginClsDefinition[ConfigurableDummyPlugin]):
     """
     A definition of a configurable dummy plugin.
     """

--- a/betty/tests/plugin/test___init__.py
+++ b/betty/tests/plugin/test___init__.py
@@ -16,7 +16,7 @@ from betty.test_utils.locale.localizable import (
     DUMMY_COUNTABLE_LOCALIZABLE,
     DUMMY_LOCALIZABLE,
 )
-from betty.test_utils.plugin import DummyPlugin, DummyPluginOne, DummyPluginTwo
+from betty.test_utils.plugin import DummyPluginOne, DummyPluginTwo
 
 
 @PluginTypeDefinition(
@@ -25,7 +25,7 @@ from betty.test_utils.plugin import DummyPlugin, DummyPluginOne, DummyPluginTwo
     label_plural="_OrderedPluginDefinitions",
     label_countable=DUMMY_COUNTABLE_LOCALIZABLE,
 )
-class _OrderedPluginDefinition(OrderedPluginDefinition[DummyPlugin]):
+class _OrderedPluginDefinition(OrderedPluginDefinition):
     pass
 
 
@@ -64,7 +64,7 @@ _ORDERED_PLUGIN_HAS_COMES_AFTER_BIDIRECTIONAL = _OrderedPluginDefinition(
     label_plural="_DependentPluginDefinition",
     label_countable=DUMMY_COUNTABLE_LOCALIZABLE,
 )
-class _DependentPluginDefinition(DependentPluginDefinition[DummyPlugin]):
+class _DependentPluginDefinition(DependentPluginDefinition):
     pass
 
 
@@ -179,7 +179,7 @@ class TestPluginDefinition:
             label_plural=DUMMY_LOCALIZABLE,
             label_countable=DUMMY_COUNTABLE_LOCALIZABLE,
         )
-        class _PluginDefinition(PluginDefinition[DummyPlugin]):
+        class _PluginDefinition(PluginDefinition):
             pass
 
         id = "my-first-plugin"  # noqa: A001

--- a/betty/tests/plugin/test_resolve.py
+++ b/betty/tests/plugin/test_resolve.py
@@ -1,4 +1,5 @@
 from betty.plugin import Plugin, PluginDefinition, PluginTypeDefinition
+from betty.plugin.cls import PluginClsDefinition
 from betty.plugin.resolve import resolve_definition, resolve_id
 from betty.test_utils.locale.localizable import (
     DUMMY_COUNTABLE_LOCALIZABLE,
@@ -16,7 +17,7 @@ class _PluginCls(Plugin["_PluginDefinition"]):
     label_plural=DUMMY_LOCALIZABLE,
     label_countable=DUMMY_COUNTABLE_LOCALIZABLE,
 )
-class _PluginDefinition(PluginDefinition[_PluginCls]):
+class _PluginDefinition(PluginClsDefinition[_PluginCls]):
     pass
 
 

--- a/betty/tests/test_deriver.py
+++ b/betty/tests/test_deriver.py
@@ -20,7 +20,7 @@ from betty.date import Date, DateRange, ResolvableDate
 from betty.deriver import Deriver
 from betty.model.collections import record_added
 from betty.plugin.discovery.static import StaticDiscovery
-from betty.plugin.resolve import ResolvableDefinition
+from betty.plugin.resolve import ResolvableClsDefinition
 from betty.project import Project
 from betty.test_utils.locale.localizable import (
     DUMMY_COUNTABLE_LOCALIZABLE,
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from betty.app import App
 
 NewProject: TypeAlias = Callable[
-    [Iterable[ResolvableDefinition[EventTypeDefinition]]],
+    [Iterable[ResolvableClsDefinition[EventTypeDefinition]]],
     AbstractAsyncContextManager[Project],
 ]
 
@@ -205,7 +205,7 @@ class TestDeriver:
     def new_project(self, isolated_app: App) -> NewProject:
         @asynccontextmanager
         async def _new_project(
-            event_types: Iterable[ResolvableDefinition[EventTypeDefinition]],
+            event_types: Iterable[ResolvableClsDefinition[EventTypeDefinition]],
         ) -> AsyncIterator[Project]:
             with EventTypeDefinition.type().override_discovery(
                 StaticDiscovery(*event_types)


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/3635

## To do
- A major challenge is resolvable definitions. Some calling code needs `ResolvableDefinition` for any plugin type, and others for a specific type
- Can we add a function that takes a plugin type and returns a `type[ClsPluginDefiniton]`? Or another way we can inject the base class cleanly and properly typed? 