### PR TITLE
Remove hydration

### DIFF
--- a/betty/data/__init__.py
+++ b/betty/data/__init__.py
@@ -15,7 +15,6 @@ from betty.importlib import fully_qualified_name
 from betty.portable import OptionalPorter, Portable, PortablePorter, Porter
 from betty.portable.error import NotPortable
 from betty.sample import Samplable, Sample, Samples, Size
-from betty.service.hydrate import Hydratable, Hydrator
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
@@ -28,9 +27,7 @@ if TYPE_CHECKING:
 _DataClsT = TypeVar("_DataClsT", default=Any)
 
 
-class DataDefinition(
-    HumanFacingDefinition, ClsDefinition[_DataClsT], Hydrator[_DataClsT]
-):
+class DataDefinition(HumanFacingDefinition, ClsDefinition[_DataClsT]):
     """
     A data definition.
     """
@@ -82,11 +79,6 @@ class DataDefinition(
                 return Samples([self.cls])
             return Samples(())
         return Samples(self._samples)
-
-    @override
-    async def hydrate(self, services: ServiceLevel, data: _DataClsT, /) -> None:
-        if isinstance(data, Hydratable):
-            await data.hydrate(services)
 
 
 _DataDefinitionT = TypeVar(

--- a/betty/service/hydrate.py
+++ b/betty/service/hydrate.py
@@ -5,7 +5,7 @@ The hydration API.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 if TYPE_CHECKING:
     from betty.service.level import ServiceLevel
@@ -29,15 +29,23 @@ class Hydratable(ABC):
         """
 
 
-class Hydrator(Generic[_T]):
+# @todo The problem with taking this out of DataDefinition and using a visitor pattern is that it means
+# @todo Hydratable.hydrate() is no longer supposed to be called directly. I mean, was it ever?
+# @todo Or in other words: where does this API belong, what does it act on, and what should be the universal entry point?
+# @todo - Currently, everything that is Hydratable is also defined data.
+# @todo - If that stays, then hydration is a service/data intersection API, not just service API.
+# @todo - Does it make sense for anything else to be hydratable? Not really, this whole thing is a roundabout way
+# @todo   of letting value objects access services.
+# @todo - What if some data is not Hydratable but we want to add some kind of hydration? E.g. a third party's class we
+# @todo   want to validate through hydration?
+# @todo
+# @todo
+async def hydrate(services: ServiceLevel, data: object, /) -> None:
     """
-    An object capable of hydrating other data.
+    Hydrate data.
+
+    Hydration allows data definitions to require a :py:type:`betty.service.level.ServiceLevel` to perform tasks
+    such as validation or enhancing the data using information or functionality from the service level.
     """
-
-    async def hydrate(self, services: ServiceLevel, data: _T, /) -> None:
-        """
-        Hydrate data.
-
-        Hydration allows data definitions to require a :py:type:`betty.service.level.ServiceLevel` to perform tasks
-        such as validation or enhancing the data using information or functionality from the service level.
-        """
+    if isinstance(data, Hydratable):
+        await data.hydrate(services)

--- a/betty/tests/coverage/test_coverage.py
+++ b/betty/tests/coverage/test_coverage.py
@@ -239,7 +239,6 @@ _BASELINE: Mapping[str, _ModuleIgnore] = {
     },
     "betty/service/hydrate.py": {
         "Hydratable": MissingReason.ABSTRACT,
-        "Hydrator": MissingReason.ABSTRACT,
     },
     "betty/service/level.py": {
         "Configurable": MissingReason.ABSTRACT,


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/3769

## To do
- Update the commit message!
- Remove hydration entirely. Different sections of complex configuration objects need different service levels to perform validation. We also cannot accurately set error indicators at the moment. 
- Replace implementations with individual `validate(services: ServiceLevel, /)` methods 