### PR TITLE
Refactor service containers and service levels

### DIFF
--- a/betty/app/__init__.py
+++ b/betty/app/__init__.py
@@ -39,7 +39,12 @@ from betty.service.container import (
     StaticService,
     service,
 )
-from betty.service.level import Configurable, ServiceLevel, universe
+from betty.service.level import (
+    Configurable,
+    EphemeralServiceLevel,
+    ServiceLevel,
+    universe,
+)
 from betty.typing import threadsafe
 from betty.user.no_op import NoOpUser
 
@@ -60,7 +65,7 @@ _PluginDefinitionT = TypeVar(
 
 @final
 @threadsafe
-class App(Configurable[AppConfiguration], ServiceLevel):
+class App(Configurable[AppConfiguration], EphemeralServiceLevel):
     """
     The Betty application.
 

--- a/betty/config.py
+++ b/betty/config.py
@@ -1,0 +1,68 @@
+"""
+The Configuration API.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Generic,
+    ParamSpec,
+    Self,
+)
+
+from typing_extensions import TypeVar
+
+from betty.data import Data
+from betty.portable import PortableData
+
+if TYPE_CHECKING:
+    from betty.service.level import ServiceLevel
+
+_PortableDataT = TypeVar("_PortableDataT", bound=PortableData, default=PortableData)
+
+
+_T = TypeVar("_T")
+_P = ParamSpec("_P")
+_DataT = TypeVar("_DataT", bound=Data, default=Data)
+
+
+class HasConfiguration(ABC, Generic[_DataT]):
+    """
+    An object with configuration.
+    """
+
+    def __init__(self, *args: Any, configuration: _DataT, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self._configuration = configuration
+
+    @property
+    def configuration(self) -> _DataT:
+        """
+        The object's configuration.
+        """
+        return self._configuration
+
+    @classmethod
+    @abstractmethod
+    def configuration_cls(cls) -> type[_DataT]:
+        """
+        The object's configuration class.
+        """
+
+
+class Configurable(HasConfiguration[_DataT]):
+    """
+    Any configurable object.
+    """
+
+    @classmethod
+    @abstractmethod
+    async def new_for_configuration(
+        cls, *, services: ServiceLevel, configuration: _DataT
+    ) -> Self:
+        """
+        Create a new instance using the given service level and configuration.
+        """

--- a/betty/extension/__init__.py
+++ b/betty/extension/__init__.py
@@ -11,7 +11,7 @@ from betty.locale.localizable.gettext import _, ngettext
 from betty.plugin import Plugin, PluginTypeDefinition, ResolvableId
 from betty.plugin.dependent import DependentPluginDefinition
 from betty.plugin.discovery.entry_point import EntryPointDiscovery
-from betty.service.container import ServiceContainer
+from betty.service.container import EphemeralServiceContainer
 from betty.service.level import ServiceLevel
 from betty.typing import private
 
@@ -29,12 +29,13 @@ _ServiceLevelCoT = TypeVar(
 
 
 class Extension(
-    ServiceContainer, Plugin["ExtensionDefinition"], Generic[_ServiceLevelCoT]
+    EphemeralServiceContainer, Plugin["ExtensionDefinition"], Generic[_ServiceLevelCoT]
 ):
     """
     Integrate custom services with a :py:class:`service level <betty.service.level.ServiceLevel>`.
     """
 
+    # @todo Remove this now? Or generalize to any ServiceLevel?
     @private
     def __init__(self, *, services: _ServiceLevelCoT):
         super().__init__()

--- a/betty/project/__init__.py
+++ b/betty/project/__init__.py
@@ -39,7 +39,12 @@ from betty.project.config import ProjectConfiguration
 from betty.render import RenderDispatcher, RendererDefinition
 from betty.serde import SerializerDefinition, serializer_for
 from betty.service.container import service
-from betty.service.level import Configurable, ServiceLevel, universe
+from betty.service.level import (
+    Configurable,
+    EphemeralServiceLevel,
+    ServiceLevel,
+    universe,
+)
 from betty.typing import internal
 
 if TYPE_CHECKING:
@@ -65,7 +70,7 @@ _PluginDefinitionT = TypeVar(
 
 
 @final
-class Project(Configurable[ProjectConfiguration], ServiceLevel):
+class Project(Configurable[ProjectConfiguration], EphemeralServiceLevel):
     """
     Define a Betty project.
 

--- a/betty/service/container.py
+++ b/betty/service/container.py
@@ -4,11 +4,10 @@ Service containers.
 
 from __future__ import annotations
 
-from _warnings import warn
 from abc import abstractmethod
 from collections.abc import Awaitable, Callable
 from functools import update_wrapper
-from inspect import getmembers, iscoroutinefunction
+from inspect import iscoroutinefunction
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -21,19 +20,21 @@ from typing import (
     final,
     overload,
 )
+from warnings import warn
 
 from typing_extensions import override
 
 from betty.concurrent import AsynchronizedLock, Lock
 from betty.service import ServiceError
 from betty.service.bootstrap import Bootstrapped, Shutdownable, ShutdownStack
-from betty.typing import Void, internal, public
+from betty.typing import Void, internal
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
     from types import FunctionType, TracebackType
 
     from ty_extensions import Intersection
+
+    from betty.service.level import ServiceLevel
 
 
 _T = TypeVar("_T")
@@ -41,8 +42,10 @@ _ServiceT = TypeVar("_ServiceT")
 _ServiceGetT = TypeVar("_ServiceGetT")
 
 
-@internal
-class ServiceContainer(Bootstrapped, Shutdownable):
+# @todo Do we need this still?
+# @todo
+# @todo
+class ServiceContainer:
     """
     A service container.
 
@@ -50,11 +53,13 @@ class ServiceContainer(Bootstrapped, Shutdownable):
     :py:func:`betty.service.container.service`, and manage their resources by being bootstrapped and shut down.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any):
+
+class EphemeralServiceContainer(Bootstrapped, Shutdownable, ServiceContainer):
+    def __init__(self, *args: Any, services: ServiceLevel, **kwargs: Any):
         super().__init__(*args, **kwargs)
+        self._services = services
         self._shutdown_stack = ShutdownStack()
 
-    @public
     async def bootstrap(self) -> None:
         """
         Bootstrap the component.
@@ -68,15 +73,13 @@ class ServiceContainer(Bootstrapped, Shutdownable):
         pass
 
     async def _post_bootstrap(self) -> None:
-        pass
+        from betty.config import Configurable
 
-    @classmethod
-    def _service_managers(cls) -> Iterable[ServiceManager[Self, Any, Any]]:
-        for _, value in getmembers(cls):
-            if isinstance(value, ServiceManager):
-                yield value
+        if isinstance(self, Configurable):
+            await self.configuration.data().hydrate(
+                services=self._services, data=self.configuration
+            )
 
-    @public
     @override
     async def shutdown(self, *, wait: bool = True) -> None:
         self.assert_bootstrapped()
@@ -90,13 +93,11 @@ class ServiceContainer(Bootstrapped, Shutdownable):
         if self.bootstrapped:
             warn(f"{self} was bootstrapped, but never shut down.", stacklevel=2)
 
-    @public
     @final
     async def __aenter__(self) -> Self:
         await self.bootstrap()
         return self
 
-    @public
     @final
     async def __aexit__(
         self,
@@ -197,6 +198,9 @@ class ServiceManager(Generic[_ServiceContainerT, _ServiceGetT, _ServiceT]):
     def __init__(
         self,
         factory: Intersection[
+            # @todo If we use __set_name__(), we can accept more types than just functions.
+            # @todo
+            # @todo
             ServiceFactory[_ServiceContainerT, _ServiceGetT], FunctionType
         ],
         /,
@@ -240,7 +244,8 @@ class ServiceManager(Generic[_ServiceContainerT, _ServiceGetT, _ServiceT]):
         """
         Get the service from an instance.
         """
-        instance.assert_bootstrapped()
+        if isinstance(instance, EphemeralServiceContainer):
+            instance.assert_bootstrapped()
 
         return self._get(instance)
 

--- a/betty/service/level.py
+++ b/betty/service/level.py
@@ -5,7 +5,7 @@ Service levels.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Final, Generic, Self, overload
+from typing import TYPE_CHECKING, Final, Generic, Self, overload
 
 from typing_extensions import TypeVar
 
@@ -15,7 +15,7 @@ from betty.exception import HumanFacingException
 from betty.importlib import fully_qualified_name
 from betty.locale.localizable.gettext import _
 from betty.plugin.manager.service import ServiceLevelPluginManager
-from betty.service.container import ServiceContainer
+from betty.service.container import EphemeralServiceContainer, ServiceContainer, service
 from betty.typing import Void
 
 if TYPE_CHECKING:
@@ -51,11 +51,6 @@ class ServiceLevel(ServiceContainer):
          - :py:class:`betty.extension.Extension`
     """
 
-    def __init__(self, *args: Any, **kwargs: Any):
-        super().__init__(*args, **kwargs)
-        self._plugins = ServiceLevelPluginManager(self)
-
-    @overload
     async def new_target(
         self,
         target: type[_ServiceLevelManufacturableT],
@@ -111,12 +106,23 @@ class ServiceLevel(ServiceContainer):
             configuration=configuration,
         )
 
-    @property
+    @service
     def plugins(self) -> PluginManager:
         """
         The plugin manager.
         """
-        return self._plugins
+        return ServiceLevelPluginManager(self)
+
+
+# @todo Finetune the name
+# @todo
+# @todo
+# @todo
+# @todo
+# @todo Also we need a mixin with parts of this, for Extensions, which have all the cool async service handling but none of the service level
+# @todo
+class EphemeralServiceLevel(EphemeralServiceContainer, ServiceLevel):
+    pass
 
 
 universe: Final[ServiceLevel] = ServiceLevel()


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/3747

## To do
- Merge `Bootstrapped` and `Shutdownable`, and see if the combined functionality can be moved into another class if we do not use it elsewhere. Except... Let's just combine them and keep them in their own class. We can later use that to make any service level plugin (such as extensions currently) managed by their owning service level. 
- Split `ShutdownStack` into a universal and an ephemeral variant. Expose this on all service levels. 
- Fix `@todo`s
- ensure configuration is hydrated if Bootstrappable is Configurable 
- either here or in a separate PR: can we use `TypeVarTupñe` and the builder pattern to create or just either to create service containers that mesh/proxy several other containers and expose all cumulative services and their typed `@service` definitions using a single flat interface? Then we can type on things like `ServiceContainer[Intersection[Project, Maps, Raspberry mint]]`. This would help fix https://github.com/bartfeenstra/betty/issues/3786
- Can we automatically inject services? Using decorators? By requiring type hints like `jinja: Service[Environment]`? The point is that if everything gets services injected automatically, nothing needs to know about which service container something comes from 
- If we automatically inject services, we can first collect all necessary service IDs, then get the services themselves concurrently (statistically some will have asynchronous factories), and then inject them into the factory method.
- Can we use `__instancecheck__()` to pretend that a container is an instance of all the containers it is composed of? 