### PR TITLE
Allow `require_*()` to be used as regular functions

### DIFF
--- a/assets/locale/ar/betty.po
+++ b/assets/locale/ar/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-02-01 02:51+0000\n"
+"POT-Creation-Date: 2026-02-04 19:03+0000\n"
 "PO-Revision-Date: 2024-11-30 19:00+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: ar\n"
@@ -18,7 +18,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
 #, python-brace-format
 msgid "\"{color}\" is not a valid hexadecimal color, such as #ffc0cb."
@@ -2957,16 +2957,16 @@ msgid "{plugin_type} configuration"
 msgstr ""
 
 #, python-brace-format
-msgid "{subject} requires a project."
+msgid "{target} requires a project."
 msgstr ""
 
 #, python-brace-format
-msgid "{subject} requires a running app."
+msgid "{target} requires a running app."
 msgstr ""
 
 #, python-brace-format
 msgid ""
-"{subject} requires the {extension} extension. Enable it in your project "
+"{target} requires the {extension} extension. Enable it in your project "
 "configuration, and try again."
 msgstr ""
 

--- a/assets/locale/betty.pot
+++ b/assets/locale/betty.pot
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-02-01 02:51+0000\n"
+"POT-Creation-Date: 2026-02-04 19:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
 #, python-brace-format
 msgid "\"{color}\" is not a valid hexadecimal color, such as #ffc0cb."
@@ -2600,16 +2600,16 @@ msgid "{plugin_type} configuration"
 msgstr ""
 
 #, python-brace-format
-msgid "{subject} requires a project."
+msgid "{target} requires a project."
 msgstr ""
 
 #, python-brace-format
-msgid "{subject} requires a running app."
+msgid "{target} requires a running app."
 msgstr ""
 
 #, python-brace-format
 msgid ""
-"{subject} requires the {extension} extension. Enable it in your project "
+"{target} requires the {extension} extension. Enable it in your project "
 "configuration, and try again."
 msgstr ""
 

--- a/assets/locale/de-DE/betty.po
+++ b/assets/locale/de-DE/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-02-01 02:51+0000\n"
+"POT-Creation-Date: 2026-02-04 19:03+0000\n"
 "PO-Revision-Date: 2025-12-30 16:01+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: de_DE\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
 #, python-brace-format
 msgid "\"{color}\" is not a valid hexadecimal color, such as #ffc0cb."
@@ -2647,16 +2647,16 @@ msgid "{plugin_type} configuration"
 msgstr ""
 
 #, python-brace-format
-msgid "{subject} requires a project."
+msgid "{target} requires a project."
 msgstr ""
 
 #, python-brace-format
-msgid "{subject} requires a running app."
+msgid "{target} requires a running app."
 msgstr ""
 
 #, python-brace-format
 msgid ""
-"{subject} requires the {extension} extension. Enable it in your project "
+"{target} requires the {extension} extension. Enable it in your project "
 "configuration, and try again."
 msgstr ""
 

--- a/assets/locale/en-GB/betty.po
+++ b/assets/locale/en-GB/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-02-01 02:51+0000\n"
+"POT-Creation-Date: 2026-02-04 19:03+0000\n"
 "PO-Revision-Date: 2025-12-29 14:25+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: en_GB\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
 #, python-brace-format
 msgid "\"{color}\" is not a valid hexadecimal color, such as #ffc0cb."
@@ -2677,16 +2677,16 @@ msgid "{plugin_type} configuration"
 msgstr ""
 
 #, python-brace-format
-msgid "{subject} requires a project."
+msgid "{target} requires a project."
 msgstr ""
 
 #, python-brace-format
-msgid "{subject} requires a running app."
+msgid "{target} requires a running app."
 msgstr ""
 
 #, python-brace-format
 msgid ""
-"{subject} requires the {extension} extension. Enable it in your project "
+"{target} requires the {extension} extension. Enable it in your project "
 "configuration, and try again."
 msgstr ""
 

--- a/assets/locale/es-ES/betty.po
+++ b/assets/locale/es-ES/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-02-01 02:51+0000\n"
+"POT-Creation-Date: 2026-02-04 19:03+0000\n"
 "PO-Revision-Date: 2026-01-18 18:06+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: es_ES\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
 #, python-brace-format
 msgid "\"{color}\" is not a valid hexadecimal color, such as #ffc0cb."
@@ -2614,16 +2614,16 @@ msgid "{plugin_type} configuration"
 msgstr ""
 
 #, python-brace-format
-msgid "{subject} requires a project."
+msgid "{target} requires a project."
 msgstr ""
 
 #, python-brace-format
-msgid "{subject} requires a running app."
+msgid "{target} requires a running app."
 msgstr ""
 
 #, python-brace-format
 msgid ""
-"{subject} requires the {extension} extension. Enable it in your project "
+"{target} requires the {extension} extension. Enable it in your project "
 "configuration, and try again."
 msgstr ""
 

--- a/assets/locale/fi-FI/betty.po
+++ b/assets/locale/fi-FI/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-02-01 02:51+0000\n"
+"POT-Creation-Date: 2026-02-04 19:03+0000\n"
 "PO-Revision-Date: 2026-01-25 12:19+0000\n"
 "Last-Translator: Kieli Puoli <kielipuoli@gmail.com>\n"
 "Language: fi_FI\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
 #, python-brace-format
 msgid "\"{color}\" is not a valid hexadecimal color, such as #ffc0cb."
@@ -2610,16 +2610,16 @@ msgid "{plugin_type} configuration"
 msgstr ""
 
 #, python-brace-format
-msgid "{subject} requires a project."
+msgid "{target} requires a project."
 msgstr ""
 
 #, python-brace-format
-msgid "{subject} requires a running app."
+msgid "{target} requires a running app."
 msgstr ""
 
 #, python-brace-format
 msgid ""
-"{subject} requires the {extension} extension. Enable it in your project "
+"{target} requires the {extension} extension. Enable it in your project "
 "configuration, and try again."
 msgstr ""
 

--- a/assets/locale/fr-FR/betty.po
+++ b/assets/locale/fr-FR/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-02-01 02:51+0000\n"
+"POT-Creation-Date: 2026-02-04 19:03+0000\n"
 "PO-Revision-Date: 2025-08-27 20:02+0000\n"
 "Last-Translator: \"David D.\" <dadu042@users.noreply.hosted.weblate.org>\n"
 "Language: fr_FR\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
 #, python-brace-format
 msgid "\"{color}\" is not a valid hexadecimal color, such as #ffc0cb."
@@ -2652,16 +2652,16 @@ msgid "{plugin_type} configuration"
 msgstr ""
 
 #, python-brace-format
-msgid "{subject} requires a project."
+msgid "{target} requires a project."
 msgstr ""
 
 #, python-brace-format
-msgid "{subject} requires a running app."
+msgid "{target} requires a running app."
 msgstr ""
 
 #, python-brace-format
 msgid ""
-"{subject} requires the {extension} extension. Enable it in your project "
+"{target} requires the {extension} extension. Enable it in your project "
 "configuration, and try again."
 msgstr ""
 

--- a/assets/locale/he/betty.po
+++ b/assets/locale/he/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-02-01 02:51+0000\n"
+"POT-Creation-Date: 2026-02-04 19:03+0000\n"
 "PO-Revision-Date: 2025-05-06 10:01+0000\n"
 "Last-Translator: Yaron Shahrabani <sh.yaron@gmail.com>\n"
 "Language: he\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
 #, python-brace-format
 msgid "\"{color}\" is not a valid hexadecimal color, such as #ffc0cb."
@@ -2610,16 +2610,16 @@ msgid "{plugin_type} configuration"
 msgstr ""
 
 #, python-brace-format
-msgid "{subject} requires a project."
+msgid "{target} requires a project."
 msgstr ""
 
 #, python-brace-format
-msgid "{subject} requires a running app."
+msgid "{target} requires a running app."
 msgstr ""
 
 #, python-brace-format
 msgid ""
-"{subject} requires the {extension} extension. Enable it in your project "
+"{target} requires the {extension} extension. Enable it in your project "
 "configuration, and try again."
 msgstr ""
 

--- a/assets/locale/nl-NL/betty.po
+++ b/assets/locale/nl-NL/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-02-01 02:51+0000\n"
+"POT-Creation-Date: 2026-02-04 19:03+0000\n"
 "PO-Revision-Date: 2025-11-08 23:46+0000\n"
 "Last-Translator: Bart Feenstra <bart@bartfeenstra.com>\n"
 "Language: nl_NL\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
 #, python-brace-format
 msgid "\"{color}\" is not a valid hexadecimal color, such as #ffc0cb."
@@ -2685,16 +2685,16 @@ msgid "{plugin_type} configuration"
 msgstr ""
 
 #, python-brace-format
-msgid "{subject} requires a project."
+msgid "{target} requires a project."
 msgstr ""
 
 #, python-brace-format
-msgid "{subject} requires a running app."
+msgid "{target} requires a running app."
 msgstr ""
 
 #, python-brace-format
 msgid ""
-"{subject} requires the {extension} extension. Enable it in your project "
+"{target} requires the {extension} extension. Enable it in your project "
 "configuration, and try again."
 msgstr ""
 

--- a/assets/locale/pt-BR/betty.po
+++ b/assets/locale/pt-BR/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-02-01 02:51+0000\n"
+"POT-Creation-Date: 2026-02-04 19:03+0000\n"
 "PO-Revision-Date: 2025-12-16 20:00+0000\n"
 "Last-Translator: Mateus Liberale Gomes <sergiogomes209403@gmail.com>\n"
 "Language: pt_BR\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
 #, python-brace-format
 msgid "\"{color}\" is not a valid hexadecimal color, such as #ffc0cb."
@@ -2651,16 +2651,16 @@ msgid "{plugin_type} configuration"
 msgstr ""
 
 #, python-brace-format
-msgid "{subject} requires a project."
+msgid "{target} requires a project."
 msgstr ""
 
 #, python-brace-format
-msgid "{subject} requires a running app."
+msgid "{target} requires a running app."
 msgstr ""
 
 #, python-brace-format
 msgid ""
-"{subject} requires the {extension} extension. Enable it in your project "
+"{target} requires the {extension} extension. Enable it in your project "
 "configuration, and try again."
 msgstr ""
 

--- a/assets/locale/ru-RU/betty.po
+++ b/assets/locale/ru-RU/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-02-01 02:51+0000\n"
+"POT-Creation-Date: 2026-02-04 19:03+0000\n"
 "PO-Revision-Date: 2025-12-08 19:00+0000\n"
 "Last-Translator: Artur Kalagov "
 "<artur.kalagov@users.noreply.hosted.weblate.org>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
 #, python-brace-format
 msgid "\"{color}\" is not a valid hexadecimal color, such as #ffc0cb."
@@ -2775,16 +2775,16 @@ msgid "{plugin_type} configuration"
 msgstr ""
 
 #, python-brace-format
-msgid "{subject} requires a project."
+msgid "{target} requires a project."
 msgstr ""
 
 #, python-brace-format
-msgid "{subject} requires a running app."
+msgid "{target} requires a running app."
 msgstr ""
 
 #, python-brace-format
 msgid ""
-"{subject} requires the {extension} extension. Enable it in your project "
+"{target} requires the {extension} extension. Enable it in your project "
 "configuration, and try again."
 msgstr ""
 

--- a/assets/locale/uk/betty.po
+++ b/assets/locale/uk/betty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Betty 0.4\n"
 "Report-Msgid-Bugs-To: illia@maier.page\n"
-"POT-Creation-Date: 2026-02-01 02:51+0000\n"
+"POT-Creation-Date: 2026-02-04 19:03+0000\n"
 "PO-Revision-Date: 2025-05-13 17:01+0000\n"
 "Last-Translator: Максим Горпиніч <maksimgorpinic4@gmail.com>\n"
 "Language: uk\n"
@@ -18,7 +18,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
 #, python-brace-format
 msgid "\"{color}\" is not a valid hexadecimal color, such as #ffc0cb."
@@ -2766,16 +2766,16 @@ msgid "{plugin_type} configuration"
 msgstr ""
 
 #, python-brace-format
-msgid "{subject} requires a project."
+msgid "{target} requires a project."
 msgstr ""
 
 #, python-brace-format
-msgid "{subject} requires a running app."
+msgid "{target} requires a running app."
 msgstr ""
 
 #, python-brace-format
 msgid ""
-"{subject} requires the {extension} extension. Enable it in your project "
+"{target} requires the {extension} extension. Enable it in your project "
 "configuration, and try again."
 msgstr ""
 

--- a/betty/app/__init__.py
+++ b/betty/app/__init__.py
@@ -39,7 +39,7 @@ from betty.service.container import (
     StaticService,
     service,
 )
-from betty.service.level import Configurable, ServiceLevel, universe
+from betty.service.level import Configurable, ServiceLevel
 from betty.typing import threadsafe
 from betty.user.no_op import NoOpUser
 
@@ -106,7 +106,7 @@ class App(Configurable[AppConfiguration], ServiceLevel):
     @override
     @classmethod
     async def new(
-        cls, *, services: ServiceLevel = universe, configuration: AppConfiguration
+        cls, services: ServiceLevel, configuration: AppConfiguration, /
     ) -> Self:
         raise NotImplementedError(
             f"Creating a new {fully_qualified_name(cls)} from its configuration is not yet supported."
@@ -170,9 +170,7 @@ class App(Configurable[AppConfiguration], ServiceLevel):
     @override
     async def _post_bootstrap(self) -> None:
         self._user.localizer = await self.localizer
-        await self._configuration.data().hydrate(
-            services=self, data=self._configuration
-        )
+        await self._configuration.data().hydrate(self, self._configuration)
 
     @override
     async def shutdown(self, *, wait: bool = True) -> None:

--- a/betty/console/command/commands/about.py
+++ b/betty/console/command/commands/about.py
@@ -42,7 +42,7 @@ class About(Manufacturable, Command):
     @override
     @classmethod
     @require_app
-    async def new(cls, *, app: App) -> Self:
+    async def new(cls, app: App, /) -> Self:
         return cls(app)
 
     @override

--- a/betty/console/command/commands/clear_caches.py
+++ b/betty/console/command/commands/clear_caches.py
@@ -34,7 +34,7 @@ class ClearCaches(Manufacturable, Command):
     @override
     @classmethod
     @require_app
-    async def new(cls, *, app: App) -> Self:
+    async def new(cls, app: App, /) -> Self:
         return cls(app)
 
     @override

--- a/betty/console/command/commands/config.py
+++ b/betty/console/command/commands/config.py
@@ -37,7 +37,7 @@ class Config(Manufacturable, Command):
     @override
     @classmethod
     @require_app
-    async def new(cls, *, app: App) -> Self:
+    async def new(cls, app: App, /) -> Self:
         return cls(app)
 
     @override

--- a/betty/console/command/commands/demo.py
+++ b/betty/console/command/commands/demo.py
@@ -33,7 +33,7 @@ class Demo(Manufacturable, Command):
     @override
     @classmethod
     @require_app
-    async def new(cls, *, app: App) -> Self:
+    async def new(cls, app: App, /) -> Self:
         return cls(app)
 
     @override

--- a/betty/console/command/commands/dev_profile_demo.py
+++ b/betty/console/command/commands/dev_profile_demo.py
@@ -65,7 +65,7 @@ class DevProfileDemo(Manufacturable, Command):
     @override
     @classmethod
     @require_app
-    async def new(cls, *, app: App) -> Self:
+    async def new(cls, app: App, /) -> Self:
         return cls(app)
 
     @override

--- a/betty/console/command/commands/dev_update_translations.py
+++ b/betty/console/command/commands/dev_update_translations.py
@@ -32,7 +32,7 @@ class DevUpdateTranslations(Manufacturable, Command):
     @override
     @classmethod
     @require_app
-    async def new(cls, *, app: App) -> Self:
+    async def new(cls, app: App, /) -> Self:
         return cls(app)
 
     @override

--- a/betty/console/command/commands/docs.py
+++ b/betty/console/command/commands/docs.py
@@ -36,7 +36,7 @@ class Docs(Manufacturable, Command):
     @override
     @classmethod
     @require_app
-    async def new(cls, *, app: App) -> Self:
+    async def new(cls, app: App, /) -> Self:
         return cls(app)
 
     @override

--- a/betty/console/command/commands/extension_new_translation.py
+++ b/betty/console/command/commands/extension_new_translation.py
@@ -37,7 +37,7 @@ class ExtensionNewTranslation(Manufacturable, Command):
     @override
     @classmethod
     @require_app
-    async def new(cls, *, app: App) -> Self:
+    async def new(cls, app: App, /) -> Self:
         return cls(app)
 
     @override

--- a/betty/console/command/commands/extension_update_translations.py
+++ b/betty/console/command/commands/extension_update_translations.py
@@ -39,7 +39,7 @@ class ExtensionUpdateTranslations(Manufacturable, Command):
     @override
     @classmethod
     @require_app
-    async def new(cls, *, app: App) -> Self:
+    async def new(cls, app: App, /) -> Self:
         return cls(app)
 
     @override

--- a/betty/console/command/commands/generate.py
+++ b/betty/console/command/commands/generate.py
@@ -31,7 +31,7 @@ class Generate(Manufacturable, Command):
     @override
     @classmethod
     @require_app
-    async def new(cls, *, app: App) -> Self:
+    async def new(cls, app: App, /) -> Self:
         return cls(app)
 
     @override

--- a/betty/console/command/commands/new.py
+++ b/betty/console/command/commands/new.py
@@ -29,7 +29,7 @@ class New(Manufacturable, Command):
     @override
     @classmethod
     @require_app
-    async def new(cls, *, app: App) -> Self:
+    async def new(cls, app: App, /) -> Self:
         return cls(app)
 
     @override

--- a/betty/console/command/commands/new_translation.py
+++ b/betty/console/command/commands/new_translation.py
@@ -35,7 +35,7 @@ class NewTranslation(Manufacturable, Command):
     @override
     @classmethod
     @require_app
-    async def new(cls, *, app: App) -> Self:
+    async def new(cls, app: App, /) -> Self:
         return cls(app)
 
     @override

--- a/betty/console/command/commands/serve.py
+++ b/betty/console/command/commands/serve.py
@@ -35,7 +35,7 @@ class Serve(Manufacturable, Command):
     @override
     @classmethod
     @require_app
-    async def new(cls, *, app: App) -> Self:
+    async def new(cls, app: App, /) -> Self:
         return cls(app)
 
     @override
@@ -47,7 +47,7 @@ class Serve(Manufacturable, Command):
 
         async with (
             project,
-            await serve.BuiltinProjectServer.new(services=project) as server,
+            await serve.BuiltinProjectServer.new(project) as server,
         ):
             await server.show()
             while True:

--- a/betty/console/command/commands/update_translations.py
+++ b/betty/console/command/commands/update_translations.py
@@ -38,7 +38,7 @@ class UpdateTranslations(Manufacturable, Command):
     @override
     @classmethod
     @require_app
-    async def new(cls, *, app: App) -> Self:
+    async def new(cls, app: App, /) -> Self:
         return cls(app)
 
     @override

--- a/betty/content_provider/content_providers.py
+++ b/betty/content_provider/content_providers.py
@@ -93,7 +93,7 @@ class Render(Configurable[RenderConfiguration], ContentProvider):
     @override
     @classmethod
     @require_project
-    async def new(cls, *, project: Project, configuration: RenderConfiguration) -> Self:
+    async def new(cls, project: Project, configuration: RenderConfiguration, /) -> Self:
         return cls(
             content=configuration.content,
             media_type=configuration.media_type,
@@ -170,7 +170,7 @@ class Notes(Template, Manufacturable):
     @override
     @classmethod
     @require_project
-    async def new(cls, *, project: Project) -> Self:
+    async def new(cls, project: Project, /) -> Self:
         return cls(jinja=await project.jinja)
 
     @override
@@ -265,7 +265,7 @@ class Box(Template, Configurable[BoxConfiguration]):
     @override
     @classmethod
     @require_project
-    async def new(cls, *, project: Project, configuration: BoxConfiguration) -> Self:
+    async def new(cls, project: Project, configuration: BoxConfiguration, /) -> Self:
         return cls(
             configuration=configuration,
             jinja=await project.jinja,

--- a/betty/copyright_notice/__init__.py
+++ b/betty/copyright_notice/__init__.py
@@ -55,7 +55,7 @@ class CopyrightNotice(Plugin["CopyrightNoticeDefinition"]):
     discovery=[
         EntryPointDiscovery("betty.copyright_notice"),
         require_project(
-            lambda *, project: (
+            lambda project: (
                 configuration.new_plugin()
                 for configuration in project.configuration.copyright_notices
             )

--- a/betty/copyright_notice/copyright_notices.py
+++ b/betty/copyright_notice/copyright_notices.py
@@ -41,7 +41,7 @@ class ProjectAuthor(Manufacturable, CopyrightNotice):
     @override
     @classmethod
     @require_project
-    async def new(cls, *, project: Project) -> Self:
+    async def new(cls, project: Project, /) -> Self:
         return cls(project.configuration.author)
 
     @property
@@ -120,7 +120,7 @@ class WikipediaContributors(Manufacturable, CopyrightNotice):
     @override
     @classmethod
     @require_app
-    async def new(cls, *, app: App) -> Self:
+    async def new(cls, app: App, /) -> Self:
         http_client = await app.http_client
         urls = {
             DEFAULT_LOCALE: _copyright_url("en", "Wikipedia:Copyrights"),

--- a/betty/data/__init__.py
+++ b/betty/data/__init__.py
@@ -84,9 +84,9 @@ class DataDefinition(
         return Samples(self._samples)
 
     @override
-    async def hydrate(self, *, services: ServiceLevel, data: _DataClsT) -> None:
+    async def hydrate(self, services: ServiceLevel, data: _DataClsT, /) -> None:
         if isinstance(data, Hydratable):
-            await data.hydrate(services=services)
+            await data.hydrate(services)
 
 
 _DataDefinitionT = TypeVar(
@@ -142,6 +142,6 @@ class OptionalDefinition(DataDefinition[_DataClsT | None]):
         return self._wrapped
 
     @override
-    async def hydrate(self, *, services: ServiceLevel, data: _DataClsT | None) -> None:
+    async def hydrate(self, services: ServiceLevel, data: _DataClsT | None, /) -> None:
         if data is not None:
-            await self.wrapped.hydrate(services=services, data=data)
+            await self.wrapped.hydrate(services, data)

--- a/betty/data/aggregate/__init__.py
+++ b/betty/data/aggregate/__init__.py
@@ -36,8 +36,8 @@ class AggregateDefinition(
         """
 
     @override
-    async def hydrate(self, *, services: ServiceLevel, data: _DataClsT) -> None:
+    async def hydrate(self, services: ServiceLevel, data: _DataClsT, /) -> None:
         for selector, element in self.elements(data):
             with reraise_with_indicator(selector):
-                await element.hydrate(services=services, data=selector.get(data))
-        await super().hydrate(services=services, data=data)
+                await element.hydrate(services, selector.get(data))
+        await super().hydrate(services, data)

--- a/betty/event_type/__init__.py
+++ b/betty/event_type/__init__.py
@@ -51,7 +51,7 @@ class ShouldExistEventType(EventType, ABC):
     discovery=[
         EntryPointDiscovery("betty.event_type"),
         require_project(
-            lambda *, project: (
+            lambda project: (
                 configuration.new_plugin()
                 for configuration in project.configuration.event_types
             )

--- a/betty/extension/demo/__init__.py
+++ b/betty/extension/demo/__init__.py
@@ -87,7 +87,7 @@ class Demo(NavigationLinkProvider, Loader, Manufacturable, Extension[Project]):
     @override
     @classmethod
     @require_project
-    async def new(cls, *, project: Project) -> Self:
+    async def new(cls, project: Project, /) -> Self:
         return cls(services=project)
 
     @override

--- a/betty/extension/demo/content_provider.py
+++ b/betty/extension/demo/content_provider.py
@@ -22,7 +22,7 @@ class _IncompleteTranslationWarning(Template, Manufacturable):
     @override
     @classmethod
     @require_project
-    async def new(cls, *, project: Project) -> Self:
+    async def new(cls, project: Project, /) -> Self:
         return cls(jinja=await project.jinja)
 
     @override

--- a/betty/extension/demo/serve.py
+++ b/betty/extension/demo/serve.py
@@ -51,7 +51,7 @@ class DemoServer(Server):
             ) as progress:
                 job_context = ProjectContext(project, progress=progress)
                 await generate_with_cleanup(project, job_context=job_context)
-            self._server = await serve.BuiltinProjectServer.new(services=project)
+            self._server = await serve.BuiltinProjectServer.new(project)
             await self._exit_stack.enter_async_context(self._server)
         except BaseException:
             # __aexit__() is not called when __aenter__() raises an exception, so ensure we clean up our resources.

--- a/betty/extension/deriver/__init__.py
+++ b/betty/extension/deriver/__init__.py
@@ -46,7 +46,7 @@ class Deriver(PostLoader, Manufacturable, Extension[Project]):
     @override
     @classmethod
     @require_project
-    async def new(cls, *, project: Project) -> Self:
+    async def new(cls, project: Project, /) -> Self:
         return cls(services=project)
 
     @override

--- a/betty/extension/gramps/__init__.py
+++ b/betty/extension/gramps/__init__.py
@@ -319,10 +319,7 @@ class Gramps(Loader, Configurable[GrampsConfiguration], Manufacturable, Extensio
     @override
     @classmethod
     async def new(
-        cls,
-        *,
-        services: ServiceLevel = universe,
-        configuration: GrampsConfiguration | None = None,
+        cls, services: ServiceLevel, configuration: GrampsConfiguration | None = None, /
     ) -> Self:
         return cls(configuration=configuration)
 

--- a/betty/extension/http_api_doc/__init__.py
+++ b/betty/extension/http_api_doc/__init__.py
@@ -38,7 +38,7 @@ class HttpApiDoc(EntryPointProvider[Project], NavigationLinkProvider, Manufactur
     @override
     @classmethod
     @require_project
-    async def new(cls, *, project: Project) -> Self:
+    async def new(cls, project: Project, /) -> Self:
         return cls(services=project)
 
     @override

--- a/betty/extension/maps/__init__.py
+++ b/betty/extension/maps/__init__.py
@@ -40,7 +40,7 @@ class Maps(Generator, EntryPointProvider[Project], Manufacturable):
     @override
     @classmethod
     @require_project
-    async def new(cls, *, project: Project) -> Self:
+    async def new(cls, project: Project, /) -> Self:
         return cls(services=project)
 
     @override

--- a/betty/extension/maps/content_provider.py
+++ b/betty/extension/maps/content_provider.py
@@ -30,8 +30,8 @@ class Map(Template, Manufacturable):
     @override
     @classmethod
     @require_extension(Maps)
-    async def new(cls, *, extension: Maps) -> Self:
-        return cls(jinja=await extension.services.jinja)
+    async def new(cls, maps: Maps, /) -> Self:
+        return cls(jinja=await maps.services.jinja)
 
     @override
     async def provide_template(
@@ -71,8 +71,8 @@ class Attribution(Template, Manufacturable):
     @override
     @classmethod
     @require_extension(Maps)
-    async def new(cls, *, extension: Maps) -> Self:
-        return cls(jinja=await extension.services.jinja)
+    async def new(cls, maps: Maps, /) -> Self:
+        return cls(jinja=await maps.services.jinja)
 
     @override
     async def provide_template(

--- a/betty/extension/privatizer/__init__.py
+++ b/betty/extension/privatizer/__init__.py
@@ -79,7 +79,7 @@ class Privatizer(PostLoader, Manufacturable, Extension[Project]):
     @override
     @classmethod
     @require_project
-    async def new(cls, *, project: Project) -> Self:
+    async def new(cls, project: Project, /) -> Self:
         return cls(services=project)
 
     @override

--- a/betty/extension/raspberry_mint/__init__.py
+++ b/betty/extension/raspberry_mint/__init__.py
@@ -113,9 +113,9 @@ class RaspberryMint(
     @require_project
     async def new(
         cls,
-        *,
         project: Project,
         configuration: RaspberryMintConfiguration | None = None,
+        /,
     ) -> Self:
         return cls(configuration=configuration, project=project)
 

--- a/betty/extension/raspberry_mint/config/__init__.py
+++ b/betty/extension/raspberry_mint/config/__init__.py
@@ -148,8 +148,8 @@ class RaspberryMintConfiguration(Data, Hydratable):
 
     @override
     @require_extension("raspberry-mint")
-    async def hydrate(self, *, extension: RaspberryMint) -> None:
-        available_regions = await extension.regions
+    async def hydrate(self, raspberry_mint: RaspberryMint, /) -> None:
+        available_regions = await raspberry_mint.regions
         with reraise_with_indicator(Attr("regional_content")):
             for region in self.regional_content:
                 with reraise_with_indicator(Key(region)):

--- a/betty/extension/raspberry_mint/content_provider.py
+++ b/betty/extension/raspberry_mint/content_provider.py
@@ -68,6 +68,7 @@ from betty.presence_role import PresenceRoleDefinition
 from betty.privacy import is_public
 from betty.service.level import Configurable, Manufacturable
 from betty.service.requirement.extension import require_extension
+from betty.service.requirement.project import require_project
 from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
 from betty.typing import private
 
@@ -81,6 +82,7 @@ if TYPE_CHECKING:
     from betty.model import Entity
     from betty.plugin import ResolvableId
     from betty.plugin.repository import PluginRepository
+    from betty.project import Project
 
 
 @final
@@ -181,11 +183,11 @@ class Section(Template, Configurable[SectionConfiguration]):
     @classmethod
     @require_extension(RaspberryMint)
     async def new(
-        cls, *, extension: RaspberryMint, configuration: SectionConfiguration
+        cls, raspberry_mint: RaspberryMint, configuration: SectionConfiguration, /
     ) -> Self:
         return cls(
             configuration=configuration,
-            jinja=await extension.services.jinja,
+            jinja=await raspberry_mint.services.jinja,
         )
 
     @override
@@ -224,7 +226,7 @@ class EntityCard(Template, Configurable[EntityReference]):
     @classmethod
     @require_extension(RaspberryMint)
     async def new(
-        cls, *, extension: RaspberryMint, configuration: EntityReference
+        cls, extension: RaspberryMint, configuration: EntityReference, /
     ) -> Self:
         return cls(
             ancestry=extension.services.ancestry,
@@ -254,8 +256,8 @@ class Families(Template, Manufacturable):
     @override
     @classmethod
     @require_extension(RaspberryMint)
-    async def new(cls, *, extension: RaspberryMint) -> Self:
-        return cls(jinja=await extension.services.jinja)
+    async def new(cls, raspberry_mint: RaspberryMint, /) -> Self:
+        return cls(jinja=await raspberry_mint.services.jinja)
 
     @override
     async def provide_template(
@@ -283,8 +285,8 @@ class Media(Template, Manufacturable):
     @override
     @classmethod
     @require_extension(RaspberryMint)
-    async def new(cls, *, extension: RaspberryMint) -> Self:
-        return cls(jinja=await extension.services.jinja)
+    async def new(cls, raspberry_mint: RaspberryMint, /) -> Self:
+        return cls(jinja=await raspberry_mint.services.jinja)
 
     @override
     async def provide_template(
@@ -311,9 +313,10 @@ class MediaGallery(Template, Manufacturable):
 
     @override
     @classmethod
-    @require_extension(RaspberryMint)
-    async def new(cls, *, extension: RaspberryMint) -> Self:
-        return cls(jinja=await extension.services.jinja)
+    @require_project
+    async def new(cls, project: Project, /) -> Self:
+        await require_extension(RaspberryMint, project)
+        return cls(jinja=await project.jinja)
 
     @override
     async def provide_template(
@@ -395,14 +398,12 @@ class ColorStyle(Template, Configurable[ColorStyleConfiguration]):
 
     @override
     @classmethod
-    @require_extension(RaspberryMint)
+    @require_project
     async def new(
-        cls, *, extension: RaspberryMint, configuration: ColorStyleConfiguration
+        cls, project: Project, configuration: ColorStyleConfiguration, /
     ) -> Self:
-        return cls(
-            configuration=configuration,
-            jinja=await extension.services.jinja,
-        )
+        await require_extension(RaspberryMint, project)
+        return cls(configuration=configuration, jinja=await project.jinja)
 
     @override
     async def provide_template(
@@ -425,8 +426,8 @@ class ExternalLinks(Template, Manufacturable):
     @override
     @classmethod
     @require_extension(RaspberryMint)
-    async def new(cls, *, extension: RaspberryMint) -> Self:
-        return cls(jinja=await extension.services.jinja)
+    async def new(cls, raspberry_mint: RaspberryMint, /) -> Self:
+        return cls(jinja=await raspberry_mint.services.jinja)
 
     @override
     async def provide_template(
@@ -454,10 +455,10 @@ class Timeline(Template, Manufacturable):
     @override
     @classmethod
     @require_extension(RaspberryMint)
-    async def new(cls, *, extension: RaspberryMint) -> Self:
+    async def new(cls, raspberry_mint: RaspberryMint, /) -> Self:
         return cls(
-            jinja=await extension.services.jinja,
-            lifetime_threshold=extension.services.configuration.lifetime_threshold,
+            jinja=await raspberry_mint.services.jinja,
+            lifetime_threshold=raspberry_mint.services.configuration.lifetime_threshold,
         )
 
     @override
@@ -493,8 +494,8 @@ class Facts(Template, Manufacturable):
     @override
     @classmethod
     @require_extension(RaspberryMint)
-    async def new(cls, *, extension: RaspberryMint) -> Self:
-        return cls(jinja=await extension.services.jinja)
+    async def new(cls, raspberry_mint: RaspberryMint, /) -> Self:
+        return cls(jinja=await raspberry_mint.services.jinja)
 
     @override
     async def provide_template(
@@ -610,12 +611,12 @@ class Presences(Template, Configurable[PresencesConfiguration]):
     @classmethod
     @require_extension(RaspberryMint)
     async def new(
-        cls, *, extension: RaspberryMint, configuration: PresencesConfiguration
+        cls, raspberry_mint: RaspberryMint, configuration: PresencesConfiguration, /
     ) -> Self:
         return cls(
             configuration=configuration,
-            jinja=await extension.services.jinja,
-            presence_roles=await extension.services.plugins.plugins(
+            jinja=await raspberry_mint.services.jinja,
+            presence_roles=await raspberry_mint.services.plugins.plugins(
                 PresenceRoleDefinition
             ),
         )
@@ -837,11 +838,11 @@ class Columns(Template, Configurable[ColumnsConfiguration]):
     @classmethod
     @require_extension(RaspberryMint)
     async def new(
-        cls, *, extension: RaspberryMint, configuration: ColumnsConfiguration
+        cls, raspberry_mint: RaspberryMint, configuration: ColumnsConfiguration, /
     ) -> Self:
         return cls(
             configuration=configuration,
-            jinja=await extension.services.jinja,
+            jinja=await raspberry_mint.services.jinja,
         )
 
     @override
@@ -869,8 +870,8 @@ class Enclosees(Template, Manufacturable):
     @override
     @classmethod
     @require_extension(RaspberryMint)
-    async def new(cls, *, extension: RaspberryMint) -> Self:
-        return cls(jinja=await extension.services.jinja)
+    async def new(cls, raspberry_mint: RaspberryMint, /) -> Self:
+        return cls(jinja=await raspberry_mint.services.jinja)
 
     @override
     async def provide_template(
@@ -899,8 +900,8 @@ class FileReferees(Template, Manufacturable):
     @override
     @classmethod
     @require_extension(RaspberryMint)
-    async def new(cls, *, extension: RaspberryMint) -> Self:
-        return cls(jinja=await extension.services.jinja)
+    async def new(cls, raspberry_mint: RaspberryMint, /) -> Self:
+        return cls(jinja=await raspberry_mint.services.jinja)
 
     @override
     async def provide_template(
@@ -924,8 +925,8 @@ class Citations(Template, Manufacturable):
     @override
     @classmethod
     @require_extension(RaspberryMint)
-    async def new(cls, *, extension: RaspberryMint) -> Self:
-        return cls(jinja=await extension.services.jinja)
+    async def new(cls, raspberry_mint: RaspberryMint, /) -> Self:
+        return cls(jinja=await raspberry_mint.services.jinja)
 
     @override
     async def provide_template(

--- a/betty/extension/spdx/__init__.py
+++ b/betty/extension/spdx/__init__.py
@@ -37,7 +37,7 @@ class Spdx(Manufacturable, Extension[App]):
     @override
     @classmethod
     @require_app
-    async def new(cls, *, app: App) -> Self:
+    async def new(cls, app: App, /) -> Self:
         return cls(services=app)
 
     @service
@@ -61,5 +61,5 @@ class Spdx(Manufacturable, Extension[App]):
 
 
 LicenseDefinition.type().discoverer.add(
-    require_extension(Spdx)(lambda *, extension: extension.license_repository),
+    require_extension(Spdx)(lambda spdx: spdx.license_repository),
 )

--- a/betty/extension/trees/__init__.py
+++ b/betty/extension/trees/__init__.py
@@ -40,7 +40,7 @@ class Trees(Generator, EntryPointProvider[Project], Manufacturable):
     @override
     @classmethod
     @require_project
-    async def new(cls, *, project: Project) -> Self:
+    async def new(cls, project: Project, /) -> Self:
         return cls(services=project)
 
     @override

--- a/betty/extension/trees/content_provider.py
+++ b/betty/extension/trees/content_provider.py
@@ -28,8 +28,8 @@ class Tree(Template, Manufacturable):
     @override
     @classmethod
     @require_extension(Trees)
-    async def new(cls, *, extension: Trees) -> Self:
-        return cls(jinja=await extension.services.jinja)
+    async def new(cls, trees: Trees, /) -> Self:
+        return cls(jinja=await trees.services.jinja)
 
     @override
     async def provide_template(

--- a/betty/extension/webpack/__init__.py
+++ b/betty/extension/webpack/__init__.py
@@ -54,7 +54,7 @@ class Webpack(
     @override
     @classmethod
     @require_project
-    async def new(cls, *, project: Project) -> Self:
+    async def new(cls, project: Project, /) -> Self:
         return cls(services=project)
 
     @override

--- a/betty/extension/wiki/__init__.py
+++ b/betty/extension/wiki/__init__.py
@@ -108,7 +108,7 @@ class Wiki(
     @classmethod
     @require_project
     async def new(
-        cls, *, project: Project, configuration: WikiConfiguration | None = None
+        cls, project: Project, configuration: WikiConfiguration | None = None, /
     ) -> Self:
         copyright_notices = await project.plugins.plugins(CopyrightNoticeDefinition)
         return cls(

--- a/betty/extension/wiki/content_provider.py
+++ b/betty/extension/wiki/content_provider.py
@@ -13,8 +13,10 @@ from betty.content_provider.content_providers import Template
 from betty.document import Document
 from betty.extension.wiki import Wiki
 from betty.locale.localizable.gettext import _
+from betty.project import Project
 from betty.service.level import Manufacturable
 from betty.service.requirement.extension import require_extension
+from betty.service.requirement.project import require_project
 
 
 @ContentProviderDefinition("wiki-wikipedia-summary", label=_("Wikipedia summary"))
@@ -27,9 +29,10 @@ class WikipediaSummary(Template, Manufacturable):
 
     @override
     @classmethod
-    @require_extension(Wiki)
-    async def new(cls, *, extension: Wiki) -> Self:
-        return cls(jinja=await extension.services.jinja)
+    @require_project
+    async def new(cls, project: Project, /) -> Self:
+        await require_extension(Wiki, project)
+        return cls(jinja=await project.jinja)
 
     @override
     async def provide_template(

--- a/betty/gender/__init__.py
+++ b/betty/gender/__init__.py
@@ -28,7 +28,7 @@ class Gender(Plugin["GenderDefinition"]):
     discovery=[
         EntryPointDiscovery("betty.gender"),
         require_project(
-            lambda *, project: (
+            lambda project: (
                 configuration.new_plugin()
                 for configuration in project.configuration.genders
             )

--- a/betty/jinja2/__init__.py
+++ b/betty/jinja2/__init__.py
@@ -186,7 +186,7 @@ class Environment(Manufacturable, Jinja2Environment):
     @override
     @classmethod
     @require_project
-    async def new(cls, *, project: Project) -> Self:
+    async def new(cls, project: Project, /) -> Self:
         extensions = list((await project.extensions).flatten())
         return cls(
             project,

--- a/betty/license/__init__.py
+++ b/betty/license/__init__.py
@@ -55,7 +55,7 @@ class License(Plugin["LicenseDefinition"]):
     discovery=[
         EntryPointDiscovery("betty.license"),
         require_project(
-            lambda *, project: (
+            lambda project: (
                 configuration.new_plugin()
                 for configuration in project.configuration.licenses
             )

--- a/betty/model/reference.py
+++ b/betty/model/reference.py
@@ -64,7 +64,7 @@ class EntityReference(Data, Hydratable):
 
     @override
     @require_project
-    async def hydrate(self, *, project: Project) -> None:
+    async def hydrate(self, project: Project, /) -> None:
         entity_type = assert_plugin(await project.plugins.plugins(EntityDefinition))(
             self.type
         )

--- a/betty/pathlib.py
+++ b/betty/pathlib.py
@@ -30,5 +30,5 @@ class FilePathDefinition(DataDefinition[Path]):
         )
 
     @override
-    async def hydrate(self, *, services: ServiceLevel, data: _DataClsT) -> None:
+    async def hydrate(self, services: ServiceLevel, data: _DataClsT, /) -> None:
         assert_file_path()(data)

--- a/betty/place_type/__init__.py
+++ b/betty/place_type/__init__.py
@@ -28,7 +28,7 @@ class PlaceType(Plugin["PlaceTypeDefinition"]):
     discovery=[
         EntryPointDiscovery("betty.place_type"),
         require_project(
-            lambda *, project: (
+            lambda project: (
                 configuration.new_plugin()
                 for configuration in project.configuration.place_types
             )

--- a/betty/plugin/data.py
+++ b/betty/plugin/data.py
@@ -46,7 +46,7 @@ class PluginIdDefinition(DataDefinition[MachineName]):
         self._plugin_type = plugin_type
 
     @override
-    async def hydrate(self, *, services: ServiceLevel, data: MachineName) -> None:
+    async def hydrate(self, services: ServiceLevel, data: MachineName, /) -> None:
         if self._plugin_type is not None:
             (await services.plugins.plugins(self._plugin_type)).get(data)
 

--- a/betty/plugin/discovery/__init__.py
+++ b/betty/plugin/discovery/__init__.py
@@ -8,19 +8,18 @@ from abc import ABC, abstractmethod
 from asyncio import gather
 from collections.abc import Awaitable, Callable, Collection, Iterable
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Generic, TypeAlias, Unpack, final
+from typing import TYPE_CHECKING, Generic, TypeAlias, final
 
 import typing_extensions
 from typing_extensions import TypeVar
 
 from betty.asyncio import resolve_await
 from betty.plugin import Plugin, PluginDefinition, ResolvableDefinition
-from betty.service.requirement import ServiceLevelKwargs
+from betty.service.level import ServiceLevel
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-    from betty.service.level import ServiceLevel
 
 _PluginDefinitionT = TypeVar(
     "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
@@ -34,7 +33,7 @@ class PluginDiscovery(ABC, Generic[_PluginDefinitionT]):
 
     @abstractmethod
     async def discover(
-        self, *, services: ServiceLevel
+        self, services: ServiceLevel, /
     ) -> Iterable[ResolvableDiscovery[_PluginDefinitionT]]:
         """
         Discover the plugin definitions.
@@ -44,7 +43,7 @@ class PluginDiscovery(ABC, Generic[_PluginDefinitionT]):
 ResolvableDiscovery: TypeAlias = (
     PluginDiscovery[_PluginDefinitionT]
     | Callable[
-        [Unpack[ServiceLevelKwargs]],
+        [ServiceLevel],
         Awaitable[Iterable["ResolvableDiscovery[_PluginDefinitionT]"]]
         | Iterable["ResolvableDiscovery[_PluginDefinitionT]"],
     ]
@@ -53,7 +52,8 @@ ResolvableDiscovery: TypeAlias = (
 
 
 async def discover(
-    *discoveries: ResolvableDiscovery[_PluginDefinitionT], services: ServiceLevel
+    services: ServiceLevel,
+    *discoveries: ResolvableDiscovery[_PluginDefinitionT],
 ) -> Iterable[_PluginDefinitionT]:
     """
     Discover plugins definitions.
@@ -74,16 +74,12 @@ async def _discover(
 
     try:
         if isinstance(discovery, PluginDiscovery):
-            return await discover(
-                *await discovery.discover(services=services), services=services
-            )  # ty:ignore[invalid-return-type]
+            return await discover(services, *await discovery.discover(services))  # ty:ignore[invalid-return-type]
         if isinstance(discovery, PluginDefinition):
             return [discovery]  # ty:ignore[invalid-return-type]
         if isinstance(discovery, type) and issubclass(discovery, Plugin):
             return [discovery.plugin()]  # ty:ignore[invalid-return-type]
-        return await discover(
-            *await resolve_await(discovery(services=services)), services=services
-        )  # ty:ignore[invalid-return-type]
+        return await discover(services, *await resolve_await(discovery(services)))  # ty:ignore[invalid-return-type]
     except UnmetRequirement:
         return ()
 
@@ -131,5 +127,5 @@ class Discoverer(PluginDiscovery[_PluginDefinitionT]):
         return self._defined != self._active
 
     @typing_extensions.override
-    async def discover(self, *, services: ServiceLevel) -> Iterable[_PluginDefinitionT]:
-        return await discover(*self._active, services=services)  # ty:ignore[invalid-return-type]
+    async def discover(self, services: ServiceLevel, /) -> Iterable[_PluginDefinitionT]:
+        return await discover(services, *self._active)  # ty:ignore[invalid-return-type]

--- a/betty/plugin/discovery/entry_point.py
+++ b/betty/plugin/discovery/entry_point.py
@@ -49,7 +49,7 @@ class EntryPointDiscovery(PluginDiscovery[_PluginDefinitionT]):
 
     @override
     async def discover(
-        self, *, services: ServiceLevel
+        self, services: ServiceLevel, /
     ) -> Iterable[ResolvableDefinition[_PluginDefinitionT]]:
         return [
             cast(ResolvableDefinition[_PluginDefinitionT], entry_point.load())

--- a/betty/plugin/manager/service.py
+++ b/betty/plugin/manager/service.py
@@ -81,6 +81,5 @@ class ServiceLevelPluginManager(PluginManager):
         self, plugin_type: type[_PluginDefinitionT]
     ) -> PluginRepository[_PluginDefinitionT]:
         return StaticPluginRepository(
-            plugin_type,
-            *await plugin_type.type().discoverer.discover(services=self._services),
+            plugin_type, *await plugin_type.type().discoverer.discover(self._services)
         )

--- a/betty/presence_role/__init__.py
+++ b/betty/presence_role/__init__.py
@@ -28,7 +28,7 @@ class PresenceRole(Plugin["PresenceRoleDefinition"]):
     discovery=[
         EntryPointDiscovery("betty.presence_role"),
         require_project(
-            lambda *, project: (
+            lambda project: (
                 configuration.new_plugin()
                 for configuration in project.configuration.presence_roles
             )

--- a/betty/project/__init__.py
+++ b/betty/project/__init__.py
@@ -96,9 +96,7 @@ class Project(Configurable[ProjectConfiguration], ServiceLevel):
 
     @override
     async def _post_bootstrap(self) -> None:
-        await self._configuration.data().hydrate(
-            services=self, data=self._configuration
-        )
+        await self._configuration.data().hydrate(self, self._configuration)
 
     @override
     @classmethod
@@ -108,7 +106,7 @@ class Project(Configurable[ProjectConfiguration], ServiceLevel):
     @override
     @classmethod
     async def new(
-        cls, *, services: ServiceLevel = universe, configuration: ProjectConfiguration
+        cls, services: ServiceLevel, configuration: ProjectConfiguration, /
     ) -> Self:
         raise NotImplementedError(
             f"Creating a new {fully_qualified_name(cls)} from its configuration is not yet supported."
@@ -310,7 +308,7 @@ class Project(Configurable[ProjectConfiguration], ServiceLevel):
         """
         from betty.jinja2 import Environment
 
-        return await Environment.new(services=self)
+        return await Environment.new(self)
 
     @service
     async def renderer(self) -> RenderDispatcher:

--- a/betty/project/config.py
+++ b/betty/project/config.py
@@ -138,7 +138,7 @@ class EntityTypeConfiguration(
         self._generate_html_list = generate_html_list
 
     @override
-    async def hydrate(self, *, services: ServiceLevel) -> None:
+    async def hydrate(self, services: ServiceLevel, /) -> None:
         entity_type = (await services.plugins.plugins(EntityDefinition)).get(
             self._entity_type
         )

--- a/betty/project/generate/jobs.py
+++ b/betty/project/generate/jobs.py
@@ -341,7 +341,7 @@ class GenerateJsonSchema(Job[ProjectContext]):
     @override
     async def do(self, scheduler: Scheduler[ProjectContext], /) -> None:
         project = scheduler.context.project
-        schema = await ProjectSchema.new(services=project)
+        schema = await ProjectSchema.new(project)
         rendered_json = dumps(schema.schema)
         async with create_file(ProjectSchema.www_path(project)) as f:
             await f.write(rendered_json)

--- a/betty/project/schema.py
+++ b/betty/project/schema.py
@@ -52,7 +52,7 @@ class ProjectSchema(Manufacturable, Schema):
     @override
     @classmethod
     @require_project
-    async def new(cls, *, project: Project) -> Self:
+    async def new(cls, project: Project, /) -> Self:
         schema = cls()
         schema._schema["$id"] = await cls.url(project)
 

--- a/betty/project/url.py
+++ b/betty/project/url.py
@@ -52,7 +52,7 @@ class _ProjectUrlGenerator(Manufacturable):
     @override
     @classmethod
     @require_project
-    async def new(cls, *, project: Project) -> Self:
+    async def new(cls, project: Project, /) -> Self:
         """
         Create a new instance using the given project.
         """
@@ -147,13 +147,13 @@ async def new_project_url_generator(project: Project, /) -> UrlGenerator:
     """
     Generate URLs for all resources provided by a Betty project.
     """
-    entity_url_generator = await _EntityUrlGenerator.new(services=project)
+    entity_url_generator = await _EntityUrlGenerator.new(project)
     return ProxyUrlGenerator(
-        await _EntityTypeUrlGenerator.new(services=project),
+        await _EntityTypeUrlGenerator.new(project),
         entity_url_generator,
         _EntityUrlUrlGenerator(project.ancestry, entity_url_generator),
-        await _LocalizedPathUrlUrlGenerator.new(services=project),
-        await _StaticPathUrlUrlGenerator.new(services=project),
+        await _LocalizedPathUrlUrlGenerator.new(project),
+        await _StaticPathUrlUrlGenerator.new(project),
         PassthroughUrlGenerator(),
     )
 

--- a/betty/render/html.py
+++ b/betty/render/html.py
@@ -40,7 +40,7 @@ class Html(Manufacturable, Renderer):
     @override
     @classmethod
     @require_project
-    async def new(cls, *, project: Project) -> Self:
+    async def new(cls, project: Project, /) -> Self:
         return cls(url_generator=await project.url_generator)
 
     @override

--- a/betty/serve.py
+++ b/betty/serve.py
@@ -149,7 +149,7 @@ class ProjectServer(Manufacturable, Server):
     @override
     @classmethod
     @require_project
-    async def new(cls, *, project: Project) -> Self:
+    async def new(cls, project: Project, /) -> Self:
         return cls(project)
 
 

--- a/betty/service/hydrate.py
+++ b/betty/service/hydrate.py
@@ -20,7 +20,7 @@ class Hydratable(ABC):
     """
 
     @abstractmethod
-    async def hydrate(self, *, services: ServiceLevel) -> None:
+    async def hydrate(self, services: ServiceLevel, /) -> None:
         """
         Hydrate ``self``.
 
@@ -34,7 +34,7 @@ class Hydrator(Generic[_T]):
     An object capable of hydrating other data.
     """
 
-    async def hydrate(self, *, services: ServiceLevel, data: _T) -> None:
+    async def hydrate(self, services: ServiceLevel, data: _T, /) -> None:
         """
         Hydrate data.
 

--- a/betty/service/level.py
+++ b/betty/service/level.py
@@ -94,7 +94,7 @@ class ServiceLevel(ServiceContainer):
         """
         if configuration is Void():
             if isinstance(target, type) and issubclass(target, Manufacturable):
-                return await target.new(services=self)
+                return await target.new(self)
             if callable(target):
                 return await resolve_await(target())
             raise RuntimeError(f"Cannot create a new instance of {target}")
@@ -106,10 +106,7 @@ class ServiceLevel(ServiceContainer):
             )
         if not isinstance(configuration, Data):
             configuration = target.configuration_cls().data().porter.load(configuration)
-        return await target.new(
-            services=self,
-            configuration=configuration,
-        )
+        return await target.new(self, configuration)
 
     @property
     def plugins(self) -> PluginManager:
@@ -132,7 +129,7 @@ class Manufacturable(ABC):
 
     @classmethod
     @abstractmethod
-    async def new(cls, *, services: ServiceLevel = universe) -> Self:
+    async def new(cls, services: ServiceLevel, /) -> Self:
         """
         Create a new instance using the given service level.
         """
@@ -150,9 +147,7 @@ class Configurable(ABC, Generic[_DataT]):
 
     @classmethod
     @abstractmethod
-    async def new(
-        cls, *, services: ServiceLevel = universe, configuration: _DataT
-    ) -> Self:
+    async def new(cls, services: ServiceLevel, configuration: _DataT, /) -> Self:
         """
         Create a new instance using the given service level and configuration.
         """

--- a/betty/service/requirement/__init__.py
+++ b/betty/service/requirement/__init__.py
@@ -4,14 +4,127 @@ Requirements for services.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, final
+from functools import partial, update_wrapper
+from typing import (
+    TYPE_CHECKING,
+    Concatenate,
+    Generic,
+    ParamSpec,
+    final,
+    overload,
+)
 
-from typing_extensions import TypedDict
+from typing_extensions import TypeVar
 
+from betty.asyncio import resolve_await
 from betty.exception import HumanFacingException
+from betty.importlib import fully_qualified_name
+from betty.service.level import ServiceLevel
 
 if TYPE_CHECKING:
-    from betty.service.level import ServiceLevel
+    from collections.abc import Awaitable, Callable
+
+_RequirementT = TypeVar("_RequirementT")
+_ReturnT = TypeVar("_ReturnT")
+_MagicT = TypeVar("_MagicT")
+_P = ParamSpec("_P")
+
+
+@final
+class Requirement(Generic[_RequirementT]):
+    """
+    A service level requirement.
+    """
+
+    def __init__(
+        self, require: Callable[[ServiceLevel, str], Awaitable[_RequirementT]], /
+    ):
+
+        self._require = require
+
+    @overload
+    def __call__(self, f: ServiceLevel, /) -> Awaitable[_RequirementT]:
+        pass
+
+    @overload
+    def __call__(
+        self,
+        f: Callable[Concatenate[_RequirementT, _P], Awaitable[_ReturnT] | _ReturnT],
+    ) -> Callable[Concatenate[ServiceLevel, _P], Awaitable[_ReturnT]]:
+        pass
+
+    @overload
+    def __call__(
+        self,
+        f: Callable[
+            Concatenate[_MagicT, _RequirementT, _P], Awaitable[_ReturnT] | _ReturnT
+        ],
+    ) -> Callable[Concatenate[_MagicT, ServiceLevel, _P], Awaitable[_ReturnT]]:
+        pass
+
+    def __call__(
+        self, f
+    ) -> CallableRequirement[_RequirementT, _P, _ReturnT] | Awaitable[_RequirementT]:
+        """
+        Decorate a callable with this requirement.
+        """
+        if isinstance(f, ServiceLevel):
+            return self._require(f, "**UNKNOWN**")
+        return CallableRequirement(self._require, f)
+
+
+@final
+class CallableRequirement(Generic[_RequirementT, _P, _ReturnT]):
+    """
+    A requirement that can be called or used as a descriptor.
+    """
+
+    def __init__(
+        self,
+        require: Callable[[ServiceLevel, str], Awaitable[_RequirementT]],
+        f: Callable[Concatenate[_RequirementT, _P], Awaitable[_ReturnT] | _ReturnT]
+        | Callable[
+            Concatenate[_MagicT, _RequirementT, _P], Awaitable[_ReturnT] | _ReturnT
+        ],
+    ):
+        self._require = require
+        update_wrapper(self, f)
+        self._f = f
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+        return partial(self, instance)
+
+    @overload
+    async def __call__(
+        self, requirement: _RequirementT, *args: _P.args, **kwargs: _P.kwargs
+    ) -> _ReturnT:
+        pass
+
+    @overload
+    async def __call__(
+        self,
+        magic: _MagicT,
+        requirement: _RequirementT,
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> _ReturnT:
+        pass
+
+    async def __call__(self, *args, **kwargs) -> _ReturnT:
+        """
+        Call the decorated callable.
+        """
+        index = 0 if isinstance(args[0], ServiceLevel) else 1
+        return await resolve_await(
+            self._f(
+                *args[:index],
+                await self._require(args[index], fully_qualified_name(self._f)),
+                *args[index + 1 :],
+                **kwargs,
+            )
+        )
 
 
 @final
@@ -19,11 +132,3 @@ class UnmetRequirement(HumanFacingException):
     """
     Raised when a requirement is not met.
     """
-
-
-class ServiceLevelKwargs(TypedDict):
-    """
-    The keyword arguments for service-level-dependent callables.
-    """
-
-    services: ServiceLevel

--- a/betty/service/requirement/app.py
+++ b/betty/service/requirement/app.py
@@ -4,56 +4,25 @@ Handle requirements on applications.
 
 from __future__ import annotations
 
-from functools import wraps
-from typing import TYPE_CHECKING, Concatenate, ParamSpec, TypeVar
+from typing import TYPE_CHECKING
 
-from betty.asyncio import resolve_await
-from betty.importlib import fully_qualified_name
 from betty.locale.localizable.gettext import _
-from betty.service.requirement import ServiceLevelKwargs, UnmetRequirement
+from betty.service.requirement import Requirement, UnmetRequirement
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
-
     from betty.app import App
     from betty.service.level import ServiceLevel
 
-_T = TypeVar("_T")
-_P = ParamSpec("_P")
+
+async def _require_app(services: ServiceLevel, target: str, /) -> App:
+    from betty.app import App
+    from betty.project import Project
+
+    if isinstance(services, Project):
+        return services.app
+    if isinstance(services, App):
+        return services
+    raise UnmetRequirement(_("{target} requires a running app.").format(target=target))
 
 
-class RequireAppKwargs(ServiceLevelKwargs):
-    """
-    The keyword arguments for callables decorated with :py:func:`betty.service.requirement.app.require_app`.
-    """
-
-    app: App
-
-
-def require_app(
-    f: Callable[Concatenate[RequireAppKwargs, _P], Awaitable[_T] | _T],
-) -> Callable[Concatenate[ServiceLevelKwargs, _P], Awaitable[_T]]:
-    """
-    Decorate a service level callable to require an :py:class:`betty.app.App`.
-    """
-
-    @wraps(f)
-    async def _require_app(
-        *args: _P.args, services: ServiceLevel, **kwargs: _P.kwargs
-    ) -> _T:
-        from betty.app import App
-        from betty.project import Project
-
-        if isinstance(services, Project):
-            app = services.app
-        elif isinstance(services, App):
-            app = services
-        else:
-            raise UnmetRequirement(
-                _("{subject} requires a running app.").format(
-                    subject=fully_qualified_name(f)
-                )
-            )
-        return await resolve_await(f(*args, app=app, **kwargs))
-
-    return _require_app
+require_app = Requirement(_require_app)

--- a/betty/service/requirement/extension.py
+++ b/betty/service/requirement/extension.py
@@ -4,72 +4,82 @@ Handle requirements on extensions.
 
 from __future__ import annotations
 
-from functools import wraps
-from typing import TYPE_CHECKING, Concatenate, Generic, ParamSpec
+from typing import TYPE_CHECKING, Any, Concatenate, ParamSpec, overload
 
 from typing_extensions import TypeVar
 
-from betty.asyncio import resolve_await
 from betty.extension import Extension, ExtensionDefinition
-from betty.importlib import fully_qualified_name
 from betty.locale.localizable.gettext import _
 from betty.plugin import ResolvableId, resolve_id
 from betty.plugin.error import PluginNotFound
-from betty.service.requirement import ServiceLevelKwargs, UnmetRequirement
+from betty.service.requirement import CallableRequirement, Requirement, UnmetRequirement
 from betty.service.requirement.project import require_project
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
     from betty.project import Project
+    from betty.service.level import ServiceLevel
 
-_T = TypeVar("_T")
+_ReturnT = TypeVar("_ReturnT")
 _P = ParamSpec("_P")
 _ExtensionT = TypeVar("_ExtensionT", bound=Extension, default=Extension)
 
 
-class RequireExtensionKwargs(ServiceLevelKwargs, Generic[_ExtensionT]):
-    """
-    The keyword arguments for callables decorated with :py:func:`betty.service.requirement.extension.require_extension`.
-    """
-
-    extension: _ExtensionT
-
-
+@overload
 def require_extension(
-    extension_id: ResolvableId[ExtensionDefinition], /
-) -> Callable[
-    [Callable[Concatenate[RequireExtensionKwargs, _P], Awaitable[_T] | _T]],
-    Callable[Concatenate[ServiceLevelKwargs, _P], Awaitable[_T]],
-]:
+    extension_id: type[_ExtensionT] | ResolvableId[ExtensionDefinition], /
+) -> Requirement[_ExtensionT]:
+    pass
+
+
+@overload
+def require_extension(
+    extension_id: type[_ExtensionT] | ResolvableId[ExtensionDefinition],
+    f: Callable[Concatenate[_ExtensionT, _P], Awaitable[_ReturnT] | _ReturnT]
+    | Callable[Concatenate[Any, _ExtensionT, _P], Awaitable[_ReturnT] | _ReturnT],
+    /,
+) -> CallableRequirement[_ExtensionT, _P, _ReturnT]:
+    pass
+
+
+@overload
+def require_extension(
+    extension_id: type[_ExtensionT] | ResolvableId[ExtensionDefinition],
+    services: ServiceLevel,
+    /,
+) -> Awaitable[_ExtensionT]:
+    pass
+
+
+def require_extension(extension_id, f=None):
     """
     Decorate a service level callable to require an :py:class:`betty.extension.Extension`.
     """
+    requirement = Requirement(
+        lambda services, target: _require_extension(services, target, extension_id)
+    )
+    if f is None:
+        return requirement
+    return requirement(f)
 
-    def _require_extension(
-        f: Callable[Concatenate[RequireExtensionKwargs, _P], Awaitable[_T] | _T],
-    ) -> Callable[Concatenate[ServiceLevelKwargs, _P], Awaitable[_T]]:
-        @require_project
-        @wraps(f)
-        async def __require_extension(
-            *args: _P.args, project: Project, **kwargs: _P.kwargs
-        ) -> _T:
-            extensions = await project.plugins.plugins(ExtensionDefinition)
-            try:
-                extension = extensions[resolve_id(extension_id)]
-            except PluginNotFound as error:
-                raise UnmetRequirement(error) from error
-            extensions = await project.extensions
-            if extension_id not in extensions:
-                raise UnmetRequirement(
-                    _(
-                        "{subject} requires the {extension} extension. Enable it in your project configuration, and try again."
-                    ).format(subject=fully_qualified_name(f), extension=extension.label)
-                )
-            return await resolve_await(
-                f(*args, extension=extensions[extension], **kwargs)
-            )
 
-        return __require_extension
-
-    return _require_extension
+@require_project
+async def _require_extension(
+    project: Project,
+    target: str,
+    extension_id: type[_ExtensionT] | ResolvableId[ExtensionDefinition],
+) -> _ExtensionT:
+    extensions = await project.plugins.plugins(ExtensionDefinition)
+    try:
+        extension = extensions[resolve_id(extension_id)]
+    except PluginNotFound as error:
+        raise UnmetRequirement(error) from error
+    project_extensions = await project.extensions
+    if extension_id in project_extensions:
+        return project_extensions[extension_id]
+    raise UnmetRequirement(
+        _(
+            "{target} requires the {extension} extension. Enable it in your project configuration, and try again."
+        ).format(target=target, extension=extension.label)
+    )

--- a/betty/service/requirement/project.py
+++ b/betty/service/requirement/project.py
@@ -4,49 +4,22 @@ Handle requirements on projects.
 
 from __future__ import annotations
 
-from functools import wraps
-from typing import TYPE_CHECKING, Concatenate, ParamSpec, TypeVar
+from typing import TYPE_CHECKING
 
-from betty.asyncio import resolve_await
-from betty.importlib import fully_qualified_name
 from betty.locale.localizable.gettext import _
-from betty.service.requirement import ServiceLevelKwargs, UnmetRequirement
+from betty.service.requirement import Requirement, UnmetRequirement
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
-
     from betty.project import Project
     from betty.service.level import ServiceLevel
 
-_T = TypeVar("_T")
-_P = ParamSpec("_P")
+
+async def _require_project(services: ServiceLevel, target: str, /) -> Project:
+    from betty.project import Project
+
+    if isinstance(services, Project):
+        return services
+    raise UnmetRequirement(_("{target} requires a project.").format(target=target))
 
 
-class RequireProjectKwargs(ServiceLevelKwargs):
-    """
-    The keyword arguments for callables decorated with :py:func:`betty.service.requirement.project.require_project`.
-    """
-
-    project: Project
-
-
-def require_project(
-    f: Callable[Concatenate[RequireProjectKwargs, _P], Awaitable[_T] | _T],
-) -> Callable[Concatenate[ServiceLevelKwargs, _P], Awaitable[_T]]:
-    """
-    Decorate a service level callable to require an :py:class:`betty.project.Project`.
-    """
-
-    @wraps(f)
-    async def _require_project(
-        *args: _P.args, services: ServiceLevel, **kwargs: _P.kwargs
-    ) -> _T:
-        from betty.project import Project
-
-        if isinstance(services, Project):
-            return await resolve_await(f(*args, project=services, **kwargs))
-        raise UnmetRequirement(
-            _("{subject} requires a project.").format(subject=fully_qualified_name(f))
-        )
-
-    return _require_project
+require_project = Requirement(_require_project)

--- a/betty/test_utils/jinja2.py
+++ b/betty/test_utils/jinja2.py
@@ -129,7 +129,7 @@ async def assert_betty_json(project: Project, url_path: str, def_name: str) -> P
         betty_json = await f.read()
     betty_json_data = json.loads(betty_json)
 
-    project_schema = await ProjectSchema.new(services=project)
+    project_schema = await ProjectSchema.new(project)
     # Somehow $ref cannot be top-level in our case, so wrap it.
     schema = AllOf(Ref(def_name))
     project_schema.embed(schema)

--- a/betty/test_utils/plugin/__init__.py
+++ b/betty/test_utils/plugin/__init__.py
@@ -23,7 +23,7 @@ class DummyPlugin(Plugin["DummyPluginDefinition"]):
     label_plural=" dummy plugin",
     label_countable=DUMMY_COUNTABLE_LOCALIZABLE,
     discovery=[
-        lambda **_: [
+        lambda _: [
             DummyPluginOne,
             DummyPluginTwo,
             DummyPluginThree,

--- a/betty/test_utils/plugin/config.py
+++ b/betty/test_utils/plugin/config.py
@@ -25,7 +25,7 @@ class ConfigurableDummyPlugin(
     label="Configurable dummy plugin",
     label_plural="Configurable dummy plugins",
     label_countable=DUMMY_COUNTABLE_LOCALIZABLE,
-    discovery=[lambda **_: [ConfigurableDummyPluginOne]],
+    discovery=[lambda _: [ConfigurableDummyPluginOne]],
 )
 class ConfigurableDummyPluginDefinition(PluginDefinition[ConfigurableDummyPlugin]):
     """

--- a/betty/test_utils/project/extension/__init__.py
+++ b/betty/test_utils/project/extension/__init__.py
@@ -16,7 +16,7 @@ class _DummyExtension(Manufacturable, Extension[Project]):
     @override
     @classmethod
     @require_project
-    async def new(cls, *, project: Project) -> Self:
+    async def new(cls, project: Project, /) -> Self:
         return cls(services=project)
 
 

--- a/betty/test_utils/project/extension/maps/__init__.py
+++ b/betty/test_utils/project/extension/maps/__init__.py
@@ -70,9 +70,7 @@ class MapsTestBase:
             )
             async with project:
                 await generate(project)
-                async with await serve.BuiltinProjectServer.new(
-                    services=project
-                ) as server:
+                async with await serve.BuiltinProjectServer.new(project) as server:
                     yield server
 
     @pytest.mark.asyncio(loop_scope="session")

--- a/betty/test_utils/service/level.py
+++ b/betty/test_utils/service/level.py
@@ -6,7 +6,7 @@ from typing import Any, Self
 
 from typing_extensions import override
 
-from betty.service.level import Configurable, Manufacturable, ServiceLevel, universe
+from betty.service.level import Configurable, Manufacturable, ServiceLevel
 from betty.test_utils.data import DummyData
 
 
@@ -29,9 +29,6 @@ class DummyConfigurable(Configurable[DummyData], Manufacturable):
     @override
     @classmethod
     async def new(
-        cls,
-        *,
-        services: ServiceLevel = universe,
-        configuration: DummyData | None = None,
+        cls, services: ServiceLevel, configuration: DummyData | None = None, /
     ) -> Self:
         return cls(configuration=configuration)

--- a/betty/tests/app/test___init__.py
+++ b/betty/tests/app/test___init__.py
@@ -18,7 +18,7 @@ class _Manufacturable(Manufacturable):
     @override
     @classmethod
     @require_app
-    async def new(cls, *, app: App) -> Self:
+    async def new(cls, app: App, /) -> Self:
         return cls(app)
 
 

--- a/betty/tests/content_provider/test_content_providers.py
+++ b/betty/tests/content_provider/test_content_providers.py
@@ -127,14 +127,14 @@ class TestNotes:
         self, isolated_app: App
     ) -> None:
         async with Project.new_isolated(isolated_app) as project, project:
-            sut = await Notes.new(services=project)
+            sut = await Notes.new(project)
             assert await sut.provide(document=Document()) is None
 
     async def test_provide_template__without_notes(self, isolated_app: App) -> None:
         has_notes = DummyHasNotes()
         async with Project.new_isolated(isolated_app) as project, project:
             project.ancestry.add(has_notes)
-            sut = await Notes.new(services=project)
+            sut = await Notes.new(project)
             assert await sut.provide(document=Document(has_notes)) is None
 
     async def test_provide_template__with_notes(self, isolated_app: App) -> None:
@@ -142,7 +142,7 @@ class TestNotes:
         has_notes = DummyHasNotes(notes=[Note(note_text)])
         async with Project.new_isolated(isolated_app) as project, project:
             project.ancestry.add(has_notes)
-            sut = await Notes.new(services=project)
+            sut = await Notes.new(project)
             actual = await sut.provide(document=Document(has_notes))
             assert actual is not None
             assert note_text in actual
@@ -160,8 +160,8 @@ class TestBox:
     async def test_provide_template__minimal(self, isolated_app: App) -> None:
         async with Project.new_isolated(isolated_app) as project, project:
             sut = await Box.new(
-                services=project,
-                configuration=BoxConfiguration(
+                project,
+                BoxConfiguration(
                     PluginConfiguration(Render, RenderConfiguration(DUMMY_LOCALIZABLE))  # ty:ignore[invalid-argument-type]
                 ),
             )
@@ -172,8 +172,8 @@ class TestBox:
     async def test_provide_template__full(self, isolated_app: App) -> None:
         async with Project.new_isolated(isolated_app) as project, project:
             sut = await Box.new(
-                services=project,
-                configuration=BoxConfiguration(
+                project,
+                BoxConfiguration(
                     PluginConfiguration(Render, RenderConfiguration(DUMMY_LOCALIZABLE)),  # ty:ignore[invalid-argument-type]
                     min_height="MIN_HEIGHT",
                     max_height="MAX_HEIGHT",

--- a/betty/tests/copyright_notice/test_copyright_notices.py
+++ b/betty/tests/copyright_notice/test_copyright_notices.py
@@ -82,5 +82,5 @@ class TestWikipediaContributors(CopyrightNoticeTestBase):
             "https://en.wikipedia.org/w/api.php?action=query&titles=Wikipedia:Copyrights&prop=langlinks&lllimit=500&format=json&formatversion=2",
             body=dumps(response_json),
         )
-        sut = await WikipediaContributors.new(services=isolated_app)
+        sut = await WikipediaContributors.new(isolated_app)
         assert sut.url.localize(DEFAULT_LOCALIZER)

--- a/betty/tests/coverage/test_coverage.py
+++ b/betty/tests/coverage/test_coverage.py
@@ -246,17 +246,10 @@ _BASELINE: Mapping[str, _ModuleIgnore] = {
         "Manufacturable": MissingReason.ABSTRACT,
     },
     "betty/service/requirement/__init__.py": {
-        "ServiceLevelKwargs": MissingReason.TYPED_DICT,
+        "CallableRequirement": {
+            "__get__": MissingReason.COVERED_ELSEWHERE,
+        },
         "UnmetRequirement": MissingReason.STATIC_CONTENT_ONLY,
-    },
-    "betty/service/requirement/app.py": {
-        "RequireAppKwargs": MissingReason.TYPED_DICT,
-    },
-    "betty/service/requirement/extension.py": {
-        "RequireExtensionKwargs": MissingReason.TYPED_DICT,
-    },
-    "betty/service/requirement/project.py": {
-        "RequireProjectKwargs": MissingReason.TYPED_DICT,
     },
     "betty/data/__init__.py": {
         "Data": MissingReason.ABSTRACT,

--- a/betty/tests/data/aggregate/test___init__.py
+++ b/betty/tests/data/aggregate/test___init__.py
@@ -14,7 +14,7 @@ from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
 
 class _AggregateDefinitionTestData(Hydratable):
     @override
-    async def hydrate(self, *, services: ServiceLevel) -> None:
+    async def hydrate(self, services: ServiceLevel, /) -> None:
         raise HumanFacingException("Uh-oh!")
 
 
@@ -39,7 +39,5 @@ class TestAggregateDefinition:
 
         sut = _Sut()
         with pytest.raises(HumanFacingException) as exc_info:
-            await sut.hydrate(
-                services=universe, data={"key": _AggregateDefinitionTestData()}
-            )
+            await sut.hydrate(universe, {"key": _AggregateDefinitionTestData()})
         assert exc_info.value.indicators == [Key("key")]

--- a/betty/tests/data/test___init__.py
+++ b/betty/tests/data/test___init__.py
@@ -34,7 +34,7 @@ class _DummyData(Portable, Hydratable, Data):
         return self.value
 
     @override
-    async def hydrate(self, *, services: ServiceLevel) -> None:
+    async def hydrate(self, services: ServiceLevel, /) -> None:
         raise HumanFacingException("Uh-oh!")
 
 
@@ -114,7 +114,7 @@ class TestDataDefinition:
 
     async def test_hydrate(self) -> None:
         sut = DataDefinition(cls=object, label=DUMMY_LOCALIZABLE)
-        await sut.hydrate(services=universe, data=object())
+        await sut.hydrate(universe, object())
 
 
 class TestOptionalDefinition:
@@ -134,10 +134,10 @@ class TestOptionalDefinition:
             DataDefinition(cls=_DummyData, label=DUMMY_LOCALIZABLE)
         )
         with pytest.raises(HumanFacingException):
-            await sut.hydrate(services=universe, data=_DummyData("Hello, world!"))
+            await sut.hydrate(universe, _DummyData("Hello, world!"))
 
     async def test_hydrate__with_none(self) -> None:
         sut = OptionalDefinition(
             DataDefinition(cls=_DummyData, label=DUMMY_LOCALIZABLE)
         )
-        await sut.hydrate(services=universe, data=None)
+        await sut.hydrate(universe, None)

--- a/betty/tests/extension/http_api_doc/test_swagger_ui.py
+++ b/betty/tests/extension/http_api_doc/test_swagger_ui.py
@@ -28,9 +28,7 @@ class TestSwaggerUi:
             project.configuration.extensions.add(HttpApiDoc)
             async with project:
                 await generate(project)
-                async with await serve.BuiltinProjectServer.new(
-                    services=project
-                ) as server:
+                async with await serve.BuiltinProjectServer.new(project) as server:
                     yield project, server
 
     @pytest.mark.asyncio(loop_scope="session")

--- a/betty/tests/extension/maps/test_content_provider.py
+++ b/betty/tests/extension/maps/test_content_provider.py
@@ -24,7 +24,7 @@ class TestMap:
         async with Project.new_isolated(isolated_app) as project:
             project.configuration.extensions.add(Maps)
             async with project:
-                sut = await Map.new(services=project)
+                sut = await Map.new(project)
                 assert await sut.provide(document=Document()) is None
 
     @pytest.mark.parametrize(
@@ -42,7 +42,7 @@ class TestMap:
             project.configuration.extensions.add(Maps)
             async with project:
                 project.ancestry.add(has_associated_places)
-                sut = await Map.new(services=project)
+                sut = await Map.new(project)
                 assert (
                     await sut.provide(
                         document=await project.new_document(has_associated_places)
@@ -76,7 +76,7 @@ class TestMap:
             project.configuration.extensions.add(Maps)
             async with project:
                 project.ancestry.add(has_associated_places)
-                sut = await Map.new(services=project)
+                sut = await Map.new(project)
                 document = await project.new_document(has_associated_places)
                 actual = await sut.provide(document=document)
         assert actual is not None
@@ -91,6 +91,6 @@ class TestAttribution:
         async with Project.new_isolated(isolated_app) as project:
             project.configuration.extensions.add(Maps)
             async with project:
-                sut = await Attribution.new(services=project)
+                sut = await Attribution.new(project)
                 actual = await sut.provide(document=Document())
         assert actual

--- a/betty/tests/extension/raspberry_mint/config/test___init__.py
+++ b/betty/tests/extension/raspberry_mint/config/test___init__.py
@@ -33,7 +33,7 @@ class TestRaspberryMintConfiguration(DataTestBase[RaspberryMintConfiguration]):
             project.configuration.extensions.add(RaspberryMint)
             async with project:
                 with pytest.raises(HumanFacingException) as exc_info:
-                    await sut.hydrate(services=project)
+                    await sut.hydrate(project)
         assert 'data.regional_content["unknown-region"]' in str(exc_info.value)
 
     def test_primary_color__from___init__(self) -> None:

--- a/betty/tests/extension/raspberry_mint/test___init__.py
+++ b/betty/tests/extension/raspberry_mint/test___init__.py
@@ -25,7 +25,7 @@ class TestRaspberryMint:
         async with (
             Project.new_isolated(isolated_app) as project,
             project,
-            await RaspberryMint.new(services=project) as sut,
+            await RaspberryMint.new(project) as sut,
         ):
             assert sut.filters
 
@@ -49,5 +49,5 @@ class TestRaspberryMint:
 
     async def test_regions(self, isolated_app: App) -> None:
         async with Project.new_isolated(isolated_app) as project, project:
-            sut = await RaspberryMint.new(services=project)
+            sut = await RaspberryMint.new(project)
             assert await sut.regions

--- a/betty/tests/extension/raspberry_mint/test_content_provider.py
+++ b/betty/tests/extension/raspberry_mint/test_content_provider.py
@@ -66,8 +66,7 @@ class TestEntityCard:
             project.ancestry.add(entity)
             async with project:
                 sut = await EntityCard.new(
-                    services=project,
-                    configuration=EntityReference(entity.plugin(), entity.id),
+                    project, EntityReference(entity.plugin(), entity.id)
                 )
 
                 provided_content = await sut.provide(document=Document())
@@ -117,8 +116,8 @@ class TestSection:
                 project.configuration.extensions.add(RaspberryMint)
                 async with project:
                     sut = await Section.new(
-                        services=project,
-                        configuration=SectionConfiguration(
+                        project,
+                        SectionConfiguration(
                             PluginConfiguration(NoOpContentProvider),  # ty:ignore[invalid-argument-type]
                             heading="My First Section",
                         ),
@@ -130,8 +129,8 @@ class TestSection:
             project.configuration.extensions.add(RaspberryMint)
             async with project:
                 sut = await Section.new(
-                    services=project,
-                    configuration=SectionConfiguration(
+                    project,
+                    SectionConfiguration(
                         PluginConfiguration(
                             Render,
                             RenderConfiguration("My First Content"),
@@ -149,8 +148,8 @@ class TestSection:
             project.configuration.extensions.add(RaspberryMint)
             async with project:
                 sut = await Section.new(
-                    services=project,
-                    configuration=SectionConfiguration(
+                    project,
+                    SectionConfiguration(
                         PluginConfiguration(
                             Render,
                             RenderConfiguration("My First Content"),
@@ -170,8 +169,8 @@ class TestSection:
             project.configuration.extensions.add(RaspberryMint)
             async with project:
                 sut = await Section.new(
-                    services=project,
-                    configuration=SectionConfiguration(
+                    project,
+                    SectionConfiguration(
                         PluginConfiguration(
                             Render,
                             RenderConfiguration("My First Content"),
@@ -201,7 +200,7 @@ class TestFamilies:
         async with Project.new_isolated(isolated_app) as project:
             project.configuration.extensions.add(RaspberryMint)
             async with project:
-                sut = await Families.new(services=project)
+                sut = await Families.new(project)
         assert await sut.provide(document=Document(resource)) is None
 
     async def test_provide_template__with_person(self, isolated_app: App) -> None:
@@ -212,7 +211,7 @@ class TestFamilies:
             project.configuration.extensions.add(RaspberryMint)
             project.ancestry.add(resource)
             async with project:
-                sut = await Families.new(services=project)
+                sut = await Families.new(project)
                 actual = await sut.provide(document=Document(resource))
         assert actual is not None
         assert parent.public_id in actual
@@ -224,7 +223,7 @@ class TestMedia:
         async with Project.new_isolated(isolated_app) as project:
             project.configuration.extensions.add(RaspberryMint)
             async with project:
-                sut = await Media.new(services=project)
+                sut = await Media.new(project)
                 assert await sut.provide(document=Document(object())) is None
 
     async def test_provide_template__with_file(self, isolated_app: App) -> None:
@@ -235,7 +234,7 @@ class TestMedia:
         async with Project.new_isolated(isolated_app) as project:
             project.configuration.extensions.add(RaspberryMint)
             async with project:
-                sut = await Media.new(services=project)
+                sut = await Media.new(project)
                 actual = await sut.provide(document=Document(resource))
         assert actual is not None
         assert resource.label.localize(DEFAULT_LOCALIZER) in actual
@@ -248,7 +247,7 @@ class TestMediaGallery:
         async with Project.new_isolated(isolated_app) as project:
             project.configuration.extensions.add(RaspberryMint)
             async with project:
-                sut = await MediaGallery.new(services=project)
+                sut = await MediaGallery.new(project)
                 assert await sut.provide(document=Document(object())) is None
 
     async def test_provide_template__with_has_file_references_without_file_references(
@@ -258,7 +257,7 @@ class TestMediaGallery:
         async with Project.new_isolated(isolated_app) as project:
             project.configuration.extensions.add(RaspberryMint)
             async with project:
-                sut = await MediaGallery.new(services=project)
+                sut = await MediaGallery.new(project)
                 assert await sut.provide(document=Document(resource)) is None
 
     async def test_provide_template__with_has_file_references_with_file_references(
@@ -270,7 +269,7 @@ class TestMediaGallery:
         async with Project.new_isolated(isolated_app) as project:
             project.configuration.extensions.add(RaspberryMint)
             async with project:
-                sut = await MediaGallery.new(services=project)
+                sut = await MediaGallery.new(project)
                 actual = await sut.provide(document=Document(resource))
         assert actual is not None
         assert file.label.localize(DEFAULT_LOCALIZER) in actual
@@ -302,8 +301,8 @@ class TestColorStyle:
                 project.configuration.extensions.add(RaspberryMint)
                 async with project:
                     sut = await ColorStyle.new(
-                        services=project,
-                        configuration=ColorStyleConfiguration(
+                        project,
+                        ColorStyleConfiguration(
                             PluginConfiguration(NoOpContentProvider),  # ty:ignore[invalid-argument-type]
                             style=ColorStyleOption.DARK,
                         ),
@@ -315,8 +314,8 @@ class TestColorStyle:
             project.configuration.extensions.add(RaspberryMint)
             async with project:
                 sut = await ColorStyle.new(
-                    services=project,
-                    configuration=ColorStyleConfiguration(
+                    project,
+                    ColorStyleConfiguration(
                         PluginConfiguration(
                             Render, RenderConfiguration("My First Content")
                         ),  # ty:ignore[invalid-argument-type]
@@ -333,7 +332,7 @@ class TestExternalLinks:
         async with Project.new_isolated(isolated_app) as project:
             project.configuration.extensions.add(RaspberryMint)
             async with project:
-                sut = await ExternalLinks.new(services=project)
+                sut = await ExternalLinks.new(project)
                 provided_content = await sut.provide(document=Document(object()))
         assert provided_content is None
 
@@ -344,7 +343,7 @@ class TestExternalLinks:
         async with Project.new_isolated(isolated_app) as project:
             project.configuration.extensions.add(RaspberryMint)
             async with project:
-                sut = await ExternalLinks.new(services=project)
+                sut = await ExternalLinks.new(project)
                 assert await sut.provide(document=Document(resource)) is None
 
     async def test_provide_template__with_has_links_with_links(
@@ -355,7 +354,7 @@ class TestExternalLinks:
         async with Project.new_isolated(isolated_app) as project:
             project.configuration.extensions.add(RaspberryMint)
             async with project:
-                sut = await ExternalLinks.new(services=project)
+                sut = await ExternalLinks.new(project)
                 actual = await sut.provide(document=Document(resource))
         assert actual is not None
         assert url in actual
@@ -377,7 +376,7 @@ class TestTimeline:
         async with Project.new_isolated(isolated_app) as project:
             project.configuration.extensions.add(RaspberryMint)
             async with project:
-                sut = await Timeline.new(services=project)
+                sut = await Timeline.new(project)
         assert await sut.provide(document=Document(resource)) is None
 
     async def test_provide_template__with_person(self, isolated_app: App) -> None:
@@ -387,7 +386,7 @@ class TestTimeline:
         async with Project.new_isolated(isolated_app) as project:
             project.configuration.extensions.add(RaspberryMint)
             async with project:
-                sut = await Timeline.new(services=project)
+                sut = await Timeline.new(project)
                 actual = await sut.provide(document=Document(resource))
         assert actual is not None
         assert event.public_id in actual
@@ -401,7 +400,7 @@ class TestTimeline:
         async with Project.new_isolated(isolated_app) as project:
             project.configuration.extensions.add(RaspberryMint)
             async with project:
-                sut = await Timeline.new(services=project)
+                sut = await Timeline.new(project)
                 actual = await sut.provide(document=Document(resource))
         assert actual is not None
         assert event.public_id in actual
@@ -424,7 +423,7 @@ class TestFacts:
         async with Project.new_isolated(isolated_app) as project:
             project.configuration.extensions.add(RaspberryMint)
             async with project:
-                sut = await Facts.new(services=project)
+                sut = await Facts.new(project)
         assert await sut.provide(document=Document(resource)) is None
 
     async def test_provide_template__with_citation(self, isolated_app: App) -> None:
@@ -433,7 +432,7 @@ class TestFacts:
         async with Project.new_isolated(isolated_app) as project:
             project.configuration.extensions.add(RaspberryMint)
             async with project:
-                sut = await Facts.new(services=project)
+                sut = await Facts.new(project)
                 actual = await sut.provide(document=Document(resource))
         assert actual is not None
         assert fact.public_id in actual
@@ -445,7 +444,7 @@ class TestFacts:
         async with Project.new_isolated(isolated_app) as project:
             project.configuration.extensions.add(RaspberryMint)
             async with project:
-                sut = await Facts.new(services=project)
+                sut = await Facts.new(project)
                 actual = await sut.provide(document=Document(resource))
         assert actual is not None
         assert fact.public_id in actual
@@ -716,7 +715,7 @@ class TestEnclosees:
         async with Project.new_isolated(isolated_app) as project:
             project.configuration.extensions.add(RaspberryMint)
             async with project:
-                sut = await Enclosees.new(services=project)
+                sut = await Enclosees.new(project)
         assert await sut.provide(document=Document(resource)) is None
 
     async def test_provide_template__with_enclosee(self, isolated_app: App) -> None:
@@ -726,7 +725,7 @@ class TestEnclosees:
         async with Project.new_isolated(isolated_app) as project:
             project.configuration.extensions.add(RaspberryMint)
             async with project:
-                sut = await Enclosees.new(services=project)
+                sut = await Enclosees.new(project)
                 actual = await sut.provide(document=Document(resource))
         assert actual is not None
         assert enclosee.public_id in actual
@@ -749,7 +748,7 @@ class TestFileReferees:
         async with Project.new_isolated(isolated_app) as project:
             project.configuration.extensions.add(RaspberryMint)
             async with project:
-                sut = await FileReferees.new(services=project)
+                sut = await FileReferees.new(project)
         assert await sut.provide(document=Document(resource)) is None
 
     async def test_provide_template__with_referee(self, isolated_app: App) -> None:
@@ -759,7 +758,7 @@ class TestFileReferees:
         async with Project.new_isolated(isolated_app) as project:
             project.configuration.extensions.add(RaspberryMint)
             async with project:
-                sut = await FileReferees.new(services=project)
+                sut = await FileReferees.new(project)
                 actual = await sut.provide(document=Document(resource))
         assert actual is not None
         assert referee.public_id in actual

--- a/betty/tests/extension/raspberry_mint/test_search_ui.py
+++ b/betty/tests/extension/raspberry_mint/test_search_ui.py
@@ -36,9 +36,7 @@ class TestSearchUi:
             project.ancestry[Person].add(person)
             async with project:
                 await generate(project)
-                async with await serve.BuiltinProjectServer.new(
-                    services=project
-                ) as server:
+                async with await serve.BuiltinProjectServer.new(project) as server:
                     yield project, server
 
     @pytest.mark.asyncio(loop_scope="session")

--- a/betty/tests/extension/spdx/test___init__.py
+++ b/betty/tests/extension/spdx/test___init__.py
@@ -8,6 +8,6 @@ class TestSpdx:
         async with (
             Project.new_isolated(isolated_app) as project,
             project,
-            await Spdx.new(services=project) as sut,
+            await Spdx.new(project) as sut,
         ):
             await sut.license_repository

--- a/betty/tests/extension/trees/test_content_provider.py
+++ b/betty/tests/extension/trees/test_content_provider.py
@@ -20,7 +20,7 @@ class TestTree:
         async with Project.new_isolated(isolated_app) as project:
             project.configuration.extensions.add(Trees)
             async with project:
-                sut = await Tree.new(services=project)
+                sut = await Tree.new(project)
                 assert await sut.provide(document=Document()) is None
 
     @pytest.mark.parametrize(
@@ -37,7 +37,7 @@ class TestTree:
             project.configuration.extensions.add(Trees)
             async with project:
                 project.ancestry.add(resource)
-                sut = await Tree.new(services=project)
+                sut = await Tree.new(project)
                 assert (
                     await sut.provide(document=await project.new_document(resource))
                     is None
@@ -52,7 +52,7 @@ class TestTree:
             project.configuration.extensions.add(Trees)
             async with project:
                 project.ancestry.add(person)
-                sut = await Tree.new(services=project)
+                sut = await Tree.new(project)
                 document = await project.new_document(person)
                 actual = await sut.provide(document=document)
         assert actual is not None

--- a/betty/tests/extension/webpack/test___init__.py
+++ b/betty/tests/extension/webpack/test___init__.py
@@ -16,7 +16,7 @@ class TestWebpack:
         async with (
             Project.new_isolated(isolated_app) as project,
             project,
-            await Webpack.new(services=project) as sut,
+            await Webpack.new(project) as sut,
         ):
             assert await sut.get_public_js_paths()
 
@@ -24,7 +24,7 @@ class TestWebpack:
         async with (
             Project.new_isolated(isolated_app) as project,
             project,
-            await Webpack.new(services=project) as sut,
+            await Webpack.new(project) as sut,
         ):
             assert sut.filters
 
@@ -32,7 +32,7 @@ class TestWebpack:
         async with (
             Project.new_isolated(isolated_app) as project,
             project,
-            await Webpack.new(services=project) as sut,
+            await Webpack.new(project) as sut,
         ):
             assert await sut.get_public_css_paths()
 
@@ -58,5 +58,5 @@ class TestWebpack:
 
     async def test_new_document_vars(self, isolated_app: App) -> None:
         async with Project.new_isolated(isolated_app) as project, project:
-            sut = await Webpack.new(services=project)
+            sut = await Webpack.new(project)
             assert sut.new_document_vars()

--- a/betty/tests/extension/wiki/test___init__.py
+++ b/betty/tests/extension/wiki/test___init__.py
@@ -21,7 +21,7 @@ class TestWiki:
         async with (
             Project.new_isolated(isolated_app) as project,
             project,
-            await Wiki.new(services=project) as sut,
+            await Wiki.new(project) as sut,
         ):
             assert sut.filters
 

--- a/betty/tests/extension/wiki/test_content_provider.py
+++ b/betty/tests/extension/wiki/test_content_provider.py
@@ -17,7 +17,7 @@ class TestWikipediaSummary:
         async with Project.new_isolated(isolated_app) as project:
             project.configuration.extensions.add(Wiki)
             async with project:
-                sut = await WikipediaSummary.new(services=project)
+                sut = await WikipediaSummary.new(project)
                 assert await sut.provide(document=Document()) is None
 
     async def test_provide_template__with_has_links_resource(
@@ -34,7 +34,7 @@ class TestWikipediaSummary:
             project.configuration.extensions.add(Wiki)
             async with project:
                 project.ancestry.add(resource)
-                sut = await WikipediaSummary.new(services=project)
+                sut = await WikipediaSummary.new(project)
                 actual = await sut.provide(document=Document(resource))
         assert actual is not None
         assert url in actual

--- a/betty/tests/jinja2/test___init__.py
+++ b/betty/tests/jinja2/test___init__.py
@@ -34,27 +34,27 @@ class TestJinja2Provider:
 class TestEnvironment:
     async def test_context_class(self, isolated_app: App) -> None:
         async with Project.new_isolated(isolated_app) as project, project:
-            sut = await Environment.new(services=project)
+            sut = await Environment.new(project)
             context_class = sut.context_class
             context_class(sut, {}, "", {}, {})
 
     async def test_project(self, isolated_app: App) -> None:
         async with Project.new_isolated(isolated_app) as project, project:
-            sut = await Environment.new(services=project)
+            sut = await Environment.new(project)
             assert sut.project is project
 
     async def test_new_with_debug(self, isolated_app: App) -> None:
         async with Project.new_isolated(isolated_app) as project:
             project.configuration.debug = True
             async with project:
-                sut = await Environment.new(services=project)
+                sut = await Environment.new(project)
                 assert "jinja2.ext.DebugExtension" in sut.extensions
 
     async def test_make_copy_function__www_directory(
         self, isolated_app: App, tmp_path: Path
     ) -> None:
         async with Project.new_isolated(isolated_app) as project, project:
-            sut = await Environment.new(services=project)
+            sut = await Environment.new(project)
             source_file_path = tmp_path / "source.test.j2"
             async with aiofiles.open(source_file_path, "w") as f:
                 await f.write("{{ document.resource }}\n{{ document.resource_url }}")
@@ -75,7 +75,7 @@ class TestEnvironment:
         self, isolated_app: App, tmp_path: Path
     ) -> None:
         async with Project.new_isolated(isolated_app) as project, project:
-            sut = await Environment.new(services=project)
+            sut = await Environment.new(project)
             source_file_path = tmp_path / "source.test.j2"
             async with aiofiles.open(source_file_path, "w") as f:
                 await f.write("{{ document.resource }}\n{{ document.resource_url }}")
@@ -95,7 +95,7 @@ class TestEnvironment:
         self, isolated_app: App, tmp_path: Path
     ) -> None:
         async with Project.new_isolated(isolated_app) as project, project:
-            sut = await Environment.new(services=project)
+            sut = await Environment.new(project)
             source_file_path = tmp_path / "source.test.j2"
             async with aiofiles.open(source_file_path, "w") as f:
                 await f.write("{{ document.resource }}\n{{ document.resource_url }}")
@@ -123,7 +123,7 @@ class Test_CacheTagExtension:
     async def test_tag__without_job_context(self, isolated_app: App) -> None:
         counter = Counter()
         async with Project.new_isolated(isolated_app) as project, project:
-            sut = await Environment.new(services=project)
+            sut = await Environment.new(project)
             template = sut.from_string(
                 "{% cache 'my-first-cache-key' %}{% do count() %}{% endcache %}"
             )
@@ -135,7 +135,7 @@ class Test_CacheTagExtension:
         counter = Counter()
         job_context = JobContext()
         async with Project.new_isolated(isolated_app) as project, project:
-            sut = await Environment.new(services=project)
+            sut = await Environment.new(project)
             template = sut.from_string(
                 "{% cache 'my-first-cache-key' %}{% do count() %}{% endcache %}"
             )

--- a/betty/tests/model/test_reference.py
+++ b/betty/tests/model/test_reference.py
@@ -35,20 +35,20 @@ class TestEntityReference(DataTestBase[EntityReference]):
             EntityDefinition.type().discoverer.override(DummyEntityOne),
             pytest.raises(HumanFacingException),
         ):
-            await sut.hydrate(services=universe)
+            await sut.hydrate(universe)
 
     async def test_hydrate__with_unknown_entity_type(self, isolated_app: App) -> None:
         sut = EntityReference(DummyEntityOne, "unknown-entity")
         async with Project.new_isolated(isolated_app) as project, project:
             with pytest.raises(HumanFacingException):
-                await sut.hydrate(services=project)
+                await sut.hydrate(project)
 
     async def test_hydrate__with_unknown_entity(self, isolated_app: App) -> None:
         sut = EntityReference(DummyEntityOne, "unknown-entity")
         async with Project.new_isolated(isolated_app) as project, project:
             with EntityDefinition.type().discoverer.override(DummyEntityOne):
                 with pytest.raises(HumanFacingException):
-                    await sut.hydrate(services=project)
+                    await sut.hydrate(project)
 
     async def test_hydrate__with_known_entity(self, isolated_app: App) -> None:
         entity_id = "my-first-entity"
@@ -57,4 +57,4 @@ class TestEntityReference(DataTestBase[EntityReference]):
             project.ancestry[DummyEntityOne].add(DummyEntityOne(entity_id))
             async with project:
                 with EntityDefinition.type().discoverer.override(DummyEntityOne):
-                    await sut.hydrate(services=project)
+                    await sut.hydrate(project)

--- a/betty/tests/plugin/discovery/test___init__.py
+++ b/betty/tests/plugin/discovery/test___init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Unpack
+from typing import TYPE_CHECKING
 
 import pytest
 from typing_extensions import TypeVar, override
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Iterable, Set
 
     from betty.service.level import ServiceLevel
-    from betty.service.requirement import ServiceLevelKwargs
+
 
 _PluginDefinitionT = TypeVar(
     "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
@@ -36,14 +36,14 @@ class _StaticDiscovery(PluginDiscovery[_PluginDefinitionT]):
 
     @override
     async def discover(
-        self, *, services: ServiceLevel
+        self, services: ServiceLevel, /
     ) -> Iterable[ResolvableDiscovery[_PluginDefinitionT]]:
         return self._discoveries
 
 
 class TestDiscoverer:
     async def _discover(self, sut: Discoverer):
-        return list(await sut.discover(services=universe))
+        return list(await sut.discover(universe))
 
     async def test_discover(self) -> None:
         sut = Discoverer([DummyPluginTwo])
@@ -78,11 +78,9 @@ class TestDiscoverer:
 
 def _new_static_discovery_sync(
     *discoveries: ResolvableDiscovery[DummyPluginDefinition],
-) -> Callable[
-    [Unpack[ServiceLevelKwargs]], Iterable[ResolvableDiscovery[DummyPluginDefinition]]
-]:
+) -> Callable[[ServiceLevel], Iterable[ResolvableDiscovery[DummyPluginDefinition]]]:
     def _static_discovery_sync(
-        *, services: ServiceLevel
+        services: ServiceLevel,
     ) -> Iterable[ResolvableDiscovery[DummyPluginDefinition]]:
         return discoveries
 
@@ -92,11 +90,11 @@ def _new_static_discovery_sync(
 def _new_static_discovery_async(
     *discoveries: ResolvableDiscovery[DummyPluginDefinition],
 ) -> Callable[
-    [Unpack[ServiceLevelKwargs]],
+    [ServiceLevel],
     Awaitable[Iterable[ResolvableDiscovery[DummyPluginDefinition]]],
 ]:
     async def _static_discovery_async(
-        *, services: ServiceLevel
+        services: ServiceLevel,
     ) -> Iterable[ResolvableDiscovery[DummyPluginDefinition]]:
         return discoveries
 
@@ -127,4 +125,4 @@ async def test_discover(
     expected: Set[DummyPluginDefinition],
     discoveries: Iterable[ResolvableDiscovery[DummyPluginDefinition]],
 ) -> None:
-    assert set(await discover(*discoveries, services=universe)) == expected
+    assert set(await discover(universe, *discoveries)) == expected

--- a/betty/tests/plugin/discovery/test_entry_point.py
+++ b/betty/tests/plugin/discovery/test_entry_point.py
@@ -32,7 +32,7 @@ class TestEntryPointDiscovery:
             ),
         )
         sut = EntryPointDiscovery(entry_point_group)
-        plugins = await sut.discover(services=universe)
+        plugins = await sut.discover(universe)
         assert DummyPluginOne in plugins
         assert DummyPluginTwo in plugins
         m_entry_points.assert_called_once_with(group=entry_point_group)

--- a/betty/tests/plugin/manager/test_service.py
+++ b/betty/tests/plugin/manager/test_service.py
@@ -36,7 +36,7 @@ class TestServiceLevelPluginManager:
         )
 
     async def test_plugins__should_forward_services(self, isolated_app: App) -> None:
-        async def _discovery(*, app: App) -> Iterable[DummyPluginDefinition]:
+        async def _discovery(app: App) -> Iterable[DummyPluginDefinition]:
             assert app is isolated_app
             return ()
 

--- a/betty/tests/plugin/test___init__.py
+++ b/betty/tests/plugin/test___init__.py
@@ -109,7 +109,7 @@ class TestPluginTypeDefinition:
             label_countable=DUMMY_COUNTABLE_LOCALIZABLE,
             discovery=[DummyPluginTwo],
         )
-        assert list(await sut.discoverer.discover(services=universe)) == [
+        assert list(await sut.discoverer.discover(universe)) == [
             DummyPluginTwo.plugin()
         ]
 

--- a/betty/tests/plugin/test_data.py
+++ b/betty/tests/plugin/test_data.py
@@ -25,12 +25,12 @@ class TestPluginIdDefinition:
 
     async def test_hydrate(self) -> None:
         sut = PluginIdDefinition(DummyPluginDefinition)
-        await sut.hydrate(services=universe, data=DummyPluginOne.plugin().id)
+        await sut.hydrate(universe, DummyPluginOne.plugin().id)
 
     async def test_hydrate__plugin_not_found(self) -> None:
         sut = PluginIdDefinition(DummyPluginDefinition)
         with pytest.raises(PluginNotFound):
-            await sut.hydrate(services=universe, data="non-existent-plugin-id")
+            await sut.hydrate(universe, "non-existent-plugin-id")
 
 
 class TestPluginConfigurationDefinition:

--- a/betty/tests/project/test___init__.py
+++ b/betty/tests/project/test___init__.py
@@ -29,7 +29,7 @@ class _DummyExtension(Manufacturable, Extension):
     @override
     @classmethod
     @require_project
-    async def new(cls, *, project: Project) -> Self:
+    async def new(cls, project: Project, /) -> Self:
         return cls(services=project)
 
 

--- a/betty/tests/project/test_config.py
+++ b/betty/tests/project/test_config.py
@@ -86,7 +86,7 @@ class TestEntityTypeConfiguration(DataTestBase[EntityTypeConfiguration]):
             EntityDefinition.type().discoverer.override(DummyNonPublicFacingEntityOne),
             pytest.raises(HumanFacingException),
         ):
-            await sut.hydrate(services=universe)
+            await sut.hydrate(universe)
 
 
 class TestProjectConfiguration(DataTestBase[ProjectConfiguration]):

--- a/betty/tests/project/test_schema.py
+++ b/betty/tests/project/test_schema.py
@@ -41,7 +41,7 @@ class TestProjectSchema(SchemaTestBase):
             project.configuration.clean_urls = clean_urls
             async with project:
                 return (
-                    await ProjectSchema.new(services=project),
+                    await ProjectSchema.new(project),
                     [
                         await Person().dump_linked_data(project),
                         await Place().dump_linked_data(project),
@@ -59,7 +59,7 @@ class TestProjectSchema(SchemaTestBase):
     )
     async def test_new(self, clean_urls: bool, isolated_app: App) -> None:
         async with Project.new_isolated(isolated_app) as project, project:
-            sut = await ProjectSchema.new(services=project)
+            sut = await ProjectSchema.new(project)
         JsonSchemaSchema().validate(sut.schema)
 
     async def test_def_url(self, isolated_app: App) -> None:

--- a/betty/tests/project/test_url.py
+++ b/betty/tests/project/test_url.py
@@ -101,7 +101,7 @@ class Test_LocalizedPathUrlUrlGenerator:
         self, expected: bool, resource: Any, isolated_app: App
     ) -> None:
         async with Project.new_isolated(isolated_app) as project, project:
-            sut = await _LocalizedPathUrlUrlGenerator.new(services=project)
+            sut = await _LocalizedPathUrlUrlGenerator.new(project)
             assert sut.supports(resource) == expected
 
     _GENERATE_RESOURCES = [
@@ -185,7 +185,7 @@ class Test_LocalizedPathUrlUrlGenerator:
                     LocaleConfiguration(additional_project_locale)
                 )
             async with project:
-                sut = await _LocalizedPathUrlUrlGenerator.new(services=project)
+                sut = await _LocalizedPathUrlUrlGenerator.new(project)
                 assert (
                     sut.generate(
                         resource,
@@ -221,7 +221,7 @@ class Test_StaticPathUrlUrlGenerator:
         self, expected: bool, resource: Any, isolated_app: App
     ) -> None:
         async with Project.new_isolated(isolated_app) as project, project:
-            sut = await _StaticPathUrlUrlGenerator.new(services=project)
+            sut = await _StaticPathUrlUrlGenerator.new(project)
             assert sut.supports(resource) == expected
 
     @pytest.mark.parametrize(
@@ -286,7 +286,7 @@ class Test_StaticPathUrlUrlGenerator:
             if additional_project_locale:
                 project.configuration.locales.add(additional_project_locale)
             async with project:
-                sut = await _StaticPathUrlUrlGenerator.new(services=project)
+                sut = await _StaticPathUrlUrlGenerator.new(project)
                 assert (
                     sut.generate(
                         resource,

--- a/betty/tests/service/requirement/test___init__.py
+++ b/betty/tests/service/requirement/test___init__.py
@@ -1,0 +1,102 @@
+from collections.abc import Awaitable, Callable
+from typing import TypeAlias
+
+import pytest
+
+from betty.service.level import ServiceLevel
+from betty.service.requirement import Requirement, UnmetRequirement
+
+
+class _RequiredServiceLevel(ServiceLevel):
+    pass
+
+
+async def _require(services: ServiceLevel, target: str, /) -> _RequiredServiceLevel:
+    if isinstance(services, _RequiredServiceLevel):
+        return services
+    raise UnmetRequirement("")
+
+
+@Requirement(_require)
+def _require_target_sync(services: _RequiredServiceLevel, /) -> _RequiredServiceLevel:
+    return services
+
+
+@Requirement(_require)
+async def _require_target_async(
+    services: _RequiredServiceLevel, /
+) -> _RequiredServiceLevel:
+    return services
+
+
+class _RequireTargetClassMethod:
+    @classmethod
+    @Requirement(_require)
+    async def target(cls, services: _RequiredServiceLevel, /) -> _RequiredServiceLevel:
+        return services
+
+
+class _RequireTargetInstanceMethod:
+    @Requirement(_require)
+    async def target(self, services: _RequiredServiceLevel, /) -> _RequiredServiceLevel:
+        return services
+
+
+_targets = pytest.mark.parametrize(
+    "target",
+    [
+        _require_target_sync,
+        _require_target_async,
+        _RequireTargetClassMethod.target,
+        _RequireTargetInstanceMethod().target,
+    ],
+)
+_Target: TypeAlias = Callable[[ServiceLevel], Awaitable[_RequiredServiceLevel]]
+
+
+class TestRequirement:
+    async def test___call____with_services_with_requirement_unmet(self) -> None:
+        sut = Requirement(_require)
+        with pytest.raises(UnmetRequirement):
+            assert await sut(ServiceLevel())
+
+    async def test___call____with_services_with_requirement_met(self) -> None:
+        sut = Requirement(_require)
+        services = _RequiredServiceLevel()
+        assert await sut(services) is services
+
+    async def test___call____with__decorated_callable_with_requirement_unmet(
+        self,
+    ) -> None:
+        def _require_target(
+            services: _RequiredServiceLevel, /
+        ) -> _RequiredServiceLevel:
+            return services
+
+        sut = Requirement(_require)
+        with pytest.raises(UnmetRequirement):
+            await sut(_require_target)(ServiceLevel())
+
+    async def test___call____with__decorated_callable_with_requirement_met(
+        self,
+    ) -> None:
+        def _require_target(
+            services: _RequiredServiceLevel, /
+        ) -> _RequiredServiceLevel:
+            return services
+
+        sut = Requirement(_require)
+        services = _RequiredServiceLevel()
+        assert await sut(_require_target)(services) is services
+
+
+class TestCallableRequirement:
+    @_targets
+    async def test___call____with_requirement_unmet(self, target: _Target) -> None:
+        with pytest.raises(UnmetRequirement):
+            await target(ServiceLevel())
+
+    @_targets
+    async def test___call____with_requirement_met(self, target: _Target) -> None:
+        services = _RequiredServiceLevel()
+        assert await target(services) is services

--- a/betty/tests/service/requirement/test_app.py
+++ b/betty/tests/service/requirement/test_app.py
@@ -1,69 +1,26 @@
-from collections.abc import Awaitable, Callable
-from typing import TypeAlias, Unpack
-
 import pytest
 
 from betty.app import App
 from betty.exception import HumanFacingException
 from betty.project import Project
 from betty.service.level import universe
-from betty.service.requirement import ServiceLevelKwargs
 from betty.service.requirement.app import require_app
 
 
 @require_app
-def _require_app_target_sync(*, app: App) -> App:
+def _require_app_target(app: App, /) -> App:
     return app
 
 
-@require_app
-async def _require_app_target_async(*, app: App) -> App:
-    return app
-
-
-class _RequireAppTargetClassMethod:
-    @classmethod
-    @require_app
-    async def target(cls, *, app: App) -> App:
-        return app
-
-
-class _RequireAppTargetInstanceMethod:
-    @require_app
-    async def target(self, *, app: App) -> App:
-        return app
-
-
-_test_require_app_targets = pytest.mark.parametrize(
-    "target",
-    [
-        _require_app_target_sync,
-        _require_app_target_async,
-        _RequireAppTargetClassMethod.target,
-        _RequireAppTargetInstanceMethod().target,
-    ],
-)
-_TestRequireAppTarget: TypeAlias = Callable[
-    [Unpack[ServiceLevelKwargs]], Awaitable[App]
-]
-
-
-@_test_require_app_targets
-async def test_require_app__with_universe(target: _TestRequireAppTarget) -> None:
+async def test_require_app__with_universe() -> None:
     with pytest.raises(HumanFacingException):
-        await target(services=universe)
+        await _require_app_target(universe)
 
 
-@_test_require_app_targets
-async def test_require_app__with_app(
-    isolated_app: App, target: _TestRequireAppTarget
-) -> None:
-    assert await target(services=isolated_app) is isolated_app
+async def test_require_app__with_app(isolated_app: App) -> None:
+    assert await _require_app_target(isolated_app) is isolated_app
 
 
-@_test_require_app_targets
-async def test_require_app__with_project(
-    isolated_app: App, target: _TestRequireAppTarget
-) -> None:
+async def test_require_app__with_project(isolated_app: App) -> None:
     async with Project.new_isolated(isolated_app) as project, project:
-        assert await target(services=project) is isolated_app
+        assert await _require_app_target(project) is isolated_app

--- a/betty/tests/service/requirement/test_extension.py
+++ b/betty/tests/service/requirement/test_extension.py
@@ -1,6 +1,3 @@
-from collections.abc import Awaitable, Callable
-from typing import TypeAlias, Unpack
-
 import pytest
 
 from betty.app import App
@@ -8,99 +5,53 @@ from betty.exception import HumanFacingException
 from betty.extension import ExtensionDefinition
 from betty.project import Project
 from betty.service.level import universe
-from betty.service.requirement import ServiceLevelKwargs
 from betty.service.requirement.extension import require_extension
 from betty.test_utils.project.extension import DummyExtensionOne
 
 
 @require_extension(DummyExtensionOne)
-def _require_extension_target_sync(
-    *, extension: DummyExtensionOne
-) -> DummyExtensionOne:
+def _require_extension_target(extension: DummyExtensionOne, /) -> DummyExtensionOne:
     return extension
 
 
-@require_extension(DummyExtensionOne)
-async def _require_extension_target_async(
-    *, extension: DummyExtensionOne
-) -> DummyExtensionOne:
-    return extension
-
-
-class _RequireExtensionTargetClassMethod:
-    @classmethod
-    @require_extension(DummyExtensionOne)
-    async def target(cls, *, extension: DummyExtensionOne) -> DummyExtensionOne:
-        return extension
-
-
-class _RequireExtensionTargetInstanceMethod:
-    @require_extension(DummyExtensionOne)
-    async def target(self, *, extension: DummyExtensionOne) -> DummyExtensionOne:
-        return extension
-
-
-_test_require_extension_targets = pytest.mark.parametrize(
-    "target",
-    [
-        _require_extension_target_sync,
-        _require_extension_target_async,
-        _RequireExtensionTargetClassMethod.target,
-        _RequireExtensionTargetInstanceMethod().target,
-    ],
-)
-_TestRequireExtensionTarget: TypeAlias = Callable[
-    [Unpack[ServiceLevelKwargs]], Awaitable[DummyExtensionOne]
-]
-
-
-@_test_require_extension_targets
-async def test_require_extension__with_universe(
-    target: _TestRequireExtensionTarget,
-) -> None:
+async def test_require_extension__with_universe() -> None:
     with (
         ExtensionDefinition.type().discoverer.override(DummyExtensionOne),
         pytest.raises(HumanFacingException),
     ):
-        await target(services=universe)
+        await _require_extension_target(universe)
 
 
-@_test_require_extension_targets
-async def test_require_extension__with_app(
-    isolated_app: App, target: _TestRequireExtensionTarget
-) -> None:
+async def test_require_extension__with_app(isolated_app: App) -> None:
     with (
         ExtensionDefinition.type().discoverer.override(DummyExtensionOne),
         pytest.raises(HumanFacingException),
     ):
-        await target(services=isolated_app)
+        await _require_extension_target(isolated_app)
 
 
-@_test_require_extension_targets
 async def test_require_extension__with_project_with_extension_plugin_not_found(
-    isolated_app: App, target: _TestRequireExtensionTarget
+    isolated_app: App,
 ) -> None:
     async with Project.new_isolated(isolated_app) as project, project:
         with pytest.raises(HumanFacingException):
-            await target(services=project)
+            await _require_extension_target(project)
 
 
-@_test_require_extension_targets
 async def test_require_extension__with_project_without_extension(
-    isolated_app: App, target: _TestRequireExtensionTarget
+    isolated_app: App,
 ) -> None:
     async with Project.new_isolated(isolated_app) as project, project:
         with ExtensionDefinition.type().discoverer.override(DummyExtensionOne):
             with pytest.raises(HumanFacingException):
-                await target(services=project)
+                await _require_extension_target(project)
 
 
-@_test_require_extension_targets
-async def test_require_extension__with_extension(
-    isolated_app: App, target: _TestRequireExtensionTarget
-) -> None:
+async def test_require_extension__with_extension(isolated_app: App) -> None:
     async with Project.new_isolated(isolated_app) as project:
         with ExtensionDefinition.type().discoverer.override(DummyExtensionOne):
             project.configuration.extensions.add(DummyExtensionOne)
             async with project:
-                assert isinstance(await target(services=project), DummyExtensionOne)
+                assert isinstance(
+                    await _require_extension_target(project), DummyExtensionOne
+                )

--- a/betty/tests/service/requirement/test_project.py
+++ b/betty/tests/service/requirement/test_project.py
@@ -1,72 +1,27 @@
-from collections.abc import Awaitable, Callable
-from typing import TypeAlias, Unpack
-
 import pytest
 
 from betty.app import App
 from betty.exception import HumanFacingException
 from betty.project import Project
 from betty.service.level import universe
-from betty.service.requirement import ServiceLevelKwargs
 from betty.service.requirement.project import require_project
 
 
 @require_project
-def _require_project_target_sync(*, project: Project) -> Project:
+def _require_project_target(project: Project, /) -> Project:
     return project
 
 
-@require_project
-async def _require_project_target_async(*, project: Project) -> Project:
-    return project
-
-
-class _RequireProjectTargetClassMethod:
-    @classmethod
-    @require_project
-    async def target(cls, *, project: Project) -> Project:
-        return project
-
-
-class _RequireProjectTargetInstanceMethod:
-    @require_project
-    async def target(self, *, project: Project) -> Project:
-        return project
-
-
-_test_require_project_targets = pytest.mark.parametrize(
-    "target",
-    [
-        _require_project_target_sync,
-        _require_project_target_async,
-        _RequireProjectTargetClassMethod.target,
-        _RequireProjectTargetInstanceMethod().target,
-    ],
-)
-_TestRequireProjectTarget: TypeAlias = Callable[
-    [Unpack[ServiceLevelKwargs]], Awaitable[Project]
-]
-
-
-@_test_require_project_targets
-async def test_require_project__with_universe(
-    target: _TestRequireProjectTarget,
-) -> None:
+async def test_require_project__with_universe() -> None:
     with pytest.raises(HumanFacingException):
-        await target(services=universe)
+        await _require_project_target(universe)
 
 
-@_test_require_project_targets
-async def test_require_project__with_app(
-    isolated_app: App, target: _TestRequireProjectTarget
-) -> None:
+async def test_require_project__with_app(isolated_app: App) -> None:
     with pytest.raises(HumanFacingException):
-        await target(services=isolated_app)
+        await _require_project_target(isolated_app)
 
 
-@_test_require_project_targets
-async def test_require_project__with_project(
-    isolated_app: App, target: _TestRequireProjectTarget
-) -> None:
+async def test_require_project__with_project(isolated_app: App) -> None:
     async with Project.new_isolated(isolated_app) as project, project:
-        assert await target(services=project) is project
+        assert await _require_project_target(project) is project

--- a/betty/tests/test_pathlib.py
+++ b/betty/tests/test_pathlib.py
@@ -22,10 +22,10 @@ class TestFilePathDefinition:
     async def test_hydrate(self) -> None:
         file_path = ASSETS_DIRECTORY_PATH / "public" / "static" / "betty-512x512.png"
         sut = FilePathDefinition()
-        await sut.hydrate(services=universe, data=str(file_path))
+        await sut.hydrate(universe, str(file_path))
 
     async def test_hydrate__with_non_existent_file(self, tmp_path: Path) -> None:
         file_path = tmp_path / "non-existent-file"
         sut = FilePathDefinition()
         with pytest.raises(FileNotFound):
-            await sut.hydrate(services=universe, data=file_path)
+            await sut.hydrate(universe, file_path)

--- a/betty/tests/test_serve.py
+++ b/betty/tests/test_serve.py
@@ -51,7 +51,7 @@ class TestBuiltinProjectServer:
             await makedirs(project.www_directory)
             async with aiofiles.open(project.www_directory / "index.html", "w") as f:
                 await f.write(content)
-            async with await BuiltinProjectServer.new(services=project) as server:
+            async with await BuiltinProjectServer.new(project) as server:
 
                 def _assert_response(response: Response) -> None:
                     assert response.status_code == 200


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/3709

## Follow-ups
- Refactor `require_extension()` into `require_plugin(plugin_type: ResolvableDefinition[_PluginDefinitionT], plugin_id: ResolvableId[_PluginTypeDefinitionT)`. Raise plugin type agnostic errors. However, limit the internal checks to extensions. This way the interface is stable for future expansion towards other service level plugin types. 