### PR TITLE
Make plugin discovery fully lazy (again)

### DIFF
--- a/betty/ancestry/event.py
+++ b/betty/ancestry/event.py
@@ -196,7 +196,7 @@ class Event(
             "type",
             PluginIdSchema(
                 EventTypeDefinition.type(),
-                await project.plugins.plugins(EventTypeDefinition),
+                await project.plugin.plugins(EventTypeDefinition).plugins(),
             ),
         )
         schema.add_property("eventStatus", String(title="Event status"))

--- a/betty/ancestry/file.py
+++ b/betty/ancestry/file.py
@@ -134,7 +134,7 @@ class File(
             "copyrightNotice",
             PluginIdSchema(
                 CopyrightNoticeDefinition.type(),
-                await project.plugins.plugins(CopyrightNoticeDefinition),
+                await project.plugin.plugins(CopyrightNoticeDefinition).plugins(),
             ),
             False,
         )
@@ -142,7 +142,7 @@ class File(
             "license",
             PluginIdSchema(
                 LicenseDefinition.type(),
-                await project.plugins.plugins(LicenseDefinition),
+                await project.plugin.plugins(LicenseDefinition).plugins(),
             ),
             False,
         )

--- a/betty/ancestry/person.py
+++ b/betty/ancestry/person.py
@@ -202,7 +202,8 @@ class Person(HasFileReferences, HasCitations, HasNotes, HasLinks, HasPrivacy):
         schema.add_property(
             "gender",
             PluginIdSchema(
-                GenderDefinition.type(), await project.plugins.plugins(GenderDefinition)
+                GenderDefinition.type(),
+                await project.plugin.plugins(GenderDefinition).plugins(),
             ),
             False,
         )

--- a/betty/ancestry/presence.py
+++ b/betty/ancestry/presence.py
@@ -99,7 +99,7 @@ class Presence(HasPrivacy, Entity):
             "role",
             PluginIdSchema(
                 PresenceRoleDefinition.type(),
-                await project.plugins.plugins(PresenceRoleDefinition),
+                await project.plugin.plugins(PresenceRoleDefinition).plugins(),
             ),
             False,
         )

--- a/betty/app/__init__.py
+++ b/betty/app/__init__.py
@@ -200,7 +200,9 @@ class App(DataManufacturable[AppConfiguration], ServiceLevel, ManagedLifeCycle):
         """
         Get the application's user-facing localizer.
         """
-        return (await self.localizers).get(self._configuration.locale or DEFAULT_LOCALE)
+        return (await self.localizers).plugin(
+            self._configuration.locale or DEFAULT_LOCALE
+        )
 
     @service
     async def localizers(self) -> LocalizerRepository:
@@ -214,9 +216,10 @@ class App(DataManufacturable[AppConfiguration], ServiceLevel, ManagedLifeCycle):
         """
         The HTTP client.
         """
-        http_rate_limits = await self.plugins.plugins(RateLimitDefinition)
-        rate_limit_sorter = sort_ordered_plugin_graph(
-            http_rate_limits, http_rate_limits
+        http_rate_limits = self.plugin.plugins(RateLimitDefinition)
+        rate_limit_sorter = await sort_ordered_plugin_graph(
+            http_rate_limits,
+            [http_rate_limit async for http_rate_limit in http_rate_limits],
         )
 
         http_client: aiohttp.ClientSession = CachedSession(
@@ -228,7 +231,9 @@ class App(DataManufacturable[AppConfiguration], ServiceLevel, ManagedLifeCycle):
                 ClientErrorToUserMessageMiddleware(self.user),
                 RateLimitMiddleware(
                     [
-                        await self.factory.new(http_rate_limits[rate_limit_id].cls)
+                        await self.factory.new(
+                            (await http_rate_limits.plugin(rate_limit_id)).cls
+                        )
                         for rate_limit_id in rate_limit_sorter.static_order()
                     ]
                 ),

--- a/betty/assertion.py
+++ b/betty/assertion.py
@@ -17,15 +17,7 @@ from enum import Enum
 from functools import lru_cache
 from pathlib import Path
 from types import NoneType
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Generic,
-    TypeAlias,
-    TypeVar,
-    final,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, Generic, TypeAlias, TypeVar, final, overload
 
 from betty.data.indicator.selector import Index, Key
 from betty.error import FileNotFound
@@ -40,9 +32,9 @@ if TYPE_CHECKING:
 
     from betty.locale.localizable import Localizable
 
+_T = TypeVar("_T")
 Number: TypeAlias = int | float
 _NumberT = TypeVar("_NumberT", bound=Number)
-
 _EnumT = TypeVar("_EnumT", bound=Enum)
 _AssertionValueT = TypeVar("_AssertionValueT")
 _AssertionReturnT = TypeVar("_AssertionReturnT")
@@ -535,20 +527,26 @@ def assert_len(
     return AssertionChain(_assert_len)
 
 
+def assert_option(*options: _T) -> AssertionChain[Any, _T]:
+    """
+    Assert that a value is one of the given options.
+    """
+
+    def _assert_option(value: Any) -> _T:
+        if value not in options:
+            raise HumanFacingException(
+                Paragraph(
+                    _("Invalid option {value}.").format(value=str(value)),
+                    do_you_mean(*map(str, options)),
+                )
+            )
+        return value
+
+    return AssertionChain(_assert_option)
+
+
 def assert_enum(options: type[_EnumT]) -> AssertionChain[Any, _EnumT]:
     """
     Assert that a value is allowed by an enum, and return the enum value.
     """
-
-    def _assert_enum(value: Any) -> Any:
-        try:
-            return options(value)
-        except ValueError:
-            raise HumanFacingException(
-                Paragraph(
-                    _("Invalid option {value}.").format(value=str(value)),
-                    do_you_mean(*[option.value for option in options]),
-                )
-            ) from None
-
-    return AssertionChain(_assert_enum)
+    return assert_option(*(option.value for option in options))

--- a/betty/console/__init__.py
+++ b/betty/console/__init__.py
@@ -160,7 +160,7 @@ async def _create_list_commands_action_class(
     app: App, *, localizer: Localizer
 ) -> type[argparse.Action]:
     command_definitions = sorted(
-        await app.plugins.plugins(CommandDefinition),
+        await app.plugin.plugins(CommandDefinition).plugins(),
         key=lambda command_definition: command_definition.id,
     )
 
@@ -228,7 +228,7 @@ async def _create_parser(app: App) -> argparse.ArgumentParser:
         help=localizer._("Show all available commands"),
     )
     subparsers = parser.add_subparsers(title=localizer._("Subcommands"))
-    for command_plugin in await app.plugins.plugins(CommandDefinition):
+    async for command_plugin in app.plugin.plugins(CommandDefinition):
         await _create_command_parser(app, subparsers, command_plugin, formatter_class)
     return parser
 

--- a/betty/console/command/commands/about.py
+++ b/betty/console/command/commands/about.py
@@ -96,12 +96,12 @@ class About(Manufacturable, Command):
         about_plugins.add_column(user.localizer._("ID"))
         about_plugins.add_column(user.localizer._("Label"))
         for plugin_type in sorted(
-            UNIVERSE.plugins.types,
+            UNIVERSE.plugin.types,
             key=lambda plugin_type: plugin_type.type().label.localize(user.localizer),
         ):
-            repository = await services.plugins.plugins(plugin_type)
+            repository = services.plugin.plugins(plugin_type)
             for index, plugin in enumerate(
-                sorted(repository, key=lambda plugin: plugin.id)
+                sorted(await repository.plugins(), key=lambda plugin: plugin.id)
             ):
                 first_column = (
                     plugin_type.type().label.localize(user.localizer)

--- a/betty/console/command/commands/config.py
+++ b/betty/console/command/commands/config.py
@@ -61,7 +61,7 @@ class Config(Manufacturable, Command):
         else:
             updated_configuration = AppConfiguration()
         updated_configuration.locale = locale
-        self._app.user.localizer = localizers.get(locale)
+        self._app.user.localizer = localizers.plugin(locale)
         await self._app.user.message_information(
             _("Betty will talk to you in {locale}").format(
                 locale=locale.get_display_name() or to_language_tag(locale)

--- a/betty/console/command/commands/extension_new_translation.py
+++ b/betty/console/command/commands/extension_new_translation.py
@@ -42,7 +42,7 @@ class ExtensionNewTranslation(Manufacturable, Command):
 
     @override
     async def configure(self, parser: argparse.ArgumentParser) -> CommandFunction:
-        extensions = await self._app.plugins.plugins(ExtensionDefinition)
+        extensions = self._app.plugin.plugins(ExtensionDefinition)
         localizer = await self._app.localizer
         parser.add_argument(
             "extension",

--- a/betty/console/command/commands/extension_update_translations.py
+++ b/betty/console/command/commands/extension_update_translations.py
@@ -44,7 +44,7 @@ class ExtensionUpdateTranslations(Manufacturable, Command):
 
     @override
     async def configure(self, parser: argparse.ArgumentParser) -> CommandFunction:
-        extensions = await self._app.plugins.plugins(ExtensionDefinition)
+        extensions = self._app.plugin.plugins(ExtensionDefinition)
         localizer = await self._app.localizer
 
         parser.add_argument(

--- a/betty/console/project.py
+++ b/betty/console/project.py
@@ -46,7 +46,7 @@ async def add_project_argument(
         help=localizer._(
             "The path to a Betty project directory or configuration file. Defaults to {default} in the current working directory."
         ).format(
-            default=f"betty.{'|'.join(extension[1:] for serializer in await app.plugins.plugins(SerializerDefinition) for extension in serializer.cls.media_type().extensions)}"
+            default=f"betty.{'|'.join([extension[1:] async for serializer in app.plugin.plugins(SerializerDefinition) for extension in serializer.cls.media_type().extensions])}"
         ),
         type=assertion_to_argument_type(assert_path(), localizer=localizer),
     )
@@ -82,7 +82,7 @@ async def _read_project_configuration(
     if provided_configuration_file_path_str is None:
         try_configuration_file_paths = [
             project_directory_path / f"betty{extension}"
-            for serializer in await UNIVERSE.plugins.plugins(SerializerDefinition)
+            async for serializer in UNIVERSE.plugin.plugins(SerializerDefinition)
             for extension in serializer.cls.media_type().extensions
         ]
         for try_configuration_file_path in try_configuration_file_paths:

--- a/betty/copyright_notice/copyright_notices.py
+++ b/betty/copyright_notice/copyright_notices.py
@@ -126,7 +126,7 @@ class WikipediaContributors(Manufacturable, CopyrightNotice):
             DEFAULT_LOCALE: _copyright_url("en", "Wikipedia:Copyrights"),
         }
         try:
-            response = await http_client.get(
+            response = await http_client.plugin(
                 "https://en.wikipedia.org/w/api.php?action=query&titles=Wikipedia:Copyrights&prop=langlinks&lllimit=500&format=json&formatversion=2"
             )
             response_json = await response.json()

--- a/betty/deriver.py
+++ b/betty/deriver.py
@@ -70,7 +70,7 @@ class Deriver:
         """
         Derive additional data.
         """
-        for derivable_event_type in await self._project.plugins.plugins(
+        async for derivable_event_type in self._project.plugin.plugins(
             EventTypeDefinition
         ):
             created_derivations = 0
@@ -103,7 +103,7 @@ class Deriver:
     async def _derive_person(
         self, person: Person, derivable_event_type: EventTypeDefinition
     ) -> tuple[int, int]:
-        event_types = await self._project.plugins.plugins(EventTypeDefinition)
+        event_types = self._project.plugin.plugins(EventTypeDefinition)
         # Gather any existing events that could be derived, or create a new derived event if needed.
         derivable_events: Sequence[tuple[Event, Derivation]] = [
             (event, Derivation.UPDATE)
@@ -138,8 +138,12 @@ class Deriver:
                 return 0, 0
 
         # Aggregate event type order from references and backreferences.
-        comes_before_event_types = get_comes_before(event_types, derivable_event_type)
-        comes_after_event_types = get_comes_after(event_types, derivable_event_type)
+        comes_before_event_types = await get_comes_before(
+            event_types, derivable_event_type
+        )
+        comes_after_event_types = await get_comes_after(
+            event_types, derivable_event_type
+        )
 
         created_derivations = 0
         updated_derivations = 0

--- a/betty/extension/_theme/search.py
+++ b/betty/extension/_theme/search.py
@@ -67,7 +67,7 @@ async def _generate_search_index_for_locale(
     job_context: Context,
 ) -> None:
     localizers = await project.localizers
-    localizer = localizers.get(locale)
+    localizer = localizers.plugin(locale)
     search_index = {
         "resultContainerTemplate": result_container_template.localize(localizer),
         "resultsContainerTemplate": results_container_template.localize(localizer),
@@ -169,7 +169,7 @@ class Index:
         """
         Build the search index.
         """
-        entity_types = await self._project.plugins.plugins(EntityDefinition)
+        entity_types = self._project.plugin.plugins(EntityDefinition)
         specialized_indexers: Mapping[type[Entity], _EntityTypeIndexer[Entity]] = {
             File: _FileIndexer(self._project),
             Person: _PersonIndexer(self._project),
@@ -186,7 +186,7 @@ class Index:
                     self._build_entities(
                         _FallbackIndexer(self._project), entity_type.cls
                     )
-                    for entity_type in entity_types
+                    async for entity_type in entity_types
                     if entity_type.public_facing
                     and entity_type.cls not in specialized_indexers
                 ],

--- a/betty/extension/demo/jobs.py
+++ b/betty/extension/demo/jobs.py
@@ -475,9 +475,13 @@ class LoadAncestry(Job[ProjectContext]):
         self,
         project: Project,
     ) -> tuple[Mapping[MachineName, Sequence[File]], Sequence[File]]:
-        licenses = await project.plugins.plugins(LicenseDefinition)
+        licenses = project.plugin.plugins(LicenseDefinition)
         license = await project.factory.new(  # noqa: A001
-            licenses[spdx_license_id_to_license_id("AGPL-3.0-or-later")].cls
+            (
+                await licenses.plugin(
+                    spdx_license_id_to_license_id("AGPL-3.0-or-later")
+                )
+            ).cls
         )
         copyright_notice = await project.factory.new(Streetmix)
         streetmix_image_directory_path = ASSETS_DIRECTORY_PATH / "vendor" / "streetmix"

--- a/betty/extension/maps/jobs.py
+++ b/betty/extension/maps/jobs.py
@@ -60,7 +60,7 @@ class _GeneratePlacePreview(Job[ProjectContext]):
         ).render_async(
             document=await project.new_document(
                 job_context=context,
-                localizer=localizers.get(self._locale),
+                localizer=localizers.plugin(self._locale),
             ),
             place=place,
         )

--- a/betty/extension/raspberry_mint/__init__.py
+++ b/betty/extension/raspberry_mint/__init__.py
@@ -163,7 +163,7 @@ class RaspberryMint(
             "entity-page-content",
             *{
                 f"entity-page-content--{entity_type.id}"
-                for entity_type in await self.services.plugins.plugins(EntityDefinition)
+                async for entity_type in self.services.plugin.plugins(EntityDefinition)
                 if entity_type.public_facing
             },
         }

--- a/betty/extension/raspberry_mint/content_provider.py
+++ b/betty/extension/raspberry_mint/content_provider.py
@@ -612,7 +612,7 @@ class Presences(Template, DataManufacturable[PresencesConfiguration]):
         return cls(
             configuration=data,
             jinja=await raspberry_mint.services.jinja,
-            presence_roles=await raspberry_mint.services.plugins.plugins(
+            presence_roles=raspberry_mint.services.plugin.plugins(
                 PresenceRoleDefinition
             ),
         )
@@ -626,7 +626,7 @@ class Presences(Template, DataManufacturable[PresencesConfiguration]):
             if self._configuration.include is not None:
                 include = self._configuration.include
             else:
-                include = {role.id for role in self._presence_roles}
+                include = {role.id async for role in self._presence_roles}
                 if self._configuration.exclude is not None:
                     include -= set(self._configuration.exclude)
             return "component/raspberry-mint/presences.html.j2", {

--- a/betty/extension/spdx/__init__.py
+++ b/betty/extension/spdx/__init__.py
@@ -61,5 +61,8 @@ class Spdx(Manufacturable, Extension[App]):
 
 
 LicenseDefinition.type().discoverer.add(
+    # @todo The repo is now aiter, not iter.
+    # @todo We could really use a helper at this point.
+    # @todo
     require_extension(Spdx)(lambda spdx: spdx.license_repository),
 )

--- a/betty/extension/spdx/__init__.py
+++ b/betty/extension/spdx/__init__.py
@@ -61,8 +61,5 @@ class Spdx(Manufacturable, Extension[App]):
 
 
 LicenseDefinition.type().discoverer.add(
-    # @todo The repo is now aiter, not iter.
-    # @todo We could really use a helper at this point.
-    # @todo
-    require_extension(Spdx)(lambda spdx: spdx.license_repository),
+    require_extension(Spdx)(lambda spdx: spdx.license_repository.plugins()),
 )

--- a/betty/extension/trees/jobs.py
+++ b/betty/extension/trees/jobs.py
@@ -42,7 +42,7 @@ class _GeneratePeopleJson(Job[ProjectContext]):
         project = scheduler.context.project
         url_generator = await project.url_generator
         localizers = await project.localizers
-        localizer = localizers.get(locale)
+        localizer = localizers.plugin(locale)
         private_label = localizer._("private")
         people = {
             person.id: {

--- a/betty/extension/wiki/__init__.py
+++ b/betty/extension/wiki/__init__.py
@@ -110,12 +110,12 @@ class Wiki(
     async def new(
         cls, project: Project, data: WikiConfiguration | None = None, /
     ) -> Self:
-        copyright_notices = await project.plugins.plugins(CopyrightNoticeDefinition)
+        copyright_notices = project.plugin.plugins(CopyrightNoticeDefinition)
         return cls(
             populate_images=None if data is None else data.populate_images,
             project=project,
             wikipedia_contributors_copyright_notice=await project.factory.new(
-                copyright_notices["wikipedia-contributors"].cls
+                (await copyright_notices.plugin("wikipedia-contributors")).cls
             ),
         )
 
@@ -192,7 +192,7 @@ class Wiki(
         localizers = await self.services.app.localizers
         try:
             page_language, page_name = parse_page_url(
-                link.url.localize(localizers.get(locale))
+                link.url.localize(localizers.plugin(locale))
             )
         except NotAPageError:
             return None

--- a/betty/gramps/loader.py
+++ b/betty/gramps/loader.py
@@ -107,7 +107,7 @@ from betty.plugin.config import (
     resolve_plugin_configuration_mapping,
 )
 from betty.plugin.error import PluginUnavailable
-from betty.presence_role import PresenceRole, PresenceRoleDefinition
+from betty.presence_role import PresenceRoleDefinition
 from betty.presence_role.presence_roles import (
     Attendee,
     Celebrant,
@@ -851,9 +851,11 @@ class GrampsLoader:
         else:
             try:
                 gender = await self._services.factory.new(
-                    (await self._services.plugins.plugins(GenderDefinition))[
-                        gender_id
-                    ].cls
+                    (
+                        await self._services.plugin.plugins(GenderDefinition).plugin(
+                            gender_id
+                        )
+                    ).cls
                 )
             except PluginUnavailable:
                 await self._user.message_warning(
@@ -866,7 +868,7 @@ class GrampsLoader:
         person = Person(id=element.get("id"), gender=gender)  # ty:ignore[invalid-argument-type]
 
         name_elements = sorted(
-            self._xpath(element, "./ns:name"), key=lambda x: x.get("alt") == "1"
+            self._xpath(element, "./ns:name"), key=lambda x: x.plugin("alt") == "1"
         )
         person_names = []
         for name_element in name_elements:

--- a/betty/html/url.py
+++ b/betty/html/url.py
@@ -24,7 +24,7 @@ def generate_urls(
     for element in fragment.xpath(f"//*[{attributes_xpath}]"):
         for attr_name in element.keys():  # noqa: SIM118
             if attr_name in attribute_names:
-                attr_value = element.get(attr_name)
+                attr_value = element.plugin(attr_name)
                 if url_generator.supports(attr_value):
                     element.set(
                         attr_name, url_generator.generate(attr_value, media_type=HTML)

--- a/betty/jinja2/test.py
+++ b/betty/jinja2/test.py
@@ -122,6 +122,6 @@ async def tests() -> Mapping[str, Callable[..., bool]]:
         "private": is_private,
         "public": is_public,
     }
-    for plugin in UNIVERSE.plugins.types:
+    for plugin in UNIVERSE.plugin.types:
         tests.update(PluginTester(plugin).tests())
     return tests

--- a/betty/model/reference.py
+++ b/betty/model/reference.py
@@ -65,14 +65,17 @@ class EntityReference(Data, Hydratable):
     @override
     @require_project
     async def hydrate(self, project: Project, /) -> None:
-        entity_type = assert_plugin(await project.plugins.plugins(EntityDefinition))(
-            self.type
-        )
+        entity_type = assert_plugin(
+            [
+                entity_type.id
+                async for entity_type in project.plugin.plugins(EntityDefinition)
+            ]
+        )(self.type)
         try:
             project.ancestry[self.type][self.id]
         except KeyError:
             raise HumanFacingException(
                 _(
                     'No {entity_type} with ID "{entity_id}" exists in your ancestry.'
-                ).format(entity_type=entity_type.label, entity_id=self.id)
+                ).format(entity_type=entity_type, entity_id=self.id)
             ) from None

--- a/betty/model/reference.py
+++ b/betty/model/reference.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, final
 
 from typing_extensions import override
 
+from betty.assertion import assert_option
 from betty.data import Data, Sample
 from betty.data.aggregate.record.object import ObjectDefinition
 from betty.data.aggregate.record.object.property import Property
@@ -16,7 +17,6 @@ from betty.exception import HumanFacingException
 from betty.locale.localizable.gettext import _
 from betty.model import EntityDefinition
 from betty.plugin import resolve_id
-from betty.plugin.assertion import assert_plugin
 from betty.plugin.data import PluginIdDefinition
 from betty.service.hydrate import Hydratable
 from betty.service.requirement.project import require_project
@@ -65,17 +65,12 @@ class EntityReference(Data, Hydratable):
     @override
     @require_project
     async def hydrate(self, project: Project, /) -> None:
-        entity_type = assert_plugin(
-            [
-                entity_type.id
-                async for entity_type in project.plugin.plugins(EntityDefinition)
-            ]
-        )(self.type)
+        assert_option(await project.plugin.plugins(EntityDefinition).ids())(self.type)
         try:
             project.ancestry[self.type][self.id]
         except KeyError:
             raise HumanFacingException(
                 _(
                     'No {entity_type} with ID "{entity_id}" exists in your ancestry.'
-                ).format(entity_type=entity_type, entity_id=self.id)
+                ).format(entity_type=self.type, entity_id=self.id)
             ) from None

--- a/betty/openapi/__init__.py
+++ b/betty/openapi/__init__.py
@@ -96,7 +96,7 @@ class Specification:
         }
 
         # Add entity operations.
-        for entity_type in await self._project.plugins.plugins(EntityDefinition):
+        async for entity_type in self._project.plugin.plugins(EntityDefinition):
             if not entity_type.public_facing:
                 continue
             await entity_type.cls.linked_data_schema(self._project)

--- a/betty/plugin/assertion.py
+++ b/betty/plugin/assertion.py
@@ -2,38 +2,34 @@
 Provide plugin assertions.
 """
 
+from collections.abc import Collection
 from typing import Any, TypeVar
 
 from betty.assertion import AssertionChain, assert_str
 from betty.exception import HumanFacingException
 from betty.locale.localizable.gettext import _
 from betty.locale.localizable.markup import Paragraph, do_you_mean
+from betty.machine_name import MachineName
 from betty.plugin import PluginDefinition
-from betty.plugin.error import PluginNotFound
-from betty.plugin.repository import PluginRepository
 
 _PluginDefinitionT = TypeVar("_PluginDefinitionT", bound=PluginDefinition)
 
 
 def assert_plugin(
-    plugins: PluginRepository[_PluginDefinitionT],
-) -> AssertionChain[Any, _PluginDefinitionT]:
+    plugins: Collection[MachineName], /
+) -> AssertionChain[Any, MachineName]:
     """
     Assert that a value is a plugin ID.
     """
 
-    def _assert(
-        value: Any,
-    ) -> _PluginDefinitionT:
-        plugin_id = assert_str()(value)
-        try:
-            return plugins[plugin_id]
-        except PluginNotFound:
+    def _assert(plugin_id: MachineName) -> MachineName:
+        if plugin_id not in plugins:
             raise HumanFacingException(
                 Paragraph(
-                    _('Unknown plugin "{plugin_id}".').format(plugin_id=plugin_id),
-                    do_you_mean(*(f'"{plugin.id}"' for plugin in plugins)),
+                    _('Unknown plugin "{plugin}".').format(plugin_id=plugin_id),
+                    do_you_mean(*(f'"{plugin}"' for plugin in plugins)),
                 )
-            ) from None
+            )
+        return plugin_id
 
-    return AssertionChain(_assert)
+    return assert_str() | _assert

--- a/betty/plugin/assertion.py
+++ b/betty/plugin/assertion.py
@@ -15,6 +15,14 @@ from betty.plugin import PluginDefinition
 _PluginDefinitionT = TypeVar("_PluginDefinitionT", bound=PluginDefinition)
 
 
+# @todo As this is right now, it's just an 'assert the value is one of theses statically defined values', which is not
+# @todo at all specific to plugins.
+# @todo
+# @todo However, we do need the original version of this assertion (which returned PluginDefinition) for things like
+# @todo assert_extension_has_assets_directory_path()
+# @todo
+# @todo
+# @todo
 def assert_plugin(
     plugins: Collection[MachineName], /
 ) -> AssertionChain[Any, MachineName]:

--- a/betty/plugin/config/__init__.py
+++ b/betty/plugin/config/__init__.py
@@ -185,7 +185,7 @@ class PluginConfiguration(
                 OptionalField("configuration"),
             ),
         )(portable)
-        return cls(record["id"], record.get("configuration", Void()))
+        return cls(record["id"], record.plugin("configuration", Void()))
 
     @override
     @classmethod
@@ -220,7 +220,7 @@ class PluginConfiguration(
         Create a new instance of the configured plugin.
         """
         return await services.factory.new(
-            (await services.plugins.plugins(plugin_type))[self.id].cls,
+            (await services.plugin.plugins(plugin_type).plugin(self.id)).cls,
             self.configuration,
         )
 

--- a/betty/plugin/data.py
+++ b/betty/plugin/data.py
@@ -48,7 +48,7 @@ class PluginIdDefinition(DataDefinition[MachineName]):
     @override
     async def hydrate(self, services: ServiceLevel, data: MachineName, /) -> None:
         if self._plugin_type is not None:
-            (await services.plugins.plugins(self._plugin_type)).get(data)
+            await services.plugin.plugins(self._plugin_type).plugin(data)
 
 
 @final

--- a/betty/plugin/dependent.py
+++ b/betty/plugin/dependent.py
@@ -75,7 +75,10 @@ async def expand_plugin_dependencies(
         dependencies.update(
             await expand_plugin_dependencies(
                 plugin_repository,
-                [plugin_repository.get(depends_on) for depends_on in plugin.depends_on],
+                [
+                    await plugin_repository.plugin(depends_on)
+                    for depends_on in plugin.depends_on
+                ],
             )
         )
     return dependencies
@@ -89,6 +92,6 @@ async def sort_dependent_plugin_graph(
     """
     Sort a dependent plugin graph.
     """
-    return sort_ordered_plugin_graph(
+    return await sort_ordered_plugin_graph(
         plugin_repository, await expand_plugin_dependencies(plugin_repository, plugins)
     )

--- a/betty/plugin/error.py
+++ b/betty/plugin/error.py
@@ -19,7 +19,7 @@ from betty.plugin import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Collection
 
     from betty.machine_name import MachineName
 
@@ -51,7 +51,7 @@ class PluginNotFound(PluginUnavailable):
         self,
         plugin_type: PluginTypeDefinition[Any, _PluginDefinitionT],
         plugin_not_found: MachineName,
-        available_plugins: Sequence[ResolvableId[_PluginDefinitionT]],
+        available_plugins: Collection[ResolvableId[_PluginDefinitionT]],
         /,
     ):
         super().__init__(

--- a/betty/plugin/manager/__init__.py
+++ b/betty/plugin/manager/__init__.py
@@ -22,6 +22,13 @@ _PluginDefinitionT = TypeVar(
 )
 
 
+# @todo Can we make this entire class obsolete?
+# @todo Make both methods separate properties on ServiceLevel.
+# @todo Move any code we still need from ServiceLevelPluginManager to betty.service
+# @todo
+# @todo
+# @todo
+# @todo
 @threadsafe
 class PluginManager(ABC):
     """

--- a/betty/plugin/manager/__init__.py
+++ b/betty/plugin/manager/__init__.py
@@ -9,11 +9,12 @@ from typing import TYPE_CHECKING
 
 from typing_extensions import TypeVar
 
-from betty.plugin import PluginDefinition, PluginTypeRepository
+from betty.plugin import PluginDefinition
 from betty.typing import threadsafe
 
 if TYPE_CHECKING:
     from betty.machine_name import MachineName
+    from betty.plugin import PluginTypeRepository
     from betty.plugin.repository import PluginRepository
 
 _PluginDefinitionT = TypeVar(
@@ -28,7 +29,7 @@ class PluginManager(ABC):
     """
 
     @abstractmethod
-    async def plugins(
+    def plugins(
         self, plugin_type: type[_PluginDefinitionT] | MachineName, /
     ) -> PluginRepository[_PluginDefinitionT]:
         """

--- a/betty/plugin/manager/service.py
+++ b/betty/plugin/manager/service.py
@@ -4,8 +4,7 @@ Provide plugin repositories for service levels.
 
 from __future__ import annotations
 
-from collections import defaultdict
-from typing import TYPE_CHECKING, Any, cast, final
+from typing import TYPE_CHECKING, cast, final
 
 from typing_extensions import TypeVar, override
 
@@ -13,10 +12,9 @@ from betty import plugin
 from betty.concurrent import AsynchronizedLock, Ledger
 from betty.plugin import PluginDefinition
 from betty.plugin.manager import PluginManager
-from betty.plugin.repository.static import StaticPluginRepository
 
 if TYPE_CHECKING:
-    from collections.abc import MutableMapping
+    from collections.abc import Mapping
 
     from betty.machine_name import MachineName
     from betty.plugin.repository import PluginRepository
@@ -38,9 +36,7 @@ class ServiceLevelPluginManager(PluginManager):
     def __init__(self, services: ServiceLevel, /):
         self._services = services
         self._types = plugin.PluginTypeRepository()
-        self._plugin_repositories: MutableMapping[
-            type[PluginDefinition], PluginRepository[Any] | None
-        ] = defaultdict(None)
+        self._plugins: Mapping[type[PluginDefinition], PluginRepository] | None = None
         self._ledger = Ledger(AsynchronizedLock.new_threadsafe())
 
     @override
@@ -49,37 +45,14 @@ class ServiceLevelPluginManager(PluginManager):
         return self._types
 
     @override
-    async def plugins(
+    def plugins(
         self, plugin_type: type[_PluginDefinitionT] | MachineName, /
     ) -> PluginRepository[_PluginDefinitionT]:
         if isinstance(plugin_type, str):
             plugin_type = cast(type[_PluginDefinitionT], self.types[plugin_type])
-        repository: PluginRepository[_PluginDefinitionT] | None
-        if plugin_type.type().discoverer.overridden:
-            return await self._new(plugin_type)
-        # If the repository exists already, return it immediately so we avoid acquiring locks.
-        repository = self._get(plugin_type)
-        if repository:
-            return repository
-        async with self._ledger.ledger(f"{plugin_type.type().id}"):
-            # The repository may have been created since we first checked.
-            repository = self._get(plugin_type)
-            if repository:
-                return repository
-            repository = await self._new(plugin_type)
-            self._plugin_repositories[plugin_type] = repository
-            return repository
-
-    def _get(
-        self, plugin_type: type[_PluginDefinitionT]
-    ) -> PluginRepository[_PluginDefinitionT] | None:
-        if plugin_type not in self._plugin_repositories:
-            return None
-        return self._plugin_repositories[plugin_type]
-
-    async def _new(
-        self, plugin_type: type[_PluginDefinitionT]
-    ) -> PluginRepository[_PluginDefinitionT]:
-        return StaticPluginRepository(
-            plugin_type, *await plugin_type.type().discoverer.discover(self._services)
-        )
+        if self._plugins is None:
+            self._plugins = {
+                plugin_type: DiscoverablePluginRepository(plugin_type)
+                for plugin_type in self.types
+            }
+        return self._plugins[plugin_type]

--- a/betty/plugin/manager/service.py
+++ b/betty/plugin/manager/service.py
@@ -12,6 +12,7 @@ from betty import plugin
 from betty.concurrent import AsynchronizedLock, Ledger
 from betty.plugin import PluginDefinition
 from betty.plugin.manager import PluginManager
+from betty.plugin.repository.discovery import DiscoveryPluginRepository
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -52,7 +53,7 @@ class ServiceLevelPluginManager(PluginManager):
             plugin_type = cast(type[_PluginDefinitionT], self.types[plugin_type])
         if self._plugins is None:
             self._plugins = {
-                plugin_type: DiscoverablePluginRepository(plugin_type)
+                plugin_type: DiscoveryPluginRepository(plugin_type)
                 for plugin_type in self.types
             }
-        return self._plugins[plugin_type]
+        return self._plugins[plugin_type]  # ty:ignore[invalid-return-type]

--- a/betty/plugin/ordered.py
+++ b/betty/plugin/ordered.py
@@ -74,7 +74,7 @@ _OrderedPluginDefinitionT = TypeVar(
 )
 
 
-def sort_ordered_plugin_graph(
+async def sort_ordered_plugin_graph(
     plugin_repository: PluginRepository[_OrderedPluginDefinitionT],
     plugins: Iterable[_OrderedPluginDefinitionT],
     /,
@@ -87,17 +87,17 @@ def sort_ordered_plugin_graph(
     for plugin in plugins:
         sorter.add(plugin.id)
         for before_identifier in map(resolve_id, plugin.comes_before):
-            before = plugin_repository[before_identifier]
+            before = await plugin_repository.plugin(before_identifier)
             if before in plugins:
                 sorter.add(before.id, plugin.id)
         for after_identifier in map(resolve_id, plugin.comes_after):
-            after = plugin_repository[after_identifier]
+            after = await plugin_repository.plugin(after_identifier)
             if after in plugins:
                 sorter.add(plugin.id, after.id)
     return sorter
 
 
-def get_comes_before(
+async def get_comes_before(
     plugin_repository: PluginRepository[_OrderedPluginDefinitionT],
     origin: _OrderedPluginDefinitionT,
     /,
@@ -106,17 +106,17 @@ def get_comes_before(
     Get all other plugins the given plugin comes before.
     """
     graph = defaultdict(set)
-    for plugin in plugin_repository:
+    async for plugin in plugin_repository:
         for comes_before_id in plugin.comes_before:
-            comes_before = plugin_repository[comes_before_id]
+            comes_before = await plugin_repository.plugin(comes_before_id)
             graph[plugin].add(comes_before)
         for comes_after_id in plugin.comes_after:
-            comes_after = plugin_repository[comes_after_id]
+            comes_after = await plugin_repository.plugin(comes_after_id)
             graph[comes_after].add(plugin)
     return set(_collect_plugin_graph(graph, origin))
 
 
-def get_comes_after(
+async def get_comes_after(
     plugin_repository: PluginRepository[_OrderedPluginDefinitionT],
     origin: _OrderedPluginDefinitionT,
     /,
@@ -125,12 +125,12 @@ def get_comes_after(
     Get all other plugins the given plugin comes after.
     """
     graph = defaultdict(set)
-    for plugin in plugin_repository:
+    async for plugin in plugin_repository:
         for comes_after_id in plugin.comes_after:
-            comes_after = plugin_repository[comes_after_id]
+            comes_after = await plugin_repository.plugin(comes_after_id)
             graph[plugin].add(comes_after)
         for comes_before_id in plugin.comes_before:
-            comes_before = plugin_repository[comes_before_id]
+            comes_before = await plugin_repository.plugin(comes_before_id)
             graph[comes_before].add(plugin)
     return set(_collect_plugin_graph(graph, origin))
 

--- a/betty/plugin/repository/__init__.py
+++ b/betty/plugin/repository/__init__.py
@@ -13,7 +13,7 @@ from betty.plugin import PluginDefinition
 
 if TYPE_CHECKING:
     import builtins
-    from collections.abc import Iterator
+    from collections.abc import AsyncIterator, Collection
 
     from betty.machine_name import MachineName
 
@@ -27,7 +27,7 @@ class PluginRepository(ABC, Generic[_PluginDefinitionT]):
     Access discovered plugins.
     """
 
-    def __init__(self, plugin_type: builtins.type[_PluginDefinitionT]):
+    def __init__(self, plugin_type: builtins.type[_PluginDefinitionT], /):
         self._type = plugin_type
 
     @property
@@ -38,19 +38,25 @@ class PluginRepository(ABC, Generic[_PluginDefinitionT]):
         return self._type
 
     @abstractmethod
-    def get(self, plugin_id: MachineName, /) -> _PluginDefinitionT:
+    async def ids(self) -> Collection[MachineName]:
+        """
+        Get the IDs of all plugins.
+        """
+
+    @abstractmethod
+    async def plugin(self, plugin_id: MachineName, /) -> _PluginDefinitionT:
         """
         Get a single plugin by its ID.
 
         :raises PluginUnavailable: if no plugin can be found for the given ID.
         """
 
-    def __len__(self) -> int:
-        return len(list(self.__iter__()))
+    @abstractmethod
+    async def plugins(self) -> Collection[_PluginDefinitionT]:
+        """
+        Get all plugins.
+        """
 
     @abstractmethod
-    def __iter__(self) -> Iterator[_PluginDefinitionT]:
+    def __aiter__(self) -> AsyncIterator[_PluginDefinitionT]:
         pass
-
-    def __getitem__(self, plugin_id: MachineName) -> _PluginDefinitionT:
-        return self.get(plugin_id)

--- a/betty/plugin/repository/__init__.py
+++ b/betty/plugin/repository/__init__.py
@@ -1,5 +1,5 @@
 """
-Access discovered plugins.
+Access plugins.
 """
 
 from __future__ import annotations
@@ -24,7 +24,7 @@ _PluginDefinitionT = TypeVar(
 
 class PluginRepository(ABC, Generic[_PluginDefinitionT]):
     """
-    Access discovered plugins.
+    Access the plugins of a given type.
     """
 
     def __init__(self, plugin_type: builtins.type[_PluginDefinitionT], /):
@@ -51,11 +51,11 @@ class PluginRepository(ABC, Generic[_PluginDefinitionT]):
         :raises PluginUnavailable: if no plugin can be found for the given ID.
         """
 
-    @abstractmethod
     async def plugins(self) -> Collection[_PluginDefinitionT]:
         """
         Get all plugins.
         """
+        return tuple(plugin async for plugin in self)
 
     @abstractmethod
     def __aiter__(self) -> AsyncIterator[_PluginDefinitionT]:

--- a/betty/plugin/repository/__init__.py
+++ b/betty/plugin/repository/__init__.py
@@ -51,11 +51,11 @@ class PluginRepository(ABC, Generic[_PluginDefinitionT]):
         :raises PluginUnavailable: if no plugin can be found for the given ID.
         """
 
+    @abstractmethod
     async def plugins(self) -> Collection[_PluginDefinitionT]:
         """
         Get all plugins.
         """
-        return tuple(plugin async for plugin in self)
 
     @abstractmethod
     def __aiter__(self) -> AsyncIterator[_PluginDefinitionT]:

--- a/betty/plugin/repository/discovery.py
+++ b/betty/plugin/repository/discovery.py
@@ -1,0 +1,40 @@
+"""
+Access discovered plugins.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, final
+
+from typing_extensions import TypeVar, override
+
+from betty.plugin import PluginDefinition
+from betty.plugin.repository import PluginRepository
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Collection
+
+    from betty.machine_name import MachineName
+
+_PluginDefinitionT = TypeVar(
+    "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
+)
+
+
+@final
+class DiscoveryPluginRepository(PluginRepository[_PluginDefinitionT]):
+    """
+    Lazily discover plugins.
+    """
+
+    @override
+    async def ids(self) -> Collection[MachineName]:
+        raise NotImplementedError
+
+    @override
+    async def plugin(self, plugin_id: MachineName, /) -> _PluginDefinitionT:
+        raise NotImplementedError
+
+    @override
+    def __aiter__(self) -> AsyncIterator[_PluginDefinitionT]:
+        raise NotImplementedError

--- a/betty/plugin/repository/discovery.py
+++ b/betty/plugin/repository/discovery.py
@@ -36,5 +36,43 @@ class DiscoveryPluginRepository(PluginRepository[_PluginDefinitionT]):
         raise NotImplementedError
 
     @override
+    async def plugins(self) -> Collection[_PluginDefinitionT]:
+        raise NotImplementedError
+
+    @override
     def __aiter__(self) -> AsyncIterator[_PluginDefinitionT]:
         raise NotImplementedError
+
+
+    async def _plugins(
+        self
+    ) -> PluginRepository[_PluginDefinitionT]:
+        repository: PluginRepository[_PluginDefinitionT] | None
+        if self._plugin_type.type().discoverer.overridden:
+            return await self._new(plugin_type)
+        # If the repository exists already, return it immediately so we avoid acquiring locks.
+        repository = self._get(plugin_type)
+        if repository:
+            return repository
+        async with self._ledger.ledger(f"{plugin_type.type().id}"):
+            # The repository may have been created since we first checked.
+            repository = self._get(plugin_type)
+            if repository:
+                return repository
+            repository = await self._new(plugin_type)
+            self._plugin_repositories[plugin_type] = repository
+            return repository
+
+    def _get(
+        self, plugin_type: type[_PluginDefinitionT]
+    ) -> PluginRepository[_PluginDefinitionT] | None:
+        if plugin_type not in self._plugin_repositories:
+            return None
+        return self._plugin_repositories[plugin_type]
+
+    async def _new(
+        self, plugin_type: type[_PluginDefinitionT]
+    ) -> PluginRepository[_PluginDefinitionT]:
+        return StaticPluginRepository(
+            plugin_type, *await plugin_type.type().discoverer.discover(self._services)
+        )

--- a/betty/plugin/repository/static.py
+++ b/betty/plugin/repository/static.py
@@ -13,7 +13,7 @@ from betty.plugin.error import PluginNotFound
 from betty.plugin.repository import PluginRepository
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import AsyncIterator
 
     from betty.machine_name import MachineName
 
@@ -38,12 +38,14 @@ class StaticPluginRepository(PluginRepository[_PluginDefinitionT]):
         }
 
     @override
-    def get(self, plugin_id: MachineName, /) -> _PluginDefinitionT:
+    async def plugin(self, plugin_id: MachineName, /) -> _PluginDefinitionT:
         try:
             return self._plugins[plugin_id]  # ty:ignore[invalid-return-type]
         except KeyError:
-            raise PluginNotFound(self.type.type(), plugin_id, list(self)) from None
+            raise PluginNotFound(
+                self.type.type(), plugin_id, await self.plugins()
+            ) from None
 
     @override
-    def __iter__(self) -> Iterator[_PluginDefinitionT]:
+    def __aiter__(self) -> AsyncIterator[_PluginDefinitionT]:
         yield from self._plugins.values()

--- a/betty/plugin/repository/static.py
+++ b/betty/plugin/repository/static.py
@@ -47,6 +47,10 @@ class StaticPluginRepository(PluginRepository[_PluginDefinitionT]):
             ) from None
 
     @override
+    async def plugins(self) -> Collection[_PluginDefinitionT]:
+        return list(self._plugins.values())
+
+    @override
     async def __aiter__(self) -> AsyncIterator[_PluginDefinitionT]:
         for value in self._plugins.values():
             yield value

--- a/betty/plugin/repository/static.py
+++ b/betty/plugin/repository/static.py
@@ -13,7 +13,7 @@ from betty.plugin.error import PluginNotFound
 from betty.plugin.repository import PluginRepository
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Collection
 
     from betty.machine_name import MachineName
 
@@ -47,5 +47,10 @@ class StaticPluginRepository(PluginRepository[_PluginDefinitionT]):
             ) from None
 
     @override
-    def __aiter__(self) -> AsyncIterator[_PluginDefinitionT]:
-        yield from self._plugins.values()
+    async def __aiter__(self) -> AsyncIterator[_PluginDefinitionT]:
+        for value in self._plugins.values():
+            yield value
+
+    @override
+    async def ids(self) -> Collection[MachineName]:
+        return list(self._plugins)

--- a/betty/portable/file.py
+++ b/betty/portable/file.py
@@ -28,7 +28,7 @@ async def assert_load_file() -> AssertionChain[Path, PortableData]:
     """
     available_formats = {
         available_format: await UNIVERSE.factory.new(available_format.cls)
-        for available_format in await UNIVERSE.plugins.plugins(SerializerDefinition)
+        async for available_format in UNIVERSE.plugin.plugins(SerializerDefinition)
     }
 
     def _assert(file_path: Path) -> PortableData:
@@ -54,7 +54,8 @@ async def dump_file(portable: PortableData, file_path: Path, /) -> None:
     """
     serializer = await UNIVERSE.factory.new(
         serializer_for(
-            list(await UNIVERSE.plugins.plugins(SerializerDefinition)), file_path.suffix
+            await UNIVERSE.plugin.plugins(SerializerDefinition).plugins(),
+            file_path.suffix,
         ).cls
     )
     dump_data = serializer.dump(portable)

--- a/betty/project/__init__.py
+++ b/betty/project/__init__.py
@@ -165,7 +165,7 @@ class Project(DataManufacturable[ProjectConfiguration], ServiceLevel, ManagedLif
         if configuration_file == self._configuration_file:
             return
         serializer_for(
-            list(await UNIVERSE.plugins.plugins(SerializerDefinition)),
+            await UNIVERSE.plugin.plugins(SerializerDefinition).plugins(),
             configuration_file.suffix,
         )
         self._configuration_file = configuration_file
@@ -278,7 +278,7 @@ class Project(DataManufacturable[ProjectConfiguration], ServiceLevel, ManagedLif
         The public localizers.
         """
         localizers = await self.localizers
-        return [localizers.get(locale) for locale in self.configuration.locales.keys()]  # noqa: SIM118
+        return [localizers.plugin(locale) for locale in self.configuration.locales]  # noqa: SIM118
 
     @service
     async def url_generator(self) -> UrlGenerator:
@@ -306,7 +306,7 @@ class Project(DataManufacturable[ProjectConfiguration], ServiceLevel, ManagedLif
         return RenderDispatcher(
             *[
                 await self.factory.new(plugin.cls)
-                for plugin in await self.plugins.plugins(RendererDefinition)
+                async for plugin in self.plugin.plugins(RendererDefinition)
             ]
         )
 
@@ -315,12 +315,12 @@ class Project(DataManufacturable[ProjectConfiguration], ServiceLevel, ManagedLif
         """
         The enabled extensions.
         """
-        extensions = await self.plugins.plugins(ExtensionDefinition)
+        extensions = self.plugin.plugins(ExtensionDefinition)
         configured_extension_definitions = []
         configured_extension_configurations = {}
         for extension_configuration in self.configuration.extensions:
             configured_extension_definitions.append(
-                extensions[extension_configuration.id]
+                await extensions.plugin(extension_configuration.id)
             )
             configured_extension_configurations[extension_configuration.id] = (
                 extension_configuration
@@ -337,7 +337,9 @@ class Project(DataManufacturable[ProjectConfiguration], ServiceLevel, ManagedLif
             enabled_extension_ids_batch = extensions_sorter.get_ready()
             enabled_extension_batch: MutableSequence[Extension] = []
             for enabled_extension_id in enabled_extension_ids_batch:
-                enabled_extension_definition = extensions[enabled_extension_id]
+                enabled_extension_definition = await extensions.plugin(
+                    enabled_extension_id
+                )
                 if enabled_extension_definition.theme:
                     theme_count += 1
                 if enabled_extension_id in configured_extension_configurations:

--- a/betty/project/data.py
+++ b/betty/project/data.py
@@ -139,7 +139,7 @@ class EntityTypeConfiguration(
 
     @override
     async def hydrate(self, services: ServiceLevel, /) -> None:
-        entity_type = (await services.plugins.plugins(EntityDefinition)).get(
+        entity_type = await services.plugin.plugins(EntityDefinition).plugin(
             self._entity_type
         )
         if self.generate_html_list and not entity_type.public_facing:

--- a/betty/project/generate/jobs.py
+++ b/betty/project/generate/jobs.py
@@ -87,7 +87,7 @@ class GenerateStaticPublicAssets(Job[ProjectContext]):
             Path("public") / "static"
         )
         await makedirs(file_destination_path.parent, exist_ok=True)
-        await copy_function(await assets.get(asset_path), file_destination_path)
+        await copy_function(await assets.plugin(asset_path), file_destination_path)
 
 
 @final
@@ -291,7 +291,7 @@ class GenerateLocalizedPublicAssets(Job[ProjectContext]):
             locale: jinja.make_copy_function(
                 document=await project.new_document(
                     job_context=scheduler.context,
-                    localizer=localizers.get(locale),
+                    localizer=localizers.plugin(locale),
                 ),
                 www_directory_path=project.www_directory,
                 is_localized_and_multilingual=project.configuration.multilingual,
@@ -319,7 +319,7 @@ class GenerateLocalizedPublicAssets(Job[ProjectContext]):
             locale
         ) / asset_path.relative_to(Path("public") / "localized")
         await makedirs(file_destination_path.parent, exist_ok=True)
-        await copy_function(await assets.get(asset_path), file_destination_path)
+        await copy_function(await assets.plugin(asset_path), file_destination_path)
 
 
 @final
@@ -450,7 +450,7 @@ class GenerateEntityTypesJson(Job[ProjectContext]):
         await gather(
             *[
                 scheduler.add(_GenerateEntityTypeJson(entity_type))
-                for entity_type in await scheduler.context.project.plugins.plugins(
+                async for entity_type in scheduler.context.project.plugin.plugins(
                     EntityDefinition
                 )
             ]
@@ -519,7 +519,7 @@ class GenerateEntityTypesHtml(Job[ProjectContext]):
                         entity_type, locale, page, self._per_page, page_count
                     )
                 )
-                for entity_type in await project.plugins.plugins(EntityDefinition)
+                async for entity_type in project.plugin.plugins(EntityDefinition)
                 if entity_type.public_facing
                 and (
                     entity_type.id in project.configuration.entity_types
@@ -578,7 +578,7 @@ class _GenerateEntityTypeHtml(Job[ProjectContext]):
                 self._entity_type,
                 self._entity_type,
                 job_context=context,
-                localizer=localizers.get(self._locale),
+                localizer=localizers.plugin(self._locale),
             ),
             page=self._page,
             per_page=self._per_page,
@@ -619,7 +619,7 @@ class GenerateEntitiesJson(Job[ProjectContext]):
         await gather(
             *[
                 scheduler.add(_GenerateEntityJson(entity_type, entity.id))
-                for entity_type in await project.plugins.plugins(EntityDefinition)
+                async for entity_type in project.plugin.plugins(EntityDefinition)
                 for entity in project.ancestry[entity_type.cls]
                 if persistent_id(entity)
             ]
@@ -669,7 +669,7 @@ class GenerateEntitiesHtml(Job[ProjectContext]):
         await gather(
             *[
                 scheduler.add(_GenerateEntityHtml(entity_type, entity.id, locale))
-                for entity_type in await project.plugins.plugins(EntityDefinition)
+                async for entity_type in project.plugin.plugins(EntityDefinition)
                 if entity_type.public_facing
                 for entity in project.ancestry[entity_type.cls]
                 if persistent_id(entity) and is_public(entity)
@@ -714,7 +714,7 @@ class _GenerateEntityHtml(Job[ProjectContext]):
                 entity,
                 entity,
                 job_context=context,
-                localizer=localizers.get(self._locale),
+                localizer=localizers.plugin(self._locale),
             )
         )
         async with create_html_resource(entity_path) as f:

--- a/betty/project/load/jobs.py
+++ b/betty/project/load/jobs.py
@@ -87,7 +87,7 @@ class PopulateLink(Job[ProjectContext]):
     ) -> None:
         http_client = await project.app.http_client
         try:
-            response = await http_client.get(url)
+            response = await http_client.plugin(url)
         except ClientError:
             return
         try:

--- a/betty/project/new.py
+++ b/betty/project/new.py
@@ -8,7 +8,6 @@ from betty.ancestry.person import Person
 from betty.ancestry.place import Place
 from betty.ancestry.source import Source
 from betty.assertion import assert_locale, assert_path, assert_str
-from betty.extension import Extension, ExtensionDefinition
 from betty.extension.deriver import Deriver
 from betty.extension.gramps import Gramps
 from betty.extension.gramps.data import FamilyTree, GrampsConfiguration
@@ -36,6 +35,7 @@ if TYPE_CHECKING:
     from babel import Locale
 
     from betty.app import App
+    from betty.extension import Extension, ExtensionDefinition
     from betty.locale.localizable import Localizable
     from betty.user import User
 
@@ -44,7 +44,6 @@ async def new(app: App) -> None:
     """
     Create a new project.
     """
-    await app.plugins.plugins(ExtensionDefinition)
     localizers = await app.localizers
 
     configuration_file_path = await app.user.ask_input(
@@ -82,7 +81,7 @@ async def new(app: App) -> None:
             RaspberryMint,
             RaspberryMintConfiguration(
                 regional_content=regional_content(
-                    localizers=[localizers.get(locale) for locale in locales]
+                    localizers=[localizers.plugin(locale) for locale in locales]
                 )
             ),
         ),
@@ -98,7 +97,7 @@ async def new(app: App) -> None:
 
     name = await app.user.ask_input(
         _("What is your project's machine name?"),
-        default=str(machinify(title.localize(localizers.get(locales[0])))),
+        default=str(machinify(title.localize(localizers.plugin(locales[0])))),
         assertion=assert_machine_name(),
     )
 

--- a/betty/project/schema.py
+++ b/betty/project/schema.py
@@ -57,7 +57,7 @@ class ProjectSchema(Manufacturable, Schema):
         schema._schema["$id"] = await cls.url(project)
 
         # Add entity schemas.
-        for entity_type in await project.plugins.plugins(EntityDefinition):
+        async for entity_type in project.plugin.plugins(EntityDefinition):
             entity_type_schema = await entity_type.cls.linked_data_schema(project)
             entity_type_schema.embed(schema)
             def_name = f"{kebab_case_to_lower_camel_case(entity_type.id)}EntityCollectionResponse"

--- a/betty/serde/__init__.py
+++ b/betty/serde/__init__.py
@@ -16,7 +16,7 @@ from betty.plugin import Plugin, PluginDefinition, PluginTypeDefinition
 from betty.plugin.discovery.entry_point import EntryPointDiscovery
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Collection
 
     from betty.media_type import MediaType
     from betty.portable import PortableData
@@ -71,7 +71,7 @@ class SerializerDefinition(HumanFacingDefinition, PluginDefinition[Serializer]):
 
 
 def serializer_for(
-    available_serializers: Sequence[SerializerDefinition], extension: str, /
+    available_serializers: Collection[SerializerDefinition], extension: str, /
 ) -> SerializerDefinition:
     """
     Get the serializer for the given file extension.

--- a/betty/service/level.py
+++ b/betty/service/level.py
@@ -31,7 +31,7 @@ class ServiceLevel:
         return self._factory
 
     @property
-    def plugins(self) -> PluginManager:
+    def plugin(self) -> PluginManager:
         """
         The plugin manager.
         """

--- a/betty/service/requirement/extension.py
+++ b/betty/service/requirement/extension.py
@@ -70,9 +70,9 @@ async def _require_extension(
     target: str,
     extension_id: type[_ExtensionT] | ResolvableId[ExtensionDefinition],
 ) -> _ExtensionT:
-    extensions = await project.plugins.plugins(ExtensionDefinition)
+    extensions = project.plugin.plugins(ExtensionDefinition)
     try:
-        extension = extensions[resolve_id(extension_id)]
+        extension = await extensions.plugin(resolve_id(extension_id))
     except PluginNotFound as error:
         raise UnmetRequirement(error) from error
     project_extensions = await project.extensions

--- a/betty/sphinx/extension/betty.py
+++ b/betty/sphinx/extension/betty.py
@@ -5,7 +5,7 @@ The Betty Sphinx extension.
 from __future__ import annotations
 
 from asyncio import run
-from collections.abc import Callable, Iterable, MutableSequence, Sequence
+from collections.abc import Callable, Iterable, Mapping, MutableSequence, Sequence
 from functools import cmp_to_key
 from textwrap import indent
 from threading import Thread
@@ -34,8 +34,8 @@ if TYPE_CHECKING:
     from sphinx.application import Sphinx
     from sphinx.util.typing import ExtensionMetadata
 
+    from betty.machine_name import MachineName
     from betty.plugin import PluginDefinition
-    from betty.plugin.repository import PluginRepository
     from betty.serde import Serializer
 
 _T = TypeVar("_T")
@@ -50,14 +50,16 @@ def _to_thread(target: Callable[[], _T]) -> _T:
     return result.result()
 
 
-async def _get_plugins(plugin_type_id: str) -> PluginRepository:
+async def _get_plugins(plugin_type_id: str) -> Mapping[MachineName, PluginDefinition]:
     async with (
         App.new_isolated() as app,
         app,
         Project.new_isolated(app) as project,
         project,
     ):
-        return await project.plugins.plugins(plugin_type_id)
+        return {
+            plugin.id: plugin async for plugin in project.plugin.plugins(plugin_type_id)
+        }
 
 
 def _cmp_formats(left: PluginDefinition, right: PluginDefinition) -> int:
@@ -78,7 +80,7 @@ async def _get_serializers() -> Sequence[Serializer]:
         return [
             await project.factory.new(serializer.cls)
             for serializer in sorted(
-                await project.plugins.plugins(SerializerDefinition),
+                await project.plugin.plugins(SerializerDefinition).plugins(),
                 key=cmp_to_key(_cmp_formats),
             )
         ]
@@ -142,7 +144,7 @@ class _PluginDirective(SphinxDirective):
         return nodes.paragraph("", "", *summary_nodes)
 
     def _build_metadata(
-        self, plugin: PluginDefinition, plugins: PluginRepository[PluginDefinition]
+        self, plugin: PluginDefinition, plugins: Mapping[MachineName, PluginDefinition]
     ) -> list[nodes.Node]:
         cls = plugin.cls
         if issubclass(cls, DataManufacturable):
@@ -163,7 +165,7 @@ class _PluginDirective(SphinxDirective):
 """
         if isinstance(plugin, DependentPluginDefinition) and (
             depends_on_content := self._build_other_plugins_references(
-                [plugins.get(plugin_id) for plugin_id in plugin.depends_on]
+                [plugins[plugin_id] for plugin_id in plugin.depends_on]
             )
         ):
             content += f"""
@@ -172,14 +174,14 @@ class _PluginDirective(SphinxDirective):
 """
         if isinstance(plugin, OrderedPluginDefinition):
             if comes_before_content := self._build_other_plugins_references(
-                [plugins.get(plugin_id) for plugin_id in plugin.comes_before]
+                [plugins[plugin_id] for plugin_id in plugin.comes_before]
             ):
                 content += f"""
    * - Comes before
 {comes_before_content}
 """
             if comes_after_content := self._build_other_plugins_references(
-                [plugins.get(plugin_id) for plugin_id in plugin.comes_after]
+                [plugins[plugin_id] for plugin_id in plugin.comes_after]
             ):
                 content += f"""
    * - Comes after
@@ -215,7 +217,7 @@ class _PluginTypeDirective(SphinxDirective):
     def run(self) -> list[nodes.Node]:
         # Right-strip periods to avoid D400 and D415 violations.
         plugin_type_id = self.arguments[0].rstrip(".")
-        plugin_type = UNIVERSE.plugins.types[plugin_type_id]
+        plugin_type = UNIVERSE.plugin.types[plugin_type_id]
         plugins = _to_thread(lambda: run(_get_plugins(plugin_type_id)))
         return [
             self._build_summary(plugin_type),
@@ -254,7 +256,9 @@ class _PluginTypeDirective(SphinxDirective):
         )
 
     def _build_builtin_plugins(
-        self, plugin_type: type[PluginDefinition], plugins: PluginRepository
+        self,
+        plugin_type: type[PluginDefinition],
+        plugins: Mapping[MachineName, PluginDefinition],
     ) -> list[nodes.Node]:
         return [
             nodes.paragraph(
@@ -267,7 +271,7 @@ class _PluginTypeDirective(SphinxDirective):
             _build_definition_list(
                 [
                     self._build_builtin_plugin_definition(plugin)
-                    for plugin in sorted(plugins, key=lambda plugin: plugin.id)
+                    for plugin in sorted(plugins.values(), key=lambda plugin: plugin.id)
                 ]
             ),
         ]
@@ -296,7 +300,7 @@ class _PluginTypesDirective(SphinxDirective):
                 [
                     self._build_builtin_plugin_type_definition(plugin_type)
                     for plugin_type in sorted(
-                        UNIVERSE.plugins.types,
+                        UNIVERSE.plugin.types,
                         key=lambda plugin_type: plugin_type.type().label.localize(
                             DEFAULT_LOCALIZER
                         ),

--- a/betty/test_utils/documentation.py
+++ b/betty/test_utils/documentation.py
@@ -30,10 +30,10 @@ class PluginDocumentationTestBase:
         Test the plugin and plugin type documentation.
         """
         async with Project.new_isolated(isolated_app) as project, project:
-            for plugin_type in UNIVERSE.plugins.types:
+            for plugin_type in UNIVERSE.plugin.types:
                 with subtests.test():
                     self._test_plugin_type(plugin_type)
-                for plugin in await project.plugins.plugins(plugin_type):
+                async for plugin in project.plugin.plugins(plugin_type):
                     with subtests.test():
                         self._test_plugin(plugin)
 

--- a/betty/tests/app/test___init__.py
+++ b/betty/tests/app/test___init__.py
@@ -7,7 +7,6 @@ from typing_extensions import override
 from betty.app import App
 from betty.service.factory import Manufacturable
 from betty.service.requirement.app import require_app
-from betty.test_utils.plugin import DummyPluginDefinition
 from betty.test_utils.user import StaticUser
 
 
@@ -23,9 +22,6 @@ class _Manufacturable(Manufacturable):
 
 
 class TestApp:
-    async def test_plugins(self, isolated_app: App) -> None:
-        await isolated_app.plugins.plugins(DummyPluginDefinition)
-
     async def test_new_from_environment(self, isolated_app: App) -> None:
         assert isolated_app.cache is isolated_app.cache
 

--- a/betty/tests/extension/_theme/test_search.py
+++ b/betty/tests/extension/_theme/test_search.py
@@ -110,7 +110,9 @@ class TestIndex:
             project.ancestry.add(person)
             async with project:
                 localizers = await project.localizers
-                actual = await Index(project, Context(), localizers.get(locale)).build()
+                actual = await Index(
+                    project, Context(), localizers.plugin(locale)
+                ).build()
 
                 assert actual[0].text == {"p1", "jane"}
                 assert expected in actual[0].result
@@ -148,7 +150,7 @@ class TestIndex:
                 actual = await Index(
                     project,
                     Context(),
-                    localizers.get(locale),
+                    localizers.plugin(locale),
                 ).build()
 
                 assert actual[0].text == {"p1", "doughnut"}
@@ -186,7 +188,9 @@ class TestIndex:
             project.ancestry.add(person)
             async with project:
                 localizers = await project.localizers
-                actual = await Index(project, Context(), localizers.get(locale)).build()
+                actual = await Index(
+                    project, Context(), localizers.plugin(locale)
+                ).build()
 
                 assert actual[0].text == {"p1", "jane", "doughnut"}
                 assert expected in actual[0].result
@@ -243,7 +247,7 @@ class TestIndex:
                 actual = await Index(
                     project,
                     Context(),
-                    localizers.get(locale),
+                    localizers.plugin(locale),
                 ).build()
 
                 assert actual[0].text == expected_text
@@ -355,7 +359,7 @@ class TestIndex:
                 actual = await Index(
                     project,
                     Context(),
-                    localizers.get(locale),
+                    localizers.plugin(locale),
                 ).build()
 
                 assert actual[0].text == expected_text

--- a/betty/tests/plugin/config/test_property.py
+++ b/betty/tests/plugin/config/test_property.py
@@ -56,7 +56,7 @@ class TestPluginDefinitionConfigurationsProperty:
     def test_load(self) -> None:
         plugin_id = "my-first-plugin"
         owner = self._Owner.data().porter.load({"plugins": {plugin_id: {}}})
-        assert owner.plugins[plugin_id].id == plugin_id
+        assert owner.plugin[plugin_id].id == plugin_id
 
     def test_dump__minimal(self) -> None:
         assert self._Owner.data().porter.dump(self._Owner()) == {}

--- a/betty/tests/plugin/manager/test_service.py
+++ b/betty/tests/plugin/manager/test_service.py
@@ -17,10 +17,11 @@ class TestServiceLevelPluginManager:
 
     async def test_plugins__with_plugin_type(self) -> None:
         sut = ServiceLevelPluginManager(UNIVERSE)
-        assert await sut.plugins(DummyPluginDefinition) is await sut.plugins(
-            DummyPluginDefinition
+        assert sut.plugins(DummyPluginDefinition) is sut.plugins(DummyPluginDefinition)
+        assert (
+            DummyPluginOne.plugin()
+            in await sut.plugins(DummyPluginDefinition).plugins()
         )
-        assert DummyPluginOne.plugin() in await sut.plugins(DummyPluginDefinition)
 
     async def test_plugins__with_plugin_type_id(self, mocker: MockerFixture) -> None:
         plugin_type_repository = PluginTypeRepository()
@@ -31,8 +32,9 @@ class TestServiceLevelPluginManager:
             "betty.plugin.PluginTypeRepository", return_value=plugin_type_repository
         )
         sut = ServiceLevelPluginManager(UNIVERSE)
-        assert DummyPluginOne.plugin() in await sut.plugins(
-            DummyPluginDefinition.type().id
+        assert (
+            DummyPluginOne.plugin()
+            in await sut.plugins(DummyPluginDefinition.type().id).plugins()
         )
 
     async def test_plugins__should_forward_services(self, isolated_app: App) -> None:
@@ -42,7 +44,7 @@ class TestServiceLevelPluginManager:
 
         sut = ServiceLevelPluginManager(isolated_app)
         with DummyPluginDefinition.type().discoverer.override(require_app(_discovery)):
-            await sut.plugins(DummyPluginDefinition)
+            await sut.plugins(DummyPluginDefinition).plugins()
 
     async def test_plugins__with_overridden_discoveries(self) -> None:
         @DummyPluginDefinition("dummy-plugin-override")
@@ -51,5 +53,9 @@ class TestServiceLevelPluginManager:
 
         sut = ServiceLevelPluginManager(UNIVERSE)
         with DummyPluginDefinition.type().discoverer.override(_Plugin):
-            assert _Plugin.plugin() in await sut.plugins(DummyPluginDefinition)
-        assert _Plugin.plugin() not in await sut.plugins(DummyPluginDefinition)
+            assert (
+                _Plugin.plugin() in await sut.plugins(DummyPluginDefinition).plugins()
+            )
+        assert (
+            _Plugin.plugin() not in await sut.plugins(DummyPluginDefinition).plugins()
+        )

--- a/betty/tests/plugin/repository/test___init__.py
+++ b/betty/tests/plugin/repository/test___init__.py
@@ -8,13 +8,10 @@ from betty.plugin.error import PluginNotFound
 from betty.plugin.repository import PluginRepository
 from betty.test_utils.plugin import (
     DummyPluginDefinition,
-    DummyPluginOne,
-    DummyPluginThree,
-    DummyPluginTwo,
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import AsyncIterator
 
     from betty.machine_name import MachineName
 
@@ -26,7 +23,7 @@ class TestPluginRepository:
             self._plugins = {plugin.id: plugin for plugin in plugins}
 
         @override
-        def get(self, plugin_id: MachineName, /) -> DummyPluginDefinition:
+        async def plugin(self, plugin_id: MachineName, /) -> DummyPluginDefinition:
             try:
                 return self._plugins[plugin_id]
             except KeyError:
@@ -35,18 +32,9 @@ class TestPluginRepository:
                 ) from None
 
         @override
-        def __iter__(self) -> Iterator[DummyPluginDefinition]:
-            yield from self._plugins.values()
+        async def __aiter__(self) -> AsyncIterator[DummyPluginDefinition]:
+            for plugin in self._plugins.values():
+                yield plugin
 
     def test_type(self) -> None:
         assert self._Sut().type is DummyPluginDefinition
-
-    def test___len__(self) -> None:
-        sut = self._Sut(
-            DummyPluginOne.plugin(), DummyPluginTwo.plugin(), DummyPluginThree.plugin()
-        )
-        assert len(sut) == 3
-
-    def test___getitem__(self) -> None:
-        sut = self._Sut(DummyPluginOne.plugin())
-        assert sut[DummyPluginOne.plugin().id] is DummyPluginOne.plugin()

--- a/betty/tests/plugin/repository/test_static.py
+++ b/betty/tests/plugin/repository/test_static.py
@@ -6,21 +6,21 @@ from betty.test_utils.plugin import DummyPluginDefinition, DummyPluginOne
 
 
 class TestStaticPluginRepository:
-    def test_get(self) -> None:
+    async def test_get(self) -> None:
         sut = StaticPluginRepository(DummyPluginDefinition, DummyPluginOne)
-        assert sut[DummyPluginOne.plugin().id] is DummyPluginOne.plugin()
+        assert await sut.plugin(DummyPluginOne.plugin().id) is DummyPluginOne.plugin()
 
-    def test_get_not_found(self) -> None:
+    def test_get__not_found(self) -> None:
         sut = StaticPluginRepository(DummyPluginDefinition)
         with pytest.raises(PluginNotFound):
-            sut.get(DummyPluginOne.plugin().id)
+            sut.plugin(DummyPluginOne.plugin().id)
 
-    def test___iter__(self) -> None:
+    async def test___aiter__(self) -> None:
         sut = StaticPluginRepository(DummyPluginDefinition, DummyPluginOne)
-        plugin = list(iter(sut))[0]
+        plugin = [plugin async for plugin in aiter(sut)][0]
         assert plugin is DummyPluginOne.plugin()
 
-    def test___iter___without_plugins(self) -> None:
+    async def test___aiter___without_plugins(self) -> None:
         sut = StaticPluginRepository(DummyPluginDefinition)
         with pytest.raises(StopIteration):
-            next(iter(sut))
+            await anext(aiter(sut))

--- a/betty/tests/plugin/test_ordered.py
+++ b/betty/tests/plugin/test_ordered.py
@@ -81,11 +81,11 @@ class TestOrderedPluginDefinition:
         ),
     ],
 )
-def test_sort_ordered_plugin_graph(
+async def test_sort_ordered_plugin_graph(
     expected: list[MachineName],
     plugins: Iterable[_OrderedPluginDefinition],
 ) -> None:
-    sorter = sort_ordered_plugin_graph(
+    sorter = await sort_ordered_plugin_graph(
         StaticPluginRepository(
             _OrderedPluginDefinition,
             _ORDERED_PLUGIN_COMES_BEFORE_TARGET,

--- a/betty/tests/project/test___init__.py
+++ b/betty/tests/project/test___init__.py
@@ -16,7 +16,6 @@ from betty.serde import SerializationError
 from betty.service.factory import Manufacturable
 from betty.service.requirement.project import require_project
 from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
-from betty.test_utils.plugin import DummyPluginDefinition
 from betty.test_utils.project.extension import DummyExtensionOne, DummyExtensionTwo
 
 if TYPE_CHECKING:
@@ -62,10 +61,6 @@ class TestProject:
             sut,
         ):
             assert sut.configuration is configuration
-
-    async def test_plugins(self, isolated_app: App) -> None:
-        async with Project.new_isolated(isolated_app) as sut, sut:
-            await sut.plugins.plugins(DummyPluginDefinition)
 
     async def test_new__without_ancestry(
         self, isolated_app: App, tmp_path: Path
@@ -122,9 +117,9 @@ class TestProject:
         async with Project.new_isolated(isolated_app) as sut, sut:
             extensions = await sut.extensions
 
-            for betty_extension in await isolated_app.plugins.plugins(
+            for betty_extension in await isolated_app.plugin.plugins(
                 ExtensionDefinition
-            ):
+            ).plugins():
                 if betty_extension.id.startswith("betty-"):
                     assert betty_extension.id in extensions
 

--- a/betty/tests/service/test_level.py
+++ b/betty/tests/service/test_level.py
@@ -8,7 +8,7 @@ class _TargetType:
 class TestServiceLevel:
     def test_plugins(self) -> None:
         sut = ServiceLevel()
-        assert len(list(sut.plugins.types))
+        assert len(list(sut.plugin.types))
 
     async def test_factory(self) -> None:
         sut = ServiceLevel()

--- a/betty/tests/test_documentation.py
+++ b/betty/tests/test_documentation.py
@@ -43,7 +43,7 @@ class TestDocumentation:
             ROOT_DIRECTORY_PATH / "documentation" / "usage" / "console.rst"
         ) as f:
             actual = await f.read()
-        for command in await isolated_app.plugins.plugins(CommandDefinition):
+        async for command in isolated_app.plugin.plugins(CommandDefinition):
             assert command.id in actual
             assert command.label.localize(DEFAULT_LOCALIZER) in actual
 


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/3772

## To do
- All of the functions calls are getting out of hand: `await project.plugin.plugins(EventTypeDefinition).plugins()`. Split plugin types off from `PluginManager`. See if we can use `__getitem__` again to replace `PluginManager.plugins()`
- Consider using a single entry point that gets a `PluginTypeManager` which exposes plugin type and plugin definitions for the given plugin type.

## Blocked by
- https://github.com/bartfeenstra/betty/issues/3803