### PR TITLE
Use Python 3.13 features

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,4 @@
-target-version = 'py311'
+target-version = 'py313'
 [lint]
 extend-select = [
     'A',

--- a/betty/ancestry/__init__.py
+++ b/betty/ancestry/__init__.py
@@ -7,16 +7,17 @@ from __future__ import annotations
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, final, override
 
-from betty.model import Entity
 from betty.model.association import AssociationRegistry
 from betty.model.collections import MultipleTypesEntityCollection
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
 
+    from betty.model import Entity
+
 
 @final
-class Ancestry(MultipleTypesEntityCollection[Entity]):
+class Ancestry(MultipleTypesEntityCollection):
     """
     An ancestry contains all the entities of a single family tree/genealogical data set.
     """

--- a/betty/app/__init__.py
+++ b/betty/app/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from contextlib import AsyncExitStack, asynccontextmanager
 from os import environ
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, Self, TypeVar, final, override
+from typing import TYPE_CHECKING, Any, Literal, Self, final, override
 
 from aiofiles.tempfile import TemporaryDirectory
 from aiohttp_client_cache.backends.filesystem import FileBackend
@@ -30,7 +30,6 @@ from betty.locale.translation import (
     TranslationRepository,
 )
 from betty.multiprocessing import ProcessPoolExecutor
-from betty.plugin import Plugin, PluginDefinition
 from betty.plugin.ordered import sort_ordered_plugin_graph
 from betty.portable.file import assert_load_file
 from betty.service.container import ServiceFactory, service
@@ -47,11 +46,6 @@ if TYPE_CHECKING:
 
     from betty.cache import Cache
     from betty.user import User
-
-_PluginT = TypeVar("_PluginT", bound=Plugin, default=Plugin)
-_PluginDefinitionT = TypeVar(
-    "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
-)
 
 
 @final

--- a/betty/argparse.py
+++ b/betty/argparse.py
@@ -4,23 +4,20 @@ Integrate the console and assertion APIs.
 
 import argparse
 from collections.abc import Callable
-from typing import TypeVar
 
 from betty.assertion import Assertion
 from betty.exception import HumanFacingException
 from betty.locale.localize import Localizer
 
-_T = TypeVar("_T")
 
-
-def assertion_to_argument_type(
-    assertion: Assertion[str, _T], *, localizer: Localizer
-) -> Callable[[str], _T]:
+def assertion_to_argument_type[T](
+    assertion: Assertion[str, T], *, localizer: Localizer
+) -> Callable[[str], T]:
     """
     Convert an assertion to an argparse argument type.
     """
 
-    def _assertion_to_argument_type(value: str) -> _T:
+    def _assertion_to_argument_type(value: str) -> T:
         try:
             return assertion(value)
         except HumanFacingException as error:

--- a/betty/assertion.py
+++ b/betty/assertion.py
@@ -17,15 +17,7 @@ from enum import Enum
 from functools import lru_cache
 from pathlib import Path
 from types import NoneType
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Generic,
-    TypeAlias,
-    TypeVar,
-    final,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, final, overload
 
 from betty.data.indicator.selector import Index, Key
 from betty.error import FileNotFound
@@ -40,27 +32,12 @@ if TYPE_CHECKING:
 
     from betty.locale.localizable import Localizable
 
-Number: TypeAlias = int | float
-_NumberT = TypeVar("_NumberT", bound=Number)
+type Number = int | float
 
-_EnumT = TypeVar("_EnumT", bound=Enum)
-_AssertionValueT = TypeVar("_AssertionValueT")
-_AssertionReturnT = TypeVar("_AssertionReturnT")
-_AssertionReturnU = TypeVar("_AssertionReturnU")
-_AssertionKeyT = TypeVar("_AssertionKeyT")
-
-Assertion: TypeAlias = Callable[
-    [
-        _AssertionValueT,
-    ],
-    _AssertionReturnT,
-]
-
-_AssertionsExtendReturnT = TypeVar("_AssertionsExtendReturnT")
-_AssertionsIntermediateValueReturnT = TypeVar("_AssertionsIntermediateValueReturnT")
+type Assertion[ValueT, ReturnT] = Callable[[ValueT], ReturnT]
 
 
-class AssertionChain(Generic[_AssertionValueT, _AssertionReturnT]):
+class AssertionChain[ValueT, ReturnT]:
     """
     An assertion chain.
 
@@ -76,23 +53,23 @@ class AssertionChain(Generic[_AssertionValueT, _AssertionReturnT]):
     can confirm that all assertions in any given chain are compatible with each other.
     """
 
-    def __init__(self, _assertion: Assertion[_AssertionValueT, _AssertionReturnT], /):
+    def __init__(self, _assertion: Assertion[ValueT, ReturnT], /):
         self._assertion = _assertion
 
-    def chain(
-        self, assertion: Assertion[_AssertionReturnT, _AssertionsExtendReturnT], /
-    ) -> AssertionChain[_AssertionValueT, _AssertionsExtendReturnT]:
+    def chain[AssertionsExtendReturnT](
+        self, assertion: Assertion[ReturnT, AssertionsExtendReturnT], /
+    ) -> AssertionChain[ValueT, AssertionsExtendReturnT]:
         """
         Extend the chain with the given assertion.
         """
         return AssertionChain(lambda value: assertion(self(value)))
 
-    def __or__(
-        self, _assertion: Assertion[_AssertionReturnT, _AssertionsExtendReturnT]
-    ) -> AssertionChain[_AssertionValueT, _AssertionsExtendReturnT]:
+    def __or__[AssertionsExtendReturnT](
+        self, _assertion: Assertion[ReturnT, AssertionsExtendReturnT]
+    ) -> AssertionChain[ValueT, AssertionsExtendReturnT]:
         return self.chain(_assertion)
 
-    def __call__(self, value: _AssertionValueT) -> _AssertionReturnT:
+    def __call__(self, value: ValueT) -> ReturnT:
         """
         Invoke the chain with a value.
 
@@ -106,7 +83,7 @@ class AssertionChain(Generic[_AssertionValueT, _AssertionReturnT]):
 
 @internal
 @dataclass(frozen=True)
-class Field(Generic[_AssertionValueT, _AssertionReturnT]):
+class Field[ValueT, ReturnT]:
     """
     A key-value mapping field.
 
@@ -115,16 +92,13 @@ class Field(Generic[_AssertionValueT, _AssertionReturnT]):
     """
 
     name: str
-    assertion: Assertion[_AssertionValueT, _AssertionReturnT] | None = None
+    assertion: Assertion[ValueT, ReturnT] | None = None
     as_name: str | None = None
 
 
 @final
 @dataclass(frozen=True)
-class RequiredField(
-    Generic[_AssertionValueT, _AssertionReturnT],
-    Field[_AssertionValueT, _AssertionReturnT],
-):
+class RequiredField[ValueT, ReturnT](Field[ValueT, ReturnT]):
     """
     A required key-value mapping field.
     """
@@ -132,24 +106,22 @@ class RequiredField(
 
 @final
 @dataclass(frozen=True)
-class OptionalField(
-    Generic[_AssertionValueT, _AssertionReturnT],
-    Field[_AssertionValueT, _AssertionReturnT],
-):
+class OptionalField[ValueT, ReturnT](Field[ValueT, ReturnT]):
     """
     An optional key-value mapping field.
     """
 
 
-_AssertionBuilderFunction = Callable[[_AssertionValueT], _AssertionReturnT]
-_AssertionBuilderMethod = Callable[[object, _AssertionValueT], _AssertionReturnT]
-_AssertionBuilder = "_AssertionBuilderFunction[ValueT, ReturnT] | _AssertionBuilderMethod[ValueT, ReturnT]"
+type _AssertionBuilderFunction[ValueT, ReturnT] = Callable[[ValueT], ReturnT]
+type _AssertionBuilderMethod[ValueT, ReturnT] = Callable[[object, ValueT], ReturnT]
+type _AssertionBuilder[ValueT, ReturnT] = (
+    "_AssertionBuilderFunction[ValueT, ReturnT] | _AssertionBuilderMethod[ValueT, ReturnT]"
+)
 
 
-AssertTypeType: TypeAlias = (
+type AssertTypeType = (
     bool | float | int | Mapping[Any, Any] | None | Sequence[Any] | str
 )
-_AssertTypeTypeT = TypeVar("_AssertTypeTypeT", bound=AssertTypeType)
 
 
 _ASSERT_TYPES: Mapping[type[AssertTypeType], tuple[type[Any] | None, Localizable]] = {
@@ -164,14 +136,14 @@ _ASSERT_TYPES: Mapping[type[AssertTypeType], tuple[type[Any] | None, Localizable
 
 
 @lru_cache
-def assert_type(
-    value_type: type[_AssertTypeTypeT], /
-) -> AssertionChain[Any, _AssertTypeTypeT]:
+def assert_type[AssertTypeTypeT: AssertTypeType](
+    value_type: type[AssertTypeTypeT], /
+) -> AssertionChain[Any, AssertTypeTypeT]:
     """
     Assert that a value is of the specified built-in type.
     """
 
-    def _assert_type(value: Any, /) -> _AssertTypeTypeT:
+    def _assert_type(value: Any, /) -> AssertTypeTypeT:
         value_is_not_type, error_message = _ASSERT_TYPES[value_type]
         if isinstance(value, value_type) and (
             value_is_not_type is None or not isinstance(value, value_is_not_type)
@@ -182,16 +154,16 @@ def assert_type(
     return AssertionChain(_assert_type)
 
 
-def assert_or(
-    if_assertion: Assertion[_AssertionValueT, _AssertionReturnT],
-    else_assertion: Assertion[_AssertionValueT, _AssertionReturnU],
+def assert_or[ValueT, ReturnT, AssertionReturnU](
+    if_assertion: Assertion[ValueT, ReturnT],
+    else_assertion: Assertion[ValueT, AssertionReturnU],
     /,
-) -> AssertionChain[_AssertionValueT, _AssertionReturnT | _AssertionReturnU]:
+) -> AssertionChain[ValueT, ReturnT | AssertionReturnU]:
     """
     Assert that at least one of the given assertions passed.
     """
 
-    def _assert_or(value: Any, /) -> _AssertionReturnT | _AssertionReturnU:
+    def _assert_or(value: Any, /) -> ReturnT | AssertionReturnU:
         assertions = (if_assertion, else_assertion)
         errors = []
         for assertion in assertions:
@@ -216,10 +188,10 @@ Assert that a value is a Python ``bool``.
 """
 
 
-def _assert_number(
+def _assert_number[NumberT: Number](
     minimum: Number | None = None, maximum: Number | None = None
-) -> AssertionChain[_NumberT, _NumberT]:
-    def __assert_number(value: _NumberT) -> _NumberT:
+) -> AssertionChain[NumberT, NumberT]:
+    def __assert_number(value: NumberT) -> NumberT:
         if minimum is not None and value < minimum:
             raise HumanFacingException(
                 _("This must be at least {minimum}.").format(minimum=str(minimum))
@@ -304,22 +276,20 @@ def assert_sequence(
 
 
 @overload
-def assert_sequence(
-    value_assertion: Assertion[Any, _AssertionReturnT], /
-) -> AssertionChain[Any, MutableSequence[_AssertionReturnT]]:
+def assert_sequence[ReturnT](
+    value_assertion: Assertion[Any, ReturnT], /
+) -> AssertionChain[Any, MutableSequence[ReturnT]]:
     pass
 
 
-def assert_sequence(
-    value_assertion: Assertion[Any, _AssertionReturnT] | None = None, /
-):
+def assert_sequence[ReturnT](value_assertion: Assertion[Any, ReturnT] | None = None, /):
     """
     Assert that a value is a sequence.
 
     Optionally assert that values are of a given type.
     """
 
-    def _assert_sequence(value: Any, /) -> MutableSequence[_AssertionReturnT]:
+    def _assert_sequence(value: Any, /) -> MutableSequence[ReturnT]:
         sequence = assert_type(Sequence)(value)
         if value_assertion is None:
             return list(sequence)
@@ -340,31 +310,31 @@ def assert_mapping(
 
 
 @overload
-def assert_mapping(
-    value_assertion: Assertion[Any, _AssertionReturnT], key_assertion: None = None, /
-) -> AssertionChain[Any, MutableMapping[Any, _AssertionReturnT]]:
+def assert_mapping[ReturnT](
+    value_assertion: Assertion[Any, ReturnT], key_assertion: None = None, /
+) -> AssertionChain[Any, MutableMapping[Any, ReturnT]]:
     pass
 
 
 @overload
-def assert_mapping(
-    value_assertion: None, key_assertion: Assertion[Any, _AssertionKeyT], /
-) -> AssertionChain[Any, MutableMapping[_AssertionKeyT, Any]]:
+def assert_mapping[AssertionKeyT](
+    value_assertion: None, key_assertion: Assertion[Any, AssertionKeyT], /
+) -> AssertionChain[Any, MutableMapping[AssertionKeyT, Any]]:
     pass
 
 
 @overload
-def assert_mapping(
-    value_assertion: Assertion[Any, _AssertionReturnT],
-    key_assertion: Assertion[Any, _AssertionKeyT],
+def assert_mapping[ReturnT, AssertionKeyT](
+    value_assertion: Assertion[Any, ReturnT],
+    key_assertion: Assertion[Any, AssertionKeyT],
     /,
-) -> AssertionChain[Any, MutableMapping[_AssertionKeyT, _AssertionReturnT]]:
+) -> AssertionChain[Any, MutableMapping[AssertionKeyT, ReturnT]]:
     pass
 
 
-def assert_mapping(
-    value_assertion: Assertion[Any, _AssertionReturnT] | None = None,
-    key_assertion: Assertion[Any, _AssertionKeyT] | None = None,
+def assert_mapping[ReturnT, AssertionKeyT](
+    value_assertion: Assertion[Any, ReturnT] | None = None,
+    key_assertion: Assertion[Any, AssertionKeyT] | None = None,
     /,
 ):
     """
@@ -373,9 +343,7 @@ def assert_mapping(
     Optionally assert that keys and/or values are of a given type.
     """
 
-    def _assert_mapping(
-        value: Any, /
-    ) -> MutableMapping[_AssertionKeyT, _AssertionReturnT]:
+    def _assert_mapping(value: Any, /) -> MutableMapping[AssertionKeyT, ReturnT]:
         mapping = assert_type(Mapping)(value)
         if value_assertion is None and key_assertion is None:
             return dict(mapping)
@@ -436,9 +404,7 @@ def assert_record(
     return assert_mapping() | _assert_record
 
 
-def assert_isinstance(
-    alleged_type: type[_AssertionValueT], /
-) -> Assertion[Any, _AssertionValueT]:
+def assert_isinstance[ValueT](alleged_type: type[ValueT], /) -> Assertion[Any, ValueT]:
     """
     Assert that a value is an instance of the given type.
 
@@ -446,7 +412,7 @@ def assert_isinstance(
     because Python types are not user-facing.
     """
 
-    def _assert(value: Any, /) -> _AssertionValueT:
+    def _assert(value: Any, /) -> ValueT:
         if isinstance(value, alleged_type):
             return value
         raise HumanFacingException(f"{value} must be an instance of {alleged_type}.")
@@ -496,12 +462,9 @@ def assert_locale() -> AssertionChain[Any, Locale]:
     return assert_str() | from_language_tag
 
 
-_SizedT = TypeVar("_SizedT", bound=Sized)
-
-
-def assert_len(
+def assert_len[SizedT: Sized](
     exact: int | None = None, *, minimum: int | None = None, maximum: int | None = None
-) -> AssertionChain[_SizedT, _SizedT]:
+) -> AssertionChain[SizedT, SizedT]:
     """
     Assert the length of a value.
 
@@ -510,7 +473,7 @@ def assert_len(
     - with minimum and/or maximum bounds (inclusive)
     """
 
-    def _assert_len(value: _SizedT, /) -> _SizedT:
+    def _assert_len(value: SizedT, /) -> SizedT:
         actual = len(value)
         if exact is not None and actual != exact:
             raise HumanFacingException(
@@ -535,7 +498,7 @@ def assert_len(
     return AssertionChain(_assert_len)
 
 
-def assert_enum(options: type[_EnumT]) -> AssertionChain[Any, _EnumT]:
+def assert_enum[EnumT: Enum](options: type[EnumT]) -> AssertionChain[Any, EnumT]:
     """
     Assert that a value is allowed by an enum, and return the enum value.
     """

--- a/betty/asyncio.py
+++ b/betty/asyncio.py
@@ -5,15 +5,13 @@ Provide asynchronous programming utilities.
 from __future__ import annotations
 
 from inspect import isawaitable
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable
 
-_T = TypeVar("_T")
 
-
-async def resolve_await(value: Awaitable[_T] | _T) -> _T:
+async def resolve_await[T](value: Awaitable[T] | T) -> T:
     """
     Return a value, but await it first if it is awaitable.
     """

--- a/betty/cache/__init__.py
+++ b/betty/cache/__init__.py
@@ -6,19 +6,15 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Generic, Self, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, Self
 
 from betty.typing import threadsafe
 
 if TYPE_CHECKING:
     from contextlib import AbstractAsyncContextManager
 
-_CacheItemValueT = TypeVar("_CacheItemValueT")
-_CacheItemValueCoT = TypeVar("_CacheItemValueCoT", covariant=True)
-_CacheItemValueContraT = TypeVar("_CacheItemValueContraT", contravariant=True)
 
-
-class CacheItem(ABC, Generic[_CacheItemValueCoT]):
+class CacheItem[CacheItemValueT](ABC):
     """
     A cache item.
     """
@@ -31,17 +27,19 @@ class CacheItem(ABC, Generic[_CacheItemValueCoT]):
         """
 
     @abstractmethod
-    async def value(self) -> _CacheItemValueCoT:
+    async def value(self) -> CacheItemValueT:
         """
         Get this cache item's value.
         """
 
 
-CacheItemValueSetter: TypeAlias = Callable[[_CacheItemValueT], Awaitable[None]]
+type CacheItemValueSetter[_CacheItemValueT] = Callable[
+    [_CacheItemValueT], Awaitable[None]
+]
 
 
 @threadsafe
-class Cache(ABC, Generic[_CacheItemValueContraT]):
+class Cache[CacheItemValueT](ABC):
     """
     A cache.
 
@@ -63,17 +61,13 @@ class Cache(ABC, Generic[_CacheItemValueContraT]):
     @abstractmethod
     def hasset(
         self, cache_item_id: str, /
-    ) -> AbstractAsyncContextManager[
-        CacheItemValueSetter[_CacheItemValueContraT] | None
-    ]:
+    ) -> AbstractAsyncContextManager[CacheItemValueSetter[CacheItemValueT] | None]:
         """
         Check if a cache item with the given ID exists, and if not, provide a setter to add or update it within the same atomic operation.
         """
 
     @abstractmethod
-    async def get(
-        self, cache_item_id: str, /
-    ) -> CacheItem[_CacheItemValueContraT] | None:
+    async def get(self, cache_item_id: str, /) -> CacheItem[CacheItemValueT] | None:
         """
         Get the cache item with the given ID.
         """
@@ -82,7 +76,7 @@ class Cache(ABC, Generic[_CacheItemValueContraT]):
     async def set(
         self,
         cache_item_id: str,
-        value: _CacheItemValueContraT,
+        value: CacheItemValueT,
         *,
         modified: int | float | None = None,
     ) -> None:
@@ -94,7 +88,7 @@ class Cache(ABC, Generic[_CacheItemValueContraT]):
     def getset(
         self, cache_item_id: str, /
     ) -> AbstractAsyncContextManager[
-        CacheItemValueSetter[_CacheItemValueContraT] | CacheItem[_CacheItemValueContraT]
+        CacheItemValueSetter[CacheItemValueT] | CacheItem[CacheItemValueT]
     ]:
         """
         Get the cache item with the given ID, or provide a setter to add it within the same atomic operation.

--- a/betty/cache/_base.py
+++ b/betty/cache/_base.py
@@ -2,31 +2,26 @@ from collections.abc import AsyncIterator, Sequence
 from contextlib import asynccontextmanager
 from datetime import datetime
 from functools import partial
-from typing import Any, Generic, Self, TypeVar, override
+from typing import Any, Self, override
 
 from betty.cache import Cache, CacheItem, CacheItemValueSetter
 from betty.concurrent import AsynchronizedLock, Ledger
 from betty.typing import threadsafe
 
-_T = TypeVar("_T")
-_CacheT = TypeVar("_CacheT", bound=Cache[Any])
-_CacheItemValueCoT = TypeVar("_CacheItemValueCoT", covariant=True)
-_CacheItemValueContraT = TypeVar("_CacheItemValueContraT", contravariant=True)
 
-
-class _StaticCacheItem(CacheItem[_CacheItemValueCoT], Generic[_CacheItemValueCoT]):
+class _StaticCacheItem[CacheItemValueT](CacheItem[CacheItemValueT]):
     __slots__ = "_value", "_modified"
 
     def __init__(
         self,
-        value: _CacheItemValueCoT,
+        value: CacheItemValueT,
         modified: int | float | None = None,
     ):
         self._value = value
         self._modified = datetime.now().timestamp() if modified is None else modified
 
     @override
-    async def value(self) -> _CacheItemValueCoT:
+    async def value(self) -> CacheItemValueT:
         return self._value
 
     @override
@@ -35,7 +30,7 @@ class _StaticCacheItem(CacheItem[_CacheItemValueCoT], Generic[_CacheItemValueCoT
         return self._modified
 
 
-class _CommonCacheBaseState(Generic[_CacheT]):
+class _CommonCacheBaseState[CacheT: Cache[Any]]:
     def __init__(
         self,
         cache_lock: AsynchronizedLock,
@@ -46,7 +41,7 @@ class _CommonCacheBaseState(Generic[_CacheT]):
 
 
 @threadsafe
-class _CommonCacheBase(Cache[_CacheItemValueContraT], Generic[_CacheItemValueContraT]):
+class _CommonCacheBase[CacheItemValueT](Cache[CacheItemValueT]):
     def __init__(
         self,
         *,
@@ -65,7 +60,7 @@ class _CommonCacheBase(Cache[_CacheItemValueContraT], Generic[_CacheItemValueCon
     @asynccontextmanager
     async def hasset(
         self, cache_item_id: str, /
-    ) -> AsyncIterator[CacheItemValueSetter[_CacheItemValueContraT] | None]:
+    ) -> AsyncIterator[CacheItemValueSetter[CacheItemValueT] | None]:
         if await self.has(cache_item_id):
             yield None
             return
@@ -80,7 +75,7 @@ class _CommonCacheBase(Cache[_CacheItemValueContraT], Generic[_CacheItemValueCon
     async def getset(
         self, cache_item_id: str, /
     ) -> AsyncIterator[
-        CacheItemValueSetter[_CacheItemValueContraT] | CacheItem[_CacheItemValueContraT]
+        CacheItemValueSetter[CacheItemValueT] | CacheItem[CacheItemValueT]
     ]:
         if cache_item := await self.get(cache_item_id):
             yield cache_item

--- a/betty/cache/file.py
+++ b/betty/cache/file.py
@@ -12,14 +12,7 @@ from contextlib import asynccontextmanager, suppress
 from functools import partial
 from os import utime
 from pickle import dumps, loads
-from typing import (
-    TYPE_CHECKING,
-    Generic,
-    Self,
-    TypeVar,
-    final,
-    override,
-)
+from typing import TYPE_CHECKING, Self, final, override
 
 import aiofiles
 from aiofiles.os import makedirs, remove
@@ -34,11 +27,8 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Sequence
     from pathlib import Path
 
-_CacheItemValueCoT = TypeVar("_CacheItemValueCoT", covariant=True)
-_CacheItemValueContraT = TypeVar("_CacheItemValueContraT", contravariant=True)
 
-
-class _FileCacheItem(CacheItem[_CacheItemValueCoT], Generic[_CacheItemValueCoT]):
+class _FileCacheItem[CacheItemValueT](CacheItem[CacheItemValueT]):
     __slots__ = "_modified", "_path"
 
     def __init__(
@@ -55,22 +45,20 @@ class _FileCacheItem(CacheItem[_CacheItemValueCoT], Generic[_CacheItemValueCoT])
         return self._modified
 
     @override
-    async def value(self) -> _CacheItemValueCoT:
+    async def value(self) -> CacheItemValueT:
         async with aiofiles.open(self._path, "rb") as f:
             value_bytes = await f.read()
         return await self._load_value(value_bytes)
 
     @abstractmethod
-    async def _load_value(self, value_bytes: bytes) -> _CacheItemValueCoT:
+    async def _load_value(self, value_bytes: bytes) -> CacheItemValueT:
         pass
 
 
 @final
-class _PickledFileCacheItem(
-    _FileCacheItem[_CacheItemValueCoT], Generic[_CacheItemValueCoT]
-):
+class _PickledFileCacheItem[CacheItemValueT](_FileCacheItem[CacheItemValueT]):
     @override
-    async def _load_value(self, value_bytes: bytes) -> _CacheItemValueCoT:
+    async def _load_value(self, value_bytes: bytes) -> CacheItemValueT:
         return loads(value_bytes)
 
 
@@ -81,14 +69,12 @@ class _BinaryFileCacheItem(_FileCacheItem[bytes]):
         return value_bytes
 
 
-class _FileCache(
-    _CommonCacheBase[_CacheItemValueContraT], Generic[_CacheItemValueContraT]
-):
+class _FileCache[CacheItemValueT](_CommonCacheBase[CacheItemValueT]):
     """
     Provide a cache that persists cache items on a file system.
     """
 
-    _cache_item_cls: type[_FileCacheItem[_CacheItemValueContraT]]
+    _cache_item_cls: type[_FileCacheItem[CacheItemValueT]]
 
     def __init__(
         self,
@@ -120,7 +106,7 @@ class _FileCache(
         return cache_item_file_path
 
     @abstractmethod
-    def _dump_value(self, value: _CacheItemValueContraT) -> bytes:
+    def _dump_value(self, value: CacheItemValueT) -> bytes:
         pass
 
     @override
@@ -130,7 +116,7 @@ class _FileCache(
     @override
     async def get(
         self, cache_item_id: str, *, suffix: str | None = None
-    ) -> CacheItem[_CacheItemValueContraT] | None:
+    ) -> CacheItem[CacheItemValueT] | None:
         try:
             cache_item_file_path = self._cache_item_file_path(cache_item_id, suffix)
             return self._cache_item_cls(
@@ -144,7 +130,7 @@ class _FileCache(
     async def set(
         self,
         cache_item_id: str,
-        value: _CacheItemValueContraT,
+        value: CacheItemValueT,
         *,
         suffix: str | None = None,
         modified: int | float | None = None,
@@ -186,7 +172,7 @@ class _FileCache(
     @asynccontextmanager
     async def hasset(
         self, cache_item_id: str, *, suffix: str | None = None
-    ) -> AsyncIterator[CacheItemValueSetter[_CacheItemValueContraT] | None]:
+    ) -> AsyncIterator[CacheItemValueSetter[CacheItemValueT] | None]:
         if await self.has(cache_item_id, suffix=suffix):
             yield None
             return
@@ -202,7 +188,7 @@ class _FileCache(
     async def getset(
         self, cache_item_id: str, *, suffix: str | None = None
     ) -> AsyncIterator[
-        CacheItemValueSetter[_CacheItemValueContraT] | CacheItem[_CacheItemValueContraT]
+        CacheItemValueSetter[CacheItemValueT] | CacheItem[CacheItemValueT]
     ]:
         if cache_item := await self.get(cache_item_id):
             yield cache_item
@@ -217,9 +203,7 @@ class _FileCache(
 
 @final
 @threadsafe
-class PickledFileCache(
-    _FileCache[_CacheItemValueContraT], Generic[_CacheItemValueContraT]
-):
+class PickledFileCache[CacheItemValueT](_FileCache[CacheItemValueT]):
     """
     Provide a cache that pickles values and persists them to files.
     """
@@ -227,7 +211,7 @@ class PickledFileCache(
     _cache_item_cls = _PickledFileCacheItem
 
     @override
-    def _dump_value(self, value: _CacheItemValueContraT) -> bytes:
+    def _dump_value(self, value: CacheItemValueT) -> bytes:
         return dumps(value)
 
 

--- a/betty/cache/memory.py
+++ b/betty/cache/memory.py
@@ -5,7 +5,7 @@ Provide caching that stores cache items in volatile memory.
 from __future__ import annotations
 
 from collections.abc import MutableMapping, Sequence
-from typing import TYPE_CHECKING, Generic, Self, TypeAlias, TypeVar, final, override
+from typing import TYPE_CHECKING, Self, final, override
 
 from betty.cache import CacheItem
 from betty.cache._base import _CommonCacheBase, _CommonCacheBaseState, _StaticCacheItem
@@ -14,24 +14,22 @@ from betty.typing import threadsafe
 if TYPE_CHECKING:
     from betty.concurrent import AsynchronizedLock, Ledger
 
-_CacheItemValueContraT = TypeVar("_CacheItemValueContraT", contravariant=True)
 
-_MemoryCacheStore: TypeAlias = MutableMapping[
+type _MemoryCacheStore[CacheItemValueT] = MutableMapping[
     tuple[str, ...],
-    "CacheItem[_CacheItemValueContraT] | None | _MemoryCacheStore[_CacheItemValueContraT]",
+    "CacheItem[CacheItemValueT] | None | _MemoryCacheStore[CacheItemValueT]",
 ]
 
 
 @final
-class _MemoryCacheState(
-    _CommonCacheBaseState["MemoryCache[_CacheItemValueContraT]"],
-    Generic[_CacheItemValueContraT],
+class _MemoryCacheState[CacheItemValueT](
+    _CommonCacheBaseState["MemoryCache[CacheItemValueT]"],
 ):
     def __init__(
         self,
         cache_lock: AsynchronizedLock,
         cache_item_lock_ledger: Ledger,
-        store: _MemoryCacheStore[_CacheItemValueContraT],
+        store: _MemoryCacheStore[CacheItemValueT],
     ):
         super().__init__(cache_lock, cache_item_lock_ledger)
         self.store = store
@@ -39,20 +37,18 @@ class _MemoryCacheState(
 
 @final
 @threadsafe
-class MemoryCache(
-    _CommonCacheBase[_CacheItemValueContraT], Generic[_CacheItemValueContraT]
-):
+class MemoryCache[CacheItemValueT](_CommonCacheBase[CacheItemValueT]):
     """
     Provide a cache that stores cache items in volatile memory.
     """
 
-    _store: _MemoryCacheStore[_CacheItemValueContraT]
+    _store: _MemoryCacheStore[CacheItemValueT]
 
     def __init__(
         self,
         *,
         scopes: Sequence[str] | None = None,
-        state: _MemoryCacheState[_CacheItemValueContraT] | None = None,
+        state: _MemoryCacheState[CacheItemValueT] | None = None,
     ):
         super().__init__(scopes=scopes, state=state)
         if state is None:
@@ -64,7 +60,7 @@ class MemoryCache(
     def with_scope(self, scope: str, /) -> Self:
         return type(self)(
             scopes=(*self._scopes, scope),
-            state=_MemoryCacheState[_CacheItemValueContraT](
+            state=_MemoryCacheState[CacheItemValueT](
                 self._cache_lock, self._cache_item_lock_ledger, self._store
             ),
         )
@@ -73,19 +69,17 @@ class MemoryCache(
         return *self._scopes, cache_item_id
 
     @override
-    async def get(
-        self, cache_item_id: str, /
-    ) -> CacheItem[_CacheItemValueContraT] | None:
+    async def get(self, cache_item_id: str, /) -> CacheItem[CacheItemValueT] | None:
         cache_item = self._store.get(self._cache_item_key(cache_item_id), None)
         if isinstance(cache_item, CacheItem):
-            return cache_item
+            return cache_item  # ty:ignore[invalid-return-type]
         return None
 
     @override
     async def set(
         self,
         cache_item_id: str,
-        value: _CacheItemValueContraT,
+        value: CacheItemValueT,
         *,
         modified: int | float | None = None,
     ) -> None:

--- a/betty/collections.py
+++ b/betty/collections.py
@@ -15,35 +15,29 @@ from collections.abc import (
 )
 from contextlib import suppress
 from itertools import chain
-from typing import Any, Generic, TypeVar, final, overload, override
+from typing import Any, final, overload, override
 
 from betty.functools import passthrough
 from betty.typing import Void
 
-_T = TypeVar("_T")
-_KeyT = TypeVar("_KeyT")
-_ValueT = TypeVar("_ValueT")
-_ResolvableKeyT = TypeVar("_ResolvableKeyT")
-_ResolvableValueT = TypeVar("_ResolvableValueT")
 
-
-class KeyedCollection(Collection[_ValueT], Generic[_KeyT, _ResolvableKeyT, _ValueT]):
+class KeyedCollection[KeyT, ResolvableKeyT, ValueT](Collection[ValueT]):
     """
     A collection of values that are accessible by their primary keys.
     """
 
     @abstractmethod
-    def keys(self) -> Iterable[_KeyT]:
+    def keys(self) -> Iterable[KeyT]:
         """
         Get an iterable over the collection's primary keys.
         """
 
     @abstractmethod
-    def __getitem__(self, key: _ResolvableKeyT) -> _ValueT:
+    def __getitem__(self, key: ResolvableKeyT) -> ValueT:
         pass
 
 
-class MutableCollection(Collection[_ValueT]):
+class MutableCollection[ValueT](Collection[ValueT]):
     """
     A mutable collection of values.
     """
@@ -55,32 +49,33 @@ class MutableCollection(Collection[_ValueT]):
         """
 
 
-class MutableKeyedCollection(
-    KeyedCollection[_KeyT, _ResolvableKeyT, _ValueT],
-    MutableCollection[_ValueT],
-    Generic[_KeyT, _ResolvableKeyT, _ValueT, _ResolvableValueT],
+class MutableKeyedCollection[KeyT, ResolvableKeyT, ValueT, ResolvableValueT](
+    KeyedCollection[KeyT, ResolvableKeyT, ValueT],
+    MutableCollection[ValueT],
 ):
     """
     A mutable collection of values that are accessible by their primary keys.
     """
 
     @abstractmethod
-    def add(self, *values: _ResolvableValueT) -> None:
+    def add(self, *values: ResolvableValueT) -> None:
         """
         Add a value to the collection.
         """
 
     @abstractmethod
-    def __delitem__(self, key: _ResolvableKeyT) -> None:
+    def __delitem__(self, key: ResolvableKeyT) -> None:
         pass
 
 
-class _DictKeyedCollection(KeyedCollection[_KeyT, _ResolvableKeyT, _ValueT]):
+class _DictKeyedCollection[KeyT, ResolvableKeyT, ValueT](
+    KeyedCollection[KeyT, ResolvableKeyT, ValueT]
+):
     def __init__(
         self,
-        values: Mapping[_KeyT, _ValueT] | None = None,
+        values: Mapping[KeyT, ValueT] | None = None,
         *,
-        key_resolver: Callable[[_ResolvableKeyT | _KeyT], _KeyT] = passthrough,
+        key_resolver: Callable[[ResolvableKeyT | KeyT], KeyT] = passthrough,
     ):
         self._values = {} if values is None else dict(values)
         self._key_resolver = key_resolver
@@ -90,7 +85,7 @@ class _DictKeyedCollection(KeyedCollection[_KeyT, _ResolvableKeyT, _ValueT]):
         return self._values.__len__()
 
     @override
-    def __iter__(self) -> Iterator[_ValueT]:
+    def __iter__(self) -> Iterator[ValueT]:
         yield from self._values.values()
 
     @override
@@ -100,25 +95,27 @@ class _DictKeyedCollection(KeyedCollection[_KeyT, _ResolvableKeyT, _ValueT]):
         return key in self._values
 
     @override
-    def __getitem__(self, key: _ResolvableKeyT) -> _ValueT:
+    def __getitem__(self, key: ResolvableKeyT) -> ValueT:
         return self._values[self._key_resolver(key)]
 
     @override
-    def keys(self) -> Iterable[_KeyT]:
+    def keys(self) -> Iterable[KeyT]:
         return self._values.keys()
 
 
 @final
-class DictKeyedCollection(_DictKeyedCollection[_KeyT, _ResolvableKeyT, _ValueT]):
+class DictKeyedCollection[KeyT, ResolvableKeyT, ValueT](
+    _DictKeyedCollection[KeyT, ResolvableKeyT, ValueT]
+):
     """
     A keyed collection backed by a dictionary.
     """
 
 
 @final
-class MutableDictKeyedCollection(
-    _DictKeyedCollection[_KeyT, _ResolvableKeyT, _ValueT],
-    MutableKeyedCollection[_KeyT, _ResolvableKeyT, _ValueT, _ResolvableValueT],
+class MutableDictKeyedCollection[KeyT, ResolvableKeyT, ValueT, ResolvableValueT](
+    _DictKeyedCollection[KeyT, ResolvableKeyT, ValueT],
+    MutableKeyedCollection[KeyT, ResolvableKeyT, ValueT, ResolvableValueT],
 ):
     """
     A mutable keyed collection backed by a dictionary.
@@ -126,13 +123,13 @@ class MutableDictKeyedCollection(
 
     def __init__(
         self,
-        values: Iterable[_ResolvableValueT] | None = None,
+        values: Iterable[ResolvableValueT] | None = None,
         *,
-        key: Callable[[_ValueT], _KeyT],
-        key_resolver: Callable[[_ResolvableKeyT | _KeyT], _KeyT] = passthrough,
-        value_resolver: Callable[[_ResolvableValueT | _KeyT], _ValueT] = passthrough,
+        key: Callable[[ValueT], KeyT],
+        key_resolver: Callable[[ResolvableKeyT | KeyT], KeyT] = passthrough,
+        value_resolver: Callable[[ResolvableValueT | KeyT], ValueT] = passthrough,
         resolver: Callable[
-            [Sequence[_ValueT]], Sequence[_ValueT | _ResolvableValueT]
+            [Sequence[ValueT]], Sequence[ValueT | ResolvableValueT]
         ] = passthrough,
     ):
         super().__init__(key_resolver=key_resolver)
@@ -143,7 +140,7 @@ class MutableDictKeyedCollection(
             self.add(*values)
 
     @override
-    def __delitem__(self, key: _ResolvableKeyT) -> None:
+    def __delitem__(self, key: ResolvableKeyT) -> None:
         del self._values[self._key_resolver(key)]
 
     @override
@@ -151,7 +148,7 @@ class MutableDictKeyedCollection(
         self._values.clear()
 
     @override
-    def add(self, *values: _ResolvableValueT) -> None:
+    def add(self, *values: ResolvableValueT) -> None:
         # Resolve the values, so the collection resolver won't have to and can stay small.
         resolved_values = list(map(self._value_resolver, values))
         # Allow the collection resolver to change the collection or raise (validation) errors.
@@ -162,10 +159,9 @@ class MutableDictKeyedCollection(
             self._values[self._key(value)] = value
 
 
-class MutableResolvedSequence(
-    MutableSequence[_ValueT],
-    MutableCollection[_ValueT],
-    Generic[_ValueT, _ResolvableValueT],
+class MutableResolvedSequence[ValueT, ResolvableValueT](
+    MutableSequence[ValueT],
+    MutableCollection[ValueT],
 ):
     """
     A mutable sequence of resolved values.
@@ -173,16 +169,16 @@ class MutableResolvedSequence(
 
     @override
     @abstractmethod
-    def insert(self, index: int, value: _ValueT | _ResolvableValueT) -> None:
+    def insert(self, index: int, value: ValueT | ResolvableValueT) -> None:
         pass
 
     @overload
-    def __setitem__(self, index: int, value: _ValueT | _ResolvableValueT) -> None:
+    def __setitem__(self, index: int, value: ValueT | ResolvableValueT) -> None:
         pass
 
     @overload
     def __setitem__(
-        self, index: slice, value: Iterable[_ValueT | _ResolvableValueT]
+        self, index: slice, value: Iterable[ValueT | ResolvableValueT]
     ) -> None:
         pass
 
@@ -192,26 +188,26 @@ class MutableResolvedSequence(
 
     @override
     @abstractmethod
-    def extend(self, values: Iterable[_ValueT | _ResolvableValueT]) -> None:
+    def extend(self, values: Iterable[ValueT | ResolvableValueT]) -> None:
         pass
 
 
-class _ResolvedSequenceProxy(Sequence[_ValueT], Generic[_ValueT, _ResolvableValueT]):
+class _ResolvedSequenceProxy[ValueT, ResolvableValueT](Sequence[ValueT]):
     def __init__(
         self,
-        upstream: Sequence[_ValueT],
+        upstream: Sequence[ValueT],
         *,
-        value_resolver: Callable[[_ValueT | _ResolvableValueT], _ValueT],
+        value_resolver: Callable[[ValueT | ResolvableValueT], ValueT],
     ):
         self._upstream = upstream
         self._value_resolver = value_resolver
 
     @overload
-    def __getitem__(self, index: int) -> _ValueT:
+    def __getitem__(self, index: int) -> ValueT:
         pass
 
     @overload
-    def __getitem__(self, index: slice) -> MutableSequence[_ValueT]:
+    def __getitem__(self, index: slice) -> MutableSequence[ValueT]:
         pass
 
     @final
@@ -237,42 +233,44 @@ class _ResolvedSequenceProxy(Sequence[_ValueT], Generic[_ValueT, _ResolvableValu
 
 
 @final
-class ResolvedSequenceProxy(_ResolvedSequenceProxy[_ValueT, _ResolvableValueT]):
+class ResolvedSequenceProxy[ValueT, ResolvableValueT](
+    _ResolvedSequenceProxy[ValueT, ResolvableValueT]
+):
     """
     Decorate another sequence to resolve any values before proxying them.
     """
 
 
 @final
-class MutableResolvedSequenceProxy(
-    _ResolvedSequenceProxy[_ValueT, _ResolvableValueT],
-    MutableResolvedSequence[_ValueT, _ResolvableValueT],
+class MutableResolvedSequenceProxy[ValueT, ResolvableValueT](
+    _ResolvedSequenceProxy[ValueT, ResolvableValueT],
+    MutableResolvedSequence[ValueT, ResolvableValueT],
 ):
     """
     Decorate another sequence to resolve any values before proxying them.
     """
 
-    _upstream: MutableSequence[_ValueT]
+    _upstream: MutableSequence[ValueT]
 
     def __init__(
         self,
-        upstream: MutableSequence[_ValueT],
+        upstream: MutableSequence[ValueT],
         *,
-        value_resolver: Callable[[_ValueT | _ResolvableValueT], _ValueT],
+        value_resolver: Callable[[ValueT | ResolvableValueT], ValueT],
     ):
         super().__init__(upstream, value_resolver=value_resolver)
 
     @override
-    def insert(self, index: int, value: _ValueT | _ResolvableValueT) -> None:
+    def insert(self, index: int, value: ValueT | ResolvableValueT) -> None:
         self._upstream.insert(index, self._value_resolver(value))
 
     @overload
-    def __setitem__(self, index: int, value: _ValueT | _ResolvableValueT) -> None:
+    def __setitem__(self, index: int, value: ValueT | ResolvableValueT) -> None:
         pass
 
     @overload
     def __setitem__(
-        self, index: slice, value: Iterable[_ValueT | _ResolvableValueT]
+        self, index: slice, value: Iterable[ValueT | ResolvableValueT]
     ) -> None:
         pass
 
@@ -286,45 +284,40 @@ class MutableResolvedSequenceProxy(
         del self._upstream[index]
 
     @override
-    def extend(self, values: Iterable[_ValueT | _ResolvableValueT]) -> None:
+    def extend(self, values: Iterable[ValueT | ResolvableValueT]) -> None:
         self._upstream.extend(map(self._value_resolver, values))
 
 
-class ResolvedMapping(
-    Mapping[_KeyT, _ValueT], Generic[_KeyT, _ResolvableKeyT, _ValueT]
-):
+class ResolvedMapping[KeyT, ResolvableKeyT, ValueT](Mapping[KeyT, ValueT]):
     """
     A mutable mapping of resolved keys.
     """
 
     @override
     @abstractmethod
-    def __getitem__(self, key: _KeyT | _ResolvableKeyT) -> _ValueT:
+    def __getitem__(self, key: KeyT | ResolvableKeyT) -> ValueT:
         pass
 
     @overload
-    def get(self, key: _KeyT | _ResolvableKeyT, default: _T, /) -> _ValueT | _T:
+    def get[T](self, key: KeyT | ResolvableKeyT, default: T, /) -> ValueT | T:
         pass
 
     @overload
-    def get(
-        self, key: _KeyT | _ResolvableKeyT, default: None = None, /
-    ) -> _ValueT | None:
+    def get(self, key: KeyT | ResolvableKeyT, default: None = None, /) -> ValueT | None:
         pass
 
     @override
     @abstractmethod
-    def get(
-        self, key: _KeyT | _ResolvableKeyT, default: _T | None = None, /
-    ) -> _ValueT | None:
+    def get[T](
+        self, key: KeyT | ResolvableKeyT, default: T | None = None, /
+    ) -> ValueT | None:
         pass
 
 
-class MutableResolvedMapping(
-    MutableMapping[_KeyT, _ValueT],
-    MutableCollection[_KeyT],
-    ResolvedMapping[_KeyT, _ResolvableKeyT, _ValueT],
-    Generic[_KeyT, _ResolvableKeyT, _ValueT, _ResolvableValueT],
+class MutableResolvedMapping[KeyT, ResolvableKeyT, ValueT, ResolvableValueT](
+    MutableMapping[KeyT, ValueT],
+    MutableCollection[KeyT],
+    ResolvedMapping[KeyT, ResolvableKeyT, ValueT],
 ):
     """
     A mutable mapping of resolved keys and values.
@@ -332,26 +325,26 @@ class MutableResolvedMapping(
 
     @abstractmethod
     def __setitem__(
-        self, key: _KeyT | _ResolvableKeyT, value: _ValueT | _ResolvableValueT
+        self, key: KeyT | ResolvableKeyT, value: ValueT | ResolvableValueT
     ) -> None:
         pass
 
     @abstractmethod
-    def __delitem__(self, key: _KeyT | _ResolvableKeyT) -> None:
+    def __delitem__(self, key: KeyT | ResolvableKeyT) -> None:
         pass
 
     @overload
     def update(
         self,
-        other: Mapping[_KeyT | _ResolvableKeyT, _ValueT | _ResolvableValueT]
-        | Iterable[tuple[_KeyT | _ResolvableKeyT, _ValueT | _ResolvableValueT]],
+        other: Mapping[KeyT | ResolvableKeyT, ValueT | ResolvableValueT]
+        | Iterable[tuple[KeyT | ResolvableKeyT, ValueT | ResolvableValueT]],
         /,
-        **kwargs: _ValueT | _ResolvableValueT,
+        **kwargs: ValueT | ResolvableValueT,
     ) -> None:
         pass
 
     @overload
-    def update(self, **kwargs: _ValueT | _ResolvableValueT) -> None:
+    def update(self, **kwargs: ValueT | ResolvableValueT) -> None:
         pass
 
     @override
@@ -360,18 +353,18 @@ class MutableResolvedMapping(
         pass
 
     @overload
-    def setdefault(
-        self: MutableMapping[_KeyT, _T | None],
-        key: _KeyT | _ResolvableKeyT,
+    def setdefault[T](
+        self: MutableMapping[KeyT, T | None],
+        key: KeyT | ResolvableKeyT,
         default: None = None,
         /,
-    ) -> _T | None:
+    ) -> T | None:
         pass
 
     @overload
-    def setdefault(
-        self, key: _KeyT | _ResolvableKeyT, default: _ValueT | _ResolvableValueT, /
-    ) -> _ValueT:
+    def setdefault[T](
+        self, key: KeyT | ResolvableKeyT, default: ValueT | ResolvableValueT, /
+    ) -> ValueT:
         pass
 
     @override
@@ -380,17 +373,17 @@ class MutableResolvedMapping(
         pass
 
     @overload
-    def pop(self, key: _KeyT | _ResolvableKeyT, /) -> _ValueT:
+    def pop(self, key: KeyT | ResolvableKeyT, /) -> ValueT:
         pass
 
     @overload
     def pop(
-        self, key: _KeyT | _ResolvableKeyT, /, default: _ValueT | _ResolvableValueT
-    ) -> _ValueT:
+        self, key: KeyT | ResolvableKeyT, /, default: ValueT | ResolvableValueT
+    ) -> ValueT:
         pass
 
     @overload
-    def pop(self, key: _KeyT | _ResolvableKeyT, /, default: _T) -> _ValueT | _T:
+    def pop[T](self, key: KeyT | ResolvableKeyT, /, default: T) -> ValueT | T:
         pass
 
     @override
@@ -400,33 +393,33 @@ class MutableResolvedMapping(
 
     @override
     @abstractmethod
-    def popitem(self) -> tuple[_KeyT, _ValueT]:
+    def popitem(self) -> tuple[KeyT, ValueT]:
         pass
 
 
-class _ResolvedMappingProxy(ResolvedMapping[_KeyT, _ResolvableKeyT, _ValueT]):
+class _ResolvedMappingProxy[KeyT, ResolvableKeyT, ValueT](
+    ResolvedMapping[KeyT, ResolvableKeyT, ValueT]
+):
     def __init__(
         self,
-        upstream: Mapping[_KeyT, _ValueT],
+        upstream: Mapping[KeyT, ValueT],
         *,
-        key_resolver: Callable[[_KeyT | _ResolvableKeyT], _KeyT] = passthrough,
+        key_resolver: Callable[[KeyT | ResolvableKeyT], KeyT] = passthrough,
     ):
         self._upstream = upstream
         self._key_resolver = key_resolver
 
     @final
     @override
-    def __getitem__(self, key: _KeyT | _ResolvableKeyT) -> _ValueT:
+    def __getitem__(self, key: KeyT | ResolvableKeyT) -> ValueT:
         return self._upstream[self._key_resolver(key)]
 
     @overload
-    def get(self, key: _KeyT | _ResolvableKeyT, default: _T, /) -> _ValueT | _T:
+    def get[T](self, key: KeyT | ResolvableKeyT, default: T, /) -> ValueT | T:
         pass
 
     @overload
-    def get(
-        self, key: _KeyT | _ResolvableKeyT, default: None = None, /
-    ) -> _ValueT | None:
+    def get(self, key: KeyT | ResolvableKeyT, default: None = None, /) -> ValueT | None:
         pass
 
     @final
@@ -436,7 +429,7 @@ class _ResolvedMappingProxy(ResolvedMapping[_KeyT, _ResolvableKeyT, _ValueT]):
 
     @final
     @override
-    def __iter__(self) -> Iterator[_KeyT]:
+    def __iter__(self) -> Iterator[KeyT]:
         return iter(self._upstream)
 
     @final
@@ -453,53 +446,55 @@ class _ResolvedMappingProxy(ResolvedMapping[_KeyT, _ResolvableKeyT, _ValueT]):
 
 
 @final
-class ResolvedMappingProxy(_ResolvedMappingProxy[_KeyT, _ResolvableKeyT, _ValueT]):
+class ResolvedMappingProxy[KeyT, ResolvableKeyT, ValueT](
+    _ResolvedMappingProxy[KeyT, ResolvableKeyT, ValueT]
+):
     """
     Decorate another mapping to resolve any values before proxying them.
     """
 
 
 @final
-class MutableResolvedMappingProxy(
-    _ResolvedMappingProxy[_KeyT, _ResolvableKeyT, _ValueT],
-    MutableResolvedMapping[_KeyT, _ResolvableKeyT, _ValueT, _ResolvableValueT],
+class MutableResolvedMappingProxy[KeyT, ResolvableKeyT, ValueT, ResolvableValueT](
+    _ResolvedMappingProxy[KeyT, ResolvableKeyT, ValueT],
+    MutableResolvedMapping[KeyT, ResolvableKeyT, ValueT, ResolvableValueT],
 ):
     """
     Decorate another mapping to resolve any values before proxying them.
     """
 
-    _upstream: MutableMapping[_KeyT, _ValueT]
+    _upstream: MutableMapping[KeyT, ValueT]
 
     def __init__(
         self,
-        upstream: MutableMapping[_KeyT, _ValueT],
+        upstream: MutableMapping[KeyT, ValueT],
         *,
-        key_resolver: Callable[[_KeyT | _ResolvableKeyT], _KeyT] = passthrough,
-        value_resolver: Callable[[_ValueT | _ResolvableValueT], _ValueT] = passthrough,
+        key_resolver: Callable[[KeyT | ResolvableKeyT], KeyT] = passthrough,
+        value_resolver: Callable[[ValueT | ResolvableValueT], ValueT] = passthrough,
     ):
         super().__init__(upstream, key_resolver=key_resolver)
         self._value_resolver = value_resolver
 
     def __setitem__(
-        self, key: _KeyT | _ResolvableKeyT, value: _ValueT | _ResolvableValueT
+        self, key: KeyT | ResolvableKeyT, value: ValueT | ResolvableValueT
     ) -> None:
         self._upstream[self._key_resolver(key)] = self._value_resolver(value)
 
-    def __delitem__(self, key: _KeyT | _ResolvableKeyT) -> None:
+    def __delitem__(self, key: KeyT | ResolvableKeyT) -> None:
         del self._upstream[self._key_resolver(key)]
 
     @overload
     def update(
         self,
-        other: Mapping[_KeyT | _ResolvableKeyT, _ValueT | _ResolvableValueT]
-        | Iterable[tuple[_KeyT | _ResolvableKeyT, _ValueT | _ResolvableValueT]],
+        other: Mapping[KeyT | ResolvableKeyT, ValueT | ResolvableValueT]
+        | Iterable[tuple[KeyT | ResolvableKeyT, ValueT | ResolvableValueT]],
         /,
-        **kwargs: _ValueT | _ResolvableValueT,
+        **kwargs: ValueT | ResolvableValueT,
     ) -> None:
         pass
 
     @overload
-    def update(self, **kwargs: _ValueT | _ResolvableValueT) -> None:
+    def update(self, **kwargs: ValueT | ResolvableValueT) -> None:
         pass
 
     @override
@@ -517,18 +512,18 @@ class MutableResolvedMappingProxy(
         )
 
     @overload
-    def setdefault(
-        self: MutableMapping[_KeyT, _T | None],
-        key: _KeyT | _ResolvableKeyT,
+    def setdefault[T](
+        self: MutableMapping[KeyT, T | None],
+        key: KeyT | ResolvableKeyT,
         default: None = None,
         /,
-    ) -> _T | None:
+    ) -> T | None:
         pass
 
     @overload
     def setdefault(
-        self, key: _KeyT | _ResolvableKeyT, default: _ValueT | _ResolvableValueT, /
-    ) -> _ValueT:
+        self, key: KeyT | ResolvableKeyT, default: ValueT | ResolvableValueT, /
+    ) -> ValueT:
         pass
 
     @override
@@ -543,17 +538,17 @@ class MutableResolvedMappingProxy(
         )  # ty:ignore[no-matching-overload]
 
     @overload
-    def pop(self, key: _KeyT | _ResolvableKeyT, /) -> _ValueT:
+    def pop(self, key: KeyT | ResolvableKeyT, /) -> ValueT:
         pass
 
     @overload
     def pop(
-        self, key: _KeyT | _ResolvableKeyT, /, default: _ValueT | _ResolvableValueT
-    ) -> _ValueT:
+        self, key: KeyT | ResolvableKeyT, /, default: ValueT | ResolvableValueT
+    ) -> ValueT:
         pass
 
     @overload
-    def pop(self, key: _KeyT | _ResolvableKeyT, /, default: _T) -> _ValueT | _T:
+    def pop[T](self, key: KeyT | ResolvableKeyT, /, default: T) -> ValueT | T:
         pass
 
     @override
@@ -568,5 +563,5 @@ class MutableResolvedMappingProxy(
         return self._upstream.pop(key, default)
 
     @override
-    def popitem(self) -> tuple[_KeyT, _ValueT]:
+    def popitem(self) -> tuple[KeyT, ValueT]:
         return self._upstream.popitem()

--- a/betty/concurrent.py
+++ b/betty/concurrent.py
@@ -10,13 +10,9 @@ from asyncio import sleep
 from collections.abc import AsyncIterator, Hashable, MutableMapping
 from math import floor
 from types import TracebackType
-from typing import Self, TypeVar, final, override
+from typing import Self, final, override
 
 from betty.typing import threadsafe
-
-_KeyT = TypeVar("_KeyT")
-_ValueT = TypeVar("_ValueT")
-
 
 MAX_STRANDS = 64
 

--- a/betty/console/__init__.py
+++ b/betty/console/__init__.py
@@ -7,7 +7,7 @@ import sys
 from asyncio import CancelledError, run
 from collections.abc import Iterable, Sequence
 from enum import IntEnum
-from typing import Any, TypeVar, cast, final, override
+from typing import Any, cast, final, override
 
 import rich  # noqa: F401
 import rich_argparse
@@ -18,8 +18,6 @@ from betty.exception import HumanFacingException
 from betty.locale.localizable.gettext import _
 from betty.locale.localize import Localizer
 from betty.user import Verbosity
-
-_T = TypeVar("_T")
 
 
 @final

--- a/betty/console/command/__init__.py
+++ b/betty/console/command/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, TypeAlias, final
+from typing import TYPE_CHECKING, final
 
 from betty import about
 from betty.definition.human_facing import HumanFacingDefinition
@@ -17,7 +17,7 @@ from betty.plugin.discovery.entry_point import EntryPointDiscovery
 if TYPE_CHECKING:
     import argparse
 
-CommandFunction: TypeAlias = Callable[..., Awaitable[None]]
+type CommandFunction = Callable[..., Awaitable[None]]
 
 
 class Command(Plugin["CommandDefinition"]):

--- a/betty/content_provider/content_providers.py
+++ b/betty/content_provider/content_providers.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from collections.abc import Iterable, Mapping
-from typing import TYPE_CHECKING, Any, Self, TypeAlias, final, override
+from typing import TYPE_CHECKING, Any, Self, final, override
 
 from betty.ancestry.has_notes import HasNotes
 from betty.content_provider import (
@@ -112,7 +112,7 @@ class Render(DataManufacturable[RenderConfiguration], ContentProvider):
         )
 
 
-ProvidedTemplate: TypeAlias = (
+type ProvidedTemplate = (
     str | Iterable[str] | tuple[str | Iterable[str], Mapping[str, Any]] | None
 )
 
@@ -290,11 +290,7 @@ class Box(Template, DataManufacturable[BoxConfiguration]):
     @require_project
     async def new(cls, project: Project, data: BoxConfiguration, /) -> Self:
         return cls(
-            content=await new_plugins(  # ty:ignore[invalid-argument-type]
-                project,
-                ContentProviderDefinition,
-                data.content,  # ty:ignore[invalid-argument-type]
-            ),
+            content=await new_plugins(project, ContentProviderDefinition, data.content),
             min_height=data.min_height,
             max_height=data.max_height,
             height=data.height,

--- a/betty/data/__init__.py
+++ b/betty/data/__init__.py
@@ -5,7 +5,7 @@ Describe, access, and manipulate arbitrary data.
 from __future__ import annotations
 
 from functools import update_wrapper
-from typing import TYPE_CHECKING, Any, Generic, Self, TypeVar, final, override
+from typing import TYPE_CHECKING, Any, Self, final, override
 
 from betty.definition.cls import ClsDefinition
 from betty.definition.human_facing import HumanFacingDefinition
@@ -21,10 +21,8 @@ if TYPE_CHECKING:
 
     from betty.locale.localizable import ResolvableLocalizable
 
-_DataClsT = TypeVar("_DataClsT", default=Any)
 
-
-class DataDefinition(HumanFacingDefinition, ClsDefinition[_DataClsT]):
+class DataDefinition[DataClsT](HumanFacingDefinition, ClsDefinition[DataClsT]):
     """
     A data definition.
     """
@@ -32,14 +30,14 @@ class DataDefinition(HumanFacingDefinition, ClsDefinition[_DataClsT]):
     def __init__(
         self,
         *,
-        cls: type[_DataClsT] | None = None,
+        cls: type[DataClsT] | None = None,
         label: ResolvableLocalizable,
         description: ResolvableLocalizable | None = None,
-        porter: Porter[_DataClsT] | None = None,
+        porter: Porter[DataClsT] | None = None,
         samples: Iterable[
-            Callable[[], Sample[_DataClsT]]
-            | Samples[_DataClsT]
-            | type[Intersection[_DataClsT, Samplable]]
+            Callable[[], Sample[DataClsT]]
+            | Samples[DataClsT]
+            | type[Intersection[DataClsT, Samplable]]
         ]
         | None = None,
     ):
@@ -48,7 +46,7 @@ class DataDefinition(HumanFacingDefinition, ClsDefinition[_DataClsT]):
         self._samples = samples
 
     @property
-    def porter(self) -> Porter[_DataClsT]:
+    def porter(self) -> Porter[DataClsT]:
         """
         The porter for the data.
         """
@@ -61,7 +59,7 @@ class DataDefinition(HumanFacingDefinition, ClsDefinition[_DataClsT]):
         return self._porter
 
     @override
-    def _set_cls(self, cls: type[_DataClsT]) -> None:
+    def _set_cls(self, cls: type[DataClsT]) -> None:
         super()._set_cls(cls)
         if issubclass(cls, Data):
             cls.data = staticmethod(update_wrapper(lambda: self, cls.data))  # ty:ignore[invalid-assignment]
@@ -78,18 +76,13 @@ class DataDefinition(HumanFacingDefinition, ClsDefinition[_DataClsT]):
         return Samples(self._samples)
 
 
-_DataDefinitionT = TypeVar(
-    "_DataDefinitionT", bound=DataDefinition, default=DataDefinition, covariant=True
-)
-
-
-class Data(Generic[_DataDefinitionT]):
+class Data[DataDefinitionT: DataDefinition = DataDefinition]:
     """
     A class that defines data for its instances.
     """
 
     @classmethod
-    def data(cls) -> Intersection[_DataDefinitionT, DataDefinition[Self]]:
+    def data(cls) -> Intersection[DataDefinitionT, DataDefinition[Self]]:
         """
         Define the data for instances of this class.
         """
@@ -105,12 +98,12 @@ class Data(Generic[_DataDefinitionT]):
 
 
 @final
-class OptionalDefinition(DataDefinition[_DataClsT | None]):
+class OptionalDefinition[DataClsT](DataDefinition[DataClsT | None]):
     """
     Wrap another data definition to make it optional, e.g. allow ``None``.
     """
 
-    def __init__(self, wrapped: DataDefinition[_DataClsT], /):
+    def __init__(self, wrapped: DataDefinition[DataClsT], /):
         super().__init__(
             cls=wrapped.cls,
             label=wrapped.label,
@@ -124,7 +117,7 @@ class OptionalDefinition(DataDefinition[_DataClsT | None]):
         self._wrapped = wrapped
 
     @property
-    def wrapped(self) -> DataDefinition[_DataClsT]:
+    def wrapped(self) -> DataDefinition[DataClsT]:
         """
         The wrapped, required (non-optional) data definition.
         """

--- a/betty/data/aggregate/__init__.py
+++ b/betty/data/aggregate/__init__.py
@@ -5,7 +5,7 @@ Aggregate data types.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any
 
 from betty.data import DataDefinition
 from betty.data.indicator.selector import Element
@@ -13,19 +13,16 @@ from betty.data.indicator.selector import Element
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-_DataClsT = TypeVar("_DataClsT")
-_ElementT = TypeVar("_ElementT", bound=Element[Any], default=Element[Any])
 
-
-class AggregateDefinition(
-    DataDefinition[_DataClsT], ABC, Generic[_DataClsT, _ElementT]
+class AggregateDefinition[DataClsT, ElementT: Element[Any] = Element[Any]](
+    DataDefinition[DataClsT], ABC
 ):
     """
     Define an aggregate data type, e.g. data that consists of other parts.
     """
 
     @abstractmethod
-    def elements(self, data: _DataClsT) -> Sequence[tuple[_ElementT, DataDefinition]]:
+    def elements(self, data: DataClsT) -> Sequence[tuple[ElementT, DataDefinition]]:
         """
         The selectors and definitions for all elements contained by the data.
         """

--- a/betty/data/aggregate/collection/__init__.py
+++ b/betty/data/aggregate/collection/__init__.py
@@ -5,7 +5,7 @@ Collection data types.
 from __future__ import annotations
 
 from collections.abc import Collection
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any
 
 from betty.data import DataDefinition
 from betty.data.aggregate import AggregateDefinition
@@ -16,11 +16,10 @@ if TYPE_CHECKING:
     from betty.locale.localizable import ResolvableLocalizable
     from betty.portable import Porter
 
-_CollectionT = TypeVar("_CollectionT", bound=Collection)
-_ElementCoT = TypeVar("_ElementCoT", bound=Element[Any], covariant=True)
 
-
-class CollectionDefinition(AggregateDefinition[_CollectionT, _ElementCoT]):
+class CollectionDefinition[CollectionT: Collection, ElementT: Element[Any]](
+    AggregateDefinition[CollectionT, ElementT]
+):
     """
     A homogenous collection data definition.
     """
@@ -28,11 +27,11 @@ class CollectionDefinition(AggregateDefinition[_CollectionT, _ElementCoT]):
     def __init__(
         self,
         *,
-        cls: type[_CollectionT] | None = None,
+        cls: type[CollectionT] | None = None,
         item: DataDefinition | type[Data],
         label: ResolvableLocalizable,
         description: ResolvableLocalizable | None = None,
-        porter: Porter[_CollectionT] | None = None,
+        porter: Porter[CollectionT] | None = None,
     ):
         super().__init__(cls=cls, label=label, description=description, porter=porter)
         self._item = item if isinstance(item, DataDefinition) else item.data()

--- a/betty/data/aggregate/collection/keyed.py
+++ b/betty/data/aggregate/collection/keyed.py
@@ -2,16 +2,14 @@
 Keyed collection data types.
 """
 
-from collections.abc import Sequence
-from typing import Any, TypeVar, final, override
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, final, override
 
 from betty.assertion import assert_mapping, assert_sequence
 from betty.collections import MutableDictKeyedCollection, MutableKeyedCollection
-from betty.data import Data, DataDefinition
 from betty.data.aggregate.collection import CollectionDefinition
-from betty.data.aggregate.record import RecordDefinition
-from betty.data.indicator.selector import Element, Key
-from betty.locale.localizable import ResolvableLocalizable
+from betty.data.indicator.selector import Element
 from betty.portable import (
     CallbackPorter,
     PortableData,
@@ -19,24 +17,31 @@ from betty.portable import (
     PortableSequence,
 )
 
-_ValueT = TypeVar("_ValueT")
-_ElementT = TypeVar("_ElementT")
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from ty_extensions import Intersection
+
+    from betty.data import Data, DataDefinition
+    from betty.data.aggregate.record import RecordDefinition
+    from betty.locale.localizable import ResolvableLocalizable
 
 
 @final
-class KeyedCollectionDefinition(
-    CollectionDefinition[MutableKeyedCollection[Any, Any, _ValueT, Any], Key]
+class KeyedCollectionDefinition[ValueT, ElementT: Element[str] = Element[str]](
+    CollectionDefinition[MutableKeyedCollection[Any, Any, ValueT, Any], ElementT]
 ):
     """
     A definition for :py:class:`betty.collections.MutableKeyedCollection`.
     """
 
-    _item: RecordDefinition[_ValueT, Key]
+    _item: RecordDefinition[ValueT, ElementT]
 
     def __init__(
         self,
         *,
-        value: RecordDefinition[_ValueT] | type[Data[RecordDefinition]],
+        value: RecordDefinition[ValueT, ElementT]
+        | type[Intersection[ValueT, Data[RecordDefinition[Any, ElementT]]]],
         key: Element[str],
         ordered: bool,
         label: ResolvableLocalizable,
@@ -54,13 +59,15 @@ class KeyedCollectionDefinition(
 
     @override
     def elements(
-        self, data: MutableKeyedCollection[Any, Any, _ValueT, Any]
-    ) -> Sequence[tuple[Key, DataDefinition]]:
-        return [(Key(self._key.get(item_data)), self.item) for item_data in data]
+        self, data: MutableKeyedCollection[Any, Any, ValueT, Any]
+    ) -> Sequence[tuple[ElementT, DataDefinition]]:
+        return [
+            (type(self._key)(self._key.get(item_data)), self.item) for item_data in data
+        ]  # ty:ignore[invalid-return-type]
 
     def _load(
         self, portable: PortableData, /
-    ) -> MutableKeyedCollection[str, str, _ValueT, Any]:
+    ) -> MutableKeyedCollection[str, str, ValueT, Any]:
         if self._ordered:
             items = assert_sequence(self._item.porter.load)(portable)
         else:
@@ -72,7 +79,7 @@ class KeyedCollectionDefinition(
         return MutableDictKeyedCollection(items, key=self._key.get)
 
     def _dump(
-        self, data: MutableKeyedCollection[str, str, _ValueT, Any]
+        self, data: MutableKeyedCollection[str, str, ValueT, Any]
     ) -> PortableMapping | PortableSequence:
         if self._ordered:
             return [self._item.porter.dump(value) for value in data]

--- a/betty/data/aggregate/collection/mapping.py
+++ b/betty/data/aggregate/collection/mapping.py
@@ -5,7 +5,7 @@ Key-value mapping data types.
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
-from typing import TYPE_CHECKING, Any, TypeVar, final, override
+from typing import TYPE_CHECKING, Any, final, override
 
 from betty.data.aggregate.collection import CollectionDefinition
 from betty.data.indicator.selector import Key
@@ -17,29 +17,25 @@ if TYPE_CHECKING:
     from betty.data import Data, DataDefinition
     from betty.locale.localizable import ResolvableLocalizable
 
-_DataKeyT = TypeVar("_DataKeyT")
-_DataItemT = TypeVar("_DataItemT")
-_MutableMappingT = TypeVar("_MutableMappingT", bound=MutableMapping[Any, Any])
-
 
 @final
-class MappingDefinition(CollectionDefinition[_MutableMappingT, Key]):
+class MappingDefinition[MutableMappingT: MutableMapping[Any, Any]](
+    CollectionDefinition[MutableMappingT, Key]
+):
     """
     A key-value mapping data definition.
     """
 
-    def __init__(
+    def __init__[KeyT, ValueT](
         self,
         *,
-        cls: type[
-            Intersection[_MutableMappingT, MutableMapping[_DataKeyT, _DataItemT]]
-        ],
-        key: DataDefinition[_DataKeyT],
-        value: DataDefinition[_DataItemT] | type[Intersection[_DataItemT, Data]],
+        cls: type[Intersection[MutableMappingT, MutableMapping[KeyT, ValueT]]],
+        key: DataDefinition[KeyT],
+        value: DataDefinition[ValueT] | type[Intersection[ValueT, Data]],
         label: ResolvableLocalizable,
         description: ResolvableLocalizable | None = None,
-        factory: Callable[[Mapping[str, _DataItemT]], _MutableMappingT] | None = None,
-        porter: Porter[_MutableMappingT] | None = None,
+        factory: Callable[[Mapping[str, ValueT]], MutableMappingT] | None = None,
+        porter: Porter[MutableMappingT] | None = None,
     ):
         super().__init__(
             cls=cls,
@@ -52,10 +48,10 @@ class MappingDefinition(CollectionDefinition[_MutableMappingT, Key]):
         self._factory = factory
 
     @override
-    def elements(self, data: _MutableMappingT) -> Sequence[tuple[Key, DataDefinition]]:
+    def elements(self, data: MutableMappingT) -> Sequence[tuple[Key, DataDefinition]]:
         return [(Key(key), self.item) for key, item_data in data.items()]
 
-    def _load(self, portable: PortableData, /) -> _MutableMappingT:
+    def _load(self, portable: PortableData, /) -> MutableMappingT:
         from betty.assertion import assert_mapping
 
         factory = self.cls if not self._factory else self._factory
@@ -63,8 +59,10 @@ class MappingDefinition(CollectionDefinition[_MutableMappingT, Key]):
             assert_mapping(self._item.porter.load, self._key.porter.load)(portable)  # ty:ignore[too-many-positional-arguments]
         )
 
-    def _dump(self, data: _MutableMappingT) -> PortableData:
+    def _dump(self, data: MutableMappingT) -> PortableData:
         return {
-            self._key.porter.dump(key): self._item.porter.dump(item)
+            self._key.porter.dump(key): self._item.porter.dump(
+                item,
+            )  # ty:ignore[invalid-argument-type]
             for key, item in data.items()
         }  # ty:ignore[invalid-return-type]

--- a/betty/data/aggregate/collection/sequence.py
+++ b/betty/data/aggregate/collection/sequence.py
@@ -5,7 +5,7 @@ Sequence data types.
 from __future__ import annotations
 
 from collections.abc import Callable, MutableSequence, Sequence
-from typing import TYPE_CHECKING, Any, TypeVar, override
+from typing import TYPE_CHECKING, Any, override
 
 from betty.data.aggregate.collection import CollectionDefinition
 from betty.data.indicator.selector import Index
@@ -17,23 +17,22 @@ if TYPE_CHECKING:
     from betty.data import Data, DataDefinition
     from betty.locale.localizable import ResolvableLocalizable
 
-_DataItemT = TypeVar("_DataItemT")
-_MutableSequenceT = TypeVar("_MutableSequenceT", bound=MutableSequence[Any])
 
-
-class SequenceDefinition(CollectionDefinition[_MutableSequenceT, Index]):
+class SequenceDefinition[MutableSequenceT: MutableSequence[Any]](
+    CollectionDefinition[MutableSequenceT, Index]
+):
     """
     A sequence data definition.
     """
 
-    def __init__(
+    def __init__[ValueT](
         self,
         *,
-        cls: type[_MutableSequenceT],
-        value: DataDefinition[_DataItemT] | type[Intersection[_DataItemT, Data]],
+        cls: type[MutableSequenceT],
+        value: DataDefinition[ValueT] | type[Intersection[ValueT, Data]],
         label: ResolvableLocalizable,
         description: ResolvableLocalizable | None = None,
-        factory: Callable[[Sequence[_DataItemT]], _MutableSequenceT] | None = None,
+        factory: Callable[[Sequence[ValueT]], MutableSequenceT] | None = None,
     ):
         super().__init__(
             cls=cls,
@@ -46,15 +45,20 @@ class SequenceDefinition(CollectionDefinition[_MutableSequenceT, Index]):
 
     @override
     def elements(
-        self, data: _MutableSequenceT
+        self, data: MutableSequenceT
     ) -> Sequence[tuple[Index, DataDefinition]]:
         return [(Index(index), self.item) for index, item_data in enumerate(data)]
 
-    def _load(self, portable: PortableData, /) -> _MutableSequenceT:
+    def _load(self, portable: PortableData, /) -> MutableSequenceT:
         from betty.assertion import assert_sequence
 
         factory = self.cls if not self._factory else self._factory
         return factory(assert_sequence(self._item.porter.load)(portable))  # ty:ignore[too-many-positional-arguments]
 
-    def _dump(self, data: _MutableSequenceT) -> PortableData:
-        return [self._item.porter.dump(item) for item in data]
+    def _dump(self, data: MutableSequenceT) -> PortableData:
+        return [
+            self._item.porter.dump(
+                item,
+            )  # ty:ignore[invalid-argument-type]
+            for item in data
+        ]  # ty:ignore[invalid-return-type]

--- a/betty/data/aggregate/record/__init__.py
+++ b/betty/data/aggregate/record/__init__.py
@@ -21,30 +21,22 @@ if TYPE_CHECKING:
     from betty.locale.localizable import Localizable, ResolvableLocalizable
     from betty.portable import PortableMapping
 
-_DataClsT = TypeVar("_DataClsT", default=Any)
-_ElementCoT = TypeVar(
-    "_ElementCoT", bound=Element[Any], default=Element[Any], covariant=True
-)
-_ElementStrCoT = TypeVar(
-    "_ElementStrCoT", bound=Element[str], default=Element[str], covariant=True
-)
-
 
 @final
-class FieldDefinition(Generic[_ElementCoT, _DataClsT]):
+class FieldDefinition[ElementT: Element[Any] = Element[Any], DataClsT = Any]:
     """
     A record field definition.
     """
 
     def __init__(
         self,
-        selector: _ElementCoT,
-        data: DataDefinition[_DataClsT] | type[Data[DataDefinition[_DataClsT]]],
+        selector: ElementT,
+        data: DataDefinition[DataClsT] | type[Data[DataDefinition[DataClsT]]],
         *,
         label: ResolvableLocalizable | None = None,
         description: ResolvableLocalizable | None = None,
         omit_load: bool | None = None,
-        omit_dump: Callable[[_DataClsT], bool] | None = None,
+        omit_dump: Callable[[DataClsT], bool] | None = None,
     ):
         self._selector = selector
         self._data = data if isinstance(data, DataDefinition) else data.data()
@@ -63,7 +55,7 @@ class FieldDefinition(Generic[_ElementCoT, _DataClsT]):
         return self._selector
 
     @property
-    def data(self) -> DataDefinition[_DataClsT]:
+    def data(self) -> DataDefinition[DataClsT]:
         """
         The field's data definition.
         """
@@ -92,7 +84,7 @@ class FieldDefinition(Generic[_ElementCoT, _DataClsT]):
             return self._omit_load
         return isinstance(self._data, OptionalDefinition)
 
-    def omit_dump(self, data: _DataClsT, /) -> bool:
+    def omit_dump(self, data: DataClsT, /) -> bool:
         """
         Check if the field may be omitted from the parent when dumping to portable data.
         """
@@ -103,7 +95,12 @@ class FieldDefinition(Generic[_ElementCoT, _DataClsT]):
         return self._omit_dump(data)
 
 
-class PortableRecord(Portable, Generic[_ElementCoT]):
+_PortableRecordElementT = TypeVar(
+    "_PortableRecordElementT", bound=Element[str], default=Element[str], covariant=True
+)
+
+
+class PortableRecord(Portable, Generic[_PortableRecordElementT]):
     """
     A record object capable of dumping and loading itself to and from portable data.
     """
@@ -111,7 +108,7 @@ class PortableRecord(Portable, Generic[_ElementCoT]):
     @classmethod
     @abstractmethod
     def load_key(
-        cls, portable: PortableData, key: _ElementCoT, portable_key: str, /
+        cls, portable: PortableData, key: _PortableRecordElementT, portable_key: str, /
     ) -> Self:
         """
         Create a new instance from portable data and a portable primary key.
@@ -120,7 +117,7 @@ class PortableRecord(Portable, Generic[_ElementCoT]):
         """
 
     @abstractmethod
-    def dump_key(self, key: _ElementCoT, /) -> tuple[str, PortableData]:
+    def dump_key(self, key: _PortableRecordElementT, /) -> tuple[str, PortableData]:
         """
         Dump the instance to portable data and a portable primary key.
 
@@ -128,18 +125,17 @@ class PortableRecord(Portable, Generic[_ElementCoT]):
         """
 
 
-_PortableRecordT = TypeVar("_PortableRecordT", bound=PortableRecord)
-
-
-class RecordPorter(Porter[_DataClsT], Generic[_DataClsT, _ElementCoT]):
+class RecordPorter[DataClsT = Any, ElementT: Element[str] = Element[str]](
+    Porter[DataClsT]
+):
     """
     An object capable of dumping and loading record data to and from portable data.
     """
 
     @abstractmethod
     def load_key(
-        self, portable: PortableData, key: _ElementCoT, portable_key: str, /
-    ) -> _DataClsT:
+        self, portable: PortableData, key: ElementT, portable_key: str, /
+    ) -> DataClsT:
         """
         Create a new data instance from portable data and a portable primary key.
 
@@ -147,46 +143,47 @@ class RecordPorter(Porter[_DataClsT], Generic[_DataClsT, _ElementCoT]):
         """
 
     @abstractmethod
-    def dump_key(
-        self, data: _DataClsT, key: _ElementCoT, /
-    ) -> tuple[str, PortableData]:
+    def dump_key(self, data: DataClsT, key: ElementT, /) -> tuple[str, PortableData]:
         """
         Dump the data to portable data and a portable primary key.
         """
 
 
 @final
-class PortableRecordPorter(
-    PortablePorter[_PortableRecordT], RecordPorter[_PortableRecordT, _ElementCoT]
-):
+class PortableRecordPorter[
+    PortableRecordT: PortableRecord,
+    ElementT: Element[str] = Element[str],
+](PortablePorter[PortableRecordT], RecordPorter[PortableRecordT, ElementT]):
     """
     Expose a portable record data type as a porter.
     """
 
     @override
     def load_key(
-        self, portable: PortableData, key: _ElementCoT, portable_key: str, /
-    ) -> _PortableRecordT:
+        self, portable: PortableData, key: ElementT, portable_key: str, /
+    ) -> PortableRecordT:
         return self._cls.load_key(portable, key, portable_key)
 
     @override
     def dump_key(
-        self, data: _PortableRecordT, key: _ElementCoT, /
+        self, data: PortableRecordT, key: ElementT, /
     ) -> tuple[str, PortableData]:
         return data.dump_key(key)
 
 
 @final
-class MappingPorter(RecordPorter[_DataClsT]):
+class MappingPorter[DataClsT = Any, ElementT: Element[str] = Element[str]](
+    RecordPorter[DataClsT]
+):
     """
     Load and dump a record from and to portable mappings.
     """
 
-    def __init__(self, record: RecordDefinition[_DataClsT, Element[str]], /):
+    def __init__(self, record: RecordDefinition[DataClsT, ElementT], /):
         self._record = record
 
     @override
-    def load(self, portable: PortableData, /) -> _DataClsT:
+    def load(self, portable: PortableData, /) -> DataClsT:
         from betty.assertion import RequiredField, assert_record
 
         return self._record.factory(
@@ -201,7 +198,7 @@ class MappingPorter(RecordPorter[_DataClsT]):
         )
 
     @override
-    def dump(self, data: _DataClsT, /) -> PortableMapping:
+    def dump(self, data: DataClsT, /) -> PortableMapping:
         portable = {}
         for field in self._record.fields:
             field_data = field.selector.get(data)
@@ -211,39 +208,48 @@ class MappingPorter(RecordPorter[_DataClsT]):
 
     @override
     def load_key(
-        self, portable: PortableData, key: _ElementCoT, portable_key: str, /
-    ) -> _DataClsT:
+        self,
+        portable: PortableData,
+        key: ElementT,
+        portable_key: str,
+        /,
+    ) -> DataClsT:  # ty:ignore[invalid-method-override]
         return self.load({**assert_mapping()(portable), key.element: portable_key})
 
     @override
     def dump_key(
-        self, data: _DataClsT, key: _ElementCoT, /
-    ) -> tuple[str, PortableMapping]:
+        self,
+        data: DataClsT,
+        key: ElementT,
+        /,
+    ) -> tuple[str, PortableData]:  # ty:ignore[invalid-method-override]
         portable = self.dump(data)
         portable_key = portable.pop(key.element)
         assert isinstance(portable_key, str)
         return portable_key, portable
 
 
-class RecordDefinition(AggregateDefinition[_DataClsT, _ElementStrCoT]):
+class RecordDefinition[DataClsT = Any, ElementT: Element[str] = Element[str]](
+    AggregateDefinition[DataClsT, ElementT]
+):
     """
     A record data definition.
 
     Records have explicitly defined fields.
     """
 
-    _porter: RecordPorter[_DataClsT] | None
+    _porter: RecordPorter[DataClsT] | None
 
     def __init__(
         self,
         *,
-        cls: type[_DataClsT] | None = None,
+        cls: type[DataClsT] | None = None,
         label: ResolvableLocalizable,
-        fields: Sequence[FieldDefinition[_ElementStrCoT, Any]] | None = None,
+        fields: Sequence[FieldDefinition[ElementT, Any]] | None = None,
         description: ResolvableLocalizable | None = None,
-        samples: Iterable[Callable[[], Sample[_DataClsT]] | Samples] | None = None,
-        factory: Callable[..., _DataClsT] | None = None,
-        porter: RecordPorter[_DataClsT] | None = None,
+        samples: Iterable[Callable[[], Sample[DataClsT]] | Samples] | None = None,
+        factory: Callable[..., DataClsT] | None = None,
+        porter: RecordPorter[DataClsT] | None = None,
     ):
         super().__init__(
             cls=cls,
@@ -253,12 +259,12 @@ class RecordDefinition(AggregateDefinition[_DataClsT, _ElementStrCoT]):
             porter=porter,
         )
         self._factory = factory
-        self._fields: MutableSequence[FieldDefinition[_ElementStrCoT, Any]] = (
+        self._fields: MutableSequence[FieldDefinition[ElementT, Any]] = (
             [] if fields is None else list(fields)
         )
 
     @property
-    def factory(self) -> Callable[..., _DataClsT]:
+    def factory(self) -> Callable[..., DataClsT]:
         """
         The factory to create new instances.
 
@@ -269,23 +275,23 @@ class RecordDefinition(AggregateDefinition[_DataClsT, _ElementStrCoT]):
 
     @override
     @property
-    def porter(self) -> RecordPorter[_DataClsT]:
+    def porter(self) -> RecordPorter[DataClsT]:
         if self._porter is None:
             if issubclass(self.cls, PortableRecord):
                 self._porter = PortableRecordPorter(self.cls)
             else:
-                self._porter = MappingPorter(self)
+                self._porter = MappingPorter(
+                    self,  # ty:ignore[invalid-argument-type]
+                )
         return self._porter
 
     @property
-    def fields(self) -> Sequence[FieldDefinition[_ElementStrCoT, Any]]:
+    def fields(self) -> Sequence[FieldDefinition[ElementT, Any]]:
         """
         The definitions of the fields contained by this record.
         """
         return self._fields
 
     @override
-    def elements(
-        self, data: _DataClsT
-    ) -> Sequence[tuple[_ElementStrCoT, DataDefinition]]:
+    def elements(self, data: DataClsT) -> Sequence[tuple[ElementT, DataDefinition]]:
         return [(field.selector, field.data) for field in self.fields]  # ty:ignore[invalid-return-type]

--- a/betty/data/aggregate/record/mapping.py
+++ b/betty/data/aggregate/record/mapping.py
@@ -5,16 +5,16 @@ Key-value mapping record data types.
 from __future__ import annotations
 
 from collections.abc import MutableMapping
-from typing import Any, TypeVar, final
+from typing import Any, final
 
 from betty.data.aggregate.record import RecordDefinition
 from betty.data.indicator.selector import Key
 
-_MutableMappingT = TypeVar("_MutableMappingT", bound=MutableMapping[str, Any])
-
 
 @final
-class TypedMappingDefinition(RecordDefinition[_MutableMappingT, Key]):
+class TypedMappingDefinition[MutableMappingT: MutableMapping[str, Any]](
+    RecordDefinition[MutableMappingT, Key]
+):
     """
     A typed mapping definition.
 

--- a/betty/data/aggregate/record/object/__init__.py
+++ b/betty/data/aggregate/record/object/__init__.py
@@ -8,12 +8,11 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from inspect import getmembers
 from types import FunctionType
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, final, override
+from typing import TYPE_CHECKING, final, override
 
 from betty.data import DataDefinition
 from betty.data.aggregate.record import FieldDefinition, RecordDefinition
 from betty.data.indicator.selector import Attr as AttrElement
-from betty.data.indicator.selector import Element
 from betty.importlib import fully_qualified_name
 from betty.locale.localizable import resolve_localizable
 
@@ -23,16 +22,12 @@ if TYPE_CHECKING:
     from betty.data import Data
     from betty.locale.localizable import Localizable, ResolvableLocalizable
 
-_FunctionTypeT = TypeVar("_FunctionTypeT", bound=FunctionType)
-_DataClsT = TypeVar("_DataClsT")
-_ElementCoT = TypeVar("_ElementCoT", bound=Element[Any], covariant=True)
-
 
 _attrs: MutableMapping[str, MutableMapping[str, AttrDefinition]] = defaultdict(dict)
 
 
 @final
-class AttrDefinition(Generic[_DataClsT]):
+class AttrDefinition[DataClsT]:
     """
     Define an object attribute.
 
@@ -50,12 +45,12 @@ class AttrDefinition(Generic[_DataClsT]):
 
     def __init__(
         self,
-        data: DataDefinition[_DataClsT] | type[Data[DataDefinition[_DataClsT]]],
+        data: DataDefinition[DataClsT] | type[Data[DataDefinition[DataClsT]]],
         *,
         label: ResolvableLocalizable | None = None,
         description: ResolvableLocalizable | None = None,
         omit_load: bool | None = None,
-        omit_dump: Callable[[_DataClsT], bool] | None = None,
+        omit_dump: Callable[[DataClsT], bool] | None = None,
     ):
         self._data = data if isinstance(data, DataDefinition) else data.data()
         self._label = None if label is None else resolve_localizable(label)
@@ -78,7 +73,9 @@ class AttrDefinition(Generic[_DataClsT]):
             omit_dump=self._omit_dump,
         )
 
-    def __call__(self, attribute: _FunctionTypeT) -> _FunctionTypeT:
+    def __call__[FunctionTypeT: FunctionType](
+        self, attribute: FunctionTypeT
+    ) -> FunctionTypeT:
         """
         Decorate an attribute.
         """
@@ -92,7 +89,7 @@ class AttrDefinition(Generic[_DataClsT]):
         return attribute
 
     @property
-    def data(self) -> DataDefinition[_DataClsT]:
+    def data(self) -> DataDefinition[DataClsT]:
         """
         The attribute's data definition.
         """
@@ -120,27 +117,27 @@ class AttrDefinition(Generic[_DataClsT]):
         return self._omit_load
 
     @property
-    def omit_dump(self) -> Callable[[_DataClsT], bool] | None:
+    def omit_dump(self) -> Callable[[DataClsT], bool] | None:
         """
         Check if the field may be omitted from the parent when dumping to portable data.
         """
         return self._omit_dump
 
 
-class Attr(ABC, Generic[_DataClsT]):
+class Attr[DataClsT](ABC):
     """
     A class attribute that exposes its data definition.
     """
 
     @property
     @abstractmethod
-    def attr(self) -> AttrDefinition[_DataClsT]:
+    def attr(self) -> AttrDefinition[DataClsT]:
         """
         The attribute's data definition.
         """
 
 
-class ObjectDefinition(RecordDefinition[_DataClsT, AttrElement]):
+class ObjectDefinition[DataClsT](RecordDefinition[DataClsT, AttrElement]):
     """
     Define an object with attributes.
 
@@ -149,7 +146,7 @@ class ObjectDefinition(RecordDefinition[_DataClsT, AttrElement]):
     """
 
     @override
-    def _set_cls(self, cls: type[_DataClsT]) -> None:
+    def _set_cls(self, cls: type[DataClsT]) -> None:
         global _attrs
         super()._set_cls(cls)
         cls_name = fully_qualified_name(cls)

--- a/betty/data/aggregate/record/object/property.py
+++ b/betty/data/aggregate/record/object/property.py
@@ -6,23 +6,10 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, MutableMapping, MutableSequence
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Generic,
-    Self,
-    TypeVar,
-    cast,
-    final,
-    overload,
-    override,
-)
+from typing import TYPE_CHECKING, Any, Self, cast, final, overload, override
 
 from betty.collections import MutableKeyedCollection
 from betty.data import OptionalDefinition
-from betty.data.aggregate.collection.keyed import KeyedCollectionDefinition
-from betty.data.aggregate.collection.mapping import MappingDefinition
-from betty.data.aggregate.collection.sequence import SequenceDefinition
 from betty.data.aggregate.record.object import Attr, AttrDefinition
 from betty.functools import passthrough
 from betty.importlib import fully_qualified_name
@@ -34,33 +21,20 @@ if TYPE_CHECKING:
     from ty_extensions import Intersection
 
     from betty.data import Data, DataDefinition
+    from betty.data.aggregate.collection.keyed import KeyedCollectionDefinition
+    from betty.data.aggregate.collection.mapping import MappingDefinition
+    from betty.data.aggregate.collection.sequence import SequenceDefinition
     from betty.locale.localizable import ResolvableLocalizable
 
 
-_ValueGetT = TypeVar("_ValueGetT")
-_ValueSetT = TypeVar("_ValueSetT")
-_MutableMappingT = TypeVar("_MutableMappingT", bound=MutableMapping[Any, Any])
-_MutableSequenceT = TypeVar("_MutableSequenceT", bound=MutableSequence[Any])
-_MappingDefinitionT = TypeVar("_MappingDefinitionT", bound=MappingDefinition)
-_SequenceDefinitionT = TypeVar("_SequenceDefinitionT", bound=SequenceDefinition)
-_KeyedCollectionDefinitionT = TypeVar(
-    "_KeyedCollectionDefinitionT", bound=KeyedCollectionDefinition
-)
-_MutableKeyedCollectionT = TypeVar(
-    "_MutableKeyedCollectionT",
-    bound=MutableKeyedCollection,
-    default=MutableKeyedCollection,
-)
-
-
-class _Property(Attr[_ValueGetT], ABC, Generic[_ValueGetT, _ValueSetT]):
+class _Property[ValueGetT, ValueSetT](Attr[ValueGetT], ABC):
     _attr_name: str
 
     def __init__(
         self,
-        attr: AttrDefinition[_ValueGetT],
+        attr: AttrDefinition[ValueGetT],
         *,
-        resolver: Callable[[_ValueSetT | _ValueGetT], _ValueGetT] = passthrough,
+        resolver: Callable[[ValueSetT | ValueGetT], ValueGetT] = passthrough,
     ):
         self._attr = attr
         self._resolver = resolver
@@ -70,7 +44,7 @@ class _Property(Attr[_ValueGetT], ABC, Generic[_ValueGetT, _ValueSetT]):
 
     @override
     @property
-    def attr(self) -> AttrDefinition[_ValueGetT]:
+    def attr(self) -> AttrDefinition[ValueGetT]:
         return self._attr
 
     @overload
@@ -78,7 +52,7 @@ class _Property(Attr[_ValueGetT], ABC, Generic[_ValueGetT, _ValueSetT]):
         pass
 
     @overload
-    def __get__(self, instance: Any, owner: type[Any], /) -> _ValueGetT:
+    def __get__(self, instance: Any, owner: type[Any], /) -> ValueGetT:
         pass
 
     def __get__(self, instance, owner):
@@ -86,16 +60,16 @@ class _Property(Attr[_ValueGetT], ABC, Generic[_ValueGetT, _ValueSetT]):
             return self
         return self.get(instance)
 
-    def __set__(self, instance: Any, value: _ValueSetT | _ValueGetT) -> None:
+    def __set__(self, instance: Any, value: ValueSetT | ValueGetT) -> None:
         self.set(instance, value)
 
     @abstractmethod
-    def get(self, instance: Any) -> _ValueGetT:
+    def get(self, instance: Any) -> ValueGetT:
         """
         Get the property value from the instance.
         """
 
-    def set(self, instance: Any, value: _ValueSetT | _ValueGetT) -> _ValueGetT:
+    def set(self, instance: Any, value: ValueSetT | ValueGetT) -> ValueGetT:
         """
         Set the value on the instance.
         """
@@ -104,21 +78,21 @@ class _Property(Attr[_ValueGetT], ABC, Generic[_ValueGetT, _ValueSetT]):
         return resolved_value
 
 
-class Property(_Property[_ValueGetT, _ValueSetT]):
+class Property[ValueGetT, ValueSetT](_Property[ValueGetT, ValueSetT]):
     """
     An object attribute with a definition.
     """
 
     def __init__(
         self,
-        data: DataDefinition[_ValueGetT] | type[Data[DataDefinition[_ValueGetT]]],
+        data: DataDefinition[ValueGetT] | type[Data[DataDefinition[ValueGetT]]],
         *,
         label: ResolvableLocalizable | None = None,
         description: ResolvableLocalizable | None = None,
         omit_load: bool | None = None,
-        omit_dump: Callable[[_ValueGetT], bool] | None = None,
-        resolver: Callable[[_ValueSetT | _ValueGetT], _ValueGetT] = passthrough,
-        default: Callable[[], _ValueGetT] | None = None,
+        omit_dump: Callable[[ValueGetT], bool] | None = None,
+        resolver: Callable[[ValueSetT | ValueGetT], ValueGetT] = passthrough,
+        default: Callable[[], ValueGetT] | None = None,
     ):
         super().__init__(
             AttrDefinition(
@@ -136,9 +110,9 @@ class Property(_Property[_ValueGetT, _ValueSetT]):
         self._default = default
 
     @override
-    def get(self, instance: Any) -> _ValueGetT:
+    def get(self, instance: Any) -> ValueGetT:
         value = cast(
-            _ValueGetT | Void,
+            ValueGetT | Void,
             getattr(instance, self._attr_name, Void()),
         )
         if isinstance(value, Void):
@@ -160,13 +134,13 @@ class PropertyNotInitialized(ValueError):
 
 
 @final
-class Optional(_Property[_ValueGetT | None, _ValueSetT | None]):
+class Optional[ValueGetT, ValueSetT](_Property[ValueGetT | None, ValueSetT | None]):
     """
     Make another property optional, e.g. allow ``None``.
     """
 
-    def __init__(self, required_property: Property[_ValueGetT, _ValueSetT], /):
-        def _omit_dump(data: _ValueGetT | None) -> bool:
+    def __init__(self, required_property: Property[ValueGetT, ValueSetT], /):
+        def _omit_dump(data: ValueGetT | None) -> bool:
             if data is None:
                 return True
             if required_property.attr.omit_dump is None:
@@ -189,14 +163,14 @@ class Optional(_Property[_ValueGetT | None, _ValueSetT | None]):
         self._required_property.__set_name__(owner, name)
 
     @override
-    def get(self, instance: Any) -> _ValueGetT | None:
+    def get(self, instance: Any) -> ValueGetT | None:
         try:
             return self._required_property.get(instance)
         except PropertyNotInitialized:
             return self.set(instance, None)
 
     @override
-    def set(self, instance: Any, value: _ValueSetT | _ValueGetT | None) -> _ValueGetT:
+    def set(self, instance: Any, value: ValueSetT | ValueGetT | None) -> ValueGetT:
         if value is None:
             return super().set(instance, value)
         return self._required_property.set(instance, value)
@@ -211,24 +185,26 @@ class Optional(_Property[_ValueGetT | None, _ValueSetT | None]):
         self.set(instance, None)
 
 
-class MappingProperty(Property[_MutableMappingT, _ValueSetT]):
+class MappingProperty[MutableMappingT: MutableMapping[Any, Any], ValueSetT](
+    Property[MutableMappingT, ValueSetT]
+):
     """
     A property that contains a :py:class:`collections.abc.MutableMapping`.
     """
 
     def __init__(
         self,
-        data: Intersection[DataDefinition[_MutableMappingT], _MappingDefinitionT]
-        | Data[Intersection[DataDefinition[_MutableMappingT], _MappingDefinitionT]],
+        data: Intersection[DataDefinition[MutableMappingT], MappingDefinition]
+        | Data[Intersection[DataDefinition[MutableMappingT], MappingDefinition]],
         *,
         label: ResolvableLocalizable | None = None,
         description: ResolvableLocalizable | None = None,
         omit_load: bool | None = None,
-        omit_dump: Callable[[_MutableMappingT], bool] | None = None,
+        omit_dump: Callable[[MutableMappingT], bool] | None = None,
         resolver: Callable[
-            [_ValueSetT | _MutableMappingT], _MutableMappingT
+            [ValueSetT | MutableMappingT], MutableMappingT
         ] = passthrough,
-        default: Callable[[], _MutableMappingT] | None = None,
+        default: Callable[[], MutableMappingT] | None = None,
     ):
         super().__init__(
             data,
@@ -241,9 +217,7 @@ class MappingProperty(Property[_MutableMappingT, _ValueSetT]):
         )
 
     @override
-    def set(
-        self, instance: Any, value: _ValueSetT | _MutableMappingT
-    ) -> _MutableMappingT:
+    def set(self, instance: Any, value: ValueSetT | MutableMappingT) -> MutableMappingT:
         configurations = self.get(instance)
         configurations.clear()
         resolved_value = self._resolver(value)
@@ -251,24 +225,26 @@ class MappingProperty(Property[_MutableMappingT, _ValueSetT]):
         return resolved_value
 
 
-class SequenceProperty(Property[_MutableSequenceT, _ValueSetT]):
+class SequenceProperty[MutableSequenceT: MutableSequence[Any], ValueSetT](
+    Property[MutableSequenceT, ValueSetT]
+):
     """
     A property that contains a :py:class:`collections.abc.MutableSequence`.
     """
 
     def __init__(
         self,
-        data: Intersection[DataDefinition[_MutableSequenceT], _SequenceDefinitionT]
-        | Data[Intersection[DataDefinition[_MutableSequenceT], _SequenceDefinitionT]],
+        data: Intersection[DataDefinition[MutableSequenceT], SequenceDefinition]
+        | Data[Intersection[DataDefinition[MutableSequenceT], SequenceDefinition]],
         *,
         label: ResolvableLocalizable | None = None,
         description: ResolvableLocalizable | None = None,
         omit_load: bool | None = None,
-        omit_dump: Callable[[_MutableSequenceT], bool] | None = None,
+        omit_dump: Callable[[MutableSequenceT], bool] | None = None,
         resolver: Callable[
-            [_ValueSetT | _MutableSequenceT], _MutableSequenceT
+            [ValueSetT | MutableSequenceT], MutableSequenceT
         ] = passthrough,
-        default: Callable[[], _MutableSequenceT] | None = None,
+        default: Callable[[], MutableSequenceT] | None = None,
     ):
         super().__init__(
             data,
@@ -282,8 +258,8 @@ class SequenceProperty(Property[_MutableSequenceT, _ValueSetT]):
 
     @override
     def set(
-        self, instance: Any, value: _ValueSetT | _MutableSequenceT
-    ) -> _MutableSequenceT:
+        self, instance: Any, value: ValueSetT | MutableSequenceT
+    ) -> MutableSequenceT:
         configurations = self.get(instance)
         configurations.clear()
         resolved_value = self._resolver(value)
@@ -291,26 +267,29 @@ class SequenceProperty(Property[_MutableSequenceT, _ValueSetT]):
         return resolved_value
 
 
-class KeyedCollectionProperty(Property[_MutableKeyedCollectionT, Iterable[_ValueSetT]]):
+class KeyedCollectionProperty[
+    MutableKeyedCollectionT: MutableKeyedCollection,
+    ValueSetT,
+](Property[MutableKeyedCollectionT, Iterable[ValueSetT]]):
     """
     A property that contains a :py:class:`betty.collections.MutableKeyedCollection`.
     """
 
-    def __init__(
+    def __init__[ValueGetT](
         self,
         data: KeyedCollectionDefinition[
             Intersection[
-                _MutableKeyedCollectionT,
-                MutableKeyedCollection[Any, Any, Any, _ValueSetT],
+                MutableKeyedCollectionT,
+                MutableKeyedCollection[Any, Any, ValueGetT, ValueSetT],
             ]
         ],
         *,
         label: ResolvableLocalizable | None = None,
         description: ResolvableLocalizable | None = None,
         omit_load: bool | None = None,
-        omit_dump: Callable[[_MutableKeyedCollectionT], bool] | None = None,
+        omit_dump: Callable[[MutableKeyedCollectionT], bool] | None = None,
         resolver: Callable[
-            [_ValueSetT | _MutableKeyedCollectionT], Iterable[_ValueGetT]
+            [ValueSetT | MutableKeyedCollectionT], Iterable[ValueGetT]
         ] = passthrough,
         default: Callable[[], MutableKeyedCollection] | None = None,
     ):
@@ -326,8 +305,8 @@ class KeyedCollectionProperty(Property[_MutableKeyedCollectionT, Iterable[_Value
 
     @override
     def set(
-        self, instance: Any, value: Iterable[_ValueSetT] | _MutableKeyedCollectionT
-    ) -> _MutableKeyedCollectionT:
+        self, instance: Any, value: Iterable[ValueSetT] | MutableKeyedCollectionT
+    ) -> MutableKeyedCollectionT:
         collection = self.get(instance)
         collection.clear()
         resolved_value = self._resolver(value)

--- a/betty/data/enum.py
+++ b/betty/data/enum.py
@@ -5,7 +5,7 @@ Enumerated data types.
 from __future__ import annotations
 
 from enum import Enum
-from typing import TYPE_CHECKING, TypeVar, final
+from typing import TYPE_CHECKING, final
 
 from betty.data import DataDefinition
 from betty.portable import CallbackPorter
@@ -13,11 +13,9 @@ from betty.portable import CallbackPorter
 if TYPE_CHECKING:
     from betty.locale.localizable import ResolvableLocalizable
 
-_EnumT = TypeVar("_EnumT", bound=Enum)
-
 
 @final
-class EnumDefinition(DataDefinition[_EnumT]):
+class EnumDefinition[EnumT: Enum](DataDefinition[EnumT]):
     """
     An enum data definition.
     """
@@ -25,7 +23,7 @@ class EnumDefinition(DataDefinition[_EnumT]):
     def __init__(
         self,
         *,
-        cls: type[_EnumT],
+        cls: type[EnumT],
         label: ResolvableLocalizable,
         description: ResolvableLocalizable | None = None,
     ):

--- a/betty/data/indicator/selector.py
+++ b/betty/data/indicator/selector.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, final, override
+from typing import TYPE_CHECKING, Any, final, override
 
 from betty.data.indicator import Indicator
 
@@ -14,9 +14,6 @@ if TYPE_CHECKING:
     from collections.abc import Iterator, MutableSequence, Sequence
 
     from betty.assertion import Assertion
-
-_T = TypeVar("_T")
-_ElementT = TypeVar("_ElementT")
 
 
 @final
@@ -42,7 +39,7 @@ class Selector(Indicator, ABC):
             raise SelectorError(self) from error
 
     @final
-    def get(self, data: Any, assertion: Assertion[Any, _T] | None = None, /) -> _T:
+    def get[T](self, data: Any, assertion: Assertion[Any, T] | None = None, /) -> T:
         """
         Get the value for this selector.
 
@@ -140,12 +137,12 @@ class Selectors(Selector):
         self._selectors[-1].delete(data)
 
 
-class Element(Selector, Generic[_ElementT]):
+class Element[ElementT](Selector):
     """
     An aggregate element selector.
     """
 
-    def __init__(self, element: _ElementT, /):
+    def __init__(self, element: ElementT, /):
         self._element = element
 
     def __eq__(self, other: Any) -> bool:
@@ -154,7 +151,7 @@ class Element(Selector, Generic[_ElementT]):
         return self._element == other._element
 
     @property
-    def element(self) -> _ElementT:
+    def element(self) -> ElementT:
         """
         The element.
         """

--- a/betty/date/__init__.py
+++ b/betty/date/__init__.py
@@ -9,7 +9,7 @@ import datetime
 import operator
 from contextlib import suppress
 from functools import total_ordering
-from typing import TYPE_CHECKING, Any, TypeAlias, override
+from typing import TYPE_CHECKING, Any, override
 
 from babel import dates
 
@@ -524,4 +524,4 @@ class DateRange(Localizable):
         )
 
 
-ResolvableDate: TypeAlias = Date | DateRange
+type ResolvableDate = Date | DateRange

--- a/betty/definition/cls.py
+++ b/betty/definition/cls.py
@@ -2,25 +2,23 @@
 Class-based definitions.
 """
 
-from typing import Any, Generic, TypeVar
+from typing import Any
 
 from betty.importlib import fully_qualified_name
 
-_ClsCoT = TypeVar("_ClsCoT", default=object, covariant=True)
 
-
-class ClsDefinition(Generic[_ClsCoT]):
+class ClsDefinition[ClsT = Any]:
     """
     A definition for a Python class.
     """
 
-    def __init__(self, *args: Any, cls: type[_ClsCoT] | None = None, **kwargs: Any):
-        self._cls: type[_ClsCoT] | None = None
+    def __init__(self, *args: Any, cls: type[ClsT] | None = None, **kwargs: Any):
+        self._cls: type[ClsT] | None = None
         if cls is not None:
             self._set_cls(cls)
 
     @property
-    def cls(self) -> type[_ClsCoT]:
+    def cls(self) -> type[ClsT]:
         """
         The class.
 
@@ -31,7 +29,7 @@ class ClsDefinition(Generic[_ClsCoT]):
         assert self._cls is not None
         return self._cls
 
-    def __call__(self, cls: type[_ClsCoT]) -> type[_ClsCoT]:
+    def __call__(self, cls: type[ClsT]) -> type[ClsT]:
         """
         Decorate a class and set it on this definition.
 
@@ -40,7 +38,7 @@ class ClsDefinition(Generic[_ClsCoT]):
         self._set_cls(cls)
         return cls
 
-    def _set_cls(self, cls: type[_ClsCoT]) -> None:
+    def _set_cls(self, cls: type[ClsT]) -> None:
         if self._cls is not None:
             raise ValueError(
                 f"This definition already has a class: {fully_qualified_name(self._cls)}."

--- a/betty/definition/human_facing.py
+++ b/betty/definition/human_facing.py
@@ -4,11 +4,9 @@ Definitions that are human-facing and provide human-friendly information.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any
 
-from betty.locale.localizable import (
-    resolve_localizable,
-)
+from betty.locale.localizable import resolve_localizable
 
 if TYPE_CHECKING:
     from betty.locale.localizable import (
@@ -16,8 +14,6 @@ if TYPE_CHECKING:
         Localizable,
         ResolvableLocalizable,
     )
-
-_BaseClsCoT = TypeVar("_BaseClsCoT", default=object, covariant=True)
 
 
 class HumanFacingDefinition:

--- a/betty/document.py
+++ b/betty/document.py
@@ -20,7 +20,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Self,
-    TypeAlias,
     final,
     override,
 )
@@ -39,7 +38,7 @@ if TYPE_CHECKING:
     from betty.model import Entity
     from betty.project import Project
 
-DocumentVars: TypeAlias = Mapping[str, Any]
+type DocumentVars = Mapping[str, Any]
 
 
 @final

--- a/betty/extension/__init__.py
+++ b/betty/extension/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Generic, TypeVar, final
+from typing import TYPE_CHECKING, final
 
 from betty.definition.human_facing import HumanFacingDefinition
 from betty.life_cycle.manage import ManagedLifeCycle
@@ -20,26 +20,21 @@ if TYPE_CHECKING:
     from betty.locale.localizable import ResolvableLocalizable
     from betty.machine_name import ResolvableMachineName
 
-_T = TypeVar("_T")
-_ServiceLevelCoT = TypeVar(
-    "_ServiceLevelCoT", bound=ServiceLevel, default=ServiceLevel, covariant=True
-)
 
-
-class Extension(
-    ManagedLifeCycle, Plugin["ExtensionDefinition"], Generic[_ServiceLevelCoT]
+class Extension[ServiceLevelT: ServiceLevel](
+    ManagedLifeCycle, Plugin["ExtensionDefinition"]
 ):
     """
     Integrate custom services with a :py:class:`service level <betty.service.level.ServiceLevel>`.
     """
 
     @private
-    def __init__(self, *, services: _ServiceLevelCoT):
+    def __init__(self, *, services: ServiceLevelT):
         super().__init__()
         self._services = services
 
     @property
-    def services(self) -> _ServiceLevelCoT:
+    def services(self) -> ServiceLevelT:
         """
         The service level this extension is attached to.
         """

--- a/betty/extension/_theme/search.py
+++ b/betty/extension/_theme/search.py
@@ -5,7 +5,6 @@ Provide search functionality.
 from __future__ import annotations
 
 import json
-from abc import ABC
 from asyncio import gather
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Generic, TypeVar, final, override
@@ -31,9 +30,6 @@ if TYPE_CHECKING:
     from betty.locale.localize import Localizer
     from betty.machine_name import MachineName
     from betty.project import Project
-
-_EntityT = TypeVar("_EntityT", bound=Entity)
-_EntityCoT = TypeVar("_EntityCoT", bound=Entity, covariant=True)
 
 
 async def generate_search_index(
@@ -86,11 +82,18 @@ async def _generate_search_index_for_locale(
         await f.write(search_index_json)
 
 
-class _EntityTypeIndexer(ABC, Generic[_EntityCoT]):
+_EntityTypeIndexerEntityT = TypeVar(
+    "_EntityTypeIndexerEntityT", bound=Entity, default=Entity, covariant=True
+)
+
+
+class EntityTypeIndexer(Generic[_EntityTypeIndexerEntityT]):
     def __init__(self, project: Project):
         self._project = project
 
-    async def text(self, localizer: Localizer, entity: _EntityCoT) -> set[str]:
+    async def text(
+        self, localizer: Localizer, entity: _EntityTypeIndexerEntityT
+    ) -> set[str]:
         text = {entity.id.lower()}
 
         # Each note is owned by a single other entity, so index it as part of that entity.
@@ -101,7 +104,7 @@ class _EntityTypeIndexer(ABC, Generic[_EntityCoT]):
         return text
 
 
-class _FallbackIndexer(_EntityTypeIndexer[Entity]):
+class _FallbackIndexer(EntityTypeIndexer[Entity]):
     @override
     async def text(self, localizer: Localizer, entity: Entity) -> set[str]:
         text = await super().text(localizer, entity)
@@ -109,7 +112,7 @@ class _FallbackIndexer(_EntityTypeIndexer[Entity]):
         return text
 
 
-class _PersonIndexer(_EntityTypeIndexer[Person]):
+class _PersonIndexer(EntityTypeIndexer[Person]):
     @override
     async def text(self, localizer: Localizer, entity: Person) -> set[str]:
         text = await super().text(localizer, entity)
@@ -121,7 +124,7 @@ class _PersonIndexer(_EntityTypeIndexer[Person]):
         return text
 
 
-class _PlaceIndexer(_EntityTypeIndexer[Place]):
+class _PlaceIndexer(EntityTypeIndexer[Place]):
     @override
     async def text(self, localizer: Localizer, entity: Place) -> set[str]:
         text = await super().text(localizer, entity)
@@ -130,7 +133,7 @@ class _PlaceIndexer(_EntityTypeIndexer[Place]):
         return text
 
 
-class _FileIndexer(_EntityTypeIndexer[File]):
+class _FileIndexer(EntityTypeIndexer[File]):
     @override
     async def text(self, localizer: Localizer, entity: File) -> set[str]:
         text = await super().text(localizer, entity)
@@ -169,7 +172,7 @@ class Index:
         Build the search index.
         """
         entity_types = await self._project.plugins.plugins(EntityDefinition)
-        specialized_indexers: Mapping[type[Entity], _EntityTypeIndexer[Entity]] = {
+        specialized_indexers: Mapping[type[Entity], EntityTypeIndexer[Entity]] = {
             File: _FileIndexer(self._project),
             Person: _PersonIndexer(self._project),
             Place: _PlaceIndexer(self._project),
@@ -194,8 +197,8 @@ class Index:
             if entry is not None
         ]
 
-    async def _build_entities(
-        self, indexer: _EntityTypeIndexer[_EntityT], entity_type: type[_EntityT]
+    async def _build_entities[EntityT: Entity](
+        self, indexer: EntityTypeIndexer[EntityT], entity_type: type[EntityT]
     ) -> Iterable[_Entry | None]:
         return await gather(
             *(
@@ -204,8 +207,8 @@ class Index:
             )
         )
 
-    async def _build_entity(
-        self, indexer: _EntityTypeIndexer[_EntityT], entity: _EntityT
+    async def _build_entity[EntityT: Entity](
+        self, indexer: EntityTypeIndexer[EntityT], entity: EntityT
     ) -> _Entry | None:
         if is_private(entity):
             return None

--- a/betty/extension/gramps/__init__.py
+++ b/betty/extension/gramps/__init__.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from betty.ancestry import Ancestry
-    from betty.job import Context
     from betty.job.scheduler import Scheduler
     from betty.project import Project
     from betty.service.level import ServiceLevel
@@ -344,7 +343,7 @@ class Gramps(
         )
 
     @override
-    async def load(self, scheduler: Scheduler[Context]) -> None:
+    async def load(self, scheduler: Scheduler) -> None:
         for family_tree in self._family_trees:
             await scheduler.add(
                 LoadAncestry(
@@ -353,9 +352,9 @@ class Gramps(
                         services=self._services,
                         attribute_prefix_key=self._attribute_prefix_key,
                         user=self._user,
-                        event_type_mapping=family_tree.event_types,  # ty:ignore[invalid-argument-type]
-                        place_type_mapping=family_tree.place_types,  # ty:ignore[invalid-argument-type]
-                        presence_role_mapping=family_tree.presence_roles,  # ty:ignore[invalid-argument-type]
+                        event_type_mapping=family_tree.event_types,
+                        place_type_mapping=family_tree.place_types,
+                        presence_role_mapping=family_tree.presence_roles,
                         executable=self._executable,
                     ),
                     source=family_tree.source,

--- a/betty/extension/gramps/data.py
+++ b/betty/extension/gramps/data.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, MutableMapping
 from pathlib import Path
-from typing import TYPE_CHECKING, TypeVar, final
+from typing import TYPE_CHECKING, final
 
 from betty.collections import MutableResolvedMapping, MutableResolvedMappingProxy
 from betty.data import Data, Sample
@@ -48,24 +48,20 @@ if TYPE_CHECKING:
     from betty.locale.localizable import ResolvableLocalizable
     from betty.place_type import PlaceType
     from betty.presence_role import PresenceRole
-_PluginT = TypeVar("_PluginT", bound=Plugin, default=Plugin)
-_PluginDefinitionT = TypeVar(
-    "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
-)
 
 
-class _PluginMappingProperty(
+class _PluginMappingProperty[PluginDefinitionT: PluginDefinition, PluginT: Plugin](
     MappingProperty[
-        MutableMapping[str, PluginConfiguration[_PluginDefinitionT, _PluginT]],
-        Mapping[str, ResolvablePluginConfiguration[_PluginDefinitionT, _PluginT]],
+        MutableMapping[str, PluginConfiguration[PluginDefinitionT, PluginT]],
+        Mapping[str, ResolvablePluginConfiguration[PluginDefinitionT, PluginT]],
     ]
 ):
     def __init__(
         self,
-        plugin_type: type[_PluginDefinitionT],
+        plugin_type: type[PluginDefinitionT],
         gramps_label: ResolvableLocalizable,
         default: Mapping[
-            str, ResolvablePluginConfiguration[_PluginDefinitionT, _PluginT]
+            str, ResolvablePluginConfiguration[PluginDefinitionT, PluginT]
         ],
     ):
         super().__init__(
@@ -80,7 +76,7 @@ class _PluginMappingProperty(
                 label=plugin_type.type().label_plural,
             ),
             default=lambda: MutableResolvedMappingProxy(
-                resolve_plugin_configuration_mapping(default),  # ty:ignore[invalid-argument-type]
+                resolve_plugin_configuration_mapping(default),
                 value_resolver=resolve_plugin_configuration,
             ),
         )
@@ -103,9 +99,7 @@ class FamilyTree(Data):
     """
 
     event_types = _PluginMappingProperty(
-        EventTypeDefinition,
-        _("Gramps event type"),
-        DEFAULT_EVENT_TYPE_MAPPING,  # ty:ignore[invalid-argument-type]
+        EventTypeDefinition, _("Gramps event type"), DEFAULT_EVENT_TYPE_MAPPING
     )
     """
     How to map event types.
@@ -122,18 +116,14 @@ class FamilyTree(Data):
     """
 
     place_types = _PluginMappingProperty(
-        PlaceTypeDefinition,
-        _("Gramps place type"),
-        DEFAULT_PLACE_TYPE_MAPPING,  # ty:ignore[invalid-argument-type]
+        PlaceTypeDefinition, _("Gramps place type"), DEFAULT_PLACE_TYPE_MAPPING
     )
     """
     How to map place types.
     """
 
     presence_roles = _PluginMappingProperty(
-        PresenceRoleDefinition,
-        _("Gramps role"),
-        DEFAULT_PRESENCE_ROLE_MAPPING,  # ty:ignore[invalid-argument-type]
+        PresenceRoleDefinition, _("Gramps role"), DEFAULT_PRESENCE_ROLE_MAPPING
     )
     """
     How to map presence roles.

--- a/betty/extension/gramps/jobs.py
+++ b/betty/extension/gramps/jobs.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, override
 
-from betty.job import Context, Job
+from betty.job import Job
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from betty.job.scheduler import Scheduler
 
 
-class LoadAncestry(Job[Context]):
+class LoadAncestry(Job):
     """
     Load Gramps data into an ancestry.
     """
@@ -33,7 +33,7 @@ class LoadAncestry(Job[Context]):
         return f"gramps:load-ancestry:{id(type(source))}:{str(source)}"
 
     @override
-    async def do(self, scheduler: Scheduler[Context], /) -> None:
+    async def do(self, scheduler: Scheduler, /) -> None:
         if isinstance(self._source, str):
             await self._loader.load_name(self._source)
         else:

--- a/betty/extension/raspberry_mint/content_provider.py
+++ b/betty/extension/raspberry_mint/content_provider.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from asyncio import gather
 from collections.abc import Iterable, Mapping, Sequence
-from typing import TYPE_CHECKING, Self, TypeAlias, final, override
+from typing import TYPE_CHECKING, Self, final, override
 
 from betty.ancestry.citation import Citation
 from betty.ancestry.event import Event
@@ -189,11 +189,7 @@ class Section(Template, DataManufacturable[SectionConfiguration]):
     async def new(cls, project: Project, data: SectionConfiguration, /) -> Self:
         await require_extension(RaspberryMint, project)
         return cls(
-            content=await new_plugins(  # ty:ignore[invalid-argument-type]
-                project,
-                ContentProviderDefinition,
-                data.content,  # ty:ignore[invalid-argument-type]
-            ),
+            content=await new_plugins(project, ContentProviderDefinition, data.content),
             heading=data.heading,
             jinja=await project.jinja,
             name=data.name,
@@ -406,11 +402,7 @@ class ColorStyle(Template, DataManufacturable[ColorStyleConfiguration]):
     async def new(cls, project: Project, data: ColorStyleConfiguration, /) -> Self:
         await require_extension(RaspberryMint, project)
         return cls(
-            content=await new_plugins(  # ty:ignore[invalid-argument-type]
-                project,
-                ContentProviderDefinition,
-                data.content,  # ty:ignore[invalid-argument-type]
-            ),
+            content=await new_plugins(project, ContentProviderDefinition, data.content),
             jinja=await project.jinja,
             style=data.style,
         )
@@ -634,8 +626,8 @@ class Presences(Template, DataManufacturable[PresencesConfiguration], Manufactur
         return None
 
 
-ColumnsWidth: TypeAlias = Mapping[Breakpoint, Sequence[int]]
-ShorthandColumnsWidth: TypeAlias = (
+type ColumnsWidth = Mapping[Breakpoint, Sequence[int]]
+type ShorthandColumnsWidth = (
     int | Sequence[int] | Mapping[Breakpoint, int] | ColumnsWidth
 )
 

--- a/betty/extension/raspberry_mint/data.py
+++ b/betty/extension/raspberry_mint/data.py
@@ -5,7 +5,7 @@ Data for the Raspberry Mint extension.
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
-from typing import TYPE_CHECKING, TypeAlias, final
+from typing import TYPE_CHECKING, final
 
 from betty.color import ColorDefinition
 from betty.content_provider import ContentProvider, ContentProviderDefinition
@@ -29,7 +29,7 @@ from betty.service.requirement.extension import require_extension
 if TYPE_CHECKING:
     from betty.extension.raspberry_mint import RaspberryMint
 
-ResolvableRegionalContent: TypeAlias = Mapping[
+type ResolvableRegionalContent = Mapping[
     str,
     Iterable[ResolvablePluginConfiguration[ContentProviderDefinition, ContentProvider]],
 ]

--- a/betty/extension/webpack/build.py
+++ b/betty/extension/webpack/build.py
@@ -7,12 +7,11 @@ from __future__ import annotations
 import json
 from abc import abstractmethod
 from asyncio import gather, to_thread
-from collections.abc import Sequence
 from json import dumps, loads
 from os import walk
 from pathlib import Path
 from shutil import copy2, copytree
-from typing import TYPE_CHECKING, TypeVar, cast
+from typing import TYPE_CHECKING, cast
 
 import aiofiles
 from aiofiles.os import makedirs
@@ -34,12 +33,8 @@ if TYPE_CHECKING:
 
 _NPM_PROJECT_DIRECTORIES_PATH = Path(__file__).parent / "webpack"
 
-_ServiceLevelCoT = TypeVar(
-    "_ServiceLevelCoT", bound=ServiceLevel, default=ServiceLevel, covariant=True
-)
 
-
-class EntryPointProvider(Extension[_ServiceLevelCoT]):
+class EntryPointProvider[ServiceLevelT: ServiceLevel](Extension[ServiceLevelT]):
     """
     An extension that provides Webpack entry points.
     """

--- a/betty/functools.py
+++ b/betty/functools.py
@@ -8,7 +8,7 @@ import contextlib
 from asyncio import sleep
 from itertools import chain
 from time import time
-from typing import TYPE_CHECKING, Any, Generic, ParamSpec, TypeVar, final
+from typing import TYPE_CHECKING, Any, final
 
 from betty.asyncio import resolve_await
 from betty.typing import Void
@@ -16,17 +16,13 @@ from betty.typing import Void
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Iterable, Iterator
 
-_T = TypeVar("_T")
-_U = TypeVar("_U")
-_P = ParamSpec("_P")
 
-
-def map_suppress(
-    raising_map: Callable[[_T], _U],
+def map_suppress[T, U](
+    raising_map: Callable[[T], U],
     exception_type: type[BaseException],
-    items: Iterable[_T],
+    items: Iterable[T],
     /,
-) -> Iterator[_U]:
+) -> Iterator[U]:
     """
     Map values, skipping those for which the application of `raising_map` raises errors.
     """
@@ -37,20 +33,16 @@ def map_suppress(
             continue
 
 
-_DoFReturnT = TypeVar("_DoFReturnT")
-_DoFP = ParamSpec("_DoFP")
-
-
-class Do(Generic[_DoFP, _DoFReturnT]):
+class Do[**DoFP, DoFReturnT]:
     """
     A functional implementation of do-while functionality, with retries and timeouts.
     """
 
     def __init__(
         self,
-        do: Callable[_DoFP, _DoFReturnT | Awaitable[_DoFReturnT]],
-        *do_args: _DoFP.args,
-        **do_kwargs: _DoFP.kwargs,
+        do: Callable[DoFP, DoFReturnT | Awaitable[DoFReturnT]],
+        *do_args: DoFP.args,
+        **do_kwargs: DoFP.kwargs,
     ):
         self._do = do
         self._do_args = do_args
@@ -58,11 +50,11 @@ class Do(Generic[_DoFP, _DoFReturnT]):
 
     async def until(
         self,
-        *conditions: Callable[[_DoFReturnT], None | bool | Awaitable[None | bool]],
+        *conditions: Callable[[DoFReturnT], None | bool | Awaitable[None | bool]],
         retries: int = 5,
         timeout: int = 300,
         interval: int | float = 0.1,
-    ) -> _DoFReturnT:
+    ) -> DoFReturnT:
         """
         Perform the 'do' until it succeeds or as long as the given arguments allow.
 
@@ -91,13 +83,9 @@ class Do(Generic[_DoFP, _DoFReturnT]):
                 return do_result
 
 
-_ValueT = TypeVar("_ValueT")
-_KeyT = TypeVar("_KeyT")
-
-
-def unique(
-    *values: Iterable[_ValueT], key: Callable[[_ValueT], Any] | None = None
-) -> Iterator[_ValueT]:
+def unique[ValueT](
+    *values: Iterable[ValueT], key: Callable[[ValueT], Any] | None = None
+) -> Iterator[ValueT]:
     """
     Yield the first occurrences of values in a sequence.
 
@@ -116,21 +104,21 @@ def unique(
             yield value
 
 
-def passthrough(value: _T, /) -> _T:
+def passthrough[T](value: T, /) -> T:
     """
     Return the value.
     """
     return value
 
 
-def suppress(
-    target: Callable[_P, _T], *exceptions: type[BaseException]
-) -> Callable[_P, _T | Void]:
+def suppress[**P, T](
+    target: Callable[P, T], *exceptions: type[BaseException]
+) -> Callable[P, T | Void]:
     """
     Return the value, but suppress any errors.
     """
 
-    def _suppress(*target_args: _P.args, **target_kwargs: _P.kwargs) -> _T | Void:
+    def _suppress(*target_args: P.args, **target_kwargs: P.kwargs) -> T | Void:
         with contextlib.suppress(*exceptions):
             return target(*target_args, **target_kwargs)
         return Void()
@@ -150,19 +138,19 @@ class ResultUnavailable(RuntimeError):
 
 
 @final
-class Result(Generic[_P, _T]):
+class Result[**P, T]:
     """
     Decorate a callable and store its return value or raised exception.
     """
 
     __slots__ = "_error", "_result", "_target"
     _error: BaseException
-    _result: _T
+    _result: T
 
-    def __init__(self, target: Callable[_P, _T], /):
+    def __init__(self, target: Callable[P, T], /):
         self._target = target
 
-    def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _T:
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T:
         """
         Call the target.
         """
@@ -173,7 +161,7 @@ class Result(Generic[_P, _T]):
             self._error = error
             raise
 
-    def result(self) -> _T:
+    def result(self) -> T:
         """
         Get the target's return value.
 

--- a/betty/gramps/loader.py
+++ b/betty/gramps/loader.py
@@ -14,7 +14,7 @@ from contextlib import ExitStack, suppress
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Generic, TypeVar, cast, final, override
+from typing import TYPE_CHECKING, cast, final, override
 from uuid import uuid4
 from xml.etree.ElementTree import tostring
 
@@ -106,7 +106,7 @@ from betty.plugin.config import (
     resolve_plugin_configuration_mapping,
 )
 from betty.plugin.error import PluginUnavailable
-from betty.presence_role import PresenceRole, PresenceRoleDefinition
+from betty.presence_role import PresenceRoleDefinition
 from betty.presence_role.presence_roles import (
     Attendee,
     Celebrant,
@@ -144,11 +144,6 @@ if TYPE_CHECKING:
     from betty.presence_role import PresenceRole
     from betty.service.level import ServiceLevel
     from betty.user import User
-
-_T = TypeVar("_T")
-_EntityT = TypeVar("_EntityT", bound=Entity)
-_PluginT = TypeVar("_PluginT", bound=Plugin)
-_PluginDefinitionT = TypeVar("_PluginDefinitionT", bound=PluginDefinition)
 
 
 class LoaderUsedAlready(GrampsError):
@@ -196,25 +191,25 @@ class GrampsEntityReference:
         return f"{self.entity_type.value} ({self.entity_id})"
 
 
-class _ToOneResolver(ToOneResolver[_EntityT], Generic[_EntityT]):
+class _ToOneResolver[EntityT: Entity](ToOneResolver[EntityT]):
     def __init__(self, handles_to_entities: Mapping[str, Entity], handle: str):
         self._handles_to_entities = handles_to_entities
         self._handle = handle
 
     @override
-    def resolve(self) -> _EntityT:
-        return cast(_EntityT, self._handles_to_entities[self._handle])
+    def resolve(self) -> EntityT:
+        return cast(EntityT, self._handles_to_entities[self._handle])
 
 
-class _ToManyResolver(ToManyResolver[_EntityT], Generic[_EntityT]):
+class _ToManyResolver[EntityT: Entity](ToManyResolver[EntityT]):
     def __init__(self, handles_to_entities: Mapping[str, Entity], *handles: str):
         self._handles_to_entities = handles_to_entities
         self._handles = handles
 
     @override
-    def resolve(self) -> Iterable[_EntityT]:
+    def resolve(self) -> Iterable[EntityT]:
         for handle in self._handles:
-            yield cast(_EntityT, self._handles_to_entities[handle])
+            yield cast(EntityT, self._handles_to_entities[handle])
 
 
 DEFAULT_GENDER_MAPPING: Mapping[
@@ -322,12 +317,16 @@ _GRAMPS_EXTENSIONS_IMPORT = (
 _GRAMPS_EXTENSIONS = (*_GRAMPS_EXTENSIONS_NATIVE, *_GRAMPS_EXTENSIONS_IMPORT)
 
 
-def _resolve_plugin_configuration_mapping(
+def _resolve_plugin_configuration_mapping[
+    T,
+    PluginDefinitionT: PluginDefinition,
+    PluginT: Plugin,
+](
     plugin_configurations: Mapping[
-        _T, ResolvablePluginConfiguration[_PluginDefinitionT, _PluginT]
+        T, ResolvablePluginConfiguration[PluginDefinitionT, PluginT]
     ]
     | None,
-) -> MutableMapping[_T, PluginConfiguration[_PluginDefinitionT, _PluginT]]:
+) -> MutableMapping[T, PluginConfiguration[PluginDefinitionT, PluginT]]:
     if plugin_configurations is None:
         return {}
     return resolve_plugin_configuration_mapping(plugin_configurations)
@@ -377,7 +376,7 @@ class GrampsLoader:
             event_type_mapping
         )
         self._gender_mapping = resolve_plugin_configuration_mapping(
-            DEFAULT_GENDER_MAPPING  # ty:ignore[invalid-argument-type]
+            DEFAULT_GENDER_MAPPING
         )
         self._place_type_mapping = _resolve_plugin_configuration_mapping(
             place_type_mapping
@@ -626,14 +625,14 @@ class GrampsLoader:
             return False
         return not version[2] < self._SUPPORTED_GRAMPS_XML_VERSION[2]
 
-    def _resolve1(
-        self, entity_type: type[_EntityT], handle: str
-    ) -> _ToOneResolver[_EntityT]:
+    def _resolve1[EntityT: Entity](
+        self, entity_type: type[EntityT], handle: str
+    ) -> _ToOneResolver[EntityT]:
         return _ToOneResolver(self._handles_to_entities, handle)
 
-    def _resolve(
-        self, entity_type: type[_EntityT], *handles: str
-    ) -> _ToManyResolver[_EntityT]:
+    def _resolve[EntityT: Entity](
+        self, entity_type: type[EntityT], *handles: str
+    ) -> _ToManyResolver[EntityT]:
         return _ToManyResolver(self._handles_to_entities, *handles)
 
     def _add_entity(self, entity: Entity, handle: str | None = None) -> None:
@@ -862,7 +861,7 @@ class GrampsLoader:
                 )
                 gender = None
 
-        person = Person(id=element.get("id"), gender=gender)  # ty:ignore[invalid-argument-type]
+        person = Person(id=element.get("id"), gender=gender)
 
         name_elements = sorted(
             self._xpath(element, "./ns:name"), key=lambda x: x.get("alt") == "1"
@@ -1327,7 +1326,7 @@ class GrampsLoader:
             )
         )
 
-    _STATIC_TRANSLATION_ATTRIBUTE_SUFFIX_PATTERN = re.compile(r"^:[^:]+$")
+    _STATICTRANSLATION_ATTRIBUTE_SUFFIX_PATTERN = re.compile(r"^:[^:]+$")
 
     async def _parse_attribute_static_translations(
         self, element: ElementTree.Element, tag: str, name: str
@@ -1340,7 +1339,7 @@ class GrampsLoader:
             if attribute_key == name:
                 translations[None] = attribute_value
             elif (
-                self._STATIC_TRANSLATION_ATTRIBUTE_SUFFIX_PATTERN.fullmatch(
+                self._STATICTRANSLATION_ATTRIBUTE_SUFFIX_PATTERN.fullmatch(
                     attribute_key[name_length:]
                 )
                 is not None

--- a/betty/html/attributes.py
+++ b/betty/html/attributes.py
@@ -8,11 +8,9 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping, MutableMapping, MutableSequence, Sequence
 from typing import (
     Any,
-    Generic,
     NotRequired,
     Self,
     TypedDict,
-    TypeVar,
     Unpack,
     cast,
     final,
@@ -20,16 +18,10 @@ from typing import (
     override,
 )
 
-from betty.string import (
-    kebab_case_to_snake_case,
-    snake_case_to_kebab_case,
-)
-
-_AttributeGetT = TypeVar("_AttributeGetT")
-_AttributeSetT = TypeVar("_AttributeSetT")
+from betty.string import kebab_case_to_snake_case, snake_case_to_kebab_case
 
 
-class _Attribute(Generic[_AttributeGetT, _AttributeSetT], ABC):
+class _Attribute[AttributeGetT, AttributeSetT](ABC):
     def __init__(self, html_name: str):
         self._html_name = html_name
         self._attr_name = f"html_{kebab_case_to_snake_case(html_name)}"
@@ -39,41 +31,41 @@ class _Attribute(Generic[_AttributeGetT, _AttributeSetT], ABC):
         pass
 
     @overload
-    def __get__(self, instance: Attributes, owner: type[Attributes]) -> _AttributeGetT:
+    def __get__(self, instance: Attributes, owner: type[Attributes]) -> AttributeGetT:
         pass
 
     def __get__(
         self, instance: Attributes | None, owner: type[Attributes]
-    ) -> _AttributeGetT | Self:
+    ) -> AttributeGetT | Self:
         if instance is None:
             return self
         return self.get(instance)
 
-    def get(self, instance: Attributes) -> _AttributeGetT:
+    def get(self, instance: Attributes) -> AttributeGetT:
         try:
-            return cast(_AttributeGetT, instance._attributes[self._attr_name])
+            return cast(AttributeGetT, instance._attributes[self._attr_name])
         except KeyError:
             value = self._new_default()
             instance._attributes[self._attr_name] = value
             return value
 
-    def __set__(self, instance: Attributes, value: _AttributeSetT) -> None:
+    def __set__(self, instance: Attributes, value: AttributeSetT) -> None:
         self.set(instance, value)
 
     @abstractmethod
-    def set(self, instance: Attributes, value: _AttributeSetT) -> None:
+    def set(self, instance: Attributes, value: AttributeSetT) -> None:
         pass
 
-    def setdefault(self, instance: Attributes, value: _AttributeSetT) -> None:
+    def setdefault(self, instance: Attributes, value: AttributeSetT) -> None:
         if self._attr_name not in instance._attributes:
             self.set(instance, value)
 
     @abstractmethod
-    def _new_default(self) -> _AttributeGetT:
+    def _new_default(self) -> AttributeGetT:
         pass
 
     @abstractmethod
-    def format(self, value: _AttributeGetT) -> str:
+    def format(self, value: AttributeGetT) -> str:
         """
         Format the attribute to a string.
         """

--- a/betty/image.py
+++ b/betty/image.py
@@ -4,7 +4,6 @@ Manipulate images.
 
 import math
 from pathlib import Path
-from typing import TypeAlias
 
 from PIL import UnidentifiedImageError
 from PIL.Image import EXTENSION, Image, init, preinit
@@ -12,12 +11,12 @@ from PIL.Image import EXTENSION, Image, init, preinit
 from betty.media_type import MediaType
 from betty.media_type.media_types import PDF
 
-Percentage: TypeAlias = int
-Pixel: TypeAlias = int
-OneDimensionalSize: TypeAlias = tuple[Pixel, None] | tuple[None, Pixel]
-TwoDimensionalSize: TypeAlias = tuple[Pixel, Pixel]
-Size: TypeAlias = OneDimensionalSize | TwoDimensionalSize
-FocusArea: TypeAlias = tuple[Percentage, Percentage, Percentage, Percentage]
+type Percentage = int
+type Pixel = int
+type OneDimensionalSize = tuple[Pixel, None] | tuple[None, Pixel]
+type TwoDimensionalSize = tuple[Pixel, Pixel]
+type Size = OneDimensionalSize | TwoDimensionalSize
+type FocusArea = tuple[Percentage, Percentage, Percentage, Percentage]
 
 
 def is_supported_media_type(media_type: MediaType) -> bool:

--- a/betty/jinja/__init__.py
+++ b/betty/jinja/__init__.py
@@ -8,7 +8,7 @@ import datetime
 from collections.abc import Awaitable, Callable, Mapping, MutableMapping
 from pathlib import Path
 from shutil import copy2
-from typing import TYPE_CHECKING, Any, Self, TypeAlias, cast, override
+from typing import TYPE_CHECKING, Any, Self, cast, override
 
 import aiofiles
 from aiofiles.os import makedirs
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
     from betty.project import Project
 
 
-CopyFunction: TypeAlias = Callable[[Path, Path], Awaitable[None]]
+type CopyFunction = Callable[[Path, Path], Awaitable[None]]
 
 
 def context_project(context: JinjaContext) -> Project:
@@ -92,9 +92,9 @@ def context_localizer(context: JinjaContext) -> Localizer:
         ) from None
 
 
-Globals: TypeAlias = Mapping[str, Any]
-Filters: TypeAlias = Mapping[str, Callable[..., Any]]
-Tests: TypeAlias = Mapping[str, Callable[..., bool]]
+type Globals = Mapping[str, Any]
+type Filters = Mapping[str, Callable[..., Any]]
+type Tests = Mapping[str, Callable[..., bool]]
 
 
 class JinjaProvider:
@@ -340,7 +340,7 @@ class Environment(Manufacturable, JinjaEnvironment):
         return _copy_function
 
 
-_CacheExtensionMap: TypeAlias = MutableMapping[str, str]
+type _CacheExtensionMap = MutableMapping[str, str]
 
 
 class _CacheTagExtension(JinjaExtension):

--- a/betty/jinja/filter.py
+++ b/betty/jinja/filter.py
@@ -10,7 +10,7 @@ import warnings
 from asyncio import get_running_loop, run
 from contextlib import suppress
 from io import BytesIO
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
 
 import aiofiles
@@ -77,8 +77,6 @@ if TYPE_CHECKING:
     from betty.locale.localizable import Localizable
     from betty.plugin.config import PluginConfiguration
 
-_T = TypeVar("_T")
-
 
 @pass_context
 async def filter_url(
@@ -115,7 +113,7 @@ def filter_localize(
     return localizable.localize(context_localizer(context))
 
 
-_CHARACTER_ORDER_TO_HTML_LANG_MAP = {
+_CHARACTER_ORDERTO_HTML_LANG_MAP = {
     "left-to-right": "ltr",
     "right-to-left": "rtl",
 }
@@ -134,13 +132,13 @@ def filter_html_lang(context: Context, has_locale: str) -> str | Markup:
     localizer = context_localizer(context)
     result: str | Markup = has_locale
     if has_locale.locale != localizer.locale:
-        localizer_dir = _CHARACTER_ORDER_TO_HTML_LANG_MAP[
+        localizer_dir = _CHARACTER_ORDERTO_HTML_LANG_MAP[
             localizer.locale.character_order
         ]
         if has_locale.locale is None:
             has_locale_dir = "auto"
         else:
-            has_locale_dir = _CHARACTER_ORDER_TO_HTML_LANG_MAP[
+            has_locale_dir = _CHARACTER_ORDERTO_HTML_LANG_MAP[
                 has_locale.locale.character_order
             ]
         dir_attribute = (
@@ -166,7 +164,9 @@ def filter_json_load(data: str) -> Any:
     return stdjson.loads(data)
 
 
-async def filter_flatten(values_of_values: Iterable[Iterable[_T]]) -> AsyncIterator[_T]:
+async def filter_flatten[T](
+    values_of_values: Iterable[Iterable[T]],
+) -> AsyncIterator[T]:
     """
     Flatten an iterable of iterables into a single iterable.
     """
@@ -195,7 +195,7 @@ def filter_format_degrees(degrees: int) -> str:
     return DEGREES_FORMAT % format_dict
 
 
-async def filter_unique(values: Iterable[_T]) -> AsyncIterator[_T]:
+async def filter_unique[T](values: Iterable[T]) -> AsyncIterator[T]:
     """
     Iterate over an iterable of values and only yield those values that have not been yielded before.
     """

--- a/betty/jinja/test.py
+++ b/betty/jinja/test.py
@@ -4,7 +4,7 @@ Provide Betty's default Jinja2 tests.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any
 
 from betty.ancestry.has_citations import HasCitations
 from betty.ancestry.has_file_references import HasFileReferences
@@ -25,8 +25,6 @@ if TYPE_CHECKING:
 
     from betty.machine_name import MachineName
     from betty.media_type import MediaType
-
-_PluginDefinitionT = TypeVar("_PluginDefinitionT", bound=PluginDefinition)
 
 
 def test_linked_data_dumpable(value: Any) -> bool:

--- a/betty/job/__init__.py
+++ b/betty/job/__init__.py
@@ -6,15 +6,13 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Generic, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from betty.cache.memory import MemoryCache
 from betty.progress.no_op import NoOpProgress
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
-
     from betty.cache import Cache
     from betty.job.scheduler import Scheduler
     from betty.progress import Progress
@@ -64,11 +62,7 @@ class Context:
         return self._progress
 
 
-_ContextCoT = TypeVar("_ContextCoT", bound=Context, covariant=True)
-JobFunction: TypeAlias = "Callable[[Job[_ContextCoT]], Awaitable[None]]"
-
-
-class Job(ABC, Generic[_ContextCoT]):
+class Job[ContextT: Context = Context](ABC):
     """
     A job.
     """
@@ -116,7 +110,7 @@ class Job(ABC, Generic[_ContextCoT]):
         return self._priority
 
     @abstractmethod
-    async def do(self, scheduler: Scheduler[_ContextCoT], /) -> None:
+    async def do(self, scheduler: Scheduler[ContextT], /) -> None:
         """
         Do the job.
         """

--- a/betty/job/executor/__init__.py
+++ b/betty/job/executor/__init__.py
@@ -5,14 +5,10 @@ Job execution.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Self, TypeVar
-
-from betty.job import Context
+from typing import TYPE_CHECKING, Self
 
 if TYPE_CHECKING:
     from types import TracebackType
-
-_ContextCoT = TypeVar("_ContextCoT", bound=Context, covariant=True)
 
 
 class Executor(ABC):

--- a/betty/job/executor/asyncio.py
+++ b/betty/job/executor/asyncio.py
@@ -6,16 +6,13 @@ from __future__ import annotations
 
 from asyncio import CancelledError, Task, as_completed, get_running_loop
 from contextlib import suppress
-from typing import TYPE_CHECKING, TypeVar, final, override
+from typing import TYPE_CHECKING, final, override
 
-from betty.job import Context
 from betty.job.executor import Executor
 from betty.job.scheduler import Cancelled, Completed
 
 if TYPE_CHECKING:
     from betty.job.scheduler import Scheduler
-
-_ContextCoT = TypeVar("_ContextCoT", bound=Context, covariant=True)
 
 
 @final
@@ -24,7 +21,7 @@ class AsyncExecutor(Executor):
     A job executor using async/await.
     """
 
-    def __init__(self, scheduler: Scheduler[_ContextCoT], *, concurrency: int = 1):
+    def __init__(self, scheduler: Scheduler, *, concurrency: int = 1):
         assert concurrency > 0
         self._scheduler = scheduler
         self._concurrency = concurrency

--- a/betty/job/executor/threading.py
+++ b/betty/job/executor/threading.py
@@ -18,8 +18,6 @@ if TYPE_CHECKING:
     from collections.abc import MutableSequence
     from concurrent.futures import Future
 
-    from betty.job import Context
-
 
 @final
 class ThreadPoolExecutor(Executor):
@@ -29,7 +27,7 @@ class ThreadPoolExecutor(Executor):
 
     def __init__(
         self,
-        scheduler: Scheduler[Context],
+        scheduler: Scheduler,
         *,
         async_concurrency: int = 1,
         threading_concurrency: int = 1,

--- a/betty/job/scheduler/__init__.py
+++ b/betty/job/scheduler/__init__.py
@@ -6,15 +6,15 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable, Sequence
-from typing import TYPE_CHECKING, Generic, Self, TypeAlias, final
+from typing import TYPE_CHECKING, Self, final
 
-from betty.job import Job, _ContextCoT
+from betty.job import Context, Job
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
     from types import TracebackType
 
-ScheduledJobBatch: TypeAlias = Callable[[], Awaitable[None]]
+type ScheduledJobBatch = Callable[[], Awaitable[None]]
 """
 A callable to call one or more jobs.
 
@@ -81,23 +81,23 @@ class Completed(Closed):
     """
 
 
-class Scheduler(ABC, Generic[_ContextCoT]):
+class Scheduler[ContextT: Context = Context](ABC):
     """
     A job scheduler.
     """
 
-    def __init__(self, context: _ContextCoT, /):
+    def __init__(self, context: ContextT, /):
         self._context = context
 
     @property
-    def context(self) -> _ContextCoT:
+    def context(self) -> ContextT:
         """
         The context for all jobs in this scheduler.
         """
         return self._context
 
     @abstractmethod
-    async def add(self, *jobs: Job[_ContextCoT]) -> None:
+    async def add(self, *jobs: Job[ContextT]) -> None:
         """
         Add a new job.
         """

--- a/betty/job/scheduler/default.py
+++ b/betty/job/scheduler/default.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from collections.abc import Iterable
 from contextlib import asynccontextmanager
 from graphlib import CycleError, TopologicalSorter
-from typing import TYPE_CHECKING, Generic, TypeVar, cast, final, override
+from typing import TYPE_CHECKING, cast, final, override
 
 from betty.classtools import Singleton
 from betty.concurrent import AsynchronizedLock, backoff
@@ -39,16 +39,13 @@ if TYPE_CHECKING:
     from betty.user import User
 
 
-_ContextCoT = TypeVar("_ContextCoT", bound=Context, covariant=True)
-
-
-class _ScheduledJobBatch:
+class _ScheduledJobBatch[ContextT: Context]:
     def __init__(
         self,
-        scheduler: Scheduler[_ContextCoT],
+        scheduler: Scheduler[ContextT],
         user: User,
         done: Callable[[Sequence[str]], Awaitable[None]],
-        jobs: Sequence[Job[_ContextCoT]],
+        jobs: Sequence[Job[ContextT]],
         /,
     ):
         self._scheduler = scheduler
@@ -74,14 +71,14 @@ class _UnknownJob(Singleton):
 
 @final
 @threadsafe
-class DefaultScheduler(Scheduler[_ContextCoT], Generic[_ContextCoT]):
+class DefaultScheduler[ContextT: Context](Scheduler[ContextT]):
     """
     Betty's default job scheduler.
     """
 
     def __init__(
         self,
-        context: _ContextCoT,
+        context: ContextT,
         *,
         progress: Progress,
         user: User,
@@ -94,7 +91,7 @@ class DefaultScheduler(Scheduler[_ContextCoT], Generic[_ContextCoT]):
         self._cancelled = False
         self._cancelled_reason: BaseException | None = None
         self._completed = False
-        self._jobs: MutableMapping[str, Job[_ContextCoT] | _UnknownJob] = defaultdict(
+        self._jobs: MutableMapping[str, Job[ContextT] | _UnknownJob] = defaultdict(
             _UnknownJob
         )
         self._job_dependencies: MutableMapping[str, set[str]] = defaultdict(set)
@@ -106,7 +103,7 @@ class DefaultScheduler(Scheduler[_ContextCoT], Generic[_ContextCoT]):
 
     @override
     @property
-    def context(self) -> _ContextCoT:
+    def context(self) -> ContextT:
         return self._context
 
     def _is_open(self) -> bool:
@@ -127,7 +124,7 @@ class DefaultScheduler(Scheduler[_ContextCoT], Generic[_ContextCoT]):
             raise Completed
 
     @override
-    async def add(self, *jobs: Job[_ContextCoT]) -> None:
+    async def add(self, *jobs: Job[ContextT]) -> None:
         async with self._lock:
             self._assert_open()
             self._releasable_jobs_sorter = None
@@ -183,7 +180,7 @@ class DefaultScheduler(Scheduler[_ContextCoT], Generic[_ContextCoT]):
                 job.id
                 for job in sorted(
                     cast(
-                        Iterable[Job[_ContextCoT]],
+                        Iterable[Job[ContextT]],
                         (
                             self._jobs[job_id]
                             for job_id in {
@@ -220,7 +217,7 @@ class DefaultScheduler(Scheduler[_ContextCoT], Generic[_ContextCoT]):
             return None
         self._update_releasable_jobs()
 
-        jobs: MutableSequence[Job[_ContextCoT]] = []
+        jobs: MutableSequence[Job[ContextT]] = []
         index = 0
         releasable_job_count = len(self._releasable_jobs_queue)
         while len(jobs) <= 9 and index < releasable_job_count:

--- a/betty/json/linked_data.py
+++ b/betty/json/linked_data.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import MutableSequence
 from inspect import getmembers
-from typing import TYPE_CHECKING, Generic, TypeVar, cast, final, override
+from typing import TYPE_CHECKING, cast, final, override
 
 from betty.classtools import Singleton
 from betty.json.schema import Object, Schema
@@ -18,11 +18,6 @@ if TYPE_CHECKING:
     from betty.ancestry.link import Link
     from betty.locale.localizable import ResolvableLocalizable
     from betty.project import Project
-
-
-_T = TypeVar("_T")
-_SchemaTypeT = TypeVar("_SchemaTypeT", bound=Schema, default=Schema, covariant=True)
-_PortableDataT = TypeVar("_PortableDataT", bound=PortableData, default=PortableData)
 
 
 async def dump_schema(
@@ -41,28 +36,29 @@ async def dump_schema(
         portable["$schema"] = await ProjectSchema.def_url(project, schema.def_name)
 
 
-class LinkedDataDumpable(Generic[_PortableDataT]):
+class LinkedDataDumpable[PortableDataT: PortableData = PortableData]:
     """
     Describe an object that can be dumped to linked data.
     """
 
     @abstractmethod
-    async def dump_linked_data(self, project: Project, /) -> _PortableDataT:
+    async def dump_linked_data(self, project: Project, /) -> PortableDataT:
         """
         Dump this instance to `JSON-LD <https://json-ld.org/>`_.
         """
 
 
-class LinkedDataDumpableWithSchema(
-    Generic[_SchemaTypeT, _PortableDataT], LinkedDataDumpable[_PortableDataT]
-):
+class LinkedDataDumpableWithSchema[
+    SchemaT: Schema,
+    PortableDataT: PortableData = PortableData,
+](LinkedDataDumpable[PortableDataT]):
     """
     Describe an object that can be dumped to linked data.
     """
 
     @classmethod
     @abstractmethod
-    async def linked_data_schema(cls, project: Project, /) -> _SchemaTypeT:
+    async def linked_data_schema(cls, project: Project, /) -> SchemaT:
         """
         Define the `JSON Schema <https://json-schema.org/>`_ for :py:meth:`betty.json.linked_data.LinkedDataDumpable.dump_linked_data`.
         """
@@ -128,21 +124,25 @@ class LinkedDataDumpableWithSchemaJsonLdObject(
         return portable
 
 
-class LinkedDataDumper(Generic[_T, _SchemaTypeT, _PortableDataT], ABC):
+class LinkedDataDumper[
+    T,
+    SchemaT: Schema = Schema,
+    PortableDataT: PortableData = PortableData,
+](ABC):
     """
     Provide linked data for instances of a target type.
     """
 
     @abstractmethod
-    async def linked_data_schema_for(self, project: Project, /) -> _SchemaTypeT:
+    async def linked_data_schema_for(self, project: Project, /) -> SchemaT:
         """
         Define the `JSON Schema <https://json-schema.org/>`_ for :py:meth:`betty.json.linked_data.LinkedDataDumper.dump_linked_data_for`.
         """
 
     @abstractmethod
     async def dump_linked_data_for(
-        self, project: Project, target: _T, /
-    ) -> _PortableDataT:
+        self, project: Project, target: T, /
+    ) -> PortableDataT:
         """
         Dump the given target to `JSON-LD <https://json-ld.org/>`_.
         """

--- a/betty/life_cycle/__init__.py
+++ b/betty/life_cycle/__init__.py
@@ -5,15 +5,7 @@ Life cycle and resource management.
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Self,
-    TypeAlias,
-    TypedDict,
-    Unpack,
-    final,
-)
+from typing import TYPE_CHECKING, Any, Self, TypedDict, Unpack, final
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -146,7 +138,7 @@ class LifeCycle:
             warn(f"{self} was bootstrapped, but never shut down.", stacklevel=2)
 
 
-Bootstrapper: TypeAlias = Callable[[], Awaitable[None] | None]
+type Bootstrapper = Callable[[], Awaitable[None] | None]
 """
 A callback to bootstrap resources.
 """
@@ -163,7 +155,7 @@ class ShutdownerKwargs(TypedDict):
     """
 
 
-Shutdowner: TypeAlias = Callable[[Unpack[ShutdownerKwargs]], Awaitable[None] | None]
+type Shutdowner = Callable[[Unpack[ShutdownerKwargs]], Awaitable[None] | None]
 """
 A callback to shut down resources.
 """

--- a/betty/locale/__init__.py
+++ b/betty/locale/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any, TypeAlias, override
+from typing import TYPE_CHECKING, Any, override
 
 from babel import Locale
 from babel.core import UnknownLocaleError
@@ -31,7 +31,7 @@ The `IETF BCP 47 <https://tools.ietf.org/html/bcp47>`_ language tag for Betty's 
 """
 
 
-ResolvableLocale: TypeAlias = Locale | str
+type ResolvableLocale = Locale | str
 """
 A locale or a locale identifier.
 """

--- a/betty/locale/localizable/__init__.py
+++ b/betty/locale/localizable/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import decimal
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, MutableMapping
-from typing import TYPE_CHECKING, Generic, TypeAlias, TypeVar, override
+from typing import TYPE_CHECKING, override
 from warnings import warn
 
 from babel import Locale
@@ -18,12 +18,10 @@ from betty.locale.localize import DEFAULT_LOCALIZER, Localizer
 if TYPE_CHECKING:
     from ty_extensions import Intersection
 
-_T = TypeVar("_T")
 
-
-class _Localizable(ABC, Generic[_T]):
+class _Localizable[T](ABC):
     @abstractmethod
-    def format(self, **format_kwargs: ResolvableLocalizable) -> _T:
+    def format(self, **format_kwargs: ResolvableLocalizable) -> T:
         """
         Apply string formatting to the eventual localized string.
 
@@ -61,7 +59,7 @@ class Localizable(_Localizable["Localizable"]):
         return localized
 
 
-LocalizableCount: TypeAlias = int | float | decimal.Decimal
+type LocalizableCount = int | float | decimal.Decimal
 """
 A count to localize strings for.
 
@@ -134,7 +132,7 @@ class _FormattedCountableLocalizable(CountableLocalizable):
         )
 
 
-StaticTranslationsMapping: TypeAlias = MutableMapping[Locale | None, str]
+type StaticTranslationsMapping = MutableMapping[Locale | None, str]
 """
 Static translations for :py:class:`betty.locale.localizable.static.StaticTranslations`.
 
@@ -144,7 +142,7 @@ See :py:func:`betty.locale.localizable.assertion.assert_static_translations`.
 """
 
 
-ShorthandStaticTranslations: TypeAlias = (
+type ShorthandStaticTranslations = (
     MutableMapping[ResolvableLocale | None, str] | str | StaticTranslationsMapping
 )
 """
@@ -156,7 +154,7 @@ See :py:func:`betty.locale.localizable.assertion.assert_static_translations`.
 """
 
 
-CountableStaticTranslationsMapping: TypeAlias = MutableMapping[
+type CountableStaticTranslationsMapping = MutableMapping[
     Locale, MutableMapping[str, str]
 ]
 """
@@ -168,7 +166,7 @@ See :py:func:`betty.locale.localizable.assertion.assert_countable_static_transla
 """
 
 
-ShorthandCountableStaticTranslations: TypeAlias = MutableMapping[
+type ShorthandCountableStaticTranslations = MutableMapping[
     ResolvableLocale, MutableMapping[str, str]
 ]
 """
@@ -180,13 +178,13 @@ See :py:func:`betty.locale.localizable.assertion.assert_static_translations`.
 """
 
 
-ResolvableLocalizable: TypeAlias = Localizable | ShorthandStaticTranslations
+type ResolvableLocalizable = Localizable | ShorthandStaticTranslations
 """
 A localizable, or a type that can be converted into a localizable with :py:func:`betty.locale.localizable.ensure_localizable`.
 """
 
 
-ResolvableCountableLocalizable: TypeAlias = (
+type ResolvableCountableLocalizable = (
     CountableLocalizable | ShorthandCountableStaticTranslations
 )
 """

--- a/betty/locale/localizable/property.py
+++ b/betty/locale/localizable/property.py
@@ -4,7 +4,7 @@ Localizable attributes.
 
 from __future__ import annotations
 
-from typing import TypeVar, final
+from typing import final
 
 from betty.data.aggregate.record.object.property import Property
 from betty.locale.localizable import (
@@ -19,9 +19,6 @@ from betty.locale.localizable.data import (
     CountableLocalizableDefinition,
     LocalizableDefinition,
 )
-
-_ValueGetT = TypeVar("_ValueGetT")
-_ValueSetT = TypeVar("_ValueSetT")
 
 
 @final

--- a/betty/locale/localizable/static/__init__.py
+++ b/betty/locale/localizable/static/__init__.py
@@ -174,7 +174,7 @@ class CountableStaticTranslations(CountableLocalizable, Portable):
         return {
             to_language_tag(locale): translations
             for locale, translations in self.translations.items()
-        }
+        }  # ty:ignore[invalid-return-type]
 
 
 @final

--- a/betty/locale/translation/project/extension.py
+++ b/betty/locale/translation/project/extension.py
@@ -4,7 +4,7 @@ Manage translations for project extensions.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING
 
 from betty.exception import HumanFacingException
 from betty.extension import ExtensionDefinition
@@ -22,8 +22,6 @@ if TYPE_CHECKING:
 
     from betty.user import User
 
-_ExtensionPluginT = TypeVar("_ExtensionPluginT", bound=ExtensionDefinition)
-
 
 def assert_extension_assets_directory_path(extension: ExtensionDefinition) -> Path:
     """
@@ -39,9 +37,9 @@ def assert_extension_assets_directory_path(extension: ExtensionDefinition) -> Pa
     return assets_directory_path
 
 
-def assert_extension_has_assets_directory_path(
-    extension: _ExtensionPluginT,
-) -> _ExtensionPluginT:
+def assert_extension_has_assets_directory_path[
+    ExtensionDefinitionT: ExtensionDefinition
+](extension: ExtensionDefinitionT) -> ExtensionDefinitionT:
     """
     Check that the given extension has an assets directory, and return it.
     """

--- a/betty/machine_name.py
+++ b/betty/machine_name.py
@@ -5,7 +5,7 @@ Machine names.
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Self, TypeAlias, final, override
+from typing import TYPE_CHECKING, Self, final, override
 
 from betty.assertion import assert_str
 from betty.data import Data, DataDefinition
@@ -82,7 +82,7 @@ class MachineName(Portable[str], str, Data):
         return cls(machine_name)
 
 
-ResolvableMachineName: TypeAlias = MachineName | str
+type ResolvableMachineName = MachineName | str
 
 
 @final

--- a/betty/media_type/__init__.py
+++ b/betty/media_type/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from email.message import EmailMessage
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Self, TypeAlias, final, override
+from typing import TYPE_CHECKING, Any, Self, final, override
 
 from betty.assertion import assert_str
 from betty.data import Data, DataDefinition
@@ -138,13 +138,13 @@ class MediaType(Data, Portable):
         return self._str
 
 
-ExtensionIndicator: TypeAlias = Path | str
+type ExtensionIndicator = Path | str
 """
 A file path or name that includes a file extension.
 """
 
 
-MediaTypeIndicator: TypeAlias = MediaType | ExtensionIndicator
+type MediaTypeIndicator = MediaType | ExtensionIndicator
 """
 A media type, or a file path or name that indicates a media type through its file extension.
 """

--- a/betty/model/__init__.py
+++ b/betty/model/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Self, TypeAlias, TypeVar, final, override
+from typing import TYPE_CHECKING, Any, Self, final, override
 from uuid import uuid4
 
 from betty.definition.human_facing import CountableHumanFacingDefinition
@@ -177,7 +177,7 @@ class EntityDefinition(CountableHumanFacingDefinition, PluginDefinition[Entity])
         return self._public_facing
 
 
-AncestryEntityId: TypeAlias = tuple[type[Entity], str]
+type AncestryEntityId = tuple[type[Entity], str]
 
 
 def persistent_id(entity_or_id: Entity | str, /) -> bool:
@@ -190,6 +190,3 @@ def persistent_id(entity_or_id: Entity | str, /) -> bool:
         entity_or_id if isinstance(entity_or_id, str) else entity_or_id.id,
         NonPersistentId,
     )
-
-
-_EntityT = TypeVar("_EntityT", bound=Entity)

--- a/betty/model/association.py
+++ b/betty/model/association.py
@@ -7,18 +7,7 @@ from __future__ import annotations
 import weakref
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Generic,
-    Self,
-    TypeAlias,
-    TypeVar,
-    cast,
-    final,
-    overload,
-    override,
-)
+from typing import TYPE_CHECKING, Any, Self, cast, final, overload, override
 from urllib.parse import quote
 
 from betty.importlib import fully_qualified_name, import_any
@@ -40,12 +29,6 @@ if TYPE_CHECKING:
     from betty.portable import PortableData
     from betty.project import Project
 
-_T = TypeVar("_T")
-_EntityT = TypeVar("_EntityT", bound=Entity)
-_OwnerT = TypeVar("_OwnerT", bound=Entity)
-_AssociateT = TypeVar("_AssociateT", bound=Entity)
-_EntityCollectionT = TypeVar("_EntityCollectionT", bound=EntityCollection[Any])
-
 
 async def _generate_associate_url(project: Project, associate: Entity, /) -> str | None:
     if not persistent_id(associate):
@@ -58,20 +41,20 @@ async def _generate_associate_url(project: Project, associate: Entity, /) -> str
     )
 
 
-class AssociationRequired(RuntimeError):
+class AssociationRequired[OwnerT: Entity](RuntimeError):
     """
     Raised when an operation cannot be performed because the association in question is required.
     """
 
-    def __init__(self, association: _Association[_OwnerT, Any], owner: _OwnerT, /):
+    def __init__(self, association: _Association[OwnerT, Any], owner: OwnerT, /):
         super().__init__(
             f"Association {fully_qualified_name(association.owner_type)}.{association.owner_attr_name} is required, but missing for {owner}."
         )
 
 
-class _Resolver(ABC, Generic[_T]):
+class _Resolver[T](ABC):
     @abstractmethod
-    def resolve(self) -> _T:
+    def resolve(self) -> T:
         """
         Return the resolved entity or entities.
 
@@ -79,34 +62,34 @@ class _Resolver(ABC, Generic[_T]):
         """
 
 
-class ToZeroOrOneResolver(_Resolver[_EntityT | None]):
+class ToZeroOrOneResolver[EntityT: Entity](_Resolver[EntityT | None]):
     """
     An object that can optionally resolve to an entity.
     """
 
 
-class ToOneResolver(_Resolver[_EntityT]):
+class ToOneResolver[EntityT: Entity](_Resolver[EntityT]):
     """
     An object that can resolve to an entity.
     """
 
 
-class ToManyResolver(_Resolver[Iterable[_EntityT]]):
+class ToManyResolver[EntityT: Entity](_Resolver[Iterable[EntityT]]):
     """
     An object that can resolve to a collection of entities.
     """
 
 
-class _TemporaryResolver(_Resolver[_T]):
+class _TemporaryResolver[T](_Resolver[T]):
     @override
-    def resolve(self) -> _T:
+    def resolve(self) -> T:
         raise RuntimeError(
             "This temporary resolver was supposed to be replaced. It intentionally cannot resolve itself."
         )
 
 
-class TemporaryToZeroOrOneResolver(
-    _TemporaryResolver[_EntityT], ToZeroOrOneResolver[_EntityT]
+class TemporaryToZeroOrOneResolver[EntityT: Entity](
+    _TemporaryResolver[EntityT], ToZeroOrOneResolver[EntityT]
 ):
     """
     A 'temporary' to-zero-or-one resolver.
@@ -116,7 +99,9 @@ class TemporaryToZeroOrOneResolver(
     """
 
 
-class TemporaryToOneResolver(_TemporaryResolver[_EntityT], ToOneResolver[_EntityT]):
+class TemporaryToOneResolver[EntityT: Entity](
+    _TemporaryResolver[EntityT], ToOneResolver[EntityT]
+):
     """
     A 'temporary' to-one resolver.
 
@@ -125,7 +110,9 @@ class TemporaryToOneResolver(_TemporaryResolver[_EntityT], ToOneResolver[_Entity
     """
 
 
-class TemporaryToManyResolver(_TemporaryResolver[_EntityT], ToManyResolver[_EntityT]):
+class TemporaryToManyResolver[EntityT: Entity](
+    _TemporaryResolver[EntityT], ToManyResolver[EntityT]
+):
     """
     A 'temporary' to-many resolver.
 
@@ -134,8 +121,8 @@ class TemporaryToManyResolver(_TemporaryResolver[_EntityT], ToManyResolver[_Enti
     """
 
 
-class _Association(LinkedDataDumper[_OwnerT], Generic[_OwnerT, _AssociateT]):
-    _owner_type: type[_OwnerT]
+class _Association[OwnerT: Entity, AssociateT: Entity](LinkedDataDumper[OwnerT]):
+    _owner_type: type[OwnerT]
     _owner_attr_name: str
     _internal_owner_attr_name: str
 
@@ -154,7 +141,7 @@ class _Association(LinkedDataDumper[_OwnerT], Generic[_OwnerT, _AssociateT]):
             None if description is None else resolve_localizable(description)
         )
 
-    def __set_name__(self, owner: type[_OwnerT], name: str) -> None:
+    def __set_name__(self, owner: type[OwnerT], name: str) -> None:
         self._owner_type = owner
         self._owner_attr_name = name
         self._internal_owner_attr_name = f"_{name}"
@@ -175,7 +162,7 @@ class _Association(LinkedDataDumper[_OwnerT], Generic[_OwnerT, _AssociateT]):
         )
 
     @property
-    def owner_type(self) -> type[_OwnerT]:
+    def owner_type(self) -> type[OwnerT]:
         """
         The type of the owning entity that contains this association.
 
@@ -191,31 +178,31 @@ class _Association(LinkedDataDumper[_OwnerT], Generic[_OwnerT, _AssociateT]):
         return self._owner_attr_name
 
     @property
-    def associate_type(self) -> type[_AssociateT]:
+    def associate_type(self) -> type[AssociateT]:
         """
         The type of any associate entities.
 
         This may be an abstract class.
         """
         return cast(
-            "type[_AssociateT]",
+            "type[AssociateT]",
             import_any(self._associate_type_name),
         )
 
     @abstractmethod
-    def resolve(self, owner: _OwnerT, /) -> None:
+    def resolve(self, owner: OwnerT, /) -> None:
         """
         Resolve any associates the owner may have for this association.
         """
 
     @abstractmethod
-    def associate(self, owner: _OwnerT, associate: _AssociateT, /) -> None:
+    def associate(self, owner: OwnerT, associate: AssociateT, /) -> None:
         """
         Associate two entities.
         """
 
     @abstractmethod
-    def disassociate(self, owner: _OwnerT, associate: _AssociateT, /) -> None:
+    def disassociate(self, owner: OwnerT, associate: AssociateT, /) -> None:
         """
         Disassociate two entities.
 
@@ -224,30 +211,32 @@ class _Association(LinkedDataDumper[_OwnerT], Generic[_OwnerT, _AssociateT]):
         """
 
     @abstractmethod
-    def get_associates(self, owner: _OwnerT, /) -> Iterable[_AssociateT]:
+    def get_associates(self, owner: OwnerT, /) -> Iterable[AssociateT]:
         """
         Get the associates for the given owner.
         """
 
 
-class _ToOneAssociation(_Association[_OwnerT, _AssociateT]):
+class _ToOneAssociation[OwnerT: Entity, AssociateT: Entity](
+    _Association[OwnerT, AssociateT]
+):
     @override
-    def associate(self, owner: _OwnerT, associate: _AssociateT, /) -> None:
+    def associate(self, owner: OwnerT, associate: AssociateT, /) -> None:
         self.__set__(owner, associate)
 
     @override
-    def disassociate(self, owner: _OwnerT, associate: _AssociateT, /) -> None:
+    def disassociate(self, owner: OwnerT, associate: AssociateT, /) -> None:
         setattr(owner, self._internal_owner_attr_name, None)
 
     @overload
-    def __get__(self, instance: None, owner: type[_OwnerT]) -> Self:
+    def __get__(self, instance: None, owner: type[OwnerT]) -> Self:
         pass
 
     @overload
-    def __get__(self, instance: _OwnerT, owner: type[_OwnerT]) -> _AssociateT:
+    def __get__(self, instance: OwnerT, owner: type[OwnerT]) -> AssociateT:
         pass
 
-    def __get__(self, instance: _OwnerT | None, owner: type[_OwnerT]):
+    def __get__(self, instance: OwnerT | None, owner: type[OwnerT]):
         if instance is None:
             return self
         try:
@@ -258,13 +247,13 @@ class _ToOneAssociation(_Association[_OwnerT, _AssociateT]):
             if value is None:
                 raise AssociationRequired(self, instance)
             assert not isinstance(value, _Resolver)
-            return cast(_AssociateT, value)
+            return cast(AssociateT, value)
 
-    def __set__(self, instance: _OwnerT, value: ToOneAssociate[_AssociateT]) -> None:
+    def __set__(self, instance: OwnerT, value: ToOneAssociate[AssociateT]) -> None:
         setattr(instance, self._internal_owner_attr_name, value)
 
     @override
-    def get_associates(self, owner: _OwnerT, /) -> Iterable[_AssociateT]:
+    def get_associates(self, owner: OwnerT, /) -> Iterable[AssociateT]:
         yield self.__get__(owner, type(owner))
 
     @override
@@ -280,7 +269,7 @@ class _ToOneAssociation(_Association[_OwnerT, _AssociateT]):
 
     @override
     async def dump_linked_data_for(
-        self, project: Project, target: Intersection[_OwnerT, Entity], /
+        self, project: Project, target: Intersection[OwnerT, Entity], /
     ) -> PortableData:
         associate = self.__get__(target, type(target))
         if self._linked_data_embedded:
@@ -288,25 +277,27 @@ class _ToOneAssociation(_Association[_OwnerT, _AssociateT]):
         return await _generate_associate_url(project, associate)
 
 
-class _ToZeroOrOneAssociation(_Association[_OwnerT, _AssociateT]):
+class _ToZeroOrOneAssociation[OwnerT: Entity, AssociateT: Entity](
+    _Association[OwnerT, AssociateT]
+):
     @override
-    def associate(self, owner: _OwnerT, associate: _AssociateT, /) -> None:
+    def associate(self, owner: OwnerT, associate: AssociateT, /) -> None:
         self.__set__(owner, associate)
 
     @override
-    def disassociate(self, owner: _OwnerT, associate: _AssociateT, /) -> None:
+    def disassociate(self, owner: OwnerT, associate: AssociateT, /) -> None:
         if associate == self.__get__(owner, type(owner)):
             self.__delete__(owner)
 
     @overload
-    def __get__(self, instance: None, owner: type[_OwnerT]) -> Self:
+    def __get__(self, instance: None, owner: type[OwnerT]) -> Self:
         pass
 
     @overload
-    def __get__(self, instance: _OwnerT, owner: type[_OwnerT]) -> _AssociateT | None:
+    def __get__(self, instance: OwnerT, owner: type[OwnerT]) -> AssociateT | None:
         pass
 
-    def __get__(self, instance: _OwnerT | None, owner: type[_OwnerT]):
+    def __get__(self, instance: OwnerT | None, owner: type[OwnerT]):
         if instance is None:
             return self
         try:
@@ -316,18 +307,18 @@ class _ToZeroOrOneAssociation(_Association[_OwnerT, _AssociateT]):
             return None
         else:
             assert not isinstance(value, _Resolver)
-            return cast(_AssociateT | None, value)
+            return cast(AssociateT | None, value)
 
     def __set__(
-        self, instance: _OwnerT, value: ToZeroOrOneAssociate[_AssociateT]
+        self, instance: OwnerT, value: ToZeroOrOneAssociate[AssociateT]
     ) -> None:
         setattr(instance, self._internal_owner_attr_name, value)
 
-    def __delete__(self, instance: _OwnerT) -> None:
+    def __delete__(self, instance: OwnerT) -> None:
         self.__set__(instance, None)
 
     @override
-    def get_associates(self, owner: _OwnerT, /) -> Iterable[_AssociateT]:
+    def get_associates(self, owner: OwnerT, /) -> Iterable[AssociateT]:
         associate = self.__get__(owner, type(owner))
         if associate is not None:
             yield associate
@@ -348,7 +339,7 @@ class _ToZeroOrOneAssociation(_Association[_OwnerT, _AssociateT]):
 
     @override
     async def dump_linked_data_for(
-        self, project: Project, target: Intersection[_OwnerT, Entity], /
+        self, project: Project, target: Intersection[OwnerT, Entity], /
     ) -> PortableData:
         associate = self.__get__(target, type(target))
         if associate is None:
@@ -358,23 +349,26 @@ class _ToZeroOrOneAssociation(_Association[_OwnerT, _AssociateT]):
         return await _generate_associate_url(project, associate)
 
 
-class _ToManyAssociation(
-    _Association[_OwnerT, _AssociateT],
-    Generic[_OwnerT, _AssociateT, _EntityCollectionT],
+class _ToManyAssociation[
+    OwnerT: Entity,
+    AssociateT: Entity,
+    EntityCollectionT: EntityCollection[Any],
+](
+    _Association[OwnerT, AssociateT],
 ):
     @abstractmethod
-    def _new_collection(self, instance: _OwnerT, /) -> _EntityCollectionT:
+    def _new_collection(self, instance: OwnerT, /) -> EntityCollectionT:
         pass
 
     @overload
-    def __get__(self, instance: None, owner: type[_OwnerT]) -> Self:
+    def __get__(self, instance: None, owner: type[OwnerT]) -> Self:
         pass
 
     @overload
-    def __get__(self, instance: _OwnerT, owner: type[_OwnerT]) -> _EntityCollectionT:
+    def __get__(self, instance: OwnerT, owner: type[OwnerT]) -> EntityCollectionT:
         pass
 
-    def __get__(self, instance: _OwnerT | None, owner: type[_OwnerT]):
+    def __get__(self, instance: OwnerT | None, owner: type[OwnerT]):
         if instance is None:
             return self
         try:
@@ -385,31 +379,31 @@ class _ToManyAssociation(
             return value
         else:
             assert not isinstance(value, _Resolver)
-            return cast(_EntityCollectionT, value)
+            return cast(EntityCollectionT, value)
 
-    def __set__(self, instance: _OwnerT, value: ToManyAssociates[_AssociateT]) -> None:
+    def __set__(self, instance: OwnerT, value: ToManyAssociates[AssociateT]) -> None:
         if isinstance(value, _Resolver):
             setattr(instance, self._internal_owner_attr_name, value)
         else:
             self.__get__(instance, type(instance)).replace(*value)
 
-    def __delete__(self, instance: _OwnerT) -> None:
+    def __delete__(self, instance: OwnerT) -> None:
         self.__get__(instance, type(instance)).clear()
 
     @override
-    def associate(self, owner: _OwnerT, associate: _AssociateT, /) -> None:
+    def associate(self, owner: OwnerT, associate: AssociateT, /) -> None:
         self.__get__(owner, type(owner)).add(associate)
 
     @override
-    def disassociate(self, owner: _OwnerT, associate: _AssociateT, /) -> None:
+    def disassociate(self, owner: OwnerT, associate: AssociateT, /) -> None:
         self.__get__(owner, type(owner)).remove(associate)
 
     @override
-    def get_associates(self, owner: _OwnerT, /) -> Iterable[_AssociateT]:
+    def get_associates(self, owner: OwnerT, /) -> Iterable[AssociateT]:
         yield from self.__get__(owner, type(owner))
 
     @override
-    def resolve(self, owner: _OwnerT, /) -> None:
+    def resolve(self, owner: OwnerT, /) -> None:
         value = getattr(owner, self._internal_owner_attr_name, None)
         if isinstance(value, _Resolver):
             collection = self._new_collection(owner)
@@ -431,7 +425,7 @@ class _ToManyAssociation(
 
     @override
     async def dump_linked_data_for(
-        self, project: Project, target: Intersection[_OwnerT, Entity], /
+        self, project: Project, target: Intersection[OwnerT, Entity], /
     ) -> PortableData:
         associates = self.__get__(target, type(target))
         if self._linked_data_embedded:
@@ -449,7 +443,9 @@ class _ToManyAssociation(
         )
 
 
-class _BidirectionalAssociation(_Association[_OwnerT, _AssociateT]):
+class _BidirectionalAssociation[OwnerT: Entity, AssociateT: Entity](
+    _Association[OwnerT, AssociateT]
+):
     def __init__(
         self,
         associate_type_name: str,
@@ -478,7 +474,7 @@ class _BidirectionalAssociation(_Association[_OwnerT, _AssociateT]):
         """
         return self._associate_attr_name
 
-    def inverse(self) -> _BidirectionalAssociation[_AssociateT, _OwnerT]:
+    def inverse(self) -> _BidirectionalAssociation[AssociateT, OwnerT]:
         """
         Get the inverse association.
         """
@@ -490,9 +486,9 @@ class _BidirectionalAssociation(_Association[_OwnerT, _AssociateT]):
 
 
 @final
-class BidirectionalToZeroOrOne(
-    _ToZeroOrOneAssociation[_OwnerT, _AssociateT],
-    _BidirectionalAssociation[_OwnerT, _AssociateT],
+class BidirectionalToZeroOrOne[OwnerT: Entity, AssociateT: Entity](
+    _ToZeroOrOneAssociation[OwnerT, AssociateT],
+    _BidirectionalAssociation[OwnerT, AssociateT],
 ):
     r"""
     A bidirectional \\*-to-zero-or-one entity type association.
@@ -500,7 +496,7 @@ class BidirectionalToZeroOrOne(
 
     @override
     def __set__(
-        self, instance: _OwnerT, value: ToZeroOrOneAssociate[_AssociateT]
+        self, instance: OwnerT, value: ToZeroOrOneAssociate[AssociateT]
     ) -> None:
         previous_associate = self.__get__(instance, type(instance))
         if previous_associate == value:
@@ -512,7 +508,7 @@ class BidirectionalToZeroOrOne(
             self.inverse().associate(value, instance)
 
     @override
-    def resolve(self, owner: _OwnerT, /) -> None:
+    def resolve(self, owner: OwnerT, /) -> None:
         value = getattr(owner, self._internal_owner_attr_name, None)
         if isinstance(value, _Resolver):
             associate = value.resolve()
@@ -522,16 +518,16 @@ class BidirectionalToZeroOrOne(
 
 
 @final
-class BidirectionalToOne(
-    _ToOneAssociation[_OwnerT, _AssociateT],
-    _BidirectionalAssociation[_OwnerT, _AssociateT],
+class BidirectionalToOne[OwnerT: Entity, AssociateT: Entity](
+    _ToOneAssociation[OwnerT, AssociateT],
+    _BidirectionalAssociation[OwnerT, AssociateT],
 ):
     r"""
     A bidirectional \\*-to-one entity type association.
     """
 
     @override
-    def resolve(self, owner: _OwnerT, /) -> None:
+    def resolve(self, owner: OwnerT, /) -> None:
         value = getattr(owner, self._internal_owner_attr_name, None)
         if value is None:
             raise AssociationRequired(self, owner)
@@ -541,10 +537,10 @@ class BidirectionalToOne(
             self.inverse().associate(associate, owner)
 
     @override
-    def __set__(self, instance: _OwnerT, value: ToOneAssociate[_AssociateT]) -> None:
+    def __set__(self, instance: OwnerT, value: ToOneAssociate[AssociateT]) -> None:
         try:
             previous_associate = cast(
-                "_AssociateT | None", getattr(self, self._internal_owner_attr_name)
+                "AssociateT | None", getattr(self, self._internal_owner_attr_name)
             )
         except AttributeError:
             previous_associate = None
@@ -558,9 +554,9 @@ class BidirectionalToOne(
 
 
 @final
-class BidirectionalToManySingleType(
-    _ToManyAssociation[_OwnerT, _AssociateT, SingleTypeEntityCollection[_AssociateT]],
-    _BidirectionalAssociation[_OwnerT, _AssociateT],
+class BidirectionalToManySingleType[OwnerT: Entity, AssociateT: Entity](
+    _ToManyAssociation[OwnerT, AssociateT, SingleTypeEntityCollection[AssociateT]],
+    _BidirectionalAssociation[OwnerT, AssociateT],
 ):
     r"""
     A bidirectional \\*-to-many entity type association where all associates are of the same entity type.
@@ -568,17 +564,15 @@ class BidirectionalToManySingleType(
 
     @override
     def _new_collection(
-        self, instance: _OwnerT, /
-    ) -> SingleTypeEntityCollection[_AssociateT]:
+        self, instance: OwnerT, /
+    ) -> SingleTypeEntityCollection[AssociateT]:
         return _BidirectionalSingleTypeAssociateCollection(instance, self)
 
 
 @final
-class BidirectionalToManyMultipleTypes(
-    _ToManyAssociation[
-        _OwnerT, _AssociateT, MultipleTypesEntityCollection[_AssociateT]
-    ],
-    _BidirectionalAssociation[_OwnerT, _AssociateT],
+class BidirectionalToManyMultipleTypes[OwnerT: Entity, AssociateT: Entity](
+    _ToManyAssociation[OwnerT, AssociateT, MultipleTypesEntityCollection[AssociateT]],
+    _BidirectionalAssociation[OwnerT, AssociateT],
 ):
     r"""
     A bidirectional \\*-to-many entity type association where associates may be of different entity types.
@@ -586,8 +580,8 @@ class BidirectionalToManyMultipleTypes(
 
     @override
     def _new_collection(
-        self, instance: _OwnerT, /
-    ) -> MultipleTypesEntityCollection[_AssociateT]:
+        self, instance: OwnerT, /
+    ) -> MultipleTypesEntityCollection[AssociateT]:
         return _BidirectionalMultipleTypesAssociateCollection(
             instance,
             self,
@@ -595,26 +589,30 @@ class BidirectionalToManyMultipleTypes(
 
 
 @final
-class UnidirectionalToZeroOrOne(_ToZeroOrOneAssociation[_OwnerT, _AssociateT]):
+class UnidirectionalToZeroOrOne[OwnerT: Entity, AssociateT: Entity](
+    _ToZeroOrOneAssociation[OwnerT, AssociateT]
+):
     """
     A unidirectional to-zero-or-one entity type association.
     """
 
     @override
-    def resolve(self, owner: _OwnerT, /) -> None:
+    def resolve(self, owner: OwnerT, /) -> None:
         value = getattr(owner, self._internal_owner_attr_name, None)
         if isinstance(value, _Resolver):
             setattr(owner, self._internal_owner_attr_name, value.resolve())
 
 
 @final
-class UnidirectionalToOne(_ToOneAssociation[_OwnerT, _AssociateT]):
+class UnidirectionalToOne[OwnerT: Entity, AssociateT: Entity](
+    _ToOneAssociation[OwnerT, AssociateT]
+):
     """
     A unidirectional to-one entity type association.
     """
 
     @override
-    def resolve(self, owner: _OwnerT, /) -> None:
+    def resolve(self, owner: OwnerT, /) -> None:
         value = getattr(owner, self._internal_owner_attr_name, None)
         if value is None:
             raise AssociationRequired(self, owner)
@@ -623,8 +621,8 @@ class UnidirectionalToOne(_ToOneAssociation[_OwnerT, _AssociateT]):
 
 
 @final
-class UnidirectionalToManySingleType(
-    _ToManyAssociation[_OwnerT, _AssociateT, SingleTypeEntityCollection[_AssociateT]]
+class UnidirectionalToManySingleType[OwnerT: Entity, AssociateT: Entity](
+    _ToManyAssociation[OwnerT, AssociateT, SingleTypeEntityCollection[AssociateT]]
 ):
     """
     A unidirectional to-many entity type association where all associates are of the same entity type.
@@ -632,16 +630,14 @@ class UnidirectionalToManySingleType(
 
     @override
     def _new_collection(
-        self, instance: _OwnerT, /
-    ) -> SingleTypeEntityCollection[_AssociateT]:
-        return SingleTypeEntityCollection[_AssociateT]()
+        self, instance: OwnerT, /
+    ) -> SingleTypeEntityCollection[AssociateT]:
+        return SingleTypeEntityCollection[AssociateT]()
 
 
 @final
-class UnidirectionalToManyMultipleTypes(
-    _ToManyAssociation[
-        _OwnerT, _AssociateT, MultipleTypesEntityCollection[_AssociateT]
-    ],
+class UnidirectionalToManyMultipleTypes[OwnerT: Entity, AssociateT: Entity](
+    _ToManyAssociation[OwnerT, AssociateT, MultipleTypesEntityCollection[AssociateT]],
 ):
     """
     A unidirectional to-many entity type association where associates may be of different entity types.
@@ -649,9 +645,9 @@ class UnidirectionalToManyMultipleTypes(
 
     @override
     def _new_collection(
-        self, instance: _OwnerT, /
-    ) -> MultipleTypesEntityCollection[_AssociateT]:
-        return MultipleTypesEntityCollection[_AssociateT]()
+        self, instance: OwnerT, /
+    ) -> MultipleTypesEntityCollection[AssociateT]:
+        return MultipleTypesEntityCollection[AssociateT]()
 
 
 @final
@@ -677,9 +673,9 @@ class AssociationRegistry:
         }
 
     @classmethod
-    def get_association(
-        cls, owner: type[_OwnerT] | _OwnerT, owner_attr_name: str, /
-    ) -> _Association[_OwnerT, Any]:
+    def get_association[OwnerT: Entity](
+        cls, owner: type[OwnerT] | OwnerT, owner_attr_name: str, /
+    ) -> _Association[OwnerT, Any]:
         """
         Get the association for a given owner and attribute name.
         """
@@ -695,13 +691,13 @@ class AssociationRegistry:
         cls._associations.add(association)
 
 
-class _BidirectionalAssociateCollection(
-    EntityCollection[_AssociateT], Generic[_AssociateT, _OwnerT]
+class _BidirectionalAssociateCollection[AssociateT: Entity, OwnerT: Entity](
+    EntityCollection[AssociateT]
 ):
     def __init__(
         self,
-        owner: _OwnerT,
-        association: _BidirectionalAssociation[_OwnerT, _AssociateT],
+        owner: OwnerT,
+        association: _BidirectionalAssociation[OwnerT, AssociateT],
         /,
     ):
         super().__init__()
@@ -709,7 +705,7 @@ class _BidirectionalAssociateCollection(
         self.__owner = weakref.ref(owner)
 
     @property
-    def _owner(self) -> _OwnerT:
+    def _owner(self) -> OwnerT:
         owner = self.__owner()
         assert owner is not None, (
             "This associate collection's owner no longer exists in memory."
@@ -717,28 +713,31 @@ class _BidirectionalAssociateCollection(
         return owner
 
     @override
-    def _on_add(self, *entities: _AssociateT) -> None:
+    def _on_add(self, *entities: AssociateT) -> None:
         super()._on_add(*entities)
         for associate in entities:
             self._association.inverse().associate(associate, self._owner)
 
     @override
-    def _on_remove(self, *entities: _AssociateT) -> None:
+    def _on_remove(self, *entities: AssociateT) -> None:
         super()._on_remove(*entities)
         for associate in entities:
             self._association.inverse().disassociate(associate, self._owner)
 
 
-class _BidirectionalSingleTypeAssociateCollection(
-    _BidirectionalAssociateCollection[_AssociateT, _OwnerT],
-    SingleTypeEntityCollection[_AssociateT],
+class _BidirectionalSingleTypeAssociateCollection[OwnerT: Entity, AssociateT: Entity](
+    _BidirectionalAssociateCollection[AssociateT, OwnerT],
+    SingleTypeEntityCollection[AssociateT],
 ):
     pass
 
 
-class _BidirectionalMultipleTypesAssociateCollection(
-    _BidirectionalAssociateCollection[_AssociateT, _OwnerT],
-    MultipleTypesEntityCollection[_AssociateT],
+class _BidirectionalMultipleTypesAssociateCollection[
+    OwnerT: Entity,
+    AssociateT: Entity,
+](
+    _BidirectionalAssociateCollection[AssociateT, OwnerT],
+    MultipleTypesEntityCollection[AssociateT],
 ):
     pass
 
@@ -754,8 +753,8 @@ def resolve(*entities: Entity) -> None:
             association.resolve(entity)
 
 
-ToOneAssociate: TypeAlias = _EntityT | ToOneResolver[_EntityT]
-ToZeroOrOneAssociate: TypeAlias = (
-    ToOneAssociate[_EntityT] | ToZeroOrOneResolver[_EntityT] | None
+type ToOneAssociate[EntityT: Entity] = EntityT | ToOneResolver[EntityT]
+type ToZeroOrOneAssociate[EntityT: Entity] = (
+    ToOneAssociate[EntityT] | ToZeroOrOneResolver[EntityT] | None
 )
-ToManyAssociates: TypeAlias = Iterable[_EntityT] | ToManyResolver[_EntityT]
+type ToManyAssociates[EntityT: Entity] = Iterable[EntityT] | ToManyResolver[EntityT]

--- a/betty/model/collections.py
+++ b/betty/model/collections.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast, override
+from typing import TYPE_CHECKING, Any, cast, override
 
 from betty.functools import unique
 from betty.model import Entity, EntityDefinition
@@ -25,43 +25,46 @@ if TYPE_CHECKING:
 
     from betty.machine_name import ResolvableMachineName
 
-_EntityT = TypeVar("_EntityT", bound=Entity, default=Entity)
-_TargetT = TypeVar("_TargetT")
 
-
-class EntityCollection(ABC, Generic[_TargetT]):
+class EntityCollection[TargetT = Entity](ABC):
     """
     Provide a collection of entities.
 
     To test your own subclasses, use :py:class:`betty.test_utils.model.collections.EntityCollectionTestBase`.
     """
 
-    def _on_add(self, *entities: Intersection[_TargetT, Entity]) -> None:
+    def _on_add(  # noqa: B027
+        self,
+        *entities: Intersection[TargetT, Entity],
+    ) -> None:
         pass
 
-    def _on_remove(self, *entities: Intersection[_TargetT, Entity]) -> None:
+    def _on_remove(  # noqa: B027
+        self,
+        *entities: Intersection[TargetT, Entity],
+    ) -> None:
         pass
 
     @property
-    def view(self) -> Sequence[Intersection[_TargetT, Entity]]:
+    def view(self) -> Sequence[Intersection[TargetT, Entity]]:
         """
         A view of the entities at the time of calling.
         """
         return [*self]
 
     @abstractmethod
-    def add(self, *entities: Intersection[_TargetT, Entity]) -> None:
+    def add(self, *entities: Intersection[TargetT, Entity]) -> None:
         """
         Add the given entities.
         """
 
     @abstractmethod
-    def remove(self, *entities: Intersection[_TargetT, Entity]) -> None:
+    def remove(self, *entities: Intersection[TargetT, Entity]) -> None:
         """
         Remove the given entities.
         """
 
-    def replace(self, *entities: Intersection[_TargetT, Entity]) -> None:
+    def replace(self, *entities: Intersection[TargetT, Entity]) -> None:
         """
         Replace all entities with the given ones.
         """
@@ -75,7 +78,7 @@ class EntityCollection(ABC, Generic[_TargetT]):
         """
 
     @abstractmethod
-    def __iter__(self) -> Iterator[Intersection[_TargetT, Entity]]:
+    def __iter__(self) -> Iterator[Intersection[TargetT, Entity]]:
         pass
 
     @abstractmethod
@@ -83,7 +86,7 @@ class EntityCollection(ABC, Generic[_TargetT]):
         pass
 
     @abstractmethod
-    def __delitem__(self, key: Intersection[_TargetT, Entity]) -> None:
+    def __delitem__(self, key: Intersection[TargetT, Entity]) -> None:
         pass
 
     @abstractmethod
@@ -91,34 +94,31 @@ class EntityCollection(ABC, Generic[_TargetT]):
         pass
 
     def _known(
-        self, *entities: Intersection[_TargetT, Entity]
-    ) -> Iterable[Intersection[_TargetT, Entity]]:
+        self, *entities: Intersection[TargetT, Entity]
+    ) -> Iterable[Intersection[TargetT, Entity]]:
         for entity in unique(entities):
             if entity in self:
                 yield entity
 
     def _unknown(
-        self, *entities: Intersection[_TargetT, Entity]
-    ) -> Iterable[Intersection[_TargetT, Entity]]:
+        self, *entities: Intersection[TargetT, Entity]
+    ) -> Iterable[Intersection[TargetT, Entity]]:
         for entity in unique(entities):
             if entity not in self:
                 yield entity
 
 
-_EntityCollectionT = TypeVar("_EntityCollectionT", bound=EntityCollection[Any])
-
-
-class SingleTypeEntityCollection(EntityCollection[_TargetT], Generic[_TargetT]):
+class SingleTypeEntityCollection[TargetT = Entity](EntityCollection[TargetT]):
     """
     Collect entities of a single type.
     """
 
-    def __init__(self, *entities: Intersection[_TargetT, Entity]):
+    def __init__(self, *entities: Intersection[TargetT, Entity]):
         super().__init__()
-        self._entities: MutableSequence[Intersection[_TargetT, Entity]] = [*entities]
+        self._entities: MutableSequence[Intersection[TargetT, Entity]] = [*entities]
 
     @override
-    def add(self, *entities: Intersection[_TargetT, Entity]) -> None:
+    def add(self, *entities: Intersection[TargetT, Entity]) -> None:
         added_entities = [*self._unknown(*entities)]
         for entity in added_entities:
             self._entities.append(entity)
@@ -126,7 +126,7 @@ class SingleTypeEntityCollection(EntityCollection[_TargetT], Generic[_TargetT]):
             self._on_add(*added_entities)
 
     @override
-    def remove(self, *entities: Intersection[_TargetT, Entity]) -> None:
+    def remove(self, *entities: Intersection[TargetT, Entity]) -> None:
         removed_entities = [*self._known(*entities)]
         for entity in removed_entities:
             self._entities.remove(entity)
@@ -138,21 +138,21 @@ class SingleTypeEntityCollection(EntityCollection[_TargetT], Generic[_TargetT]):
         self.remove(*self)
 
     @override
-    def __iter__(self) -> Iterator[Intersection[_TargetT, Entity]]:
+    def __iter__(self) -> Iterator[Intersection[TargetT, Entity]]:
         return self._entities.__iter__()
 
     @override
     def __len__(self) -> int:
         return len(self._entities)
 
-    def __getitem__(self, entity_id: str) -> Intersection[_TargetT, Entity]:
+    def __getitem__(self, entity_id: str) -> Intersection[TargetT, Entity]:
         for entity in self._entities:
             if entity_id == entity.id:
                 return entity
         raise KeyError(f'Cannot find an entity with ID "{entity_id}".')
 
     @override
-    def __delitem__(self, key: str | Intersection[_TargetT, Entity]) -> None:
+    def __delitem__(self, key: str | Intersection[TargetT, Entity]) -> None:
         if isinstance(key, str):
             for entity in self._entities:
                 if entity.id == key:
@@ -167,44 +167,42 @@ class SingleTypeEntityCollection(EntityCollection[_TargetT], Generic[_TargetT]):
         return any(entity is value for entity in self._entities)
 
 
-class MultipleTypesEntityCollection(EntityCollection[_TargetT], Generic[_TargetT]):
+class MultipleTypesEntityCollection[TargetT = Entity](EntityCollection[TargetT]):
     """
     Collect entities of multiple types.
     """
 
-    def __init__(self, *entities: Intersection[_TargetT, Entity]):
+    def __init__(self, *entities: Intersection[TargetT, Entity]):
         super().__init__()
-        self._collections: MutableMapping[str, SingleTypeEntityCollection[Entity]] = (
+        self._collections: MutableMapping[str, SingleTypeEntityCollection] = (
             defaultdict(SingleTypeEntityCollection)
         )
         self.add(*entities)
 
-    def _get_collection(
-        self, entity_type: type[_EntityT] | EntityDefinition | ResolvableMachineName, /
-    ) -> SingleTypeEntityCollection[_EntityT]:
+    def _get_collection[EntityT: Entity](
+        self, entity_type: type[EntityT] | EntityDefinition | ResolvableMachineName, /
+    ) -> SingleTypeEntityCollection[EntityT]:
         if isinstance(entity_type, EntityDefinition):
             entity_type = entity_type.id
         if isinstance(entity_type, type):
             entity_type = entity_type.plugin().id
-        return cast(
-            SingleTypeEntityCollection[_EntityT], self._collections[entity_type]
-        )
+        return cast(SingleTypeEntityCollection[EntityT], self._collections[entity_type])
 
-    def __getitem__(
+    def __getitem__[EntityT: Entity](
         self,
-        key: type[_EntityT] | EntityDefinition | ResolvableMachineName,
-    ) -> SingleTypeEntityCollection[_EntityT]:
+        key: type[EntityT] | EntityDefinition | ResolvableMachineName,
+    ) -> SingleTypeEntityCollection[EntityT]:
         return self._get_collection(key)
 
     @override
-    def __delitem__(self, key: Intersection[_TargetT, Entity]) -> None:
+    def __delitem__(self, key: Intersection[TargetT, Entity]) -> None:
         self.remove(key)
 
     @override
-    def __iter__(self) -> Iterator[Intersection[_TargetT, Entity]]:
+    def __iter__(self) -> Iterator[Intersection[TargetT, Entity]]:
         for collection in self._collections.values():
             for entity in collection:
-                yield cast("Intersection[_TargetT , Entity]", entity)
+                yield cast("Intersection[TargetT , Entity]", entity)
 
     @override
     def __len__(self) -> int:
@@ -217,7 +215,7 @@ class MultipleTypesEntityCollection(EntityCollection[_TargetT], Generic[_TargetT
         return False
 
     @override
-    def add(self, *entities: Intersection[_TargetT, Entity]) -> None:
+    def add(self, *entities: Intersection[TargetT, Entity]) -> None:
         added_entities = [*self._unknown(*entities)]
         for entity in added_entities:
             self[type(entity)].add(entity)
@@ -225,7 +223,7 @@ class MultipleTypesEntityCollection(EntityCollection[_TargetT], Generic[_TargetT
             self._on_add(*added_entities)
 
     @override
-    def remove(self, *entities: Intersection[_TargetT, Entity]) -> None:
+    def remove(self, *entities: Intersection[TargetT, Entity]) -> None:
         removed_entities = [*self._known(*entities)]
         for entity in removed_entities:
             self[type(entity)].remove(entity)
@@ -242,13 +240,13 @@ class MultipleTypesEntityCollection(EntityCollection[_TargetT], Generic[_TargetT
 
 
 @contextmanager
-def record_added(
-    entities: EntityCollection[_EntityT], /
-) -> Iterator[MultipleTypesEntityCollection[_EntityT]]:
+def record_added[EntityT: Entity](
+    entities: EntityCollection[EntityT], /
+) -> Iterator[MultipleTypesEntityCollection[EntityT]]:
     """
     Record all entities that are added to a collection.
     """
     original = [*entities]
-    added = MultipleTypesEntityCollection[_EntityT]()
+    added = MultipleTypesEntityCollection[EntityT]()
     yield added
     added.add(*[entity for entity in entities if entity not in original])

--- a/betty/pathlib.py
+++ b/betty/pathlib.py
@@ -3,14 +3,12 @@ File path tools.
 """
 
 from pathlib import Path
-from typing import Any, TypeVar, final
+from typing import final
 
 from betty.assertion import assert_path
 from betty.data import DataDefinition
 from betty.locale.localizable.gettext import _
 from betty.portable import CallbackPorter
-
-_DataClsT = TypeVar("_DataClsT", default=Any)
 
 
 @final

--- a/betty/plugin/__init__.py
+++ b/betty/plugin/__init__.py
@@ -9,16 +9,7 @@ from __future__ import annotations
 
 from functools import update_wrapper
 from importlib import metadata
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Generic,
-    Self,
-    TypeAlias,
-    TypeVar,
-    final,
-    override,
-)
+from typing import TYPE_CHECKING, Any, Self, final, override
 
 from betty.definition.cls import ClsDefinition
 from betty.definition.human_facing import CountableHumanFacingDefinition
@@ -37,10 +28,8 @@ if TYPE_CHECKING:
     )
     from betty.plugin.discovery import Discoverer, ResolvableDiscovery
 
-_BaseClsCoT = TypeVar("_BaseClsCoT", default=object, covariant=True)
 
-
-class PluginDefinition(ClsDefinition[_BaseClsCoT], Generic[_BaseClsCoT]):
+class PluginDefinition[BaseClsT](ClsDefinition[BaseClsT]):
     """
     A plugin definition.
     """
@@ -50,7 +39,7 @@ class PluginDefinition(ClsDefinition[_BaseClsCoT], Generic[_BaseClsCoT]):
         self._id = MachineName.resolve(plugin_id)
 
     @classmethod
-    def type(cls) -> PluginTypeDefinition[_BaseClsCoT, Self]:
+    def type(cls) -> PluginTypeDefinition[BaseClsT, Self]:
         """
         The plugin type definition.
         """
@@ -71,7 +60,7 @@ class PluginDefinition(ClsDefinition[_BaseClsCoT], Generic[_BaseClsCoT]):
         return self._id
 
     @override
-    def _set_cls(self, cls: builtins.type[_BaseClsCoT]) -> None:
+    def _set_cls(self, cls: builtins.type[BaseClsT]) -> None:
         super()._set_cls(cls)
         cls.plugin = staticmethod(update_wrapper(lambda: self, cls.plugin))  # ty:ignore[unresolved-attribute]
 
@@ -93,22 +82,9 @@ class PluginDefinition(ClsDefinition[_BaseClsCoT], Generic[_BaseClsCoT]):
         )
 
 
-_PluginDefinitionT = TypeVar(
-    "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
-)
-_PluginDefinitionCoT = TypeVar(
-    "_PluginDefinitionCoT",
-    bound=PluginDefinition,
-    default=PluginDefinition,
-    covariant=True,
-)
-
-
 @final
-class PluginTypeDefinition(
-    CountableHumanFacingDefinition,
-    ClsDefinition[_PluginDefinitionT],
-    Generic[_BaseClsCoT, _PluginDefinitionT],
+class PluginTypeDefinition[BaseClsT, PluginDefinitionT: PluginDefinition](
+    CountableHumanFacingDefinition, ClsDefinition[PluginDefinitionT]
 ):
     """
     A plugin type definition.
@@ -122,7 +98,7 @@ class PluginTypeDefinition(
         label_plural: ResolvableLocalizable,
         label_countable: CountableLocalizable,
         description: ResolvableLocalizable | None = None,
-        discovery: Iterable[ResolvableDiscovery[_PluginDefinitionT]] | None = None,
+        discovery: Iterable[ResolvableDiscovery[PluginDefinitionT]] | None = None,
     ):
         from betty.plugin.discovery import Discoverer
 
@@ -134,7 +110,7 @@ class PluginTypeDefinition(
         )
 
         self._id = MachineName.resolve(plugin_type_id)
-        self._discoverer = Discoverer[_PluginDefinitionT](discovery)
+        self._discoverer = Discoverer[PluginDefinitionT](discovery)
 
     @property
     def id(self) -> MachineName:
@@ -144,36 +120,33 @@ class PluginTypeDefinition(
         return self._id
 
     @override
-    def _set_cls(self, cls: type[_PluginDefinitionT]) -> None:
+    def _set_cls(self, cls: type[PluginDefinitionT]) -> None:
         super()._set_cls(cls)
         cls.type = staticmethod(update_wrapper(lambda: self, cls.type))  # ty:ignore[invalid-assignment]
 
     @property
     def discoverer(
         self,
-    ) -> Discoverer[_PluginDefinitionT]:
+    ) -> Discoverer[PluginDefinitionT]:
         """
         The plugin discoverer for this type.
         """
         return self._discoverer
 
 
-class Plugin(Generic[_PluginDefinitionCoT]):
+class Plugin[PluginDefinitionT: PluginDefinition]:
     """
     A plugin class.
     """
 
     @classmethod
-    def plugin(cls) -> _PluginDefinitionCoT:
+    def plugin(cls) -> PluginDefinitionT:
         """
         The plugin definition.
         """
         raise NotImplementedError(
             f"{fully_qualified_name(cls)} was not decorated with a {fully_qualified_name(PluginDefinition)} subclass."
         )
-
-
-_PluginT = TypeVar("_PluginT", bound=Plugin, default=Plugin)
 
 
 @final
@@ -206,23 +179,25 @@ class PluginTypeRepository:
         return iter(self._get_plugin_types().values())
 
 
-ResolvableDefinition: TypeAlias = _PluginDefinitionT | type[Plugin[_PluginDefinitionT]]
+type ResolvableDefinition[PluginDefinitionT: PluginDefinition = PluginDefinition] = (
+    PluginDefinitionT | type[Plugin[PluginDefinitionT]]
+)
 """
 Use :py:func:`betty.plugin.resolve.resolve_definition` to resolve this to a :py:class:`betty.plugin.PluginDefinition`
 """
 
 
-ResolvableId: TypeAlias = (
-    ResolvableMachineName | ResolvableDefinition[_PluginDefinitionT]
+type ResolvableId[PluginDefinitionT: PluginDefinition = PluginDefinition] = (
+    ResolvableMachineName | ResolvableDefinition[PluginDefinitionT]
 )
 """
 Use :py:func:`betty.plugin.resolve.resolve_id` to resolve this to a plugin ID.
 """
 
 
-def resolve_definition(
-    definition: ResolvableDefinition[_PluginDefinitionT], /
-) -> _PluginDefinitionT:
+def resolve_definition[PluginDefinitionT: PluginDefinition](
+    definition: ResolvableDefinition[PluginDefinitionT], /
+) -> PluginDefinitionT:
     """
     Resolve a plugin definition.
     """

--- a/betty/plugin/assertion.py
+++ b/betty/plugin/assertion.py
@@ -2,7 +2,7 @@
 Provide plugin assertions.
 """
 
-from typing import Any, TypeVar
+from typing import Any
 
 from betty.assertion import AssertionChain, assert_str
 from betty.exception import HumanFacingException
@@ -12,19 +12,17 @@ from betty.plugin import PluginDefinition
 from betty.plugin.error import PluginNotFound
 from betty.plugin.repository import PluginRepository
 
-_PluginDefinitionT = TypeVar("_PluginDefinitionT", bound=PluginDefinition)
 
-
-def assert_plugin(
-    plugins: PluginRepository[_PluginDefinitionT],
-) -> AssertionChain[Any, _PluginDefinitionT]:
+def assert_plugin[PluginDefinitionT: PluginDefinition](
+    plugins: PluginRepository[PluginDefinitionT],
+) -> AssertionChain[Any, PluginDefinitionT]:
     """
     Assert that a value is a plugin ID.
     """
 
     def _assert(
         value: Any,
-    ) -> _PluginDefinitionT:
+    ) -> PluginDefinitionT:
         plugin_id = assert_str()(value)
         try:
             return plugins[plugin_id]

--- a/betty/plugin/config/__init__.py
+++ b/betty/plugin/config/__init__.py
@@ -7,16 +7,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from asyncio import gather
 from collections.abc import Iterable, Mapping, MutableMapping, MutableSequence
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Generic,
-    Self,
-    TypeAlias,
-    TypeVar,
-    final,
-    override,
-)
+from typing import TYPE_CHECKING, Any, Generic, Self, TypeVar, final, override
 
 from betty.assertion import (
     AssertionChain,
@@ -57,18 +48,10 @@ if TYPE_CHECKING:
     from betty.portable import PortableData
     from betty.service.level import ServiceLevel
 
-_T = TypeVar("_T")
-_PluginT = TypeVar("_PluginT", bound=Plugin, default=Plugin)
-_PluginDefinitionT = TypeVar(
-    "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
-)
 
-
-class PluginDefinitionConfiguration(
-    Data[ObjectDefinition["PluginDefinitionConfiguration"]],
-    ABC,
-    Generic[_PluginDefinitionT],
-):
+class PluginDefinitionConfiguration[
+    PluginDefinitionT: PluginDefinition = PluginDefinition
+](Data[ObjectDefinition["PluginDefinitionConfiguration"]], ABC):
     """
     Configure a :py:class:`betty.plugin.PluginDefinition`.
 
@@ -89,15 +72,15 @@ class PluginDefinitionConfiguration(
         self.id = id
 
     @abstractmethod
-    def new_plugin(self) -> _PluginDefinitionT:
+    def new_plugin(self) -> PluginDefinitionT:
         """
         Create a new plugin from this configuration.
         """
 
 
-class HumanFacingPluginDefinitionConfiguration(
-    PluginDefinitionConfiguration[_PluginDefinitionT]
-):
+class HumanFacingPluginDefinitionConfiguration[
+    PluginDefinitionT: PluginDefinition = PluginDefinition
+](PluginDefinitionConfiguration[PluginDefinitionT]):
     """
     Configure a :py:class:`betty.definition.human_facing.HumanFacingDefinition`.
 
@@ -119,9 +102,9 @@ class HumanFacingPluginDefinitionConfiguration(
         self.description = description
 
 
-class CountableHumanFacingPluginDefinitionConfiguration(
-    HumanFacingPluginDefinitionConfiguration[_PluginDefinitionT]
-):
+class CountableHumanFacingPluginDefinitionConfiguration[
+    PluginDefinitionT: PluginDefinition = PluginDefinition
+](HumanFacingPluginDefinitionConfiguration[PluginDefinitionT]):
     """
     Configure a :py:class:`betty.definition.human_facing.CountableHumanFacingDefinition`.
 
@@ -143,9 +126,19 @@ class CountableHumanFacingPluginDefinitionConfiguration(
         self.label_countable = label_countable
 
 
+_PluginConfigurationPluginT = TypeVar(
+    "_PluginConfigurationPluginT", bound=Plugin, covariant=True
+)
+_PluginConfigurationPluginDefinitionT = TypeVar(
+    "_PluginConfigurationPluginDefinitionT", bound=PluginDefinition
+)
+
+
 @final
 class PluginConfiguration(
-    PortableRecord[Attr], Samplable, Generic[_PluginDefinitionT, _PluginT]
+    PortableRecord[Attr],
+    Samplable,
+    Generic[_PluginConfigurationPluginDefinitionT, _PluginConfigurationPluginT],  # noqa: UP046
 ):
     """
     Configure a single plugin instance.
@@ -155,7 +148,7 @@ class PluginConfiguration(
 
     def __init__(
         self,
-        id: ResolvableId[_PluginDefinitionT],  # noqa: A002
+        id: ResolvableId[_PluginConfigurationPluginDefinitionT],  # noqa: A002
         configuration: Data | PortableData | Void = Void(),  # noqa: B008
         /,
     ):
@@ -202,7 +195,9 @@ class PluginConfiguration(
 
     def _dump_configuration(self, configuration: Data | PortableData) -> PortableData:
         if isinstance(configuration, Data):
-            return configuration.data().porter.dump(configuration)  # ty:ignore[invalid-argument-type]
+            return configuration.data().porter.dump(
+                configuration,  # ty:ignore[invalid-argument-type]
+            )  # ty:ignore[invalid-argument-type, invalid-return-type]
         return configuration
 
     @override
@@ -222,8 +217,11 @@ class PluginConfiguration(
         }
 
     async def new_plugin(
-        self, services: ServiceLevel, plugin_type: type[_PluginDefinitionT], /
-    ) -> _PluginT:
+        self,
+        services: ServiceLevel,
+        plugin_type: type[_PluginConfigurationPluginDefinitionT],
+        /,
+    ) -> _PluginConfigurationPluginT:
         """
         Create a new instance of the configured plugin.
         """
@@ -256,14 +254,15 @@ class PluginConfiguration(
         )
 
 
-ResolvablePluginConfiguration: TypeAlias = (
-    ResolvableId[_PluginDefinitionT] | PluginConfiguration[_PluginDefinitionT, _PluginT]
-)
+type ResolvablePluginConfiguration[
+    PluginDefinitionT: PluginDefinition = PluginDefinition,
+    PluginT: Plugin = Plugin,
+] = ResolvableId[PluginDefinitionT] | PluginConfiguration[PluginDefinitionT, PluginT]
 
 
-def resolve_plugin_configuration(
-    plugin_configuration: ResolvablePluginConfiguration[_PluginDefinitionT, _PluginT],
-) -> PluginConfiguration[_PluginDefinitionT, _PluginT]:
+def resolve_plugin_configuration[PluginDefinitionT: PluginDefinition, PluginT: Plugin](
+    plugin_configuration: ResolvablePluginConfiguration[PluginDefinitionT, PluginT],
+) -> PluginConfiguration[PluginDefinitionT, PluginT]:
     """
     Resolve a value to a plugin configuration.
     """
@@ -271,20 +270,26 @@ def resolve_plugin_configuration(
         return plugin_configuration
     if isinstance(plugin_configuration, str):
         return PluginConfiguration(plugin_configuration)
-    return PluginConfiguration(resolve_definition(plugin_configuration).id)  # ty:ignore[invalid-argument-type]
+    return PluginConfiguration(resolve_definition(plugin_configuration).id)
 
 
-ResolvablePluginConfigurationSequence: TypeAlias = (
-    ResolvablePluginConfiguration[_PluginDefinitionT, _PluginT]
-    | Iterable[ResolvablePluginConfiguration[_PluginDefinitionT, _PluginT]]
+type ResolvablePluginConfigurationSequence[
+    PluginDefinitionT: PluginDefinition = PluginDefinition,
+    PluginT: Plugin = Plugin,
+] = (
+    ResolvablePluginConfiguration[PluginDefinitionT, PluginT]
+    | Iterable[ResolvablePluginConfiguration[PluginDefinitionT, PluginT]]
 )
 
 
-def resolve_plugin_configuration_sequence(
+def resolve_plugin_configuration_sequence[
+    PluginDefinitionT: PluginDefinition,
+    PluginT: Plugin,
+](
     plugin_configurations: ResolvablePluginConfigurationSequence[
-        _PluginDefinitionT, _PluginT
+        PluginDefinitionT, PluginT
     ],
-) -> MutableSequence[PluginConfiguration[_PluginDefinitionT, _PluginT]]:
+) -> MutableSequence[PluginConfiguration[PluginDefinitionT, PluginT]]:
     """
     Resolve a value to a sequence of plugin configurations.
     """
@@ -295,15 +300,23 @@ def resolve_plugin_configuration_sequence(
         or isinstance(plugin_configurations, type)
         and issubclass(plugin_configurations, Plugin)
     ):
-        return [resolve_plugin_configuration(plugin_configurations)]  # ty:ignore[invalid-argument-type]
+        return [
+            resolve_plugin_configuration(
+                plugin_configurations,  # ty:ignore[invalid-argument-type]
+            )
+        ]
     return list(map(resolve_plugin_configuration, plugin_configurations))  # ty:ignore[invalid-argument-type]
 
 
-def resolve_plugin_configuration_mapping(
+def resolve_plugin_configuration_mapping[
+    PluginDefinitionT: PluginDefinition,
+    PluginT: Plugin,
+    KeyT,
+](
     plugin_configurations: Mapping[
-        _T, ResolvablePluginConfiguration[_PluginDefinitionT, _PluginT]
+        KeyT, ResolvablePluginConfiguration[PluginDefinitionT, PluginT]
     ],
-) -> MutableMapping[_T, PluginConfiguration[_PluginDefinitionT, _PluginT]]:
+) -> MutableMapping[KeyT, PluginConfiguration[PluginDefinitionT, PluginT]]:
     """
     Resolve a value to a mapping of plugin configurations.
     """
@@ -313,22 +326,20 @@ def resolve_plugin_configuration_mapping(
     }
 
 
-async def new_plugins(
+async def new_plugins[PluginDefinitionT: PluginDefinition, PluginT: Plugin](
     services: ServiceLevel,
-    plugin_type: type[Intersection[_PluginDefinitionT, PluginDefinition[_PluginT]]],
+    plugin_type: type[Intersection[PluginDefinitionT, PluginDefinition[PluginT]]],
     plugins: ResolvablePluginConfigurationSequence[
-        Intersection[_PluginDefinitionT, PluginDefinition[_PluginT]], _PluginT
+        Intersection[PluginDefinitionT, PluginDefinition[PluginT]], PluginT
     ],
     /,
-) -> Iterable[_PluginT]:
+) -> Iterable[PluginT]:
     """
     Create new instances of the configured plugins.
     """
     return await gather(
         *[
             plugin.new_plugin(services, plugin_type)
-            for plugin in resolve_plugin_configuration_sequence(
-                plugins,  # ty:ignore[invalid-argument-type]
-            )
+            for plugin in resolve_plugin_configuration_sequence(plugins)
         ]
     )

--- a/betty/plugin/config/ordered.py
+++ b/betty/plugin/config/ordered.py
@@ -4,7 +4,7 @@ Configuration for ordered plugins.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any
 
 from betty.data.aggregate.collection.sequence import SequenceDefinition
 from betty.data.aggregate.record.object.property import SequenceProperty
@@ -16,13 +16,9 @@ from betty.plugin.config import PluginDefinitionConfiguration
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-_PluginDefinitionT = TypeVar(
-    "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
-)
 
-
-class OrderedPluginDefinitionConfiguration(
-    PluginDefinitionConfiguration[_PluginDefinitionT]
+class OrderedPluginDefinitionConfiguration[PluginDefinitionT: PluginDefinition](
+    PluginDefinitionConfiguration[PluginDefinitionT]
 ):
     """
     Configure a :py:class:`betty.plugin.ordered.OrderedPluginDefinition`.

--- a/betty/plugin/config/property.py
+++ b/betty/plugin/config/property.py
@@ -4,7 +4,7 @@ Plugin configuration properties.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar, final
+from typing import TYPE_CHECKING, final
 
 from betty.collections import (
     MutableDictKeyedCollection,
@@ -31,20 +31,18 @@ from betty.plugin.data import PluginConfigurationSequenceDefinition
 if TYPE_CHECKING:
     from betty.locale.localizable import ResolvableLocalizable
 
-_PluginT = TypeVar("_PluginT", bound=Plugin, default=Plugin)
-_PluginDefinitionT = TypeVar(
-    "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
-)
-
 
 @final
-class PluginConfigurationSequenceProperty(
+class PluginConfigurationSequenceProperty[
+    PluginDefinitionT: PluginDefinition,
+    PluginT: Plugin,
+](
     SequenceProperty[
         MutableResolvedSequence[
-            PluginConfiguration[_PluginDefinitionT, _PluginT],
-            ResolvablePluginConfiguration[_PluginDefinitionT, _PluginT],
+            PluginConfiguration[PluginDefinitionT, PluginT],
+            ResolvablePluginConfiguration[PluginDefinitionT, PluginT],
         ],
-        ResolvablePluginConfigurationSequence[_PluginDefinitionT, _PluginT],
+        ResolvablePluginConfigurationSequence[PluginDefinitionT, PluginT],
     ]
 ):
     """
@@ -53,7 +51,7 @@ class PluginConfigurationSequenceProperty(
 
     def __init__(
         self,
-        plugin_type: type[_PluginDefinitionT],
+        plugin_type: type[PluginDefinitionT],
         *,
         label: ResolvableLocalizable | None = None,
         description: ResolvableLocalizable | None = None,
@@ -70,15 +68,17 @@ class PluginConfigurationSequenceProperty(
 
 
 @final
-class PluginDefinitionConfigurationsProperty(KeyedCollectionProperty):
+class PluginDefinitionConfigurationsProperty[PluginDefinitionT: PluginDefinition](
+    KeyedCollectionProperty
+):
     """
     A property containing a :py:class:`betty.collections.KeyedCollection` of :py:class:`betty.plugin.config.PluginDefinitionConfiguration`.
     """
 
     def __init__(
         self,
-        plugin_type: type[_PluginDefinitionT],
-        item: type[PluginDefinitionConfiguration[_PluginDefinitionT]],
+        plugin_type: type[PluginDefinitionT],
+        item: type[PluginDefinitionConfiguration[PluginDefinitionT]],
         *,
         label: ResolvableLocalizable | None = None,
         description: ResolvableLocalizable | None = None,

--- a/betty/plugin/data.py
+++ b/betty/plugin/data.py
@@ -4,7 +4,7 @@ Data types for plugins.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar, final
+from typing import TYPE_CHECKING, final
 
 from betty.collections import MutableResolvedSequence, MutableResolvedSequenceProxy
 from betty.data import DataDefinition
@@ -14,15 +14,11 @@ from betty.data.aggregate.record.object import ObjectDefinition
 from betty.data.indicator.selector import Attr
 from betty.locale.localizable.gettext import _
 from betty.machine_name import MachineName
-from betty.plugin import PluginDefinition
 from betty.plugin.config import PluginConfiguration, resolve_plugin_configuration
 
 if TYPE_CHECKING:
     from betty.locale.localizable import ResolvableLocalizable
-
-_PluginDefinitionT = TypeVar(
-    "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
-)
+    from betty.plugin import PluginDefinition
 
 
 @final
@@ -55,7 +51,7 @@ class PluginConfigurationSequenceDefinition(SequenceDefinition):
 
     def __init__(
         self,
-        plugin_type: type[_PluginDefinitionT],
+        plugin_type: type[PluginDefinition],
         *,
         label: ResolvableLocalizable | None = None,
     ):

--- a/betty/plugin/dependent.py
+++ b/betty/plugin/dependent.py
@@ -4,7 +4,7 @@ Plugins that can declare dependencies on other plugins.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any
 
 from betty.plugin import ResolvableId, resolve_id
 from betty.plugin.ordered import OrderedPluginDefinition, sort_ordered_plugin_graph
@@ -17,10 +17,7 @@ if TYPE_CHECKING:
     from betty.plugin.repository import PluginRepository
 
 
-_BaseClsCoT = TypeVar("_BaseClsCoT", default=object, covariant=True)
-
-
-class DependentPluginDefinition(OrderedPluginDefinition[_BaseClsCoT]):
+class DependentPluginDefinition[BaseClsT = Any](OrderedPluginDefinition[BaseClsT]):
     """
     A definition of a plugin that can declare its dependency on other plugins.
     """
@@ -54,16 +51,13 @@ class DependentPluginDefinition(OrderedPluginDefinition[_BaseClsCoT]):
         return self._depends_on
 
 
-_DependentPluginDefinitionT = TypeVar(
-    "_DependentPluginDefinitionT", bound=DependentPluginDefinition
-)
-
-
-async def expand_plugin_dependencies(
-    plugin_repository: PluginRepository[_DependentPluginDefinitionT],
-    plugins: Iterable[_DependentPluginDefinitionT],
+async def expand_plugin_dependencies[
+    DependentPluginDefinitionT: DependentPluginDefinition
+](
+    plugin_repository: PluginRepository[DependentPluginDefinitionT],
+    plugins: Iterable[DependentPluginDefinitionT],
     /,
-) -> Set[_DependentPluginDefinitionT]:
+) -> Set[DependentPluginDefinitionT]:
     """
     Expand a collection of plugins to include their dependencies.
     """
@@ -79,9 +73,11 @@ async def expand_plugin_dependencies(
     return dependencies
 
 
-async def sort_dependent_plugin_graph(
-    plugin_repository: PluginRepository[_DependentPluginDefinitionT],
-    plugins: Iterable[_DependentPluginDefinitionT],
+async def sort_dependent_plugin_graph[
+    DependentPluginDefinitionT: DependentPluginDefinition
+](
+    plugin_repository: PluginRepository[DependentPluginDefinitionT],
+    plugins: Iterable[DependentPluginDefinitionT],
     /,
 ) -> TopologicalSorter[MachineName]:
     """

--- a/betty/plugin/discovery/__init__.py
+++ b/betty/plugin/discovery/__init__.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from asyncio import gather
 from collections.abc import Awaitable, Callable, Collection, Iterable
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Generic, TypeAlias, TypeVar, final
+from typing import TYPE_CHECKING, final
 
 from betty.asyncio import resolve_await
 from betty.plugin import Plugin, PluginDefinition, ResolvableDefinition
@@ -19,12 +19,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
 
-_PluginDefinitionT = TypeVar(
-    "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
-)
-
-
-class PluginDiscovery(ABC, Generic[_PluginDefinitionT]):
+class PluginDiscovery[PluginDefinitionT: PluginDefinition = PluginDefinition](ABC):
     """
     A plugin definition discovery.
     """
@@ -32,27 +27,26 @@ class PluginDiscovery(ABC, Generic[_PluginDefinitionT]):
     @abstractmethod
     async def discover(
         self, services: ServiceLevel, /
-    ) -> Iterable[ResolvableDiscovery[_PluginDefinitionT]]:
+    ) -> Iterable[ResolvableDiscovery[PluginDefinitionT]]:
         """
         Discover the plugin definitions.
         """
 
 
-ResolvableDiscovery: TypeAlias = (
-    PluginDiscovery[_PluginDefinitionT]
+type ResolvableDiscovery[PluginDefinitionT: PluginDefinition = PluginDefinition] = (
+    PluginDiscovery[PluginDefinitionT]
     | Callable[
         [ServiceLevel],
-        Awaitable[Iterable["ResolvableDiscovery[_PluginDefinitionT]"]]
-        | Iterable["ResolvableDiscovery[_PluginDefinitionT]"],
+        Awaitable[Iterable["ResolvableDiscovery[PluginDefinitionT]"]]
+        | Iterable["ResolvableDiscovery[PluginDefinitionT]"],
     ]
-    | ResolvableDefinition[_PluginDefinitionT]
+    | ResolvableDefinition[PluginDefinitionT]
 )
 
 
-async def discover(
-    services: ServiceLevel,
-    *discoveries: ResolvableDiscovery[_PluginDefinitionT],
-) -> Iterable[_PluginDefinitionT]:
+async def discover[PluginDefinitionT: PluginDefinition](
+    services: ServiceLevel, *discoveries: ResolvableDiscovery[PluginDefinitionT]
+) -> Iterable[PluginDefinitionT]:
     """
     Discover plugins definitions.
     """
@@ -65,40 +59,40 @@ async def discover(
     ]
 
 
-async def _discover(
-    discovery: ResolvableDiscovery[_PluginDefinitionT], services: ServiceLevel
-) -> Iterable[_PluginDefinitionT]:
+async def _discover[PluginDefinitionT: PluginDefinition](
+    discovery: ResolvableDiscovery[PluginDefinitionT], services: ServiceLevel
+) -> Iterable[PluginDefinitionT]:
     from betty.service.requirement import UnmetRequirement
 
     try:
         if isinstance(discovery, PluginDiscovery):
-            return await discover(services, *await discovery.discover(services))  # ty:ignore[invalid-return-type]
+            return await discover(services, *await discovery.discover(services))
         if isinstance(discovery, PluginDefinition):
             return [discovery]  # ty:ignore[invalid-return-type]
         if isinstance(discovery, type) and issubclass(discovery, Plugin):
-            return [discovery.plugin()]  # ty:ignore[invalid-return-type]
-        return await discover(services, *await resolve_await(discovery(services)))  # ty:ignore[invalid-return-type]
+            return [discovery.plugin()]  # ty:ignore[invalid-argument-type,invalid-return-type]
+        return await discover(services, *await resolve_await(discovery(services)))
     except UnmetRequirement:
         return ()
 
 
 @final
-class Discoverer(PluginDiscovery[_PluginDefinitionT]):
+class Discoverer[PluginDefinitionT: PluginDefinition](
+    PluginDiscovery[PluginDefinitionT]
+):
     """
     A plugin discoverer.
     """
 
     def __init__(
         self,
-        discovery: Iterable[ResolvableDiscovery[_PluginDefinitionT]] | None = None,
+        discovery: Iterable[ResolvableDiscovery[PluginDefinitionT]] | None = None,
         /,
     ):
         self._defined = [] if discovery is None else list(discovery)
-        self._active: Collection[ResolvableDiscovery[_PluginDefinitionT]] = (
-            self._defined
-        )
+        self._active: Collection[ResolvableDiscovery[PluginDefinitionT]] = self._defined
 
-    def add(self, *discoveries: ResolvableDiscovery[_PluginDefinitionT]) -> None:
+    def add(self, *discoveries: ResolvableDiscovery[PluginDefinitionT]) -> None:
         """
         Add discoveries.
         """
@@ -106,7 +100,7 @@ class Discoverer(PluginDiscovery[_PluginDefinitionT]):
 
     @contextmanager
     def override(
-        self, *discoveries: ResolvableDiscovery[_PluginDefinitionT]
+        self, *discoveries: ResolvableDiscovery[PluginDefinitionT]
     ) -> Iterator[None]:
         """
         Temporarily override the defined discoveries with the given discoveries.
@@ -125,5 +119,5 @@ class Discoverer(PluginDiscovery[_PluginDefinitionT]):
         return self._defined != self._active
 
     @typing.override
-    async def discover(self, services: ServiceLevel, /) -> Iterable[_PluginDefinitionT]:
-        return await discover(services, *self._active)  # ty:ignore[invalid-return-type]
+    async def discover(self, services: ServiceLevel, /) -> Iterable[PluginDefinitionT]:
+        return await discover(services, *self._active)

--- a/betty/plugin/discovery/entry_point.py
+++ b/betty/plugin/discovery/entry_point.py
@@ -5,7 +5,7 @@ Discover plugins defined as distribution package entry points.
 from __future__ import annotations
 
 from importlib import metadata
-from typing import TYPE_CHECKING, TypeVar, cast, final, override
+from typing import TYPE_CHECKING, cast, final, override
 
 from betty.plugin import PluginDefinition, ResolvableDefinition
 from betty.plugin.discovery import PluginDiscovery
@@ -15,13 +15,11 @@ if TYPE_CHECKING:
 
     from betty.service.level import ServiceLevel
 
-_PluginDefinitionT = TypeVar(
-    "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
-)
-
 
 @final
-class EntryPointDiscovery(PluginDiscovery[_PluginDefinitionT]):
+class EntryPointDiscovery[PluginDefinitionT: PluginDefinition](
+    PluginDiscovery[PluginDefinitionT]
+):
     """
     Discover plugins defined as distribution package `entry points <https://packaging.python.org/en/latest/specifications/entry-points/>`_.
 
@@ -48,8 +46,8 @@ class EntryPointDiscovery(PluginDiscovery[_PluginDefinitionT]):
     @override
     async def discover(
         self, services: ServiceLevel, /
-    ) -> Iterable[ResolvableDefinition[_PluginDefinitionT]]:
+    ) -> Iterable[ResolvableDefinition[PluginDefinitionT]]:
         return [
-            cast(ResolvableDefinition[_PluginDefinitionT], entry_point.load())
+            cast(ResolvableDefinition[PluginDefinitionT], entry_point.load())
             for entry_point in metadata.entry_points(group=self._entry_point_group)
         ]

--- a/betty/plugin/error.py
+++ b/betty/plugin/error.py
@@ -4,7 +4,7 @@ Generic plugin API errors.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, TypeVar, final
+from typing import TYPE_CHECKING, Any, final
 
 from betty.exception import HumanFacingException
 from betty.locale.localizable.gettext import _
@@ -20,10 +20,6 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from betty.machine_name import ResolvableMachineName
-
-_PluginDefinitionT = TypeVar(
-    "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
-)
 
 
 class PluginError(Exception):
@@ -44,11 +40,11 @@ class PluginNotFound(PluginUnavailable):
     Raised when a plugin cannot be found.
     """
 
-    def __init__(
+    def __init__[PluginDefinitionT: PluginDefinition](
         self,
-        plugin_type: PluginTypeDefinition[Any, _PluginDefinitionT],
+        plugin_type: PluginTypeDefinition[Any, PluginDefinitionT],
         plugin_not_found: ResolvableMachineName,
-        available_plugins: Sequence[ResolvableId[_PluginDefinitionT]],
+        available_plugins: Sequence[ResolvableId[PluginDefinitionT]],
         /,
     ):
         super().__init__(

--- a/betty/plugin/manager/__init__.py
+++ b/betty/plugin/manager/__init__.py
@@ -5,7 +5,7 @@ Tools to automatically provide repositories for plugin types.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING
 
 from betty.plugin import PluginDefinition, PluginTypeRepository
 from betty.typing import threadsafe
@@ -13,10 +13,6 @@ from betty.typing import threadsafe
 if TYPE_CHECKING:
     from betty.machine_name import ResolvableMachineName
     from betty.plugin.repository import PluginRepository
-
-_PluginDefinitionT = TypeVar(
-    "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
-)
 
 
 @threadsafe
@@ -26,9 +22,9 @@ class PluginManager(ABC):
     """
 
     @abstractmethod
-    async def plugins(
-        self, plugin_type: type[_PluginDefinitionT] | ResolvableMachineName, /
-    ) -> PluginRepository[_PluginDefinitionT]:
+    async def plugins[PluginDefinitionT: PluginDefinition](
+        self, plugin_type: type[PluginDefinitionT] | ResolvableMachineName, /
+    ) -> PluginRepository[PluginDefinitionT]:
         """
         Get the available plugins for the given type.
         """

--- a/betty/plugin/manager/service.py
+++ b/betty/plugin/manager/service.py
@@ -5,7 +5,7 @@ Provide plugin repositories for service levels.
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, TypeVar, cast, final, override
+from typing import TYPE_CHECKING, Any, cast, final, override
 
 from betty import plugin
 from betty.concurrent import AsynchronizedLock, Ledger
@@ -19,12 +19,6 @@ if TYPE_CHECKING:
     from betty.machine_name import ResolvableMachineName
     from betty.plugin.repository import PluginRepository
     from betty.service.level import ServiceLevel
-
-
-_T = TypeVar("_T")
-_PluginDefinitionT = TypeVar(
-    "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
-)
 
 
 @final
@@ -47,12 +41,12 @@ class ServiceLevelPluginManager(PluginManager):
         return self._types
 
     @override
-    async def plugins(
-        self, plugin_type: type[_PluginDefinitionT] | ResolvableMachineName, /
-    ) -> PluginRepository[_PluginDefinitionT]:
+    async def plugins[PluginDefinitionT: PluginDefinition](
+        self, plugin_type: type[PluginDefinitionT] | ResolvableMachineName, /
+    ) -> PluginRepository[PluginDefinitionT]:
         if isinstance(plugin_type, str):
-            plugin_type = cast(type[_PluginDefinitionT], self.types[plugin_type])
-        repository: PluginRepository[_PluginDefinitionT] | None
+            plugin_type = cast(type[PluginDefinitionT], self.types[plugin_type])
+        repository: PluginRepository[PluginDefinitionT] | None
         if plugin_type.type().discoverer.overridden:
             return await self._new(plugin_type)
         # If the repository exists already, return it immediately so we avoid acquiring locks.
@@ -68,16 +62,16 @@ class ServiceLevelPluginManager(PluginManager):
             self._plugin_repositories[plugin_type] = repository
             return repository
 
-    def _get(
-        self, plugin_type: type[_PluginDefinitionT]
-    ) -> PluginRepository[_PluginDefinitionT] | None:
+    def _get[PluginDefinitionT: PluginDefinition](
+        self, plugin_type: type[PluginDefinitionT]
+    ) -> PluginRepository[PluginDefinitionT] | None:
         if plugin_type not in self._plugin_repositories:
             return None
         return self._plugin_repositories[plugin_type]
 
-    async def _new(
-        self, plugin_type: type[_PluginDefinitionT]
-    ) -> PluginRepository[_PluginDefinitionT]:
+    async def _new[PluginDefinitionT: PluginDefinition](
+        self, plugin_type: type[PluginDefinitionT]
+    ) -> PluginRepository[PluginDefinitionT]:
         return StaticPluginRepository(
             plugin_type, *await plugin_type.type().discoverer.discover(self._services)
         )

--- a/betty/plugin/ordered.py
+++ b/betty/plugin/ordered.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from graphlib import TopologicalSorter
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any
 
 from betty.machine_name import MachineName, ResolvableMachineName
 from betty.plugin import PluginDefinition, ResolvableId, resolve_id
@@ -17,13 +17,7 @@ if TYPE_CHECKING:
     from betty.plugin.repository import PluginRepository
 
 
-_BaseClsCoT = TypeVar("_BaseClsCoT", default=object, covariant=True)
-_PluginDefinitionT = TypeVar(
-    "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
-)
-
-
-class OrderedPluginDefinition(PluginDefinition[_BaseClsCoT]):
+class OrderedPluginDefinition[BaseClsT](PluginDefinition[BaseClsT]):
     """
     A definition of plugin that can declare its order with respect to other plugins.
     """
@@ -67,14 +61,9 @@ class OrderedPluginDefinition(PluginDefinition[_BaseClsCoT]):
         return self._comes_after
 
 
-_OrderedPluginDefinitionT = TypeVar(
-    "_OrderedPluginDefinitionT", bound=OrderedPluginDefinition
-)
-
-
-def sort_ordered_plugin_graph(
-    plugin_repository: PluginRepository[_OrderedPluginDefinitionT],
-    plugins: Iterable[_OrderedPluginDefinitionT],
+def sort_ordered_plugin_graph[OrderedPluginDefinitionT: OrderedPluginDefinition](
+    plugin_repository: PluginRepository[OrderedPluginDefinitionT],
+    plugins: Iterable[OrderedPluginDefinitionT],
     /,
 ) -> TopologicalSorter[MachineName]:
     """
@@ -95,11 +84,11 @@ def sort_ordered_plugin_graph(
     return sorter
 
 
-def get_comes_before(
-    plugin_repository: PluginRepository[_OrderedPluginDefinitionT],
-    origin: _OrderedPluginDefinitionT,
+def get_comes_before[OrderedPluginDefinitionT: OrderedPluginDefinition](
+    plugin_repository: PluginRepository[OrderedPluginDefinitionT],
+    origin: OrderedPluginDefinitionT,
     /,
-) -> Set[_OrderedPluginDefinitionT]:
+) -> Set[OrderedPluginDefinitionT]:
     """
     Get all other plugins the given plugin comes before.
     """
@@ -114,11 +103,11 @@ def get_comes_before(
     return set(_collect_plugin_graph(graph, origin))
 
 
-def get_comes_after(
-    plugin_repository: PluginRepository[_OrderedPluginDefinitionT],
-    origin: _OrderedPluginDefinitionT,
+def get_comes_after[OrderedPluginDefinitionT: OrderedPluginDefinition](
+    plugin_repository: PluginRepository[OrderedPluginDefinitionT],
+    origin: OrderedPluginDefinitionT,
     /,
-) -> Set[_OrderedPluginDefinitionT]:
+) -> Set[OrderedPluginDefinitionT]:
     """
     Get all other plugins the given plugin comes after.
     """
@@ -133,10 +122,10 @@ def get_comes_after(
     return set(_collect_plugin_graph(graph, origin))
 
 
-def _collect_plugin_graph(
-    graph: Mapping[_PluginDefinitionT, Set[_PluginDefinitionT]],
-    origin: _PluginDefinitionT,
-) -> Iterator[_PluginDefinitionT]:
+def _collect_plugin_graph[PluginDefinitionT: PluginDefinition](
+    graph: Mapping[PluginDefinitionT, Set[PluginDefinitionT]],
+    origin: PluginDefinitionT,
+) -> Iterator[PluginDefinitionT]:
     yield from graph[origin]
     for target in graph[origin]:
         yield from _collect_plugin_graph(graph, target)

--- a/betty/plugin/repository/__init__.py
+++ b/betty/plugin/repository/__init__.py
@@ -5,7 +5,7 @@ Access discovered plugins.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING
 
 from betty.plugin import PluginDefinition
 
@@ -15,28 +15,24 @@ if TYPE_CHECKING:
 
     from betty.machine_name import ResolvableMachineName
 
-_PluginDefinitionT = TypeVar(
-    "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
-)
 
-
-class PluginRepository(ABC, Generic[_PluginDefinitionT]):
+class PluginRepository[PluginDefinitionT: PluginDefinition = PluginDefinition](ABC):
     """
     Access discovered plugins.
     """
 
-    def __init__(self, plugin_type: builtins.type[_PluginDefinitionT]):
+    def __init__(self, plugin_type: builtins.type[PluginDefinitionT]):
         self._type = plugin_type
 
     @property
-    def type(self) -> builtins.type[_PluginDefinitionT]:
+    def type(self) -> builtins.type[PluginDefinitionT]:
         """
         The plugin type contained by this repository.
         """
         return self._type
 
     @abstractmethod
-    def get(self, plugin_id: ResolvableMachineName, /) -> _PluginDefinitionT:
+    def get(self, plugin_id: ResolvableMachineName, /) -> PluginDefinitionT:
         """
         Get a single plugin by its ID.
 
@@ -47,8 +43,8 @@ class PluginRepository(ABC, Generic[_PluginDefinitionT]):
         return len(list(self.__iter__()))
 
     @abstractmethod
-    def __iter__(self) -> Iterator[_PluginDefinitionT]:
+    def __iter__(self) -> Iterator[PluginDefinitionT]:
         pass
 
-    def __getitem__(self, plugin_id: ResolvableMachineName) -> _PluginDefinitionT:
+    def __getitem__(self, plugin_id: ResolvableMachineName) -> PluginDefinitionT:
         return self.get(plugin_id)

--- a/betty/plugin/repository/static.py
+++ b/betty/plugin/repository/static.py
@@ -4,7 +4,7 @@ Provide static plugin management.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar, final, override
+from typing import TYPE_CHECKING, final, override
 
 from betty.plugin import PluginDefinition, ResolvableDefinition, resolve_definition
 from betty.plugin.error import PluginNotFound
@@ -15,19 +15,19 @@ if TYPE_CHECKING:
 
     from betty.machine_name import ResolvableMachineName
 
-_PluginDefinitionT = TypeVar("_PluginDefinitionT", bound=PluginDefinition)
-
 
 @final
-class StaticPluginRepository(PluginRepository[_PluginDefinitionT]):
+class StaticPluginRepository[PluginDefinitionT: PluginDefinition](
+    PluginRepository[PluginDefinitionT]
+):
     """
     A repository that is given a static collection of plugins, and exposes those.
     """
 
     def __init__(
         self,
-        plugin_type: type[_PluginDefinitionT],  # noqa: A002
-        *plugins: ResolvableDefinition[_PluginDefinitionT],
+        plugin_type: type[PluginDefinitionT],  # noqa: A002
+        *plugins: ResolvableDefinition[PluginDefinitionT],
     ):
         super().__init__(plugin_type)
         self._plugins = {
@@ -36,12 +36,12 @@ class StaticPluginRepository(PluginRepository[_PluginDefinitionT]):
         }
 
     @override
-    def get(self, plugin_id: ResolvableMachineName, /) -> _PluginDefinitionT:
+    def get(self, plugin_id: ResolvableMachineName, /) -> PluginDefinitionT:
         try:
-            return self._plugins[plugin_id]  # ty:ignore[invalid-return-type]
+            return self._plugins[plugin_id]
         except KeyError:
             raise PluginNotFound(self.type.type(), plugin_id, list(self)) from None
 
     @override
-    def __iter__(self) -> Iterator[_PluginDefinitionT]:
+    def __iter__(self) -> Iterator[PluginDefinitionT]:
         yield from self._plugins.values()

--- a/betty/plugin/schema.py
+++ b/betty/plugin/schema.py
@@ -4,7 +4,7 @@ Access discovered plugins.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Generic, TypeVar, final
+from typing import TYPE_CHECKING, final
 
 from betty.json.schema import Enum
 from betty.locale.localize import DEFAULT_LOCALIZER
@@ -14,22 +14,20 @@ from betty.string import kebab_case_to_lower_camel_case
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-_PluginT = TypeVar("_PluginT", bound=Plugin, default=Plugin)
-_PluginDefinitionT = TypeVar(
-    "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
-)
-
 
 @final
-class PluginIdSchema(Enum, Generic[_PluginDefinitionT, _PluginT]):
+class PluginIdSchema[
+    PluginDefinitionT: PluginDefinition = PluginDefinition,
+    PluginT: Plugin = Plugin,
+](Enum):
     """
     The JSON schema for the IDs of the plugins in this repository.
     """
 
     def __init__(
         self,
-        plugin_type: PluginTypeDefinition[_PluginT, _PluginDefinitionT],
-        plugins: Iterable[PluginDefinition[_PluginT]],
+        plugin_type: PluginTypeDefinition[PluginT, PluginDefinitionT],
+        plugins: Iterable[PluginDefinition[PluginT]],
         /,
     ):
         label = plugin_type.label.localize(DEFAULT_LOCALIZER)

--- a/betty/portable/__init__.py
+++ b/betty/portable/__init__.py
@@ -8,19 +8,16 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable, MutableMapping, MutableSequence
-from typing import Generic, Self, TypeAlias, TypeVar, final, override
+from typing import Any, Self, final, override
 
-_DataClsT = TypeVar("_DataClsT")
-
-
-PortableData: TypeAlias = (
+type PortableData = (
     bool
     | int
     | float
     | str
     | None
-    | MutableSequence["PortableData"]
-    | MutableMapping[str, "PortableData"]
+    | MutableSequence[PortableData]
+    | MutableMapping[str, PortableData]
 )
 """
 Portable data.
@@ -29,16 +26,13 @@ Data of this type is portable and can easily be persisted or transmitted.
 """
 
 
-_PortableDataT = TypeVar("_PortableDataT", bound=PortableData, default=PortableData)
-
-
-PortableSequence: TypeAlias = MutableSequence[_PortableDataT]
+type PortableSequence[PortableDataT: PortableData] = MutableSequence[PortableDataT]
 """
 A sequence of portable data.
 """
 
 
-PortableMapping: TypeAlias = MutableMapping[str, _PortableDataT]
+type PortableMapping[PortableDataT: PortableData] = MutableMapping[str, PortableDataT]
 """
 A key-value mapping of portable data.
 
@@ -46,7 +40,7 @@ Keys are strings.
 """
 
 
-class Portable(ABC, Generic[_PortableDataT]):
+class Portable[PortableDataT: PortableData](ABC):
     """
     A class that can be dumped to and loaded from portable data.
     """
@@ -61,7 +55,7 @@ class Portable(ABC, Generic[_PortableDataT]):
         """
 
     @abstractmethod
-    def dump(self) -> _PortableDataT:
+    def dump(self) -> PortableDataT:
         """
         Dump the instance to portable data.
 
@@ -69,27 +63,24 @@ class Portable(ABC, Generic[_PortableDataT]):
         """
 
 
-_PortableT = TypeVar("_PortableT", bound=Portable)
-
-
-class Porter(ABC, Generic[_DataClsT, _PortableDataT]):
+class Porter[DataClsT = Any, PortableDataT: PortableData = PortableData](ABC):
     """
     An object capable of dumping and loading data to and from portable data.
     """
 
     @abstractmethod
-    def load(self, portable: PortableData, /) -> _DataClsT:
+    def load(self, portable: PortableData, /) -> DataClsT:
         """
         Load data from its portable form.
         """
 
     @abstractmethod
-    def dump(self, data: _DataClsT, /) -> _PortableDataT:
+    def dump(self, data: DataClsT, /) -> PortableDataT:
         """
         Dump data to its portable form.
         """
 
-    def copy(self, data: _DataClsT) -> _DataClsT:
+    def copy(self, data: DataClsT) -> DataClsT:
         """
         Deep-copy data into a new instance.
         """
@@ -97,66 +88,69 @@ class Porter(ABC, Generic[_DataClsT, _PortableDataT]):
 
 
 @final
-class CallbackPorter(Porter[_DataClsT, _PortableDataT]):
+class CallbackPorter[DataClsT, PortableDataT: PortableData = PortableData](
+    Porter[DataClsT, PortableDataT]
+):
     """
     Make data portable using a separate loader and dumper.
     """
 
     def __init__(
         self,
-        loader: Callable[[PortableData], _DataClsT],
-        dumper: Callable[[_DataClsT], _PortableDataT],
+        loader: Callable[[PortableData], DataClsT],
+        dumper: Callable[[DataClsT], PortableDataT],
         /,
     ):
         self._loader = loader
         self._dumper = dumper
 
     @override
-    def load(self, portable: PortableData) -> _DataClsT:
+    def load(self, portable: PortableData) -> DataClsT:
         return self._loader(portable)
 
     @override
-    def dump(self, data: _DataClsT) -> _PortableDataT:
+    def dump(self, data: DataClsT) -> PortableDataT:
         return self._dumper(data)
 
 
-class PortablePorter(Porter[_PortableT, _PortableDataT]):
+class PortablePorter[PortableT: Portable, PortableDataT: PortableData = PortableData](
+    Porter[PortableT, PortableDataT]
+):
     """
     Expose a portable data type as a porter.
     """
 
-    def __init__(self, cls: type[_PortableT]):
+    def __init__(self, cls: type[PortableT]):
         self._cls = cls
 
     @override
-    def load(self, portable: PortableData) -> _PortableT:
+    def load(self, portable: PortableData) -> PortableT:
         return self._cls.load(portable)
 
     @override
-    def dump(self, data: _PortableT) -> _PortableDataT:
-        return data.dump()  # ty:ignore[invalid-return-type]
+    def dump(self, data: PortableT) -> PortableDataT:
+        return data.dump()
 
 
 @final
-class OptionalPorter(
-    Porter[_PortableT | None, _PortableDataT | None],
-    Generic[_PortableT, _PortableDataT],
+class OptionalPorter[PortableT: Portable, PortableDataT: PortableData = PortableData](
+    Porter[PortableT | None, PortableDataT | None]
 ):
     """
     Add optional (``None``) support to another porter.
     """
 
-    def __init__(self, upstream: Porter[_PortableT, _PortableDataT]):
+    def __init__(self, upstream: Porter[PortableT, PortableDataT]):
         self._upstream = upstream
 
     @override
-    def load(self, portable: PortableData) -> _PortableT | None:
+    def load(self, portable: PortableData) -> PortableT | None:
         if portable is None:
             return None
         return self._upstream.load(portable)
 
     @override
-    def dump(self, data: _PortableT | None) -> _PortableDataT | None:
+    def dump(self, data: PortableT | None) -> PortableDataT | None:
         if data is None:
             return None
         return self._upstream.dump(data)

--- a/betty/privacy/privatizer.py
+++ b/betty/privacy/privatizer.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from contextlib import suppress
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, TypeAlias
+from typing import TYPE_CHECKING, Any
 
 from betty.ancestry.event import Event
 from betty.ancestry.has_citations import HasCitations
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from betty.user import User
 
 
-_Expirable: TypeAlias = Person | Event | Date | None
+type _Expirable = Person | Event | Date | None
 
 
 class Privatizer:

--- a/betty/project/__init__.py
+++ b/betty/project/__init__.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from contextlib import AsyncExitStack, asynccontextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Self, TypeVar, final, overload, override
+from typing import TYPE_CHECKING, Self, final, overload, override
 
 from aiofiles.tempfile import TemporaryDirectory
 
@@ -33,7 +33,7 @@ from betty.locale.translation import (
     TranslationRepository,
 )
 from betty.machine_name import MachineName
-from betty.plugin import PluginDefinition, ResolvableId, resolve_id
+from betty.plugin import ResolvableId, resolve_id
 from betty.plugin.dependent import sort_dependent_plugin_graph
 from betty.privacy.privatizer import Privatizer
 from betty.project.data import ProjectConfiguration
@@ -59,10 +59,6 @@ if TYPE_CHECKING:
     from betty.jinja import Environment
     from betty.license import License
     from betty.url import UrlGenerator
-
-_PluginDefinitionT = TypeVar(
-    "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
-)
 
 
 @final
@@ -429,9 +425,6 @@ class Project(DataManufacturable[ProjectConfiguration], ServiceLevel, ManagedLif
         )
 
 
-_ExtensionT = TypeVar("_ExtensionT", bound=Extension)
-
-
 @internal
 @final
 class ProjectExtensions:
@@ -444,7 +437,9 @@ class ProjectExtensions:
         self._project_extensions = project_extensions
 
     @overload
-    def __getitem__(self, extension: type[_ExtensionT]) -> _ExtensionT:
+    def __getitem__[ExensionT: Extension](
+        self, extension: type[ExensionT]
+    ) -> ExensionT:
         pass
 
     @overload

--- a/betty/rich/user.py
+++ b/betty/rich/user.py
@@ -5,7 +5,7 @@ Console user sessions.
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import TextIO, TypeVar, cast, final, overload, override
+from typing import TextIO, cast, final, overload, override
 
 from rich.console import Console
 from rich.progress import BarColumn, TaskProgressColumn, TextColumn, TimeElapsedColumn
@@ -23,8 +23,6 @@ from betty.rich.progress import RichProgress
 from betty.typing import Void, internal
 from betty.user import User, Verbosity
 from betty.user.logging import UserHandler
-
-_T = TypeVar("_T")
 
 
 @internal
@@ -190,25 +188,25 @@ class RichUser(ManagedLifeCycle, User):
         pass
 
     @overload
-    async def ask_input(
+    async def ask_input[T](
         self,
         question: ResolvableLocalizable,
         *,
-        assertion: Assertion[str, _T],
+        assertion: Assertion[str, T],
         default: str | Void = Void(),  # noqa: B008
         stdin: TextIO | None = None,
-    ) -> _T:
+    ) -> T:
         pass
 
     @override
-    async def ask_input(
+    async def ask_input[T](
         self,
         question: ResolvableLocalizable,
         *,
-        assertion: Assertion[str, _T] | None = None,
+        assertion: Assertion[str, T] | None = None,
         default: str | Void = Void(),  # noqa: B008
         stdin: TextIO | None = None,
-    ) -> str | _T:
+    ) -> str | T:
         self.assert_alive()
         ask_kwargs = {}
         if not isinstance(default, Void):

--- a/betty/sample.py
+++ b/betty/sample.py
@@ -17,8 +17,6 @@ if TYPE_CHECKING:
 
     from betty.locale.localizable import Localizable, ResolvableLocalizable
 
-_CoT = TypeVar("_CoT", covariant=True)
-
 
 @final
 class Size(IntEnum):
@@ -32,7 +30,7 @@ class Size(IntEnum):
 
 
 @final
-class Sample(Generic[_CoT]):
+class Sample[T]:
     """
     A sample.
 
@@ -41,7 +39,7 @@ class Sample(Generic[_CoT]):
 
     def __init__(
         self,
-        subject: _CoT,
+        subject: T,
         *,
         label: ResolvableLocalizable,
         description: ResolvableLocalizable | None = None,
@@ -53,7 +51,7 @@ class Sample(Generic[_CoT]):
         self._size = size
 
     @property
-    def subject(self) -> _CoT:
+    def subject(self) -> T:
         """
         The sample subject.
         """
@@ -81,8 +79,13 @@ class Sample(Generic[_CoT]):
         return self._size
 
 
+_SampleT = TypeVar("_SampleT", covariant=True)
+
+
 @final
-class Samples(Generic[_CoT]):
+class Samples(
+    Generic[_SampleT],  # noqa: UP046
+):
     """
     A set of samples.
     """
@@ -90,14 +93,14 @@ class Samples(Generic[_CoT]):
     def __init__(
         self,
         samples: Iterable[
-            Callable[[], Sample[_CoT]]
-            | Samples[_CoT]
-            | type[Intersection[_CoT, Samplable]]
+            Callable[[], Sample[_SampleT]]
+            | Samples[_SampleT]
+            | type[Intersection[_SampleT, Samplable]]
         ],
     ):
         self._samples = list(samples)
 
-    def __iter__(self) -> Iterator[Sample[_CoT]]:
+    def __iter__(self) -> Iterator[Sample[_SampleT]]:
         for sample in self._samples:
             if isinstance(sample, Samples):
                 yield from sample

--- a/betty/service/container.py
+++ b/betty/service/container.py
@@ -8,18 +8,7 @@ from abc import abstractmethod
 from collections.abc import Awaitable, Callable
 from functools import update_wrapper
 from inspect import iscoroutinefunction
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Generic,
-    Protocol,
-    Self,
-    TypeAlias,
-    TypeVar,
-    cast,
-    overload,
-    override,
-)
+from typing import TYPE_CHECKING, Any, Protocol, Self, cast, overload, override
 
 from betty.concurrent import AsynchronizedLock, Lock
 from betty.life_cycle.manage import ManagedLifeCycle
@@ -32,40 +21,36 @@ if TYPE_CHECKING:
     from ty_extensions import Intersection
 
 
-_T = TypeVar("_T")
-_ServiceT = TypeVar("_ServiceT")
-_ServiceGetT = TypeVar("_ServiceGetT")
-_ManagedLifeCycleT = TypeVar("_ManagedLifeCycleT", bound=ManagedLifeCycle)
+type ServiceFactory[ManagedLifeCycleT: ManagedLifeCycle, ServiceT] = Callable[
+    [ManagedLifeCycleT], ServiceT
+]
 
 
-ServiceFactory: TypeAlias = Callable[[_ManagedLifeCycleT], _ServiceT]
-
-
-class _ServiceDecorator(Protocol):
+class _ServiceDecorator[ManagedLifeCycleT: ManagedLifeCycle, ServiceT](Protocol):
     @overload
     def __call__(
-        self, factory: Callable[[_ManagedLifeCycleT], _ServiceT], /
-    ) -> _SynchronousServiceManager[_ManagedLifeCycleT, _ServiceT]:
+        self, factory: Callable[[ManagedLifeCycleT], ServiceT], /
+    ) -> _SynchronousServiceManager[ManagedLifeCycleT, ServiceT]:
         pass
 
     @overload
     def __call__(
-        self, factory: Callable[[_ManagedLifeCycleT], Awaitable[_ServiceT]], /
-    ) -> _AsynchronousServiceManager[_ManagedLifeCycleT, _ServiceT]:
+        self, factory: Callable[[ManagedLifeCycleT], Awaitable[ServiceT]], /
+    ) -> _AsynchronousServiceManager[ManagedLifeCycleT, ServiceT]:
         pass
 
 
 @overload
-def service(
-    factory: Callable[[_ManagedLifeCycleT], Awaitable[_ServiceT]], /
-) -> _AsynchronousServiceManager[_ManagedLifeCycleT, _ServiceT]:
+def service[ManagedLifeCycleT: ManagedLifeCycle, ServiceT](
+    factory: Callable[[ManagedLifeCycleT], Awaitable[ServiceT]], /
+) -> _AsynchronousServiceManager[ManagedLifeCycleT, ServiceT]:
     pass
 
 
 @overload
-def service(
-    factory: Callable[[_ManagedLifeCycleT], _ServiceT], /
-) -> _SynchronousServiceManager[_ManagedLifeCycleT, _ServiceT]:
+def service[ManagedLifeCycleT: ManagedLifeCycle, ServiceT](
+    factory: Callable[[ManagedLifeCycleT], ServiceT], /
+) -> _SynchronousServiceManager[ManagedLifeCycleT, ServiceT]:
     pass
 
 
@@ -84,9 +69,9 @@ def service(factory):
     The decorated factory method should return a new service instance.
     """
 
-    def _service(
-        factory: Callable[[_ManagedLifeCycleT], _ServiceGetT], /
-    ) -> ServiceManager[_ManagedLifeCycleT, _ServiceGetT, Any]:
+    def _service[ManagedLifeCycleT: ManagedLifeCycle, ServiceT](
+        factory: Callable[[ManagedLifeCycleT], ServiceT], /
+    ) -> ServiceManager[ManagedLifeCycleT, ServiceT, Any]:
         if iscoroutinefunction(factory):
             return _AsynchronousServiceManager(
                 factory,  # ty:ignore[invalid-argument-type]
@@ -101,7 +86,7 @@ def service(factory):
 
 
 @internal
-class ServiceManager(Generic[_ManagedLifeCycleT, _ServiceGetT, _ServiceT]):
+class ServiceManager[ManagedLifeCycleT: ManagedLifeCycle, ServiceGetT, ServiceT]:
     """
     Manages a single service for a service container.
     """
@@ -109,7 +94,7 @@ class ServiceManager(Generic[_ManagedLifeCycleT, _ServiceGetT, _ServiceT]):
     def __init__(
         self,
         factory: Intersection[
-            ServiceFactory[_ManagedLifeCycleT, _ServiceGetT], FunctionType
+            ServiceFactory[ManagedLifeCycleT, ServiceGetT], FunctionType
         ],
         /,
     ):
@@ -131,24 +116,24 @@ class ServiceManager(Generic[_ManagedLifeCycleT, _ServiceGetT, _ServiceT]):
         return self._service_name
 
     @overload
-    def __get__(self, instance: None, owner: type[_ManagedLifeCycleT]) -> Self:
+    def __get__(self, instance: None, owner: type[ManagedLifeCycleT]) -> Self:
         pass
 
     @overload
     def __get__(
-        self, instance: _ManagedLifeCycleT, owner: type[_ManagedLifeCycleT]
-    ) -> _ServiceGetT:
+        self, instance: ManagedLifeCycleT, owner: type[ManagedLifeCycleT]
+    ) -> ServiceGetT:
         pass
 
     def __get__(
-        self, instance: _ManagedLifeCycleT | None, owner: type[_ManagedLifeCycleT]
-    ) -> _ServiceGetT | Self:
+        self, instance: ManagedLifeCycleT | None, owner: type[ManagedLifeCycleT]
+    ) -> ServiceGetT | Self:
         if instance is None:
             return self
 
         return self.get(instance)
 
-    def get(self, instance: _ManagedLifeCycleT, /) -> _ServiceGetT:
+    def get(self, instance: ManagedLifeCycleT, /) -> ServiceGetT:
         """
         Get the service from an instance.
         """
@@ -157,30 +142,30 @@ class ServiceManager(Generic[_ManagedLifeCycleT, _ServiceGetT, _ServiceT]):
         return self._get(instance)
 
     @abstractmethod
-    def _get(self, instance: _ManagedLifeCycleT, /) -> _ServiceGetT:
+    def _get(self, instance: ManagedLifeCycleT, /) -> ServiceGetT:
         pass
 
-    def _get_attr(self, instance: _ManagedLifeCycleT, /) -> _ServiceT | Void:
+    def _get_attr(self, instance: ManagedLifeCycleT, /) -> ServiceT | Void:
         return getattr(instance, self._service_attr_name, Void())
 
     def _get_factory(
-        self, instance: _ManagedLifeCycleT, /
-    ) -> ServiceFactory[_ManagedLifeCycleT, _ServiceGetT]:
+        self, instance: ManagedLifeCycleT, /
+    ) -> ServiceFactory[ManagedLifeCycleT, ServiceGetT]:
         factory = cast(
-            "ServiceFactory[_ManagedLifeCycleT, _ServiceGetT] | None",
+            "ServiceFactory[ManagedLifeCycleT, ServiceGetT] | None",
             getattr(instance, self._factory_override_attr_name, None),
         )
         if factory is not None:
             return factory
         return self._factory
 
-    def _assert_not_initialized(self, instance: _ManagedLifeCycleT, /):
+    def _assert_not_initialized(self, instance: ManagedLifeCycleT, /):
         if not isinstance(self._get_attr(instance), Void):
             raise ServiceInitializedError(
                 f"{instance}.{self._service_name} was initialized already."
             )
 
-    def override(self, instance: _ManagedLifeCycleT, service: _ServiceT, /) -> None:
+    def override(self, instance: ManagedLifeCycleT, service: ServiceT, /) -> None:
         """
         Override the service for the given instance.
 
@@ -194,8 +179,8 @@ class ServiceManager(Generic[_ManagedLifeCycleT, _ServiceGetT, _ServiceT]):
 
     def override_factory(
         self,
-        instance: _ManagedLifeCycleT,
-        factory: ServiceFactory[_ManagedLifeCycleT, _ServiceGetT],
+        instance: ManagedLifeCycleT,
+        factory: ServiceFactory[ManagedLifeCycleT, ServiceGetT],
         /,
     ) -> None:
         """
@@ -208,11 +193,10 @@ class ServiceManager(Generic[_ManagedLifeCycleT, _ServiceGetT, _ServiceT]):
         setattr(instance, self._factory_override_attr_name, factory)
 
 
-class _AsynchronousServiceManager(
-    Generic[_ManagedLifeCycleT, _ServiceT],
-    ServiceManager[_ManagedLifeCycleT, Awaitable[_ServiceT], _ServiceT],
+class _AsynchronousServiceManager[ManagedLifeCycleT: ManagedLifeCycle, ServiceT](
+    ServiceManager[ManagedLifeCycleT, Awaitable[ServiceT], ServiceT],
 ):
-    def _lock(self, instance: _ManagedLifeCycleT, /) -> Lock:
+    def _lock(self, instance: ManagedLifeCycleT, /) -> Lock:
         lock_attr_name = f"_{self._service_attr_name}_lock"
         try:
             return cast(Lock, getattr(instance, lock_attr_name))
@@ -222,7 +206,7 @@ class _AsynchronousServiceManager(
             return lock
 
     @override
-    async def _get(self, instance: _ManagedLifeCycleT, /) -> _ServiceT:
+    async def _get(self, instance: ManagedLifeCycleT, /) -> ServiceT:
         async with self._lock(instance):
             service = self._get_attr(instance)
 
@@ -234,12 +218,11 @@ class _AsynchronousServiceManager(
             return new_service
 
 
-class _SynchronousServiceManager(
-    Generic[_ManagedLifeCycleT, _ServiceT],
-    ServiceManager[_ManagedLifeCycleT, _ServiceT, _ServiceT],
+class _SynchronousServiceManager[ManagedLifeCycleT: ManagedLifeCycle, ServiceT](
+    ServiceManager[ManagedLifeCycleT, ServiceT, ServiceT]
 ):
     @override
-    def _get(self, instance: _ManagedLifeCycleT, /) -> _ServiceT:
+    def _get(self, instance: ManagedLifeCycleT, /) -> ServiceT:
         service = self._get_attr(instance)
         if not isinstance(service, Void):
             return service

--- a/betty/service/factory.py
+++ b/betty/service/factory.py
@@ -5,7 +5,7 @@ Object factories.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Generic, Self, TypeVar, final, overload
+from typing import TYPE_CHECKING, Self, final, overload
 
 from betty.asyncio import resolve_await
 from betty.data import Data
@@ -19,9 +19,6 @@ if TYPE_CHECKING:
 
     from betty.portable import PortableData
     from betty.service.level import ServiceLevel
-
-_T = TypeVar("_T")
-_DataT = TypeVar("_DataT", bound=Data)
 
 
 class Manufacturable(ABC):
@@ -37,24 +34,21 @@ class Manufacturable(ABC):
         """
 
 
-_ManufacturableT = TypeVar("_ManufacturableT", bound=Manufacturable)
-
-
-class DataManufacturable(ABC, Generic[_DataT]):
+class DataManufacturable[DataT: Data](ABC):
     """
     A class that can be initialized using defined data.
     """
 
     @classmethod
     @abstractmethod
-    async def new(cls, services: ServiceLevel, data: _DataT, /) -> Self:
+    async def new(cls, services: ServiceLevel, data: DataT, /) -> Self:
         """
         Create a new instance using the given service level and defined data.
         """
 
     @classmethod
     @abstractmethod
-    def new_data_cls(cls) -> type[_DataT]:
+    def new_data_cls(cls) -> type[DataT]:
         """
         The object's defined data class.
         """
@@ -70,30 +64,30 @@ class Factory:
         self._services = services
 
     @overload
-    async def new(
+    async def new[ManufacturableT](
         self,
-        target: type[_ManufacturableT],
+        target: type[ManufacturableT],
         data: Data | PortableData | Void = Void(),  # noqa: B008
         /,
-    ) -> _ManufacturableT:
+    ) -> ManufacturableT:
         pass
 
     @overload
-    async def new(
+    async def new[T](
         self,
-        target: Callable[[], Awaitable[_T] | _T],
+        target: Callable[[], Awaitable[T] | T],
         data: Data | PortableData | Void = Void(),  # noqa: B008
         /,
-    ) -> _T:
+    ) -> T:
         pass
 
     @overload
-    async def new(
+    async def new[T](
         self,
-        target: type[_T],
+        target: type[T],
         data: Data | PortableData | Void = Void(),  # noqa: B008
         /,
-    ) -> _T:
+    ) -> T:
         pass
 
     async def new(

--- a/betty/service/requirement/__init__.py
+++ b/betty/service/requirement/__init__.py
@@ -5,15 +5,7 @@ Requirements for services.
 from __future__ import annotations
 
 from functools import partial, update_wrapper
-from typing import (
-    TYPE_CHECKING,
-    Concatenate,
-    Generic,
-    ParamSpec,
-    TypeVar,
-    final,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, Concatenate, final, overload
 
 from betty.asyncio import resolve_await
 from betty.exception import HumanFacingException
@@ -23,47 +15,40 @@ from betty.service.level import ServiceLevel
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
-_RequirementT = TypeVar("_RequirementT")
-_ReturnT = TypeVar("_ReturnT")
-_MagicT = TypeVar("_MagicT")
-_P = ParamSpec("_P")
-
 
 @final
-class Requirement(Generic[_RequirementT]):
+class Requirement[RequirementT]:
     """
     A service level requirement.
     """
 
     def __init__(
-        self, require: Callable[[ServiceLevel, str], Awaitable[_RequirementT]], /
+        self, require: Callable[[ServiceLevel, str], Awaitable[RequirementT]], /
     ):
 
         self._require = require
 
     @overload
-    def __call__(self, f: ServiceLevel, /) -> Awaitable[_RequirementT]:
+    def __call__(self, f: ServiceLevel, /) -> Awaitable[RequirementT]:
         pass
 
     @overload
-    def __call__(
+    def __call__[**P, ReturnT](
         self,
-        f: Callable[Concatenate[_RequirementT, _P], Awaitable[_ReturnT] | _ReturnT],
-    ) -> Callable[Concatenate[ServiceLevel, _P], Awaitable[_ReturnT]]:
+        f: Callable[Concatenate[RequirementT, P], Awaitable[ReturnT] | ReturnT],
+    ) -> Callable[Concatenate[ServiceLevel, P], Awaitable[ReturnT]]:
         pass
 
     @overload
-    def __call__(
+    def __call__[**P, ReturnT, MagicT](
         self,
-        f: Callable[
-            Concatenate[_MagicT, _RequirementT, _P], Awaitable[_ReturnT] | _ReturnT
-        ],
-    ) -> Callable[Concatenate[_MagicT, ServiceLevel, _P], Awaitable[_ReturnT]]:
+        f: Callable[Concatenate[MagicT, RequirementT, P], Awaitable[ReturnT] | ReturnT],
+    ) -> Callable[Concatenate[MagicT, ServiceLevel, P], Awaitable[ReturnT]]:
         pass
 
-    def __call__(
+    def __call__[**P, ReturnT](
         self, f
-    ) -> CallableRequirement[_RequirementT, _P, _ReturnT] | Awaitable[_RequirementT]:
+    ) -> CallableRequirement[RequirementT, P, ReturnT] | Awaitable[RequirementT]:
         """
         Decorate a callable with this requirement.
         """
@@ -73,18 +58,16 @@ class Requirement(Generic[_RequirementT]):
 
 
 @final
-class CallableRequirement(Generic[_RequirementT, _P, _ReturnT]):
+class CallableRequirement[RequirementT, **P, ReturnT, MagicT = Any]:
     """
     A requirement that can be called or used as a descriptor.
     """
 
     def __init__(
         self,
-        require: Callable[[ServiceLevel, str], Awaitable[_RequirementT]],
-        f: Callable[Concatenate[_RequirementT, _P], Awaitable[_ReturnT] | _ReturnT]
-        | Callable[
-            Concatenate[_MagicT, _RequirementT, _P], Awaitable[_ReturnT] | _ReturnT
-        ],
+        require: Callable[[ServiceLevel, str], Awaitable[RequirementT]],
+        f: Callable[Concatenate[RequirementT, P], Awaitable[ReturnT] | ReturnT]
+        | Callable[Concatenate[MagicT, RequirementT, P], Awaitable[ReturnT] | ReturnT],
     ):
         self._require = require
         update_wrapper(self, f)
@@ -97,21 +80,21 @@ class CallableRequirement(Generic[_RequirementT, _P, _ReturnT]):
 
     @overload
     async def __call__(
-        self, requirement: _RequirementT, *args: _P.args, **kwargs: _P.kwargs
-    ) -> _ReturnT:
+        self, requirement: RequirementT, *args: P.args, **kwargs: P.kwargs
+    ) -> ReturnT:
         pass
 
     @overload
     async def __call__(
         self,
-        magic: _MagicT,
-        requirement: _RequirementT,
-        *args: _P.args,
-        **kwargs: _P.kwargs,
-    ) -> _ReturnT:
+        magic: MagicT,
+        requirement: RequirementT,
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> ReturnT:
         pass
 
-    async def __call__(self, *args, **kwargs) -> _ReturnT:
+    async def __call__(self, *args, **kwargs) -> ReturnT:
         """
         Call the decorated callable.
         """

--- a/betty/service/requirement/extension.py
+++ b/betty/service/requirement/extension.py
@@ -4,7 +4,7 @@ Handle requirements on extensions.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Concatenate, ParamSpec, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Concatenate, overload
 
 from betty.extension import Extension, ExtensionDefinition
 from betty.locale.localizable.gettext import _
@@ -19,34 +19,30 @@ if TYPE_CHECKING:
     from betty.project import Project
     from betty.service.level import ServiceLevel
 
-_ReturnT = TypeVar("_ReturnT")
-_P = ParamSpec("_P")
-_ExtensionT = TypeVar("_ExtensionT", bound=Extension, default=Extension)
-
 
 @overload
-def require_extension(
-    extension_id: type[_ExtensionT] | ResolvableId[ExtensionDefinition], /
-) -> Requirement[_ExtensionT]:
+def require_extension[ExtensionT: Extension](
+    extension_id: type[ExtensionT] | ResolvableId[ExtensionDefinition], /
+) -> Requirement[ExtensionT]:
     pass
 
 
 @overload
-def require_extension(
-    extension_id: type[_ExtensionT] | ResolvableId[ExtensionDefinition],
-    f: Callable[Concatenate[_ExtensionT, _P], Awaitable[_ReturnT] | _ReturnT]
-    | Callable[Concatenate[Any, _ExtensionT, _P], Awaitable[_ReturnT] | _ReturnT],
+def require_extension[ExtensionT: Extension, **P, ReturnT](
+    extension_id: type[ExtensionT] | ResolvableId[ExtensionDefinition],
+    f: Callable[Concatenate[ExtensionT, P], Awaitable[ReturnT] | ReturnT]
+    | Callable[Concatenate[Any, ExtensionT, P], Awaitable[ReturnT] | ReturnT],
     /,
-) -> CallableRequirement[_ExtensionT, _P, _ReturnT]:
+) -> CallableRequirement[ExtensionT, P, ReturnT]:
     pass
 
 
 @overload
-def require_extension(
-    extension_id: type[_ExtensionT] | ResolvableId[ExtensionDefinition],
+def require_extension[ExtensionT: Extension](
+    extension_id: type[ExtensionT] | ResolvableId[ExtensionDefinition],
     services: ServiceLevel,
     /,
-) -> Awaitable[_ExtensionT]:
+) -> Awaitable[ExtensionT]:
     pass
 
 
@@ -63,11 +59,11 @@ def require_extension(extension_id, f=None):
 
 
 @require_project
-async def _require_extension(
+async def _require_extension[ExtensionT: Extension](
     project: Project,
     target: str,
-    extension_id: type[_ExtensionT] | ResolvableId[ExtensionDefinition],
-) -> _ExtensionT:
+    extension_id: type[ExtensionT] | ResolvableId[ExtensionDefinition],
+) -> ExtensionT:
     extensions = await project.plugins.plugins(ExtensionDefinition)
     try:
         extension = extensions[resolve_id(extension_id)]

--- a/betty/sphinx/extension/betty.py
+++ b/betty/sphinx/extension/betty.py
@@ -9,7 +9,7 @@ from collections.abc import Callable, Iterable, MutableSequence, Sequence
 from functools import cmp_to_key
 from textwrap import indent
 from threading import Thread
-from typing import TYPE_CHECKING, TypeAlias, TypeVar, override
+from typing import TYPE_CHECKING, override
 
 from docutils import nodes
 from sphinx.util.docutils import SphinxDirective
@@ -37,11 +37,11 @@ if TYPE_CHECKING:
     from betty.plugin.repository import PluginRepository
     from betty.serde import Serializer
 
-_T = TypeVar("_T")
-NodesLike: TypeAlias = nodes.Node | Iterable[nodes.Node] | None
+
+type NodesLike = nodes.Node | Iterable[nodes.Node] | None
 
 
-def _to_thread(target: Callable[[], _T]) -> _T:
+def _to_thread[T](target: Callable[[], T]) -> T:
     result = Result(target)
     thread = Thread(target=result)
     thread.start()

--- a/betty/test_utils/cache.py
+++ b/betty/test_utils/cache.py
@@ -4,16 +4,13 @@ Test utilities for :py:mod:`betty.cache`.
 
 from collections.abc import Iterator, Sequence
 from contextlib import AbstractAsyncContextManager
-from typing import Generic, TypeVar
 
 import pytest
 
 from betty.cache import Cache, CacheItem
 
-_CacheItemValueT = TypeVar("_CacheItemValueT")
 
-
-class CacheTestBase(Generic[_CacheItemValueT]):
+class CacheTestBase[CacheItemValueT]:
     """
     A base class for tests of :py:class:`betty.cache.Cache` implementations.
     """
@@ -22,10 +19,10 @@ class CacheTestBase(Generic[_CacheItemValueT]):
         self,
         *,
         scopes: Sequence[str] | None = None,
-    ) -> AbstractAsyncContextManager[Cache[_CacheItemValueT]]:
+    ) -> AbstractAsyncContextManager[Cache[CacheItemValueT]]:
         raise NotImplementedError
 
-    def _values(self) -> Iterator[_CacheItemValueT]:
+    def _values(self) -> Iterator[CacheItemValueT]:
         raise NotImplementedError
 
     @staticmethod

--- a/betty/test_utils/console/__init__.py
+++ b/betty/test_utils/console/__init__.py
@@ -5,12 +5,10 @@ Test utilities for :py:mod:`betty.console`.
 from contextlib import redirect_stderr, redirect_stdout
 from dataclasses import dataclass
 from io import StringIO
-from typing import TypeVar, final
+from typing import final
 
 from betty.app import App
 from betty.console import SystemExitCode, main
-
-_T = TypeVar("_T")
 
 
 @final

--- a/betty/test_utils/copyright_notice.py
+++ b/betty/test_utils/copyright_notice.py
@@ -4,41 +4,37 @@ Test utilities for :py:mod:`betty.copyright_notice`.
 
 from __future__ import annotations
 
-from typing import Generic, TypeVar
-
 import pytest
 
 from betty.copyright_notice import CopyrightNotice
 from betty.locale.localize import DEFAULT_LOCALIZER
 
-_CopyrightNoticeT = TypeVar("_CopyrightNoticeT", bound=CopyrightNotice)
 
-
-class CopyrightNoticeTestBase(Generic[_CopyrightNoticeT]):
+class CopyrightNoticeTestBase[CopyrightNoticeT: CopyrightNotice]:
     """
     A base class for testing :py:class:`betty.copyright_notice.CopyrightNotice` implementations.
     """
 
     @pytest.fixture
-    def sut(self) -> type[_CopyrightNoticeT]:
+    def sut(self) -> type[CopyrightNoticeT]:
         """
         Provide the system(s) under test.
         """
         raise NotImplementedError
 
-    def test_summary(self, sut: _CopyrightNoticeT) -> None:
+    def test_summary(self, sut: CopyrightNoticeT) -> None:
         """
         Tests :py:meth:`betty.copyright_notice.CopyrightNotice.summary` implementations.
         """
         assert sut.summary.localize(DEFAULT_LOCALIZER)
 
-    def test_text(self, sut: _CopyrightNoticeT) -> None:
+    def test_text(self, sut: CopyrightNoticeT) -> None:
         """
         Tests :py:meth:`betty.copyright_notice.CopyrightNotice.text` implementations.
         """
         assert sut.text.localize(DEFAULT_LOCALIZER)
 
-    def test_url(self, sut: _CopyrightNoticeT) -> None:
+    def test_url(self, sut: CopyrightNoticeT) -> None:
         """
         Tests :py:meth:`betty.copyright_notice.CopyrightNotice.url` implementations.
         """

--- a/betty/test_utils/data.py
+++ b/betty/test_utils/data.py
@@ -2,7 +2,7 @@
 Test utilities for :py:mod:`betty.data`.
 """
 
-from typing import Any, Generic, TypeVar
+from typing import Any
 
 import pytest
 
@@ -14,15 +14,13 @@ from betty.importlib import fully_qualified_name
 from betty.locale.localizable.plain import Plain
 from betty.locale.localize import DEFAULT_LOCALIZER
 
-_DataT = TypeVar("_DataT", bound=Data, covariant=True)
 
-
-class DataTestBase(Generic[_DataT]):
+class DataTestBase[DataT: Data]:
     """
     A base class for testing :py:class:`betty.data.Data` subclasses.
     """
 
-    sut_cls: type[_DataT]
+    sut_cls: type[DataT]
     """
     The system under test.
     """

--- a/betty/test_utils/job/__init__.py
+++ b/betty/test_utils/job/__init__.py
@@ -2,7 +2,7 @@
 Test utilities for :py:mod:`betty.job`.
 """
 
-from typing import TypeVar, final, override
+from typing import final, override
 
 from betty.job import Context, Job
 from betty.job.executor.asyncio import AsyncExecutor
@@ -11,21 +11,19 @@ from betty.job.scheduler.default import DefaultScheduler
 from betty.progress.no_op import NoOpProgress
 from betty.user.no_op import NoOpUser
 
-_ContextT = TypeVar("_ContextT", bound=Context)
-
 
 @final
-class NoOpJob(Job[Context]):
+class NoOpJob(Job):
     """
     A job that does nothing.
     """
 
     @override
-    async def do(self, scheduler: Scheduler[Context], /) -> None:
+    async def do(self, scheduler: Scheduler, /) -> None:
         pass
 
 
-async def do(context: _ContextT, *jobs: Job[_ContextT]) -> None:
+async def do[ContextT: Context](context: ContextT, *jobs: Job[ContextT]) -> None:
     """
     Do a number of jobs.
     """

--- a/betty/test_utils/job/executor.py
+++ b/betty/test_utils/job/executor.py
@@ -5,7 +5,7 @@ Test utilities for :py:mod:`betty.job.executor`.
 from __future__ import annotations
 
 from asyncio import sleep
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -18,8 +18,6 @@ if TYPE_CHECKING:
 
     from betty.job.executor import Executor
 
-_ContextCoT = TypeVar("_ContextCoT", bound=Context, covariant=True)
-
 
 async def _sleep() -> None:
     await sleep(999)
@@ -31,14 +29,14 @@ class ExecutorTestBase:
     """
 
     @pytest.fixture
-    async def new_sut(self) -> Callable[[Scheduler[Context]], Executor]:
+    async def new_sut(self) -> Callable[[Scheduler], Executor]:
         """
         Provide the systems under test.
         """
         raise NotImplementedError
 
     async def test___aexit___with_scheduler_cancelled(
-        self, new_sut: Callable[[Scheduler[Context]], Executor]
+        self, new_sut: Callable[[Scheduler], Executor]
     ) -> None:
         """
         Tests :py:meth:`betty.job.executor.Executor.__aexit__` implementations.
@@ -48,7 +46,7 @@ class ExecutorTestBase:
             pass
 
     async def test___aexit___with_scheduler_completed(
-        self, new_sut: Callable[[Scheduler[Context]], Executor]
+        self, new_sut: Callable[[Scheduler], Executor]
     ) -> None:
         """
         Tests :py:meth:`betty.job.executor.Executor.__aexit__` implementations.
@@ -58,7 +56,7 @@ class ExecutorTestBase:
             pass
 
     async def test___aexit___with_arbitrary_exception(
-        self, new_sut: Callable[[Scheduler[Context]], Executor]
+        self, new_sut: Callable[[Scheduler], Executor]
     ) -> None:
         """
         Tests :py:meth:`betty.job.executor.Executor.__aexit__` implementations.
@@ -70,9 +68,7 @@ class ExecutorTestBase:
                 raise exception
         assert exc_info.value is exception
 
-    async def test_start(
-        self, new_sut: Callable[[Scheduler[Context]], Executor]
-    ) -> None:
+    async def test_start(self, new_sut: Callable[[Scheduler], Executor]) -> None:
         """
         Tests :py:meth:`betty.job.executor.Executor.start` implementations.
         """
@@ -82,7 +78,7 @@ class ExecutorTestBase:
         await sut.complete()
 
     async def test_start__when_started(
-        self, new_sut: Callable[[Scheduler[Context]], Executor]
+        self, new_sut: Callable[[Scheduler], Executor]
     ) -> None:
         """
         Tests :py:meth:`betty.job.executor.Executor.start` implementations.
@@ -101,7 +97,7 @@ class ExecutorTestBase:
         ],
     )
     async def test_complete(
-        self, batch_count: int, new_sut: Callable[[Scheduler[Context]], Executor]
+        self, batch_count: int, new_sut: Callable[[Scheduler], Executor]
     ) -> None:
         """
         Tests :py:meth:`betty.job.executor.Executor.complete` implementations.
@@ -125,7 +121,7 @@ class ExecutorTestBase:
         assert actual == expected
 
     async def test_complete__when_not_started(
-        self, new_sut: Callable[[Scheduler[Context]], Executor]
+        self, new_sut: Callable[[Scheduler], Executor]
     ) -> None:
         """
         Tests :py:meth:`betty.job.executor.Executor.complete` implementations.
@@ -135,7 +131,7 @@ class ExecutorTestBase:
         await sut.complete()
 
     async def test_complete__when_completed(
-        self, new_sut: Callable[[Scheduler[Context]], Executor]
+        self, new_sut: Callable[[Scheduler], Executor]
     ) -> None:
         """
         Tests :py:meth:`betty.job.executor.Executor.complete` implementations.
@@ -146,9 +142,7 @@ class ExecutorTestBase:
         await sut.complete()
         await sut.complete()
 
-    async def test_cancel(
-        self, new_sut: Callable[[Scheduler[Context]], Executor]
-    ) -> None:
+    async def test_cancel(self, new_sut: Callable[[Scheduler], Executor]) -> None:
         """
         Tests :py:meth:`betty.job.executor.Executor.cancel` implementations.
         """
@@ -158,7 +152,7 @@ class ExecutorTestBase:
         await sut.cancel()
 
     async def test_cancel__when_not_started(
-        self, new_sut: Callable[[Scheduler[Context]], Executor]
+        self, new_sut: Callable[[Scheduler], Executor]
     ) -> None:
         """
         Tests :py:meth:`betty.job.executor.Executor.cancel` implementations.
@@ -168,7 +162,7 @@ class ExecutorTestBase:
         await sut.cancel()
 
     async def test_cancel__when_cancelled(
-        self, new_sut: Callable[[Scheduler[Context]], Executor]
+        self, new_sut: Callable[[Scheduler], Executor]
     ) -> None:
         """
         Tests :py:meth:`betty.job.executor.Executor.cancel` implementations.

--- a/betty/test_utils/job/scheduler.py
+++ b/betty/test_utils/job/scheduler.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from asyncio import create_task, sleep
 from collections.abc import Iterator, MutableSequence
-from typing import TYPE_CHECKING, Generic, Self, TypeVar, cast, final, override
+from typing import TYPE_CHECKING, Self, cast, final, override
 
 import pytest
 
@@ -28,16 +28,13 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
 
-_ContextCoT = TypeVar("_ContextCoT", bound=Context, covariant=True)
-
-
-class StaticScheduler(Scheduler[_ContextCoT], Generic[_ContextCoT]):
+class StaticScheduler[ContextT: Context](Scheduler[ContextT]):
     """
     A scheduler that issues static job batches.
     """
 
     def __init__(
-        self, context: _ContextCoT, batches: Sequence[ScheduledJobBatch | Closed]
+        self, context: ContextT, batches: Sequence[ScheduledJobBatch | Closed]
     ):
         self._context = context
         self._batches: Iterable[ScheduledJobBatch | Closed] | Closed = iter(batches)
@@ -58,7 +55,7 @@ class StaticScheduler(Scheduler[_ContextCoT], Generic[_ContextCoT]):
             return batch
 
     @override
-    async def add(self, *jobs: Job[_ContextCoT]) -> None:
+    async def add(self, *jobs: Job[ContextT]) -> None:
         raise NotImplementedError
 
     @override
@@ -78,7 +75,7 @@ class StaticScheduler(Scheduler[_ContextCoT], Generic[_ContextCoT]):
 
     @override
     @property
-    def context(self) -> _ContextCoT:
+    def context(self) -> ContextT:
         return self._context
 
 
@@ -92,17 +89,12 @@ class SchedulerTestBaseContext(Context):
         self.jobs: MutableSequence[Job[Self]] = []
 
 
-_SchedulerTestBaseContextCoT = TypeVar(
-    "_SchedulerTestBaseContextCoT", bound=SchedulerTestBaseContext, covariant=True
-)
-
-
-class _Job(Job[_SchedulerTestBaseContextCoT]):
+class _Job(Job[SchedulerTestBaseContext]):
     def __init__(
         self,
         job_id: str,
         *,
-        additional_jobs: Sequence[_Job[_SchedulerTestBaseContextCoT]] | None = None,
+        additional_jobs: Sequence[_Job[SchedulerTestBaseContext]] | None = None,
         dependencies: set[str] | None = None,
         dependents: set[str] | None = None,
         priority: bool = False,
@@ -113,25 +105,25 @@ class _Job(Job[_SchedulerTestBaseContextCoT]):
         self._additional_jobs = additional_jobs
 
     @override
-    async def do(self, scheduler: Scheduler[_SchedulerTestBaseContextCoT], /) -> None:
+    async def do(self, scheduler: Scheduler[SchedulerTestBaseContext], /) -> None:
         if self._additional_jobs is not None:
             for additional_job in self._additional_jobs:
                 await scheduler.add(additional_job)
-        scheduler.context.jobs.append(self)  # ty:ignore[invalid-argument-type]
+        scheduler.context.jobs.append(self)
 
 
 @final
-class Sleep(Job[_SchedulerTestBaseContextCoT]):
+class Sleep(Job[SchedulerTestBaseContext]):
     """
     A job that sleeps for a long, long time.
     """
 
     @override
-    async def do(self, scheduler: Scheduler[_SchedulerTestBaseContextCoT], /) -> None:
+    async def do(self, scheduler: Scheduler[SchedulerTestBaseContext], /) -> None:
         await sleep(999999999)
 
 
-class Raise(Job[_SchedulerTestBaseContextCoT]):
+class Raise(Job[SchedulerTestBaseContext]):
     """
     A job that raises an exception.
     """
@@ -151,24 +143,24 @@ class Raise(Job[_SchedulerTestBaseContextCoT]):
         self._reason = reason
 
     @override
-    async def do(self, scheduler: Scheduler[_SchedulerTestBaseContextCoT], /) -> None:
+    async def do(self, scheduler: Scheduler[SchedulerTestBaseContext], /) -> None:
         raise self._reason
 
 
-class SchedulerTestBase(Generic[_SchedulerTestBaseContextCoT]):
+class SchedulerTestBase:
     """
     A base class for testing :py:class:`betty.job.scheduler.Scheduler` implementations.
     """
 
     @pytest.fixture
-    def sut(self) -> Scheduler[_SchedulerTestBaseContextCoT]:
+    def sut(self) -> Scheduler[SchedulerTestBaseContext]:
         """
         Provide the systems under test.
         """
         raise NotImplementedError
 
     async def test___aexit___with_exception(
-        self, sut: Scheduler[_SchedulerTestBaseContextCoT]
+        self, sut: Scheduler[SchedulerTestBaseContext]
     ) -> None:
         """
         Tests :py:meth:`betty.job.scheduler.Scheduler.__aexit__` implementations.
@@ -179,14 +171,14 @@ class SchedulerTestBase(Generic[_SchedulerTestBaseContextCoT]):
                 raise exception
         assert exc_info.value is exception
 
-    async def test_add(self, sut: Scheduler[_SchedulerTestBaseContextCoT]) -> None:
+    async def test_add(self, sut: Scheduler[SchedulerTestBaseContext]) -> None:
         """
         Tests :py:meth:`betty.job.scheduler.Scheduler.add` implementations.
         """
         await sut.add(_Job("job"))
 
     async def test_add__with_duplicate_job(
-        self, sut: Scheduler[_SchedulerTestBaseContextCoT]
+        self, sut: Scheduler[SchedulerTestBaseContext]
     ) -> None:
         """
         Tests :py:meth:`betty.job.scheduler.Scheduler.add` implementations.
@@ -196,7 +188,7 @@ class SchedulerTestBase(Generic[_SchedulerTestBaseContextCoT]):
             await sut.add(_Job("job"))
 
     async def test_add__with_dependent_post_release(
-        self, sut: Scheduler[_SchedulerTestBaseContextCoT]
+        self, sut: Scheduler[SchedulerTestBaseContext]
     ) -> None:
         """
         Tests :py:meth:`betty.job.scheduler.Scheduler.add` implementations.
@@ -207,7 +199,7 @@ class SchedulerTestBase(Generic[_SchedulerTestBaseContextCoT]):
                 _Job("dependent"), _Job("dependency", dependents={"dependent"})
             )
 
-    async def test_release(self, sut: Scheduler[_SchedulerTestBaseContextCoT]) -> None:
+    async def test_release(self, sut: Scheduler[SchedulerTestBaseContext]) -> None:
         """
         Tests :py:meth:`betty.job.scheduler.Scheduler.release` implementations.
         """
@@ -306,9 +298,9 @@ class SchedulerTestBase(Generic[_SchedulerTestBaseContextCoT]):
     async def test_get__returns_job(
         self,
         expected: set[str] | Sequence[str],
-        pre_release_jobs: Sequence[Job[_SchedulerTestBaseContextCoT]],
-        post_release_jobs: Sequence[Job[_SchedulerTestBaseContextCoT]],
-        sut: Scheduler[_SchedulerTestBaseContextCoT],
+        pre_release_jobs: Sequence[Job[SchedulerTestBaseContext]],
+        post_release_jobs: Sequence[Job[SchedulerTestBaseContext]],
+        sut: Scheduler[SchedulerTestBaseContext],
     ) -> None:
         """
         Tests :py:meth:`betty.job.scheduler.Scheduler.get` implementations.
@@ -325,7 +317,7 @@ class SchedulerTestBase(Generic[_SchedulerTestBaseContextCoT]):
 
     async def test_get__raises_when_unknown_dependency(
         self,
-        sut: Scheduler[_SchedulerTestBaseContextCoT],
+        sut: Scheduler[SchedulerTestBaseContext],
     ) -> None:
         """
         Tests :py:meth:`betty.job.scheduler.Scheduler.get` implementations.
@@ -337,7 +329,7 @@ class SchedulerTestBase(Generic[_SchedulerTestBaseContextCoT]):
                     pass
 
     async def test_get__raises_when_cyclic(
-        self, sut: Scheduler[_SchedulerTestBaseContextCoT]
+        self, sut: Scheduler[SchedulerTestBaseContext]
     ) -> None:
         """
         Tests :py:meth:`betty.job.scheduler.Scheduler.get` implementations.
@@ -349,7 +341,7 @@ class SchedulerTestBase(Generic[_SchedulerTestBaseContextCoT]):
                 await sut.get()
 
     async def test_get__raises_when_cancelled(
-        self, sut: Scheduler[_SchedulerTestBaseContextCoT]
+        self, sut: Scheduler[SchedulerTestBaseContext]
     ) -> None:
         """
         Tests :py:meth:`betty.job.scheduler.Scheduler.get` implementations.
@@ -359,7 +351,7 @@ class SchedulerTestBase(Generic[_SchedulerTestBaseContextCoT]):
             await sut.get()
 
     async def test_get__raises_when_completed(
-        self, sut: Scheduler[_SchedulerTestBaseContextCoT]
+        self, sut: Scheduler[SchedulerTestBaseContext]
     ) -> None:
         """
         Tests :py:meth:`betty.job.scheduler.Scheduler.get` implementations.
@@ -369,7 +361,7 @@ class SchedulerTestBase(Generic[_SchedulerTestBaseContextCoT]):
             await sut.get()
 
     async def test_get___job_exception_should_cancel(
-        self, sut: Scheduler[_SchedulerTestBaseContextCoT]
+        self, sut: Scheduler[SchedulerTestBaseContext]
     ) -> None:
         """
         Tests :py:meth:`betty.job.scheduler.Scheduler.get` implementations.
@@ -383,7 +375,7 @@ class SchedulerTestBase(Generic[_SchedulerTestBaseContextCoT]):
         assert exc_info.value.__cause__ is reason
 
     async def test_get___done_when_cancelled(
-        self, sut: Scheduler[_SchedulerTestBaseContextCoT]
+        self, sut: Scheduler[SchedulerTestBaseContext]
     ) -> None:
         """
         Tests :py:meth:`betty.job.scheduler.Scheduler.get` implementations.
@@ -398,9 +390,7 @@ class SchedulerTestBase(Generic[_SchedulerTestBaseContextCoT]):
         actual = [job.id for job in sut.context.jobs]
         assert actual == ["one"]
 
-    async def test___aiter__(
-        self, sut: Scheduler[_SchedulerTestBaseContextCoT]
-    ) -> None:
+    async def test___aiter__(self, sut: Scheduler[SchedulerTestBaseContext]) -> None:
         """
         Tests :py:meth:`betty.job.scheduler.Scheduler.__aiter__` implementations.
         """
@@ -409,7 +399,7 @@ class SchedulerTestBase(Generic[_SchedulerTestBaseContextCoT]):
         await completion
 
     async def test_complete__when_completed(
-        self, sut: Scheduler[_SchedulerTestBaseContextCoT]
+        self, sut: Scheduler[SchedulerTestBaseContext]
     ) -> None:
         """
         Tests :py:meth:`betty.job.scheduler.Scheduler.complete` implementations.
@@ -418,7 +408,7 @@ class SchedulerTestBase(Generic[_SchedulerTestBaseContextCoT]):
         await sut.complete()
 
     async def test_complete__when_cancelled(
-        self, sut: Scheduler[_SchedulerTestBaseContextCoT]
+        self, sut: Scheduler[SchedulerTestBaseContext]
     ) -> None:
         """
         Tests :py:meth:`betty.job.scheduler.Scheduler.complete` implementations.
@@ -427,7 +417,7 @@ class SchedulerTestBase(Generic[_SchedulerTestBaseContextCoT]):
         with pytest.raises(Cancelled):
             await sut.complete()
 
-    async def test_cancel(self, sut: Scheduler[_SchedulerTestBaseContextCoT]) -> None:
+    async def test_cancel(self, sut: Scheduler[SchedulerTestBaseContext]) -> None:
         """
         Tests :py:meth:`betty.job.scheduler.Scheduler.cancel` implementations.
         """
@@ -437,7 +427,7 @@ class SchedulerTestBase(Generic[_SchedulerTestBaseContextCoT]):
             await sut.get()
 
     async def test_cancel__with_exception(
-        self, sut: Scheduler[_SchedulerTestBaseContextCoT]
+        self, sut: Scheduler[SchedulerTestBaseContext]
     ) -> None:
         """
         Tests :py:meth:`betty.job.scheduler.Scheduler.cancel` implementations.
@@ -451,7 +441,7 @@ class SchedulerTestBase(Generic[_SchedulerTestBaseContextCoT]):
         assert exc_info.value.__cause__ is reason
 
     async def test_cancel__when_cancelled(
-        self, sut: Scheduler[_SchedulerTestBaseContextCoT]
+        self, sut: Scheduler[SchedulerTestBaseContext]
     ) -> None:
         """
         Tests :py:meth:`betty.job.scheduler.Scheduler.cancel` implementations.
@@ -460,7 +450,7 @@ class SchedulerTestBase(Generic[_SchedulerTestBaseContextCoT]):
         await sut.cancel()
 
     async def test_cancel__when_completed(
-        self, sut: Scheduler[_SchedulerTestBaseContextCoT]
+        self, sut: Scheduler[SchedulerTestBaseContext]
     ) -> None:
         """
         Tests :py:meth:`betty.job.scheduler.Scheduler.cancel` implementations.
@@ -468,7 +458,7 @@ class SchedulerTestBase(Generic[_SchedulerTestBaseContextCoT]):
         await sut.complete()
         await sut.cancel()
 
-    async def test_context(self, sut: Scheduler[_SchedulerTestBaseContextCoT]) -> None:
+    async def test_context(self, sut: Scheduler[SchedulerTestBaseContext]) -> None:
         """
         Tests :py:meth:`betty.job.scheduler.Scheduler.context` implementations.
         """

--- a/betty/test_utils/json/linked_data.py
+++ b/betty/test_utils/json/linked_data.py
@@ -5,7 +5,7 @@ Test utilities for :py:mod:`betty.json.linked_data`.
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, MutableMapping, MutableSequence
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING
 
 from betty.app import App
 from betty.json.schema import Schema
@@ -18,36 +18,33 @@ if TYPE_CHECKING:
         LinkedDataDumper,
     )
 
-_T = TypeVar("_T")
-_PortableDataT = TypeVar("_PortableDataT", bound=PortableData, default=PortableData)
 
-
-async def assert_dumps_linked_data(
-    sut: LinkedDataDumpableWithSchema[Schema, _PortableDataT],
-) -> _PortableDataT:
+async def assert_dumps_linked_data[PortableDataT: PortableData](
+    sut: LinkedDataDumpableWithSchema[Schema, PortableDataT],
+) -> PortableDataT:
     """
     Dump an object's linked data and assert it is valid.
     """
     return await assert_linked_data_dump(sut.linked_data_schema, sut.dump_linked_data)
 
 
-async def assert_dumps_linked_data_for(
-    sut: LinkedDataDumper[_T, Schema, _PortableDataT], target: _T
-) -> _PortableDataT:
+async def assert_dumps_linked_data_for[PortableDataT: PortableData, T](
+    sut: LinkedDataDumper[T, Schema, PortableDataT], target: T
+) -> PortableDataT:
     """
     Dump an object's linked data and assert it is valid.
     """
 
-    async def _dump(project: Project) -> _PortableDataT:
+    async def _dump(project: Project) -> PortableDataT:
         return await sut.dump_linked_data_for(project, target)
 
     return await assert_linked_data_dump(sut.linked_data_schema_for, _dump)
 
 
-async def assert_linked_data_dump(
+async def assert_linked_data_dump[PortableDataT: PortableData](
     schema: Callable[[Project], Awaitable[Schema]] | Schema,
-    portable: Callable[[Project], Awaitable[_PortableDataT]] | _PortableDataT,
-) -> _PortableDataT:
+    portable: Callable[[Project], Awaitable[PortableDataT]] | PortableDataT,
+) -> PortableDataT:
     """
     Assert that dumped linked data is valid against a schema.
     """
@@ -68,7 +65,7 @@ async def assert_linked_data_dump(
         return _normalize(actual)
 
 
-def _normalize(portable: _PortableDataT) -> _PortableDataT:
+def _normalize[PortableDataT: PortableData](portable: PortableDataT) -> PortableDataT:
     if isinstance(portable, MutableMapping):
         return {
             key: _normalize(value)

--- a/betty/test_utils/json/schema.py
+++ b/betty/test_utils/json/schema.py
@@ -3,7 +3,6 @@ Test utilities for :py:mod:`betty.json.schema`.
 """
 
 from collections.abc import MutableMapping, Sequence
-from typing import TypeAlias
 
 import pytest
 from jsonschema.exceptions import ValidationError
@@ -30,9 +29,7 @@ DUMMY_SCHEMAS: Sequence[
 )
 
 
-SchemaTestBaseSut: TypeAlias = tuple[
-    Schema, Sequence[PortableData], Sequence[PortableData]
-]
+type SchemaTestBaseSut = tuple[Schema, Sequence[PortableData], Sequence[PortableData]]
 
 
 class SchemaTestBase:

--- a/betty/test_utils/license.py
+++ b/betty/test_utils/license.py
@@ -4,41 +4,37 @@ Test utilities for :py:mod:`betty.license`.
 
 from __future__ import annotations
 
-from typing import Generic, TypeVar
-
 import pytest
 
 from betty.license import License
 from betty.locale.localize import DEFAULT_LOCALIZER
 
-_LicenseT = TypeVar("_LicenseT", bound=License)
 
-
-class LicenseTestBase(Generic[_LicenseT]):
+class LicenseTestBase[LicenseT: License]:
     """
     A base class for testing :py:class:`betty.license.License` implementations.
     """
 
     @pytest.fixture
-    def sut(self) -> type[_LicenseT]:
+    def sut(self) -> type[LicenseT]:
         """
         Provide the system(s) under test.
         """
         raise NotImplementedError
 
-    def test_summary(self, sut: _LicenseT) -> None:
+    def test_summary(self, sut: LicenseT) -> None:
         """
         Tests :py:meth:`betty.license.License.summary` implementations.
         """
         assert sut.summary.localize(DEFAULT_LOCALIZER)
 
-    def test_text(self, sut: _LicenseT) -> None:
+    def test_text(self, sut: LicenseT) -> None:
         """
         Tests :py:meth:`betty.license.License.text` implementations.
         """
         assert sut.text.localize(DEFAULT_LOCALIZER)
 
-    def test_url(self, sut: _LicenseT) -> None:
+    def test_url(self, sut: LicenseT) -> None:
         """
         Tests :py:meth:`betty.license.License.url` implementations.
         """

--- a/betty/test_utils/model/__init__.py
+++ b/betty/test_utils/model/__init__.py
@@ -4,7 +4,7 @@ Test utilities for :py:mod:`betty.model`.
 
 from __future__ import annotations
 
-from typing import Generic, TypeVar, final
+from typing import final
 
 import pytest
 
@@ -13,22 +13,20 @@ from betty.locale.localizable.static import CountableStaticTranslations
 from betty.locale.localize import DEFAULT_LOCALIZER
 from betty.model import Entity, EntityDefinition
 
-_EntityT = TypeVar("_EntityT", bound=Entity)
 
-
-class EntityTestBase(Generic[_EntityT]):
+class EntityTestBase[EntityT: Entity]:
     """
     A base class for testing :py:class:`betty.model.Entity` implementations.
     """
 
     @pytest.fixture
-    def sut(self) -> type[_EntityT]:
+    def sut(self) -> type[EntityT]:
         """
         Provide the system(s) under test.
         """
         raise NotImplementedError
 
-    async def test_label(self, sut: _EntityT) -> None:
+    async def test_label(self, sut: EntityT) -> None:
         """
         Tests :py:meth:`betty.model.Entity.label` implementations.
         """

--- a/betty/test_utils/model/collections.py
+++ b/betty/test_utils/model/collections.py
@@ -3,31 +3,28 @@ Test utilities for :py:mod:`betty.model.collections`.
 """
 
 from collections.abc import Sequence
-from typing import Any, Generic, TypeVar
+from typing import Any
 
 import pytest
 
 from betty.model import Entity
 from betty.model.collections import EntityCollection
 
-_EntityT = TypeVar("_EntityT", bound=Entity)
-_EntityCollectionT = TypeVar("_EntityCollectionT", bound=EntityCollection[Entity])
 
-
-class EntityCollectionTestBase(Generic[_EntityT]):
+class EntityCollectionTestBase[EntityT: Entity]:
     """
     A base class for testing :py:class:`betty.model.collections.EntityCollection` implementations.
     """
 
     @pytest.fixture
-    def sut(self) -> EntityCollection[_EntityT]:
+    def sut(self) -> EntityCollection[EntityT]:
         """
         Provide the system(s) under test.
         """
         raise NotImplementedError
 
     @pytest.fixture
-    async def sut_entities(self) -> Sequence[_EntityT]:
+    async def sut_entities(self) -> Sequence[EntityT]:
         """
         Produce entities to test the collections with.
 
@@ -36,7 +33,7 @@ class EntityCollectionTestBase(Generic[_EntityT]):
         raise NotImplementedError
 
     async def test_entity_collection_test_base_sut_entities(
-        self, sut_entities: Sequence[_EntityT]
+        self, sut_entities: Sequence[EntityT]
     ) -> None:
         """
         Tests :py:meth:`betty.test_utils.model.collections.EntityCollectionTestBase.sut_entities` implementations.
@@ -44,7 +41,7 @@ class EntityCollectionTestBase(Generic[_EntityT]):
         assert len(sut_entities) >= 3
 
     async def test_add(
-        self, sut: EntityCollection[_EntityT], sut_entities: Sequence[_EntityT]
+        self, sut: EntityCollection[EntityT], sut_entities: Sequence[EntityT]
     ) -> None:
         """
         Tests :py:meth:`betty.model.collections.EntityCollection.add` implementations.
@@ -53,7 +50,7 @@ class EntityCollectionTestBase(Generic[_EntityT]):
         assert list(sut) == list(sut_entities)
 
     async def test_add_with_duplicate_entities(
-        self, sut: EntityCollection[_EntityT], sut_entities: Sequence[_EntityT]
+        self, sut: EntityCollection[EntityT], sut_entities: Sequence[EntityT]
     ) -> None:
         """
         Tests :py:meth:`betty.model.collections.EntityCollection.add` implementations.
@@ -62,7 +59,7 @@ class EntityCollectionTestBase(Generic[_EntityT]):
         assert list(sut) == list(sut_entities[0:3])
 
     async def test_remove(
-        self, sut: EntityCollection[_EntityT], sut_entities: Sequence[_EntityT]
+        self, sut: EntityCollection[EntityT], sut_entities: Sequence[EntityT]
     ) -> None:
         """
         Tests :py:meth:`betty.model.collections.EntityCollection.remove` implementations.
@@ -76,7 +73,7 @@ class EntityCollectionTestBase(Generic[_EntityT]):
         assert list(sut) == []
 
     async def test___delitem____by_entity(
-        self, sut: EntityCollection[_EntityT], sut_entities: Sequence[_EntityT]
+        self, sut: EntityCollection[EntityT], sut_entities: Sequence[EntityT]
     ) -> None:
         """
         Tests :py:meth:`betty.model.collections.EntityCollection.__delitem__` implementations.
@@ -88,7 +85,7 @@ class EntityCollectionTestBase(Generic[_EntityT]):
         assert list(sut) == list(sut_entities[1:])
 
     async def test___contains____by_entity(
-        self, sut: EntityCollection[_EntityT], sut_entities: Sequence[_EntityT]
+        self, sut: EntityCollection[EntityT], sut_entities: Sequence[EntityT]
     ) -> None:
         """
         Tests :py:meth:`betty.model.collections.EntityCollection.__contains__` implementations.
@@ -106,7 +103,7 @@ class EntityCollectionTestBase(Generic[_EntityT]):
         ],
     )
     async def test___contains____by_unsupported_type(
-        self, value: Any, sut: EntityCollection[_EntityT]
+        self, value: Any, sut: EntityCollection[EntityT]
     ) -> None:
         """
         Tests :py:meth:`betty.model.collections.EntityCollection.__contains__` implementations.
@@ -114,7 +111,7 @@ class EntityCollectionTestBase(Generic[_EntityT]):
         assert value not in sut
 
     async def test___len__(
-        self, sut: EntityCollection[_EntityT], sut_entities: Sequence[_EntityT]
+        self, sut: EntityCollection[EntityT], sut_entities: Sequence[EntityT]
     ) -> None:
         """
         Tests :py:meth:`betty.model.collections.EntityCollection.__len__` implementations.
@@ -124,7 +121,7 @@ class EntityCollectionTestBase(Generic[_EntityT]):
         assert len(sut) == len(sut_entities)
 
     async def test___iter__(
-        self, sut: EntityCollection[_EntityT], sut_entities: Sequence[_EntityT]
+        self, sut: EntityCollection[EntityT], sut_entities: Sequence[EntityT]
     ) -> None:
         """
         Tests :py:meth:`betty.model.collections.EntityCollection.__iter__` implementations.
@@ -134,7 +131,7 @@ class EntityCollectionTestBase(Generic[_EntityT]):
         assert list(iter(sut)) == list(sut_entities)
 
     async def test_clear(
-        self, sut: EntityCollection[_EntityT], sut_entities: Sequence[_EntityT]
+        self, sut: EntityCollection[EntityT], sut_entities: Sequence[EntityT]
     ) -> None:
         """
         Tests :py:meth:`betty.model.collections.EntityCollection.__iter__` implementations.
@@ -144,7 +141,7 @@ class EntityCollectionTestBase(Generic[_EntityT]):
         assert list(sut) == []
 
     async def test_replace(
-        self, sut: EntityCollection[_EntityT], sut_entities: Sequence[_EntityT]
+        self, sut: EntityCollection[EntityT], sut_entities: Sequence[EntityT]
     ) -> None:
         """
         Tests :py:meth:`betty.model.collections.EntityCollection.replace` implementations.

--- a/betty/test_utils/serde.py
+++ b/betty/test_utils/serde.py
@@ -2,23 +2,19 @@
 Test utilities for :py:mod:`betty.serde`.
 """
 
-from typing import Generic, TypeVar
-
 import pytest
 
 from betty.portable import PortableData
 from betty.serde import Serializer
 
-_SerializerT = TypeVar("_SerializerT", bound=Serializer)
 
-
-class SerializerTestBase(Generic[_SerializerT]):
+class SerializerTestBase[SerializerT: Serializer]:
     """
     A base class for testing :py:class:`betty.serde.Serializer` implementations.
     """
 
     @pytest.fixture
-    def sut(self) -> type[_SerializerT]:
+    def sut(self) -> type[SerializerT]:
         """
         Provide the system(s) under test.
         """
@@ -38,7 +34,7 @@ class SerializerTestBase(Generic[_SerializerT]):
             ["value"],
         ],
     )
-    def test_dump_and_load(self, portable: PortableData, sut: _SerializerT) -> None:
+    def test_dump_and_load(self, portable: PortableData, sut: SerializerT) -> None:
         """
         Tests :py:meth:`betty.serde.Serializer.load` and :py:meth:`betty.serde.Serializer.dump` implementations.
         """

--- a/betty/test_utils/user.py
+++ b/betty/test_utils/user.py
@@ -6,7 +6,7 @@ import logging
 import sys
 from collections.abc import AsyncIterator, Collection, Iterable, MutableSequence
 from contextlib import asynccontextmanager
-from typing import TypeVar, overload, override
+from typing import overload, override
 
 from betty.assertion import Assertion
 from betty.locale.localizable import ResolvableLocalizable
@@ -15,8 +15,6 @@ from betty.progress import Progress
 from betty.progress.no_op import NoOpProgress
 from betty.typing import Void, internal
 from betty.user import User, UserTimeoutError, Verbosity
-
-_T = TypeVar("_T")
 
 
 @internal
@@ -263,23 +261,23 @@ class StaticUser(User):  # pragma: no cover
         pass
 
     @overload
-    async def ask_input(
+    async def ask_input[T](
         self,
         question: ResolvableLocalizable,
         *,
-        assertion: Assertion[str, _T],
+        assertion: Assertion[str, T],
         default: str | Void = Void(),  # noqa: B008
-    ) -> _T:
+    ) -> T:
         pass
 
     @override
-    async def ask_input(
+    async def ask_input[T](
         self,
         question: ResolvableLocalizable,
         *,
-        assertion: Assertion[str, _T] | None = None,
-        default: str | _T | Void = Void(),  # noqa: B008
-    ) -> str | _T:
+        assertion: Assertion[str, T] | None = None,
+        default: str | T | Void = Void(),  # noqa: B008
+    ) -> str | T:
         value = next(self._inputs)
         if value is None:
             if isinstance(default, Void):

--- a/betty/tests/ancestry/test___init__.py
+++ b/betty/tests/ancestry/test___init__.py
@@ -62,7 +62,7 @@ class _TestAncestry_OneToOne_Right(Entity):
 class TestAncestry(EntityCollectionTestBase[Entity]):
     @override
     @pytest.fixture
-    def sut(self) -> EntityCollection[Entity]:
+    def sut(self) -> EntityCollection:
         return Ancestry()
 
     @override

--- a/betty/tests/coverage/test_coverage.py
+++ b/betty/tests/coverage/test_coverage.py
@@ -17,7 +17,7 @@ from importlib import import_module
 from inspect import getmembers, isclass, isdatadescriptor, isfunction
 from os import walk
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 import aiofiles
 import pytest
@@ -58,13 +58,13 @@ class MissingReason(Enum):
     INHERITED = "This testable is inherited"
 
 
-_ModuleFunctionExistsIgnore: TypeAlias = None
-_ModuleFunctionIgnore = _ModuleFunctionExistsIgnore | MissingReason
-_ModuleClassExistsIgnore = Mapping[str, _ModuleFunctionIgnore]
-_ModuleClassIgnore = _ModuleClassExistsIgnore | MissingReason
-_ModuleMemberIgnore = _ModuleFunctionIgnore | _ModuleClassIgnore
-_ModuleExistsIgnore = Mapping[str, _ModuleMemberIgnore]
-_ModuleIgnore = _ModuleExistsIgnore | MissingReason
+type _ModuleFunctionExistsIgnore = None
+type _ModuleFunctionIgnore = _ModuleFunctionExistsIgnore | MissingReason
+type _ModuleClassExistsIgnore = Mapping[str, _ModuleFunctionIgnore]
+type _ModuleClassIgnore = _ModuleClassExistsIgnore | MissingReason
+type _ModuleMemberIgnore = _ModuleFunctionIgnore | _ModuleClassIgnore
+type _ModuleExistsIgnore = Mapping[str, _ModuleMemberIgnore]
+type _ModuleIgnore = _ModuleExistsIgnore | MissingReason
 
 # Keys are paths to module files with ignore rules. These paths area relative to the project root directory.
 # This baseline MUST NOT be extended. It SHOULD decrease in size as more coverage is added to Betty over time.

--- a/betty/tests/data/aggregate/record/object/test_property.py
+++ b/betty/tests/data/aggregate/record/object/test_property.py
@@ -149,7 +149,7 @@ class TestKeyedCollectionProperty:
         keyed_collection = KeyedCollectionProperty(
             KeyedCollectionDefinition(
                 label=DUMMY_LOCALIZABLE,
-                value=_Item.data(),
+                value=_Item,
                 key=AttrSelector("attr"),
                 ordered=False,
             ),

--- a/betty/tests/data/aggregate/record/test___init__.py
+++ b/betty/tests/data/aggregate/record/test___init__.py
@@ -263,7 +263,7 @@ class TestMappingPorter:
         assert sut.dump_key(data, Attr(field_name)) == (value, {})
 
 
-class PortableRecordPorterTestPortable(PortableRecord[Attr]):
+class PortableRecordPorterTestPortableRecord(PortableRecord[Attr]):
     def __init__(self, key: str, value: str):
         self.key = key
         self.value = value
@@ -289,7 +289,7 @@ class PortableRecordPorterTestPortable(PortableRecord[Attr]):
 
 class TestPortableRecordPorter:
     def test_load_key(self) -> None:
-        sut = PortableRecordPorter(PortableRecordPorterTestPortable)
+        sut = PortableRecordPorter(PortableRecordPorterTestPortableRecord)
         key = "hello-world"
         value = "Hello, world!"
         data = sut.load_key({"value": value}, Attr("key"), key)
@@ -297,8 +297,8 @@ class TestPortableRecordPorter:
         assert data.value == value
 
     def test_dump_key(self) -> None:
-        sut = PortableRecordPorter(PortableRecordPorterTestPortable)
+        sut = PortableRecordPorter(PortableRecordPorterTestPortableRecord)
         key = "hello-world"
         value = "Hello, world!"
-        data = PortableRecordPorterTestPortable(key, value)
+        data = PortableRecordPorterTestPortableRecord(key, value)
         assert sut.dump_key(data, Attr("key")) == (key, {"value": value})

--- a/betty/tests/http_client/test_rate_limit.py
+++ b/betty/tests/http_client/test_rate_limit.py
@@ -1,7 +1,7 @@
 import time
 from asyncio import gather
 from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
-from typing import TypeAlias, override
+from typing import override
 from unittest.mock import AsyncMock
 
 import pytest
@@ -44,7 +44,7 @@ class _AlwaysMatchingHighRateLimit(RateLimit):
         return 999999999, 1
 
 
-DoAssert: TypeAlias = Callable[[int, int, Sequence[RateLimit]], Awaitable[None]]
+type DoAssert = Callable[[int, int, Sequence[RateLimit]], Awaitable[None]]
 
 
 class TestRateLimitMiddleware:

--- a/betty/tests/job/executor/test_asyncio.py
+++ b/betty/tests/job/executor/test_asyncio.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar, override
+from typing import TYPE_CHECKING, override
 
 import pytest
 
-from betty.job import Context
 from betty.job.executor.asyncio import AsyncExecutor
 from betty.test_utils.job.executor import ExecutorTestBase
 
@@ -14,13 +13,11 @@ if TYPE_CHECKING:
     from betty.job.executor import Executor
     from betty.job.scheduler import Scheduler
 
-_ContextCoT = TypeVar("_ContextCoT", bound=Context, covariant=True)
-
 
 class TestAsyncExecutor(ExecutorTestBase):
     @pytest.fixture(params=(1, 999))
     @override
     async def new_sut(
         self, request: pytest.FixtureRequest
-    ) -> Callable[[Scheduler[Context]], Executor]:
+    ) -> Callable[[Scheduler], Executor]:
         return lambda scheduler: AsyncExecutor(scheduler, concurrency=request.param)

--- a/betty/tests/job/executor/test_threading.py
+++ b/betty/tests/job/executor/test_threading.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar, override
+from typing import TYPE_CHECKING, override
 
 import pytest
 
-from betty.job import Context
 from betty.job.executor.threading import ThreadPoolExecutor
 from betty.test_utils.job.executor import ExecutorTestBase
 
@@ -13,8 +12,6 @@ if TYPE_CHECKING:
 
     from betty.job.executor import Executor
     from betty.job.scheduler import Scheduler
-
-_ContextCoT = TypeVar("_ContextCoT", bound=Context, covariant=True)
 
 
 class TestThreadPoolExecutor(ExecutorTestBase):
@@ -29,7 +26,7 @@ class TestThreadPoolExecutor(ExecutorTestBase):
     @override
     async def new_sut(
         self, request: pytest.FixtureRequest
-    ) -> Callable[[Scheduler[Context]], Executor]:
+    ) -> Callable[[Scheduler], Executor]:
         return lambda scheduler: ThreadPoolExecutor(
             scheduler,
             async_concurrency=request.param[0],

--- a/betty/tests/job/scheduler/test_default.py
+++ b/betty/tests/job/scheduler/test_default.py
@@ -29,7 +29,7 @@ class _Progress(Progress):
         self.total -= done
 
 
-class TestDefaultScheduler(SchedulerTestBase[SchedulerTestBaseContext]):
+class TestDefaultScheduler(SchedulerTestBase):
     @pytest.fixture
     @override
     def sut(self) -> Scheduler[SchedulerTestBaseContext]:

--- a/betty/tests/job/test___init__.py
+++ b/betty/tests/job/test___init__.py
@@ -39,9 +39,9 @@ class TestContext:
         sut.progress  # noqa: B018
 
 
-class _Job(Job[Context]):
+class _Job(Job):
     @override
-    async def do(self, scheduler: Scheduler[Context], /) -> None:
+    async def do(self, scheduler: Scheduler, /) -> None:
         pass
 
 

--- a/betty/tests/model/test_association.py
+++ b/betty/tests/model/test_association.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar, override
+from typing import TYPE_CHECKING, override
 
 import pytest
 
@@ -38,33 +38,31 @@ if TYPE_CHECKING:
     from betty.app import App
     from betty.portable import PortableMapping
 
-_EntityT = TypeVar("_EntityT", bound=Entity)
 
-
-class _PassthroughToOneResolver(ToOneResolver[_EntityT]):
-    def __init__(self, entity: _EntityT):
+class _PassthroughToOneResolver[EntityT: Entity](ToOneResolver[EntityT]):
+    def __init__(self, entity: EntityT):
         self._entity = entity
 
     @override
-    def resolve(self) -> _EntityT:
+    def resolve(self) -> EntityT:
         return self._entity
 
 
-class _PassthroughToZeroOrOneResolver(ToZeroOrOneResolver[_EntityT]):
-    def __init__(self, entity: _EntityT | None):
+class _PassthroughToZeroOrOneResolver[EntityT: Entity](ToZeroOrOneResolver[EntityT]):
+    def __init__(self, entity: EntityT | None):
         self._entity = entity
 
     @override
-    def resolve(self) -> _EntityT | None:
+    def resolve(self) -> EntityT | None:
         return self._entity
 
 
-class _PassthroughToManyResolver(ToManyResolver[_EntityT]):
-    def __init__(self, *entities: _EntityT):
+class _PassthroughToManyResolver[EntityT: Entity](ToManyResolver[EntityT]):
+    def __init__(self, *entities: EntityT):
         self._entities = entities
 
     @override
-    def resolve(self) -> Iterable[_EntityT]:
+    def resolve(self) -> Iterable[EntityT]:
         return self._entities
 
 

--- a/betty/tests/plugin/config/test___init__.py
+++ b/betty/tests/plugin/config/test___init__.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, final, override
+from typing import TYPE_CHECKING, Any, final, override
 
 import pytest
 
@@ -35,10 +35,6 @@ from betty.typing import Void
 if TYPE_CHECKING:
     from betty.portable import PortableData
 
-_PluginDefinitionT = TypeVar(
-    "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
-)
-
 
 class _DataManufacturableDummyPlugin(
     DummyDataManufacturable, Plugin["_DataManufacturableDummyPluginDefinition"]
@@ -66,9 +62,11 @@ class _DataManufacturableDummyPluginOne(_DataManufacturableDummyPlugin):
     pass
 
 
-class _DummyPluginDefinitionConfiguration(PluginDefinitionConfiguration):
+class _DummyPluginDefinitionConfiguration(
+    PluginDefinitionConfiguration[DummyPluginDefinition]
+):
     @override
-    def new_plugin(self) -> _PluginDefinitionT:
+    def new_plugin(self) -> DummyPluginDefinition:
         raise NotImplementedError
 
 
@@ -87,9 +85,7 @@ class TestHumanFacingPluginDefinitionConfiguration:
     class _Sut(
         HumanFacingPluginDefinitionConfiguration, _DummyPluginDefinitionConfiguration
     ):
-        @override
-        def new_plugin(self) -> _PluginDefinitionT:
-            raise NotImplementedError
+        pass
 
     def test_label(self) -> None:
         label = DUMMY_LOCALIZABLE
@@ -109,9 +105,7 @@ class TestCountableHumanFacingPluginDefinitionConfiguration:
         CountableHumanFacingPluginDefinitionConfiguration,
         _DummyPluginDefinitionConfiguration,
     ):
-        @override
-        def new_plugin(self) -> _PluginDefinitionT:
-            raise NotImplementedError
+        pass
 
     def test_label_plural(self) -> None:
         label_plural = DUMMY_LOCALIZABLE
@@ -417,7 +411,7 @@ async def test_new_plugins() -> None:
                 PluginConfiguration(DummyPluginOne),
                 PluginConfiguration(DummyPluginOne.plugin()),
                 PluginConfiguration(DummyPluginOne.plugin().id),
-            ],  # ty:ignore[invalid-argument-type]
+            ],
         )
     )
     assert len(actual) == 6

--- a/betty/tests/plugin/discovery/test___init__.py
+++ b/betty/tests/plugin/discovery/test___init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar, override
+from typing import TYPE_CHECKING, override
 
 import pytest
 
@@ -24,19 +24,16 @@ if TYPE_CHECKING:
     from betty.service.level import ServiceLevel
 
 
-_PluginDefinitionT = TypeVar(
-    "_PluginDefinitionT", bound=PluginDefinition, default=PluginDefinition
-)
-
-
-class _StaticDiscovery(PluginDiscovery[_PluginDefinitionT]):
-    def __init__(self, *discoveries: ResolvableDiscovery[_PluginDefinitionT]):
+class _StaticDiscovery[PluginDefinitionT: PluginDefinition](
+    PluginDiscovery[PluginDefinitionT]
+):
+    def __init__(self, *discoveries: ResolvableDiscovery[PluginDefinitionT]):
         self._discoveries = discoveries
 
     @override
     async def discover(
         self, services: ServiceLevel, /
-    ) -> Iterable[ResolvableDiscovery[_PluginDefinitionT]]:
+    ) -> Iterable[ResolvableDiscovery[PluginDefinitionT]]:
         return self._discoveries
 
 

--- a/betty/tests/plugin/manager/test_service.py
+++ b/betty/tests/plugin/manager/test_service.py
@@ -41,7 +41,7 @@ class TestServiceLevelPluginManager:
             return ()
 
         sut = ServiceLevelPluginManager(isolated_app)
-        with DummyPluginDefinition.type().discoverer.override(require_app(_discovery)):
+        with DummyPluginDefinition.type().discoverer.override(require_app(_discovery)):  # ty:ignore[invalid-argument-type]
             await sut.plugins(DummyPluginDefinition)
 
     async def test_plugins__with_overridden_discoveries(self) -> None:

--- a/betty/tests/service/requirement/test___init__.py
+++ b/betty/tests/service/requirement/test___init__.py
@@ -1,5 +1,4 @@
 from collections.abc import Awaitable, Callable
-from typing import TypeAlias
 
 import pytest
 
@@ -51,7 +50,7 @@ _targets = pytest.mark.parametrize(
         _RequireTargetInstanceMethod().target,
     ],
 )
-_Target: TypeAlias = Callable[[ServiceLevel], Awaitable[_RequiredServiceLevel]]
+type _Target = Callable[[ServiceLevel], Awaitable[_RequiredServiceLevel]]
 
 
 class TestRequirement:

--- a/betty/tests/service/test_container.py
+++ b/betty/tests/service/test_container.py
@@ -1,5 +1,5 @@
 from collections.abc import Awaitable
-from typing import Any, TypeVar, override
+from typing import Any, override
 
 import pytest
 
@@ -14,8 +14,6 @@ from betty.service.container import (
     service,
 )
 from betty.test_utils.service.level import DummyDataManufacturable
-
-_T = TypeVar("_T")
 
 
 class _DataManufacturableManagedLifeCycle(DummyDataManufacturable, ManagedLifeCycle):

--- a/betty/tests/test_assertion.py
+++ b/betty/tests/test_assertion.py
@@ -5,7 +5,7 @@ from enum import Enum
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from types import NoneType
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any
 
 import pytest
 from aiofiles.tempfile import TemporaryDirectory
@@ -43,8 +43,6 @@ from betty.locale.localizable.static import StaticTranslations
 
 if TYPE_CHECKING:
     from collections.abc import Sized
-
-_T = TypeVar("_T")
 
 
 class TestAssertionChain:

--- a/betty/tests/test_concurrent.py
+++ b/betty/tests/test_concurrent.py
@@ -2,15 +2,13 @@ import asyncio
 import threading
 import time
 from asyncio import create_task, gather, run, sleep, wait_for
-from typing import TypeVar, override
+from typing import override
 from unittest.mock import call
 
 import pytest
 from pytest_mock import MockerFixture
 
 from betty.concurrent import AsynchronizedLock, Ledger, Lock, RateLimiter, backoff
-
-_KeyT = TypeVar("_KeyT")
 
 
 class _LockTestDummyLock(Lock):

--- a/betty/tests/test_deriver.py
+++ b/betty/tests/test_deriver.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
-from typing import TYPE_CHECKING, TypeAlias, final, override
+from typing import TYPE_CHECKING, final, override
 
 import pytest
 
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 
     from betty.app import App
 
-NewProject: TypeAlias = Callable[
+type NewProject = Callable[
     [Iterable[ResolvableDefinition[EventTypeDefinition]]],
     AbstractAsyncContextManager[Project],
 ]

--- a/betty/tests/test_functools.py
+++ b/betty/tests/test_functools.py
@@ -1,5 +1,5 @@
 from collections.abc import Awaitable, Callable, Iterable, Sequence
-from typing import Any, Literal, TypeVar
+from typing import Any, Literal
 
 import pytest
 
@@ -13,8 +13,6 @@ from betty.functools import (
     unique,
 )
 from betty.typing import Void
-
-_T = TypeVar("_T")
 
 
 class TestDo:
@@ -113,10 +111,10 @@ class TestDo:
         ),
     ],
 )
-async def test_unique(
-    expected: Sequence[_T],
-    values: Iterable[Iterable[_T]],
-    key: Callable[[_T], Any] | None,
+async def test_unique[T](
+    expected: Sequence[T],
+    values: Iterable[Iterable[T]],
+    key: Callable[[T], Any] | None,
 ) -> None:
     sut = unique(*values, key=key)
     assert list(sut) == expected

--- a/betty/typing.py
+++ b/betty/typing.py
@@ -4,12 +4,10 @@ Providing typing utilities.
 
 from __future__ import annotations
 
-from typing import Any, TypeVar, final
+from typing import Any, final
 
 from betty.classtools import Singleton
 from betty.docstring import append
-
-_T = TypeVar("_T")
 
 
 def _should_mark(target: Any, key: str, /) -> bool:
@@ -20,7 +18,7 @@ def _should_mark(target: Any, key: str, /) -> bool:
     return True
 
 
-def _internal(target: _T, /) -> _T:
+def _internal[T](target: T, /) -> T:
     if _should_mark(target, "internal"):
         target.__doc__ = append(
             target.__doc__ or "",
@@ -30,7 +28,7 @@ def _internal(target: _T, /) -> _T:
 
 
 @_internal
-def internal(target: _T, /) -> _T:
+def internal[T](target: T, /) -> T:
     """
     Mark a target as internal to Betty.
 
@@ -41,7 +39,7 @@ def internal(target: _T, /) -> _T:
 
 
 @internal
-def public(target: _T, /) -> _T:
+def public[T](target: T, /) -> T:
     """
     Mark a target as publicly usable.
 
@@ -52,7 +50,7 @@ def public(target: _T, /) -> _T:
     return target
 
 
-def private(target: _T, /) -> _T:
+def private[T](target: T, /) -> T:
     """
     Mark a target as private to its containing scope.
 
@@ -66,7 +64,7 @@ def private(target: _T, /) -> _T:
     return target
 
 
-def threadsafe(target: _T, /) -> _T:
+def threadsafe[T](target: T, /) -> T:
     """
     Mark a target as thread-safe.
     """

--- a/betty/user/__init__.py
+++ b/betty/user/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from enum import IntEnum
-from typing import TYPE_CHECKING, TypeVar, overload
+from typing import TYPE_CHECKING, overload
 
 from betty.locale.localize import DEFAULT_LOCALIZER
 from betty.typing import Void
@@ -19,9 +19,6 @@ if TYPE_CHECKING:
     from betty.locale.localizable import ResolvableLocalizable
     from betty.locale.localize import Localizer
     from betty.progress import Progress
-
-
-_T = TypeVar("_T")
 
 
 class Verbosity(IntEnum):
@@ -188,23 +185,23 @@ class User(ABC):
         pass
 
     @overload
-    async def ask_input(
+    async def ask_input[T](
         self,
         question: ResolvableLocalizable,
         *,
-        assertion: Assertion[str, _T],
+        assertion: Assertion[str, T],
         default: str | Void = Void(),  # noqa: B008
-    ) -> _T:
+    ) -> T:
         pass
 
     @abstractmethod
-    async def ask_input(
+    async def ask_input[T](
         self,
         question: ResolvableLocalizable,
         *,
-        assertion: Assertion[str, _T] | None = None,
-        default: str | _T | Void = Void(),  # noqa: B008
-    ) -> str | _T:
+        assertion: Assertion[str, T] | None = None,
+        default: str | T | Void = Void(),  # noqa: B008
+    ) -> str | T:
         """
         Ask the user to input text.
 

--- a/betty/user/no_op.py
+++ b/betty/user/no_op.py
@@ -5,7 +5,7 @@ User sessions that do nothing.
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import TypeVar, final, overload, override
+from typing import final, overload, override
 
 from betty.assertion import Assertion
 from betty.locale.localizable import ResolvableLocalizable
@@ -13,8 +13,6 @@ from betty.progress import Progress
 from betty.progress.no_op import NoOpProgress
 from betty.typing import Void
 from betty.user import User, UserTimeoutError, Verbosity
-
-_T = TypeVar("_T")
 
 
 @final
@@ -82,21 +80,21 @@ class NoOpUser(User):
         pass
 
     @overload
-    async def ask_input(
+    async def ask_input[T](
         self,
         question: ResolvableLocalizable,
         *,
-        assertion: Assertion[str, _T],
+        assertion: Assertion[str, T],
         default: str | Void = Void(),  # noqa: B008
-    ) -> _T:
+    ) -> T:
         pass
 
     @override
-    async def ask_input(
+    async def ask_input[T](
         self,
         question: ResolvableLocalizable,
         *,
-        assertion: Assertion[str, _T] | None = None,
-        default: str | _T | Void = Void(),  # noqa: B008
-    ) -> str | _T:
+        assertion: Assertion[str, T] | None = None,
+        default: str | T | Void = Void(),  # noqa: B008
+    ) -> str | T:
         raise UserTimeoutError


### PR DESCRIPTION
Use the new typing syntaxes introduced in Pythons 3.12 and 3.13 to improve code readability and lower the risk of bugs caused by incorrectly defined or (re)used type variables.