### PR TITLE
Check requirements for non-service plugins

### DIFF
--- a/betty/app/__init__.py
+++ b/betty/app/__init__.py
@@ -31,7 +31,11 @@ from betty.portable.file import assert_load_file
 from betty.service.factory import DataManufacturable
 from betty.service.level import ChainedServiceLevel, Plugins, ServiceLevel
 from betty.service.level.universe import UNIVERSE
-from betty.service.plugin import ServicePluginManager, ServicePluginProvider
+from betty.service.plugin import (
+    ServicePluginManager,
+    ServicePluginProvider,
+    ServicePlugins,
+)
 from betty.service.provider import ServiceFactory, service
 from betty.typing import threadsafe
 from betty.user.no_op import NoOpUser
@@ -47,11 +51,15 @@ if TYPE_CHECKING:
     from betty.plugin.discovery import ResolvableDiscovery
     from betty.user import User
 
+type AppServicePlugin = AssetDefinition | RateLimitDefinition
+
 
 @final
 @threadsafe
 class App(
-    DataManufacturable[AppConfiguration], ChainedServiceLevel, ServicePluginProvider
+    DataManufacturable[AppConfiguration],
+    ChainedServiceLevel,
+    ServicePluginProvider[AppServicePlugin],
 ):
     """
     The Betty application.
@@ -72,6 +80,7 @@ class App(
         locale: ResolvableLocale | None = None,
         plugins: Plugins | None = None,
         process_pool: futures.ProcessPoolExecutor | None = None,
+        service_plugins: ServicePlugins[AppServicePlugin] = (),
         translations: TranslationRepository | None = None,
         user: User | None = None,
     ):
@@ -99,6 +108,7 @@ class App(
             if cache_factory is None
             else cache_factory,
         )
+        self._service_plugins = service_plugins
 
     async def _bootstrap_localizer(self) -> None:
         self._user.localizer = await self.localizer
@@ -166,12 +176,13 @@ class App(
 
     @override
     @service
-    async def service_plugins(self) -> ServicePluginManager:
+    async def service_plugins(self) -> ServicePluginManager[AppServicePlugin]:
         service_plugins = ServicePluginManager(
-            {
-                AssetDefinition: (),
-                RateLimitDefinition: (),
+            plugin_types={
+                AssetDefinition,
+                RateLimitDefinition,
             },
+            plugin_manufacturers=self._service_plugins,
             services=self,
         )
         await service_plugins.bootstrap()

--- a/betty/asset.py
+++ b/betty/asset.py
@@ -21,7 +21,6 @@ from betty.service.plugin import Requires, ServicePluginDefinition
 from betty.typing import threadsafe
 
 if TYPE_CHECKING:
-    import builtins
     from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 
     from betty.machine_name import ResolvableMachineName
@@ -217,5 +216,5 @@ class AssetManufacturer(PluginManufacturer[AssetDefinition, Asset]):
 
     @override
     @classmethod
-    def type(cls) -> builtins.type[AssetDefinition]:
+    def plugin_type(cls) -> type[AssetDefinition]:
         return AssetDefinition

--- a/betty/content.py
+++ b/betty/content.py
@@ -11,9 +11,8 @@ from markupsafe import Markup
 
 from betty.definition.human_facing import HumanFacingDefinition
 from betty.locale.localizable.gettext import _, ngettext
-from betty.plugin import Plugin, PluginTypeDefinition
+from betty.plugin import Plugin, PluginDefinition, PluginTypeDefinition
 from betty.plugin.factory import PluginManufacturer
-from betty.service.plugin import ServicePluginDefinition
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -40,7 +39,7 @@ class Content(ABC, Plugin["ContentDefinition"]):
     label_plural=_("Contents"),
     label_countable=ngettext("{count} content", "{count} contents"),
 )
-class ContentDefinition(HumanFacingDefinition, ServicePluginDefinition[Content]):
+class ContentDefinition(HumanFacingDefinition, PluginDefinition[Content]):
     """
     .. plugin_type:: content.
     """

--- a/betty/content.py
+++ b/betty/content.py
@@ -16,7 +16,6 @@ from betty.plugin.factory import PluginManufacturer
 from betty.service.plugin import ServicePluginDefinition
 
 if TYPE_CHECKING:
-    import builtins
     from collections.abc import Iterable
 
     from betty.document import Document
@@ -55,7 +54,7 @@ class ContentManufacturer(PluginManufacturer[ContentDefinition, Content]):
 
     @override
     @classmethod
-    def type(cls) -> builtins.type[ContentDefinition]:
+    def plugin_type(cls) -> type[ContentDefinition]:
         return ContentDefinition
 
 

--- a/betty/copyright_notice/__init__.py
+++ b/betty/copyright_notice/__init__.py
@@ -13,8 +13,6 @@ from betty.plugin import Plugin, PluginDefinition, PluginTypeDefinition
 from betty.plugin.factory import PluginManufacturer
 
 if TYPE_CHECKING:
-    import builtins
-
     from betty.locale.localizable import Localizable
 
 
@@ -72,5 +70,5 @@ class CopyrightNoticeManufacturer(
 
     @override
     @classmethod
-    def type(cls) -> builtins.type[CopyrightNoticeDefinition]:
+    def plugin_type(cls) -> type[CopyrightNoticeDefinition]:
         return CopyrightNoticeDefinition

--- a/betty/event_type/__init__.py
+++ b/betty/event_type/__init__.py
@@ -19,8 +19,6 @@ from betty.plugin.factory import PluginManufacturer
 from betty.plugin.ordered import Order, OrderedPluginDefinition
 
 if TYPE_CHECKING:
-    import builtins
-
     from betty.locale.localizable import CountableLocalizable, ResolvableLocalizable
     from betty.machine_name import MachineName, ResolvableMachineName
     from betty.plugins.entity.person import Person
@@ -99,5 +97,5 @@ class EventTypeManufacturer(PluginManufacturer[EventTypeDefinition, EventType]):
 
     @override
     @classmethod
-    def type(cls) -> builtins.type[EventTypeDefinition]:
+    def plugin_type(cls) -> type[EventTypeDefinition]:
         return EventTypeDefinition

--- a/betty/extension/__init__.py
+++ b/betty/extension/__init__.py
@@ -13,8 +13,6 @@ from betty.plugin.ordered import OrderedPluginDefinition
 from betty.service.plugin import ServicePluginDefinition
 
 if TYPE_CHECKING:
-    import builtins
-
     from betty.locale.localizable import ResolvableLocalizable
     from betty.machine_name import ResolvableMachineName
     from betty.plugin.ordered import Order
@@ -78,5 +76,5 @@ class ExtensionManufacturer(PluginManufacturer[ExtensionDefinition, Extension]):
 
     @override
     @classmethod
-    def type(cls) -> builtins.type[ExtensionDefinition]:
+    def plugin_type(cls) -> type[ExtensionDefinition]:
         return ExtensionDefinition

--- a/betty/gender/__init__.py
+++ b/betty/gender/__init__.py
@@ -4,15 +4,12 @@ Provide Betty's ancestry genders.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, final, override
+from typing import final, override
 
 from betty.definition.human_facing import CountableHumanFacingDefinition
 from betty.locale.localizable.gettext import _, ngettext
 from betty.plugin import Plugin, PluginDefinition, PluginTypeDefinition
 from betty.plugin.factory import PluginManufacturer
-
-if TYPE_CHECKING:
-    import builtins
 
 
 class Gender(Plugin["GenderDefinition"]):
@@ -47,5 +44,5 @@ class GenderManufacturer(PluginManufacturer[GenderDefinition, Gender]):
 
     @override
     @classmethod
-    def type(cls) -> builtins.type[GenderDefinition]:
+    def plugin_type(cls) -> type[GenderDefinition]:
         return GenderDefinition

--- a/betty/html/css.py
+++ b/betty/html/css.py
@@ -2,7 +2,6 @@
 CSS resources for HTML pages.
 """
 
-import builtins
 from typing import Any, final, override
 
 from betty.locale.localizable.gettext import _, ngettext
@@ -68,5 +67,5 @@ class CssResourceManufacturer(PluginManufacturer[CssResourceDefinition, CssResou
 
     @override
     @classmethod
-    def type(cls) -> builtins.type[CssResourceDefinition]:
+    def plugin_type(cls) -> type[CssResourceDefinition]:
         return CssResourceDefinition

--- a/betty/html/js.py
+++ b/betty/html/js.py
@@ -2,7 +2,6 @@
 JavaScript resources for HTML pages.
 """
 
-import builtins
 from typing import Any, final, override
 
 from betty.locale.localizable.gettext import _, ngettext
@@ -70,5 +69,5 @@ class JsResourceManufacturer(PluginManufacturer[JsResourceDefinition, JsResource
 
     @override
     @classmethod
-    def type(cls) -> builtins.type[JsResourceDefinition]:
+    def plugin_type(cls) -> type[JsResourceDefinition]:
         return JsResourceDefinition

--- a/betty/http_client/rate_limit.py
+++ b/betty/http_client/rate_limit.py
@@ -16,7 +16,6 @@ from betty.service.plugin import Requires, ServicePluginDefinition
 from betty.typing import threadsafe
 
 if TYPE_CHECKING:
-    import builtins
     from collections.abc import Iterable, MutableMapping
 
     from aiohttp.client_middlewares import ClientHandlerType
@@ -127,5 +126,5 @@ class RateLimitManufacturer(PluginManufacturer[RateLimitDefinition, RateLimit]):
 
     @override
     @classmethod
-    def type(cls) -> builtins.type[RateLimitDefinition]:
+    def plugin_type(cls) -> type[RateLimitDefinition]:
         return RateLimitDefinition

--- a/betty/jinja/filter.py
+++ b/betty/jinja/filter.py
@@ -4,15 +4,12 @@ The Jinja filter API.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, final, override
+from typing import final, override
 
 from betty.locale.localizable.gettext import _, ngettext
 from betty.plugin import Plugin, PluginTypeDefinition
 from betty.plugin.factory import PluginManufacturer
 from betty.service.plugin import ServicePluginDefinition
-
-if TYPE_CHECKING:
-    import builtins
 
 
 class JinjaFilter(Plugin["JinjaFilterDefinition"]):
@@ -44,5 +41,5 @@ class JinjaFilterManufacturer(PluginManufacturer[JinjaFilterDefinition, JinjaFil
 
     @override
     @classmethod
-    def type(cls) -> builtins.type[JinjaFilterDefinition]:
+    def plugin_type(cls) -> type[JinjaFilterDefinition]:
         return JinjaFilterDefinition

--- a/betty/jinja/test.py
+++ b/betty/jinja/test.py
@@ -5,15 +5,12 @@ The Jinja test API.
 from __future__ import annotations
 
 from abc import ABC
-from typing import TYPE_CHECKING, final, override
+from typing import final, override
 
 from betty.locale.localizable.gettext import _, ngettext
 from betty.plugin import Plugin, PluginTypeDefinition
 from betty.plugin.factory import PluginManufacturer
 from betty.service.plugin import ServicePluginDefinition
-
-if TYPE_CHECKING:
-    import builtins
 
 
 class JinjaTest(Plugin["JinjaTestDefinition"], ABC):
@@ -45,5 +42,5 @@ class JinjaTestManufacturer(PluginManufacturer[JinjaTestDefinition, JinjaTest]):
 
     @override
     @classmethod
-    def type(cls) -> builtins.type[JinjaTestDefinition]:
+    def plugin_type(cls) -> type[JinjaTestDefinition]:
         return JinjaTestDefinition

--- a/betty/license/__init__.py
+++ b/betty/license/__init__.py
@@ -13,8 +13,6 @@ from betty.plugin import Plugin, PluginDefinition, PluginTypeDefinition
 from betty.plugin.factory import PluginManufacturer
 
 if TYPE_CHECKING:
-    import builtins
-
     from betty.locale.localizable import Localizable
 
 
@@ -68,5 +66,5 @@ class LicenseManufacturer(PluginManufacturer[LicenseDefinition, License]):
 
     @override
     @classmethod
-    def type(cls) -> builtins.type[LicenseDefinition]:
+    def plugin_type(cls) -> type[LicenseDefinition]:
         return LicenseDefinition

--- a/betty/link.py
+++ b/betty/link.py
@@ -2,7 +2,6 @@
 An API for linking to web resources.
 """
 
-import builtins
 from abc import abstractmethod
 from typing import Any, Protocol, final, override
 
@@ -89,5 +88,5 @@ class LinkManufacturer(PluginManufacturer[LinkDefinition, Link]):
 
     @override
     @classmethod
-    def type(cls) -> builtins.type[LinkDefinition]:
+    def plugin_type(cls) -> type[LinkDefinition]:
         return LinkDefinition

--- a/betty/place_type/__init__.py
+++ b/betty/place_type/__init__.py
@@ -4,15 +4,12 @@ Provide Betty's ancestry place types.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, final, override
+from typing import final, override
 
 from betty.definition.human_facing import CountableHumanFacingDefinition
 from betty.locale.localizable.gettext import _, ngettext
 from betty.plugin import Plugin, PluginDefinition, PluginTypeDefinition
 from betty.plugin.factory import PluginManufacturer
-
-if TYPE_CHECKING:
-    import builtins
 
 
 class PlaceType(Plugin["PlaceTypeDefinition"]):
@@ -42,5 +39,5 @@ class PlaceTypeManufacturer(PluginManufacturer[PlaceTypeDefinition, PlaceType]):
 
     @override
     @classmethod
-    def type(cls) -> builtins.type[PlaceTypeDefinition]:
+    def plugin_type(cls) -> type[PlaceTypeDefinition]:
         return PlaceTypeDefinition

--- a/betty/plugin/__init__.py
+++ b/betty/plugin/__init__.py
@@ -15,21 +15,15 @@ from betty.definition.cls import ClsDefinition
 from betty.definition.human_facing import CountableHumanFacingDefinition
 from betty.importlib import fully_qualified_name
 from betty.machine_name import MachineName, ResolvableMachineName
+from betty.requirement import HasRequirements, Requires
 
 if TYPE_CHECKING:
     import builtins
-    from collections.abc import Iterable
 
     from betty.locale.localizable import CountableLocalizable, ResolvableLocalizable
-    from betty.requirement import Requirement, ResolvableRequirement
-
-if TYPE_CHECKING:
-    type Requires = Iterable[ResolvableRequirement]
-else:
-    type Requires = Any
 
 
-class PluginDefinition[BaseClsT](ClsDefinition[BaseClsT]):
+class PluginDefinition[BaseClsT](HasRequirements, ClsDefinition[BaseClsT]):
     """
     A plugin definition.
     """
@@ -37,13 +31,9 @@ class PluginDefinition[BaseClsT](ClsDefinition[BaseClsT]):
     def __init__(
         self, plugin_id: ResolvableMachineName, *, requires: Requires | None = None
     ):
-        from betty.requirement import resolve_requirement
 
-        super().__init__()
+        super().__init__(requires=requires)
         self._id = MachineName.resolve(plugin_id)
-        self._requires = (
-            () if requires is None else tuple(map(resolve_requirement, requires))
-        )
 
     @classmethod
     def type(cls) -> PluginTypeDefinition[BaseClsT, Self]:
@@ -65,13 +55,6 @@ class PluginDefinition[BaseClsT](ClsDefinition[BaseClsT]):
         - Different plugin repositories **MAY** each have a plugin with the same ID.
         """
         return self._id
-
-    @property
-    def requires(self) -> Iterable[Requirement]:
-        """
-        The plugin's requirements.
-        """
-        return self._requires
 
     @override
     def _set_cls(self, cls: builtins.type[BaseClsT]) -> None:

--- a/betty/plugin/__init__.py
+++ b/betty/plugin/__init__.py
@@ -18,8 +18,15 @@ from betty.machine_name import MachineName, ResolvableMachineName
 
 if TYPE_CHECKING:
     import builtins
+    from collections.abc import Iterable
 
     from betty.locale.localizable import CountableLocalizable, ResolvableLocalizable
+    from betty.requirement import Requirement, ResolvableRequirement
+
+if TYPE_CHECKING:
+    type Requires = Iterable[ResolvableRequirement]
+else:
+    type Requires = Any
 
 
 class PluginDefinition[BaseClsT](ClsDefinition[BaseClsT]):
@@ -27,9 +34,16 @@ class PluginDefinition[BaseClsT](ClsDefinition[BaseClsT]):
     A plugin definition.
     """
 
-    def __init__(self, plugin_id: ResolvableMachineName, /):
+    def __init__(
+        self, plugin_id: ResolvableMachineName, *, requires: Requires | None = None
+    ):
+        from betty.requirement import resolve_requirement
+
         super().__init__()
         self._id = MachineName.resolve(plugin_id)
+        self._requires = (
+            () if requires is None else tuple(map(resolve_requirement, requires))
+        )
 
     @classmethod
     def type(cls) -> PluginTypeDefinition[BaseClsT, Self]:
@@ -51,6 +65,13 @@ class PluginDefinition[BaseClsT](ClsDefinition[BaseClsT]):
         - Different plugin repositories **MAY** each have a plugin with the same ID.
         """
         return self._id
+
+    @property
+    def requires(self) -> Iterable[Requirement]:
+        """
+        The plugin's requirements.
+        """
+        return self._requires
 
     @override
     def _set_cls(self, cls: builtins.type[BaseClsT]) -> None:

--- a/betty/plugin/data/__init__.py
+++ b/betty/plugin/data/__init__.py
@@ -126,5 +126,7 @@ class PluginManufacturerSequenceDefinition(SequenceDefinition):
                 [], value_resolver=manufacturer.resolve
             ),
             value=manufacturer,
-            label=manufacturer.type().type().label_plural if label is None else label,
+            label=manufacturer.plugin_type().type().label_plural
+            if label is None
+            else label,
         )

--- a/betty/plugin/factory.py
+++ b/betty/plugin/factory.py
@@ -29,8 +29,6 @@ from betty.sample import Samplable, Sample, Samples, Size
 from betty.typing import Void, VoidType
 
 if TYPE_CHECKING:
-    import builtins
-
     from betty.portable import PortableData
     from betty.service.level import ServiceLevel
 
@@ -65,7 +63,7 @@ class PluginManufacturer[
     def __hash__(self):
         return hash(
             (
-                self.type(),
+                self.plugin_type(),
                 self.plugin_id,
                 Void
                 if self.plugin_data is Void
@@ -79,7 +77,7 @@ class PluginManufacturer[
 
     @classmethod
     @abstractmethod
-    def type(cls) -> builtins.type[_PluginManufacturerPluginDefinitionT]:
+    def plugin_type(cls) -> type[_PluginManufacturerPluginDefinitionT]:
         """
         The type of plugin that can be manufactured.
         """
@@ -89,7 +87,7 @@ class PluginManufacturer[
     @classmethod
     @cache
     def data(cls) -> ObjectDefinition[Self]:
-        return ObjectDefinition(cls, label=cls.type().type().label)
+        return ObjectDefinition(cls, label=cls.plugin_type().type().label)
 
     @final
     @override
@@ -169,10 +167,11 @@ class PluginManufacturer[
         Create a new instance of the configured plugin.
         """
         return await services.factory.new(
-            (await services.plugins[self.type()][self.plugin_id]).cls,
+            (await services.plugins[self.plugin_type()][self.plugin_id]).cls,
             self.plugin_data,
         )
 
+    @final
     @classmethod
     def resolve(
         cls,
@@ -190,6 +189,7 @@ class PluginManufacturer[
         except ValueError:
             return manufacturer  # ty:ignore[invalid-return-type]
 
+    @final
     @classmethod
     def resolve_sequence(
         cls,

--- a/betty/plugin/factory.py
+++ b/betty/plugin/factory.py
@@ -25,7 +25,15 @@ from betty.data.indicator.selector import Attr
 from betty.locale.localizable.gettext import _
 from betty.machine_name import MachineName
 from betty.plugin import Plugin, PluginDefinition, ResolvablePluginId, resolve_plugin_id
+from betty.requirement import (
+    HasRequirements,
+    PluginRequirementsRequirement,
+    Requirement,
+    ServicePluginRequirement,
+    ManufacturableServicePluginRequirement,
+)
 from betty.sample import Samplable, Sample, Samples, Size
+from betty.service.plugin import ServicePluginDefinition
 from betty.typing import Void, VoidType
 
 if TYPE_CHECKING:
@@ -43,7 +51,7 @@ _PluginManufacturerPluginDefinitionT = TypeVar(
 class PluginManufacturer[
     PluginManufacturerPluginDefinitionT: PluginDefinition,
     PluginManufacturerPluginT: Plugin,
-](PortableRecord[Attr], Samplable, Data[RecordDefinition], ABC):
+](HasRequirements, PortableRecord[Attr], Samplable, Data[RecordDefinition], ABC):
     """
     Configure a single plugin instance.
     """
@@ -74,6 +82,25 @@ class PluginManufacturer[
                 ),
             )
         )
+
+    @override
+    @property
+    def requires(self) -> Iterable[Requirement]:
+        # @todo Whichever way we look at it, we won't be able to extract requirements from data/config until we have a ServiceLevel,
+        # @todo because without it we cannot access plugin classes, and without those we do not know which data/config classes
+        # @todo to load portable data into.
+        # @todo
+        # @todo
+        if issubclass(self.plugin_type(), ServicePluginDefinition):
+            yield ManufacturableServicePluginRequirement(self)
+        else:
+            yield PluginRequirementsRequirement(self.plugin_type(), self.plugin_id)
+        # @todo We may not always have data objects here, quite often this will just be portable data.
+        # @todo
+        # @todo
+        raise NotImplementedError
+        if isinstance(self.plugin_data, HasRequirements):
+            yield from self.plugin_data.requires
 
     @classmethod
     @abstractmethod

--- a/betty/plugins/asset/project.py
+++ b/betty/plugins/asset/project.py
@@ -24,6 +24,7 @@ def _discover(project: Project, /) -> Iterable[ResolvableDiscovery[AssetDefiniti
         assets=project.assets_directory,
         after=lambda other: other != Universe.plugin().id,
         before={Universe},
+        auto=True,
     )
     class _Project(Asset):
         """

--- a/betty/plugins/extension/gramps/data.py
+++ b/betty/plugins/extension/gramps/data.py
@@ -66,7 +66,7 @@ class _PluginMappingProperty[PluginDefinitionT: PluginDefinition, PluginT: Plugi
                 ),
                 key=StrDefinition(label=gramps_label),
                 value=manufacturer,
-                label=manufacturer.type().type().label_plural,
+                label=manufacturer.plugin_type().type().label_plural,
             ),
             default=lambda: MutableResolvedMappingAdapter(
                 dict(

--- a/betty/plugins/extension/raspberry_mint/data.py
+++ b/betty/plugins/extension/raspberry_mint/data.py
@@ -4,7 +4,8 @@ Data for the Raspberry Mint extension.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, final
+from itertools import chain
+from typing import TYPE_CHECKING, final, override
 
 from betty.collection.mapping import MutableResolvedMapping
 from betty.collection.mapping.adapter import MutableResolvedMappingAdapter
@@ -20,9 +21,14 @@ from betty.locale.localizable.gettext import _
 from betty.locale.localizable.markup import Paragraph, do_you_mean
 from betty.plugin.data import PluginManufacturerSequenceDefinition
 from betty.plugins.extension.raspberry_mint.region import Region
+from betty.project import ProjectServicePlugin
 from betty.property import Optional, Property
 from betty.property.collection.mapping import MappingProperty
 from betty.sample import Size
+from betty.service.plugin import (
+    HasServicePluginRequirements,
+    HasServicePluginRequirementsRequirements,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
@@ -62,7 +68,9 @@ if TYPE_CHECKING:
         ),
     ],
 )
-class RaspberryMintConfiguration(Data):
+class RaspberryMintConfiguration(
+    Data, HasServicePluginRequirements[ProjectServicePlugin]
+):
     """
     Configuration for the :py:class:`betty.plugins.extension.raspberry_mint.RaspberryMint` extension.
 
@@ -131,6 +139,15 @@ class RaspberryMintConfiguration(Data):
                     for region, content in regional_content.items()
                 }
             )
+
+    @override
+    @property
+    def service_plugin_requirements(
+        self,
+    ) -> HasServicePluginRequirementsRequirements[ProjectServicePlugin]:
+        return self._get_service_plugin_requirements_from_manufacturers(
+            *chain(*self.regional_content.values())
+        )
 
     async def validate(self, project: Project, /) -> None:
         """

--- a/betty/plugins/extension/raspberry_mint/data.py
+++ b/betty/plugins/extension/raspberry_mint/data.py
@@ -21,14 +21,10 @@ from betty.locale.localizable.gettext import _
 from betty.locale.localizable.markup import Paragraph, do_you_mean
 from betty.plugin.data import PluginManufacturerSequenceDefinition
 from betty.plugins.extension.raspberry_mint.region import Region
-from betty.project import ProjectServicePlugin
 from betty.property import Optional, Property
 from betty.property.collection.mapping import MappingProperty
+from betty.requirement import HasRequirements, Requirement
 from betty.sample import Size
-from betty.service.plugin import (
-    HasServicePluginRequirements,
-    HasServicePluginRequirementsRequirements,
-)
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
@@ -68,9 +64,7 @@ if TYPE_CHECKING:
         ),
     ],
 )
-class RaspberryMintConfiguration(
-    Data, HasServicePluginRequirements[ProjectServicePlugin]
-):
+class RaspberryMintConfiguration(Data, HasRequirements):
     """
     Configuration for the :py:class:`betty.plugins.extension.raspberry_mint.RaspberryMint` extension.
 
@@ -142,9 +136,7 @@ class RaspberryMintConfiguration(
 
     @override
     @property
-    def service_plugin_requirements(
-        self,
-    ) -> HasServicePluginRequirementsRequirements[ProjectServicePlugin]:
+    def requires(self) -> Iterable[Requirement]:
         return self._get_service_plugin_requirements_from_manufacturers(
             *chain(*self.regional_content.values())
         )

--- a/betty/project/__init__.py
+++ b/betty/project/__init__.py
@@ -42,10 +42,10 @@ from betty.locale.translation import (
 )
 from betty.machine_name import MachineName
 from betty.privacy.privatizer import Privatizer
-from betty.project.data import ProjectConfiguration
 from betty.render import RenderDispatcher, RendererDefinition
 from betty.service.level import ChainedServiceLevel
 from betty.service.plugin import (
+    HasServicePluginRequirementsRequirement,
     ServicePluginManager,
     ServicePluginProvider,
     ServicePlugins,
@@ -60,8 +60,10 @@ if TYPE_CHECKING:
     from betty.copyright_notice import CopyrightNotice
     from betty.jinja import Environment
     from betty.license import License
-    from betty.plugin import PluginDefinition
+    from betty.plugin import Plugin, PluginDefinition
     from betty.plugin.discovery import ResolvableDiscovery
+    from betty.plugin.factory import PluginManufacturer
+    from betty.project.data import ProjectConfiguration
     from betty.service.plugin import PluginCollection
     from betty.url import UrlGenerator
 type ProjectServicePlugin = (
@@ -113,11 +115,30 @@ class Project(ChainedServiceLevel[App], ServicePluginProvider[ProjectServicePlug
         self._ancestry = Ancestry() if ancestry is None else ancestry
         self._service_plugins = service_plugins
 
-    def _ensure_service_plugins(self) -> None:
+    async def _ensure_service_plugins(self) -> None:
         self._service_plugins = (
             *self._service_plugins,
-            *self._configuration.extensions,
+            *await gather(
+                *map(
+                    self._ensure_service_plugin,
+                    self._configuration.service_plugin_requirements,
+                )
+            ),
         )
+
+    async def _ensure_service_plugin(
+        self,
+        service_plugin_requirement: HasServicePluginRequirementsRequirement[
+            ProjectServicePlugin
+        ],
+    ) -> (
+        PluginManufacturer[ProjectServicePlugin, Plugin[ProjectServicePlugin]]
+        | type[Plugin[ProjectServicePlugin]]
+    ):
+        if not isinstance(service_plugin_requirement, tuple):
+            return service_plugin_requirement
+        plugin_type, plugin_id = service_plugin_requirement
+        return await self.plugins[plugin_type][plugin_id]  # ty:ignore[invalid-argument-type]
 
     def _ensure_locale(self) -> None:
         if not self._configuration.locales:
@@ -163,6 +184,8 @@ class Project(ChainedServiceLevel[App], ServicePluginProvider[ProjectServicePlug
         The project will not leave any traces on the system, except when it uses
         global Betty functionality such as caches.
         """
+        from betty.project.data import ProjectConfiguration
+
         async with AsyncExitStack() as stack:
             if directory is None:
                 directory = Path(await stack.enter_async_context(TemporaryDirectory()))

--- a/betty/project/__init__.py
+++ b/betty/project/__init__.py
@@ -106,7 +106,6 @@ class Project(ChainedServiceLevel[App], ServicePluginProvider[ProjectServicePlug
         service_plugins: ServicePlugins[ProjectServicePlugin] = (),
     ):
         super().__init__(plugins=plugins, upstream=app)
-        self.life_cycle.on_bootstrap(self._ensure_service_plugins)
         self.life_cycle.on_bootstrap(self._ensure_locale)
         self.life_cycle.on_bootstrap(self._validate)
         self._app = app
@@ -115,13 +114,30 @@ class Project(ChainedServiceLevel[App], ServicePluginProvider[ProjectServicePlug
         self._ancestry = Ancestry() if ancestry is None else ancestry
         self._service_plugins = service_plugins
 
-    async def _ensure_service_plugins(self) -> None:
-        self._service_plugins = (
-            *self._service_plugins,
-            *await gather(
+    def _ensure_locale(self) -> None:
+        if not self._configuration.locales:
+            self._configuration.locales.add(DEFAULT_LOCALE)
+
+    async def _validate(self) -> None:
+        for entity_type in self._configuration.entity_types:
+            await entity_type.validate(self)
+
+    @classmethod
+    async def new(
+        cls, app: App, data: ProjectConfiguration, *, directory: Path
+    ) -> Self:
+        """
+        Create a new instance.
+        """
+        # @todo How do we get requirements for non-service plugins here, if we cannot access self.plugins?
+        return cls(
+            directory,
+            app=app,
+            configuration=data,
+            service_plugins=await gather(
                 *map(
                     self._ensure_service_plugin,
-                    self._configuration.service_plugin_requirements,
+                    data.service_plugin_requirements,
                 )
             ),
         )
@@ -139,23 +155,6 @@ class Project(ChainedServiceLevel[App], ServicePluginProvider[ProjectServicePlug
             return service_plugin_requirement
         plugin_type, plugin_id = service_plugin_requirement
         return await self.plugins[plugin_type][plugin_id]  # ty:ignore[invalid-argument-type]
-
-    def _ensure_locale(self) -> None:
-        if not self._configuration.locales:
-            self._configuration.locales.add(DEFAULT_LOCALE)
-
-    async def _validate(self) -> None:
-        for entity_type in self._configuration.entity_types:
-            await entity_type.validate(self)
-
-    @classmethod
-    async def new(
-        cls, app: App, data: ProjectConfiguration, *, directory: Path
-    ) -> Self:
-        """
-        Create a new instance.
-        """
-        return cls(directory, app=app, configuration=data)
 
     @property
     def configuration(self) -> ProjectConfiguration:

--- a/betty/project/__init__.py
+++ b/betty/project/__init__.py
@@ -7,6 +7,7 @@ site from the entire project.
 """
 
 from __future__ import annotations
+from betty.plugin.factory import PluginManufacturer, ResolvablePluginManufacturer
 
 from asyncio import gather
 from contextlib import AsyncExitStack, asynccontextmanager
@@ -43,12 +44,15 @@ from betty.locale.translation import (
 from betty.machine_name import MachineName
 from betty.privacy.privatizer import Privatizer
 from betty.render import RenderDispatcher, RendererDefinition
+from betty.requirement import (
+    PluginRequirementsRequirement,
+    Requirement,
+    ServicePluginRequirement,
+)
 from betty.service.level import ChainedServiceLevel
 from betty.service.plugin import (
-    HasServicePluginRequirementsRequirement,
     ServicePluginManager,
     ServicePluginProvider,
-    ServicePlugins,
 )
 from betty.service.provider import service
 
@@ -60,9 +64,8 @@ if TYPE_CHECKING:
     from betty.copyright_notice import CopyrightNotice
     from betty.jinja import Environment
     from betty.license import License
-    from betty.plugin import Plugin, PluginDefinition
+    from betty.plugin import PluginDefinition
     from betty.plugin.discovery import ResolvableDiscovery
-    from betty.plugin.factory import PluginManufacturer
     from betty.project.data import ProjectConfiguration
     from betty.service.plugin import PluginCollection
     from betty.url import UrlGenerator
@@ -103,7 +106,9 @@ class Project(ChainedServiceLevel[App], ServicePluginProvider[ProjectServicePlug
             type[PluginDefinition], Iterable[ResolvableDiscovery[PluginDefinition]]
         ]
         | None = None,
-        service_plugins: ServicePlugins[ProjectServicePlugin] = (),
+        extensions: Iterable[
+            ResolvablePluginManufacturer[ExtensionDefinition, Extension]
+        ] = (),
     ):
         super().__init__(plugins=plugins, upstream=app)
         self.life_cycle.on_bootstrap(self._ensure_locale)
@@ -112,7 +117,7 @@ class Project(ChainedServiceLevel[App], ServicePluginProvider[ProjectServicePlug
         self._configuration = configuration
         self._directory = directory
         self._ancestry = Ancestry() if ancestry is None else ancestry
-        self._service_plugins = service_plugins
+        self._extensions = tuple(extensions)
 
     def _ensure_locale(self) -> None:
         if not self._configuration.locales:
@@ -129,32 +134,7 @@ class Project(ChainedServiceLevel[App], ServicePluginProvider[ProjectServicePlug
         """
         Create a new instance.
         """
-        # @todo How do we get requirements for non-service plugins here, if we cannot access self.plugins?
-        return cls(
-            directory,
-            app=app,
-            configuration=data,
-            service_plugins=await gather(
-                *map(
-                    self._ensure_service_plugin,
-                    data.service_plugin_requirements,
-                )
-            ),
-        )
-
-    async def _ensure_service_plugin(
-        self,
-        service_plugin_requirement: HasServicePluginRequirementsRequirement[
-            ProjectServicePlugin
-        ],
-    ) -> (
-        PluginManufacturer[ProjectServicePlugin, Plugin[ProjectServicePlugin]]
-        | type[Plugin[ProjectServicePlugin]]
-    ):
-        if not isinstance(service_plugin_requirement, tuple):
-            return service_plugin_requirement
-        plugin_type, plugin_id = service_plugin_requirement
-        return await self.plugins[plugin_type][plugin_id]  # ty:ignore[invalid-argument-type]
+        return cls(directory, app=app, configuration=data, extensions=data.extensions)
 
     @property
     def configuration(self) -> ProjectConfiguration:
@@ -204,7 +184,8 @@ class Project(ChainedServiceLevel[App], ServicePluginProvider[ProjectServicePlug
     @service
     async def service_plugins(self) -> ServicePluginManager[ProjectServicePlugin]:
         service_plugins = ServicePluginManager(
-            plugin_types={
+            self,
+            {
                 AssetDefinition,
                 CssResourceDefinition,
                 ExtensionDefinition,
@@ -213,8 +194,14 @@ class Project(ChainedServiceLevel[App], ServicePluginProvider[ProjectServicePlug
                 JsResourceDefinition,
                 LinkDefinition,
             },
-            plugin_manufacturers=self._service_plugins,
-            services=self,
+            (
+                requirement
+                for requirement in self._requires
+                if isinstance(
+                    requirement,
+                    (ServicePluginRequirement, PluginRequirementsRequirement),
+                )
+            ),
         )
         await service_plugins.bootstrap()
         self.life_cycle.attach(service_plugins)

--- a/betty/project/__init__.py
+++ b/betty/project/__init__.py
@@ -21,7 +21,6 @@ from betty.ancestry import Ancestry
 from betty.app import App
 from betty.asset import (
     AssetDefinition,
-    AssetManufacturer,
     AssetRepository,
     ProxyAssetRepository,
     StaticAssetRepository,
@@ -46,7 +45,11 @@ from betty.privacy.privatizer import Privatizer
 from betty.project.data import ProjectConfiguration
 from betty.render import RenderDispatcher, RendererDefinition
 from betty.service.level import ChainedServiceLevel
-from betty.service.plugin import ServicePluginManager, ServicePluginProvider
+from betty.service.plugin import (
+    ServicePluginManager,
+    ServicePluginProvider,
+    ServicePlugins,
+)
 from betty.service.provider import service
 
 if TYPE_CHECKING:
@@ -61,10 +64,19 @@ if TYPE_CHECKING:
     from betty.plugin.discovery import ResolvableDiscovery
     from betty.service.plugin import PluginCollection
     from betty.url import UrlGenerator
+type ProjectServicePlugin = (
+    AssetDefinition
+    | CssResourceDefinition
+    | ExtensionDefinition
+    | JinjaFilterDefinition
+    | JinjaTestDefinition
+    | JsResourceDefinition
+    | LinkDefinition
+)
 
 
 @final
-class Project(ChainedServiceLevel[App], ServicePluginProvider):
+class Project(ChainedServiceLevel[App], ServicePluginProvider[ProjectServicePlugin]):
     """
     Define a Betty project.
 
@@ -89,14 +101,23 @@ class Project(ChainedServiceLevel[App], ServicePluginProvider):
             type[PluginDefinition], Iterable[ResolvableDiscovery[PluginDefinition]]
         ]
         | None = None,
+        service_plugins: ServicePlugins[ProjectServicePlugin] = (),
     ):
         super().__init__(plugins=plugins, upstream=app)
+        self.life_cycle.on_bootstrap(self._ensure_service_plugins)
         self.life_cycle.on_bootstrap(self._ensure_locale)
         self.life_cycle.on_bootstrap(self._validate)
         self._app = app
         self._configuration = configuration
         self._directory = directory
         self._ancestry = Ancestry() if ancestry is None else ancestry
+        self._service_plugins = service_plugins
+
+    def _ensure_service_plugins(self) -> None:
+        self._service_plugins = (
+            *self._service_plugins,
+            *self._configuration.extensions,
+        )
 
     def _ensure_locale(self) -> None:
         if not self._configuration.locales:
@@ -159,17 +180,18 @@ class Project(ChainedServiceLevel[App], ServicePluginProvider):
 
     @override
     @service
-    async def service_plugins(self) -> ServicePluginManager:
+    async def service_plugins(self) -> ServicePluginManager[ProjectServicePlugin]:
         service_plugins = ServicePluginManager(
-            {
-                AssetDefinition: [AssetManufacturer("project")],
-                CssResourceDefinition: [],
-                ExtensionDefinition: self.configuration.extensions,
-                JinjaFilterDefinition: [],
-                JinjaTestDefinition: [],
-                JsResourceDefinition: [],
-                LinkDefinition: [],
+            plugin_types={
+                AssetDefinition,
+                CssResourceDefinition,
+                ExtensionDefinition,
+                JinjaFilterDefinition,
+                JinjaTestDefinition,
+                JsResourceDefinition,
+                LinkDefinition,
             },
+            plugin_manufacturers=self._service_plugins,
             services=self,
         )
         await service_plugins.bootstrap()

--- a/betty/project/data.py
+++ b/betty/project/data.py
@@ -50,19 +50,16 @@ from betty.place_type.data import PlaceTypeDefinitionConfiguration
 from betty.plugin import ResolvablePluginId, resolve_plugin_id
 from betty.plugin.data.property import PluginDefinitionConfigurationsProperty
 from betty.plugins.entity.person import Person
-from betty.project import Extension, ExtensionDefinition, ProjectServicePlugin
-from betty.property import (
-    Optional,
-    Property,
-)
+from betty.project import Extension, ExtensionDefinition
+from betty.property import Optional, Property
 from betty.property.collection.keyed import KeyedCollectionProperty
+from betty.requirement import (
+    HasRequirements,
+    Requirement,
+)
 from betty.role import RoleDefinition
 from betty.role.data import RoleDefinitionConfiguration
 from betty.sample import Size
-from betty.service.plugin import (
-    HasServicePluginRequirements,
-    HasServicePluginRequirementsRequirements,
-)
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -266,7 +263,7 @@ class ProjectLocale(Data["ObjectDefinition"]):
         ),
     ],
 )
-class ProjectConfiguration(Data, HasServicePluginRequirements[ProjectServicePlugin]):
+class ProjectConfiguration(Data, HasRequirements):
     """
     Configuration for a :py:class:`betty.project.Project`.
 
@@ -556,12 +553,9 @@ class ProjectConfiguration(Data, HasServicePluginRequirements[ProjectServicePlug
 
     @override
     @property
-    def service_plugin_requirements(
-        self,
-    ) -> HasServicePluginRequirementsRequirements[ProjectServicePlugin]:
-        return self._get_service_plugin_requirements_from_manufacturers(
-            *self.extensions
-        )
+    def requires(self) -> Iterable[Requirement]:
+        for plugin in self.extensions:
+            yield from plugin.requires
 
     @property
     @AttrDefinition(

--- a/betty/project/data.py
+++ b/betty/project/data.py
@@ -4,7 +4,7 @@ Project data.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, final
+from typing import TYPE_CHECKING, final, override
 from urllib.parse import urlparse
 
 from babel import Locale
@@ -50,7 +50,7 @@ from betty.place_type.data import PlaceTypeDefinitionConfiguration
 from betty.plugin import ResolvablePluginId, resolve_plugin_id
 from betty.plugin.data.property import PluginDefinitionConfigurationsProperty
 from betty.plugins.entity.person import Person
-from betty.project import Extension, ExtensionDefinition
+from betty.project import Extension, ExtensionDefinition, ProjectServicePlugin
 from betty.property import (
     Optional,
     Property,
@@ -59,6 +59,10 @@ from betty.property.collection.keyed import KeyedCollectionProperty
 from betty.role import RoleDefinition
 from betty.role.data import RoleDefinitionConfiguration
 from betty.sample import Size
+from betty.service.plugin import (
+    HasServicePluginRequirements,
+    HasServicePluginRequirementsRequirements,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -262,7 +266,7 @@ class ProjectLocale(Data["ObjectDefinition"]):
         ),
     ],
 )
-class ProjectConfiguration(Data):
+class ProjectConfiguration(Data, HasServicePluginRequirements[ProjectServicePlugin]):
     """
     Configuration for a :py:class:`betty.project.Project`.
 
@@ -549,6 +553,13 @@ class ProjectConfiguration(Data):
         from betty.plugins.license.all_rights_reserved import AllRightsReserved
 
         return LicenseManufacturer(AllRightsReserved)
+
+    @override
+    @property
+    def service_plugin_requirements(
+        self,
+    ) -> HasServicePluginRequirementsRequirements[ProjectServicePlugin]:
+        return self.extensions
 
     @property
     @AttrDefinition(

--- a/betty/project/data.py
+++ b/betty/project/data.py
@@ -559,7 +559,9 @@ class ProjectConfiguration(Data, HasServicePluginRequirements[ProjectServicePlug
     def service_plugin_requirements(
         self,
     ) -> HasServicePluginRequirementsRequirements[ProjectServicePlugin]:
-        return self.extensions
+        return self._get_service_plugin_requirements_from_manufacturers(
+            *self.extensions
+        )
 
     @property
     @AttrDefinition(

--- a/betty/requirement.py
+++ b/betty/requirement.py
@@ -15,9 +15,11 @@ from betty.locale.localizable.gettext import _
 from betty.service.level import ChainedServiceLevel, ServiceLevel
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from collections.abc import Awaitable, Callable, Iterable
 
-    from betty.plugin import Plugin
+    from betty.machine_name import MachineName
+    from betty.plugin import Plugin, PluginDefinition
+    from betty.plugin.factory import PluginManufacturer
     from betty.service.plugin import ServicePluginDefinition
 
 
@@ -136,23 +138,35 @@ class ServiceLevelRequirement[ServiceLevelT: ServiceLevel]:
         )
 
 
-@final
-class ServicePluginRequirement[ServicePluginT: Plugin[ServicePluginDefinition]]:
+class ServicePluginRequirement[ServicePluginDefinitionT: ServicePluginDefinition]:
     """
     Check that a service plugin is available.
     """
 
-    def __init__(self, plugin: type[ServicePluginT], /):
-        self._plugin = plugin
+    def __init__(
+        self, plugin_type: type[ServicePluginDefinitionT], plugin_id: MachineName, /
+    ):
+        self._plugin_type = plugin_type
+        self._plugin_id = plugin_id
 
     @property
-    def plugin(self) -> type[ServicePluginT]:
+    def plugin_type(self) -> type[ServicePluginDefinition]:
         """
-        The required service plugin.
+        The plugin type.
         """
-        return self._plugin
+        return self._plugin_type
 
-    async def __call__(self, services: ServiceLevel, /) -> ServicePluginT:
+    @property
+    def plugin_id(self) -> MachineName:
+        """
+        The plugin ID.
+        """
+        return self._plugin_id
+
+    @final
+    async def __call__(
+        self, services: ServiceLevel, /
+    ) -> Plugin[ServicePluginDefinitionT]:
         """
         Check the requirement.
         """
@@ -161,15 +175,75 @@ class ServicePluginRequirement[ServicePluginT: Plugin[ServicePluginDefinition]]:
         if isinstance(services, ServicePluginProvider):
             service_plugins = await services.service_plugins
             with suppress(KeyError):
-                return service_plugins[type(self._plugin.plugin())][self._plugin]
+                return service_plugins[self.plugin_type][self._plugin_id]
         if isinstance(services, ChainedServiceLevel):
             return await self(services.upstream)
         raise UnmetRequirement(
             _("The {plugin_id} {plugin_type} is required.").format(
-                plugin_id=self._plugin.plugin().id,
-                plugin_type=self._plugin.plugin().type().label,
+                plugin_id=self._plugin_id,
+                plugin_type=self.plugin_type.type().label,
             )
         )
+
+
+@final
+class ManufacturableServicePluginRequirement[
+    PluginDefinitionT: ServicePluginDefinition
+](ServicePluginRequirement):
+    """
+    Check that a service plugin is available.
+    """
+
+    def __init__(
+        self,
+        manufacturer: PluginManufacturer[PluginDefinitionT, Plugin[PluginDefinitionT]],
+        /,
+    ):
+        super().__init__()
+        self._manufacturer = manufacturer
+
+    @property
+    def manufacturer(
+        self,
+    ) -> PluginManufacturer[PluginDefinitionT, Plugin[PluginDefinitionT]]:
+        """
+        The plugin manufacturer.
+        """
+        return self._manufacturer
+
+
+@final
+class PluginRequirementsRequirement:
+    """
+    Check that a plugin's requirements are met.
+    """
+
+    def __init__(self, plugin_type: type[PluginDefinition], plugin_id: MachineName, /):
+        self._plugin_type = plugin_type
+        self._plugin_id = plugin_id
+
+    @property
+    def plugin_type(self) -> type[PluginDefinition]:
+        """
+        The plugin type.
+        """
+        return self._plugin_type
+
+    @property
+    def plugin_id(self) -> MachineName:
+        """
+        The plugin ID.
+        """
+        return self._plugin_id
+
+    async def __call__(self, services: ServiceLevel, /) -> None:
+        """
+        Check the requirement.
+        """
+        for requirement in (
+            await services.plugins[self._plugin_type][self._plugin_id]
+        ).requires:
+            await requirement(services)
 
 
 if TYPE_CHECKING:
@@ -191,3 +265,29 @@ def resolve_requirement(requirement: ResolvableRequirement[Any], /) -> Requireme
             return ServiceLevelRequirement(requirement)
         return ServicePluginRequirement(requirement)
     return requirement
+
+
+if TYPE_CHECKING:
+    type Requires = Iterable[ResolvableRequirement]
+else:
+    type Requires = Any
+
+
+class HasRequirements:
+    """
+    An object that exposes requirements.
+    """
+
+    def __init__(self, *args: Any, requires: Requires | None = None, **kwargs: Any):
+
+        super().__init__(*args, **kwargs)
+        self.__requires = (
+            () if requires is None else tuple(map(resolve_requirement, requires))
+        )
+
+    @property
+    def requires(self) -> Iterable[Requirement]:
+        """
+        The requirements.
+        """
+        return self.__requires

--- a/betty/role/__init__.py
+++ b/betty/role/__init__.py
@@ -4,15 +4,12 @@ Presence roles.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, final, override
+from typing import final, override
 
 from betty.definition.human_facing import CountableHumanFacingDefinition
 from betty.locale.localizable.gettext import _, ngettext
 from betty.plugin import Plugin, PluginDefinition, PluginTypeDefinition
 from betty.plugin.factory import PluginManufacturer
-
-if TYPE_CHECKING:
-    import builtins
 
 
 class Role(Plugin["RoleDefinition"]):
@@ -42,5 +39,5 @@ class RoleManufacturer(PluginManufacturer[RoleDefinition, Role]):
 
     @override
     @classmethod
-    def type(cls) -> builtins.type[RoleDefinition]:
+    def plugin_type(cls) -> type[RoleDefinition]:
         return RoleDefinition

--- a/betty/service/level/__init__.py
+++ b/betty/service/level/__init__.py
@@ -28,9 +28,12 @@ class _PluginTypeNotFound(PluginTypeNotFound, KeyError):
     pass
 
 
-type Plugins = Mapping[
-    type[PluginDefinition], Iterable[ResolvableDiscovery[PluginDefinition]]
-]
+if TYPE_CHECKING:
+    type Plugins = Mapping[
+        type[PluginDefinition], Iterable[ResolvableDiscovery[PluginDefinition]]
+    ]
+else:
+    type Plugins = Any
 
 
 class ServiceLevel:

--- a/betty/service/plugin.py
+++ b/betty/service/plugin.py
@@ -414,3 +414,14 @@ class HasServicePluginRequirements[ServicePluginT: ServicePluginDefinition](ABC)
         """
         The required service plugins.
         """
+
+    @final
+    def _get_service_plugin_requirements_from_manufacturers(
+        self,
+        *plugins: PluginManufacturer,
+    ) -> HasServicePluginRequirementsRequirements[ServicePluginT]:
+        for plugin in plugins:
+            if issubclass(plugin.plugin_type(), ServicePluginDefinition):
+                yield plugin
+            if isinstance(plugin.plugin_data, HasServicePluginRequirements):
+                yield from plugin.plugin_data.service_plugin_requirements

--- a/betty/service/plugin.py
+++ b/betty/service/plugin.py
@@ -208,12 +208,16 @@ class ServicePluginDefinition[BaseClsT = Any](PluginDefinition[BaseClsT]):
         return self._auto
 
 
-type ServicePlugins[
+type ServicePlugin[
     ServicePluginDefinitionT: ServicePluginDefinition = ServicePluginDefinition
-] = Iterable[
+] = (
     PluginManufacturer[ServicePluginDefinitionT, Plugin[ServicePluginDefinitionT]]
     | type[Plugin[ServicePluginDefinitionT]]
-]
+)
+
+type ServicePlugins[
+    ServicePluginDefinitionT: ServicePluginDefinition = ServicePluginDefinition
+] = Iterable[ServicePlugin[ServicePluginDefinitionT]]
 
 
 @final
@@ -382,4 +386,31 @@ class ServicePluginProvider[ServicePluginTypesT: ServicePluginDefinition](
     async def service_plugins(self) -> ServicePluginManager[ServicePluginTypesT]:
         """
         The service plugins.
+        """
+
+
+type HasServicePluginRequirementsRequirement[
+    ServicePluginT: ServicePluginDefinition
+] = (
+    PluginManufacturer[ServicePluginT, Plugin[ServicePluginT]]
+    | tuple[type[ServicePluginT], MachineName]
+)
+
+type HasServicePluginRequirementsRequirements[
+    ServicePluginT: ServicePluginDefinition
+] = Iterable[HasServicePluginRequirementsRequirement[ServicePluginT]]
+
+
+class HasServicePluginRequirements[ServicePluginT: ServicePluginDefinition](ABC):
+    """
+    An object that requires service plugins to be enabled.
+    """
+
+    @property
+    @abstractmethod
+    def service_plugin_requirements(
+        self,
+    ) -> HasServicePluginRequirementsRequirements[ServicePluginT]:
+        """
+        The required service plugins.
         """

--- a/betty/service/plugin.py
+++ b/betty/service/plugin.py
@@ -22,23 +22,23 @@ from typing import (
 
 from betty.collection.keyed import KeyedCollection
 from betty.concurrent import AsynchronizedLock
+from betty.importlib import fully_qualified_name
 from betty.life_cycle import LifeCycle
 from betty.life_cycle.manage import ManagedLifeCycle
 from betty.machine_name import MachineName, ResolvableMachineName
 from betty.plugin import (
     Plugin,
     PluginDefinition,
+    Requires,
     ResolvablePluginId,
     resolve_plugin_id,
 )
 from betty.plugin.discovery import ResolvableDiscovery
 from betty.plugin.error import PluginNotFound
+from betty.plugin.factory import PluginManufacturer
 from betty.plugin.ordered import OrderedPluginDefinition
 from betty.requirement import (
-    Requirement,
-    ResolvableRequirement,
     ServicePluginRequirement,
-    resolve_requirement,
 )
 from betty.service.provider import service
 from betty.string import kebab_case_to_snake_case
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
     from collections.abc import (
         AsyncIterator,
         Awaitable,
+        Collection,
         Iterable,
         Iterator,
         Mapping,
@@ -56,7 +57,6 @@ if TYPE_CHECKING:
 
     from ty_extensions import Intersection
 
-    from betty.plugin.factory import PluginManufacturer
     from betty.service.level import ServiceLevel
 
 
@@ -181,9 +181,6 @@ class PluginManager[PluginDefinitionT: PluginDefinition]:
         return (await self._plugins()).keys()
 
 
-type Requires = Iterable[ResolvableRequirement]
-
-
 class ServicePluginDefinition[BaseClsT = Any](PluginDefinition[BaseClsT]):
     """
     A definition of a service plugin.
@@ -200,11 +197,8 @@ class ServicePluginDefinition[BaseClsT = Any](PluginDefinition[BaseClsT]):
         requires: Requires | None = None,
         **kwargs: Any,
     ):
-        super().__init__(plugin_id, *args, **kwargs)
+        super().__init__(plugin_id, *args, requires=requires, **kwargs)
         self._auto = auto
-        self._requires = (
-            () if requires is None else tuple(map(resolve_requirement, requires))
-        )
 
     @property
     def auto(self) -> bool:
@@ -213,43 +207,47 @@ class ServicePluginDefinition[BaseClsT = Any](PluginDefinition[BaseClsT]):
         """
         return self._auto
 
-    @property
-    def requires(self) -> Iterable[Requirement]:
-        """
-        The plugin's requirements.
-        """
-        return self._requires
 
-
-type ServicePluginManufacturers = Mapping[
-    type[ServicePluginDefinition],
-    Iterable[
-        PluginManufacturer[ServicePluginDefinition, Plugin[ServicePluginDefinition]]
-    ],
+type ServicePlugins[
+    ServicePluginDefinitionT: ServicePluginDefinition = ServicePluginDefinition
+] = Iterable[
+    PluginManufacturer[ServicePluginDefinitionT, Plugin[ServicePluginDefinitionT]]
+    | type[Plugin[ServicePluginDefinitionT]]
 ]
 
 
 @final
-class ServicePluginManager(ManagedLifeCycle):
+class ServicePluginManager[ServicePluginTypesT: ServicePluginDefinition](
+    ManagedLifeCycle
+):
     """
     The service plugin manager.
     """
 
     def __init__(
         self,
-        service_plugin_manufacturers: ServicePluginManufacturers | None,
         *,
+        plugin_types: Collection[type[ServicePluginTypesT]],
+        plugin_manufacturers: ServicePlugins | None,
         services: ServiceLevel,
     ):
         super().__init__()
-        self._service_plugin_manufacturers = (
-            {}
-            if service_plugin_manufacturers is None
-            else {
-                plugin_type: {plugin.plugin_id: plugin for plugin in plugins}
-                for plugin_type, plugins in service_plugin_manufacturers.items()
-            }
-        )
+        self._service_plugin_types = plugin_types
+        self._service_plugin_manufacturers = defaultdict(dict)
+        if plugin_manufacturers is not None:
+            for service_plugin_manufacturer in plugin_manufacturers:
+                if isinstance(service_plugin_manufacturer, PluginManufacturer):
+                    (
+                        self._service_plugin_manufacturers[
+                            service_plugin_manufacturer.plugin_type()
+                        ][service_plugin_manufacturer.plugin_id]
+                    ) = service_plugin_manufacturer
+                else:
+                    (
+                        self._service_plugin_manufacturers[
+                            type(service_plugin_manufacturer.plugin())
+                        ][service_plugin_manufacturer.plugin().id]
+                    ) = service_plugin_manufacturer
         self._service_plugins = {}
         self._services = services
         self.life_cycle.on_bootstrap(self._bootstrap)
@@ -257,16 +255,20 @@ class ServicePluginManager(ManagedLifeCycle):
     async def _bootstrap(self) -> None:
         sorter = TopologicalSorter[tuple[type[ServicePluginDefinition], MachineName]]()
         for (
-            plugin_type,
-            requested_plugins,
+            service_plugin_type,
+            service_plugin_manufacturers,
         ) in self._service_plugin_manufacturers.items():
-            auto_plugins = {
-                plugin.id
-                async for plugin in self._services.plugins[plugin_type]
-                if plugin.auto
-            }
-            for plugin in {*requested_plugins, *auto_plugins}:
-                await self._expand_requires(sorter, plugin_type, plugin)
+            for service_plugin_id in service_plugin_manufacturers:
+                assert service_plugin_type in self._service_plugin_types, (
+                    f"{fully_qualified_name(service_plugin_type)} is not a service plugin type on {fully_qualified_name(type(self._services))}."
+                )
+                await self._expand_requires(
+                    sorter, service_plugin_type, service_plugin_id
+                )
+        for service_plugin_type in self._service_plugin_types:
+            async for plugin in self._services.plugins[service_plugin_type]:
+                if plugin.auto:
+                    await self._expand_requires(sorter, type(plugin), plugin.id)
         sorter.prepare()
         service_plugins = defaultdict(list)
         while sorter.is_active():
@@ -276,8 +278,7 @@ class ServicePluginManager(ManagedLifeCycle):
                 plugin_type = type(plugin.plugin())
                 service_plugins[plugin_type].append(plugin)
                 sorter.done((plugin_type, plugin.plugin().id))
-        plugin_types = set(self._service_plugin_manufacturers) | set(service_plugins)
-        for plugin_type in plugin_types:
+        for plugin_type in self._service_plugin_types:
             self._service_plugins[plugin_type] = await self._new_plugin_collection(
                 plugin_type, service_plugins[plugin_type]
             )
@@ -315,28 +316,28 @@ class ServicePluginManager(ManagedLifeCycle):
     async def _bootstrap_plugin(
         self, plugin_type_and_id: tuple[type[ServicePluginDefinition], MachineName]
     ) -> Plugin:
-        plugin = await self._new_plugin(plugin_type_and_id)
+        plugin_type, plugin_id = plugin_type_and_id
+        plugin = await self._new_plugin(plugin_type, plugin_id)
         if isinstance(plugin, LifeCycle):
             await plugin.bootstrap()
             self.life_cycle.attach(plugin)
         return plugin
 
     async def _new_plugin(
-        self, plugin_type_and_id: tuple[type[ServicePluginDefinition], MachineName]
+        self, plugin_type: type[ServicePluginDefinition], plugin_id: MachineName
     ) -> Plugin:
-        plugin_type, plugin_id = plugin_type_and_id
         try:
             manufacturer = self._service_plugin_manufacturers[plugin_type][plugin_id]
         except KeyError:
             return await self._services.factory.new(
                 (await self._services.plugins[plugin_type][plugin_id]).cls
             )
-        return await manufacturer(self._services)
+        return await self._services.factory.new(manufacturer)
 
     async def _expand_requires(
         self,
         sorter: TopologicalSorter[tuple[type[ServicePluginDefinition], MachineName]],
-        origin_type: type[ServicePluginDefinition],
+        origin_type: type[PluginDefinition],
         origin_id: MachineName,
     ) -> None:
         origin = await self._services.plugins[origin_type][origin_id]
@@ -350,7 +351,8 @@ class ServicePluginManager(ManagedLifeCycle):
                 await self._expand_requires(
                     sorter, requires_plugin_type, requires_plugin_id
                 )
-        sorter.add((origin_type, origin_id), *predecessors)
+        if issubclass(origin_type, ServicePluginDefinition):
+            sorter.add((origin_type, origin_id), *predecessors)
 
     def __getitem__[ServicePluginDefinitionT: ServicePluginDefinition, PluginT: Plugin](
         self,
@@ -368,14 +370,16 @@ class ServicePluginManager(ManagedLifeCycle):
         return iter(self._service_plugins)
 
 
-class ServicePluginProvider(ManagedLifeCycle, ABC):
+class ServicePluginProvider[ServicePluginTypesT: ServicePluginDefinition](
+    ManagedLifeCycle, ABC
+):
     """
     A service plugin provider.
     """
 
     @service
     @abstractmethod
-    async def service_plugins(self) -> ServicePluginManager:
+    async def service_plugins(self) -> ServicePluginManager[ServicePluginTypesT]:
         """
         The service plugins.
         """

--- a/betty/service/plugin.py
+++ b/betty/service/plugin.py
@@ -38,6 +38,7 @@ from betty.plugin.error import PluginNotFound
 from betty.plugin.factory import PluginManufacturer
 from betty.plugin.ordered import OrderedPluginDefinition
 from betty.requirement import (
+    PluginRequirementsRequirement,
     ServicePluginRequirement,
 )
 from betty.service.provider import service
@@ -208,18 +209,6 @@ class ServicePluginDefinition[BaseClsT = Any](PluginDefinition[BaseClsT]):
         return self._auto
 
 
-type ServicePlugin[
-    ServicePluginDefinitionT: ServicePluginDefinition = ServicePluginDefinition
-] = (
-    PluginManufacturer[ServicePluginDefinitionT, Plugin[ServicePluginDefinitionT]]
-    | type[Plugin[ServicePluginDefinitionT]]
-)
-
-type ServicePlugins[
-    ServicePluginDefinitionT: ServicePluginDefinition = ServicePluginDefinition
-] = Iterable[ServicePlugin[ServicePluginDefinitionT]]
-
-
 @final
 class ServicePluginManager[ServicePluginTypesT: ServicePluginDefinition](
     ManagedLifeCycle
@@ -230,28 +219,29 @@ class ServicePluginManager[ServicePluginTypesT: ServicePluginDefinition](
 
     def __init__(
         self,
-        *,
-        plugin_types: Collection[type[ServicePluginTypesT]],
-        plugin_manufacturers: ServicePlugins | None,
         services: ServiceLevel,
+        plugin_types: Collection[type[ServicePluginTypesT]],
+        plugins: Iterable[
+            ServicePluginRequirement | PluginRequirementsRequirement
+        ] = (),
+        /,
     ):
         super().__init__()
         self._service_plugin_types = plugin_types
         self._service_plugin_manufacturers = defaultdict(dict)
-        if plugin_manufacturers is not None:
-            for service_plugin_manufacturer in plugin_manufacturers:
-                if isinstance(service_plugin_manufacturer, PluginManufacturer):
-                    (
-                        self._service_plugin_manufacturers[
-                            service_plugin_manufacturer.plugin_type()
-                        ][service_plugin_manufacturer.plugin_id]
-                    ) = service_plugin_manufacturer
-                else:
-                    (
-                        self._service_plugin_manufacturers[
-                            type(service_plugin_manufacturer.plugin())
-                        ][service_plugin_manufacturer.plugin().id]
-                    ) = service_plugin_manufacturer
+        for _plugin in plugins:
+            if isinstance(service_plugin_manufacturer, PluginManufacturer):
+                (
+                    self._service_plugin_manufacturers[
+                        service_plugin_manufacturer.plugin_type()
+                    ][service_plugin_manufacturer.plugin_id]
+                ) = service_plugin_manufacturer
+            else:
+                (
+                    self._service_plugin_manufacturers[
+                        type(service_plugin_manufacturer.plugin())
+                    ][service_plugin_manufacturer.plugin().id]
+                ) = service_plugin_manufacturer
         self._service_plugins = {}
         self._services = services
         self.life_cycle.on_bootstrap(self._bootstrap)
@@ -387,41 +377,3 @@ class ServicePluginProvider[ServicePluginTypesT: ServicePluginDefinition](
         """
         The service plugins.
         """
-
-
-type HasServicePluginRequirementsRequirement[
-    ServicePluginT: ServicePluginDefinition
-] = (
-    PluginManufacturer[ServicePluginT, Plugin[ServicePluginT]]
-    | tuple[type[ServicePluginT], MachineName]
-)
-
-type HasServicePluginRequirementsRequirements[
-    ServicePluginT: ServicePluginDefinition
-] = Iterable[HasServicePluginRequirementsRequirement[ServicePluginT]]
-
-
-class HasServicePluginRequirements[ServicePluginT: ServicePluginDefinition](ABC):
-    """
-    An object that requires service plugins to be enabled.
-    """
-
-    @property
-    @abstractmethod
-    def service_plugin_requirements(
-        self,
-    ) -> HasServicePluginRequirementsRequirements[ServicePluginT]:
-        """
-        The required service plugins.
-        """
-
-    @final
-    def _get_service_plugin_requirements_from_manufacturers(
-        self,
-        *plugins: PluginManufacturer,
-    ) -> HasServicePluginRequirementsRequirements[ServicePluginT]:
-        for plugin in plugins:
-            if issubclass(plugin.plugin_type(), ServicePluginDefinition):
-                yield plugin
-            if isinstance(plugin.plugin_data, HasServicePluginRequirements):
-                yield from plugin.plugin_data.service_plugin_requirements

--- a/betty/service/provider.py
+++ b/betty/service/provider.py
@@ -101,9 +101,11 @@ class ServiceManager[ServiceProviderT, ServiceGetT, ServiceT]:
         )
         self._factory = factory
         self._service_name: str = factory.__name__
-        self._service_attr_name = f"_{self._service_name}"
-        self._service_override_attr_name = f"{self._service_attr_name}_override"
-        self._factory_override_attr_name = f"{self._service_attr_name}_factory_override"
+        self._service_attr_name = f"_service__{self._service_name}"
+        self._service_override_attr_name = f"{self._service_attr_name}__override"
+        self._factory_override_attr_name = (
+            f"{self._service_attr_name}__factory_override"
+        )
 
     @property
     def name(self) -> str:

--- a/betty/test_utils/plugin/__init__.py
+++ b/betty/test_utils/plugin/__init__.py
@@ -4,14 +4,11 @@ Test utilities for :py:mod:`betty.plugin`.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, final, override
+from typing import final, override
 
 from betty.plugin import Plugin, PluginDefinition, PluginTypeDefinition
 from betty.plugin.factory import PluginManufacturer
 from betty.test_utils.locale.localizable import DUMMY_COUNTABLE_LOCALIZABLE
-
-if TYPE_CHECKING:
-    import builtins
 
 
 class DummyPlugin(Plugin["DummyPluginDefinition"]):
@@ -73,5 +70,5 @@ class DummyPluginManufacturer(PluginManufacturer[DummyPluginDefinition, DummyPlu
 
     @override
     @classmethod
-    def type(cls) -> builtins.type[DummyPluginDefinition]:
+    def plugin_type(cls) -> type[DummyPluginDefinition]:
         return DummyPluginDefinition

--- a/betty/test_utils/service/plugin.py
+++ b/betty/test_utils/service/plugin.py
@@ -1,0 +1,51 @@
+"""
+Test utilities for :py:mod:`betty.service.plugin`.
+"""
+
+from typing import final, override
+
+from betty.plugin import Plugin, PluginTypeDefinition
+from betty.plugin.factory import PluginManufacturer
+from betty.service.plugin import ServicePluginDefinition
+from betty.test_utils.locale.localizable import DUMMY_COUNTABLE_LOCALIZABLE
+
+
+class DummyServicePlugin(Plugin["DummyServicePluginDefinition"]):
+    """
+    A dummy service plugin.
+    """
+
+
+@final
+@PluginTypeDefinition(
+    "dummy-service-plugin",
+    label="Dummy service plugin",
+    label_plural="Dummy service plugins",
+    label_countable=DUMMY_COUNTABLE_LOCALIZABLE,
+)
+class DummyServicePluginDefinition(ServicePluginDefinition[DummyServicePlugin]):
+    """
+    Define a dummy service plugin.
+    """
+
+
+@final
+class DummyServicePluginManufacturer(
+    PluginManufacturer[DummyServicePluginDefinition, DummyServicePlugin]
+):
+    """
+    Create new dummy service plugins.
+    """
+
+    @override
+    @classmethod
+    def plugin_type(cls) -> type[DummyServicePluginDefinition]:
+        return DummyServicePluginDefinition
+
+
+@final
+@DummyServicePluginDefinition("dummy-service-plugin-isolated")
+class DummyServicePluginOne(DummyServicePlugin):
+    """
+    A dummy service plugin, one.
+    """

--- a/betty/tests/plugin/test___init__.py
+++ b/betty/tests/plugin/test___init__.py
@@ -16,11 +16,13 @@ from betty.plugin import (
     resolve_plugin_type_id,
 )
 from betty.plugin.ordered import OrderedPluginDefinition
+from betty.requirement import ServicePluginRequirement
 from betty.test_utils.locale.localizable import (
     DUMMY_COUNTABLE_LOCALIZABLE,
     DUMMY_LOCALIZABLE,
 )
 from betty.test_utils.plugin import DummyPlugin, DummyPluginDefinition, DummyPluginOne
+from betty.test_utils.service.plugin import DummyServicePluginOne
 
 
 @final
@@ -80,6 +82,16 @@ class TestPluginDefinition:
         id = "my-first-plugin"  # noqa: A001
         sut = PluginDefinition(id)
         assert sut.id == id
+
+    def test_requires(self) -> None:
+        requires = list(
+            PluginDefinition(
+                "my-first-plugin-id", requires={DummyServicePluginOne}
+            ).requires
+        )
+        assert len(requires) == 1
+        assert isinstance(requires[0], ServicePluginRequirement)
+        assert requires[0].plugin is DummyServicePluginOne
 
 
 class _PluginCls(Plugin["_PluginDefinition"]):

--- a/betty/tests/plugin/test_factory.py
+++ b/betty/tests/plugin/test_factory.py
@@ -1,4 +1,3 @@
-import builtins
 from typing import TYPE_CHECKING, final, override
 
 import pytest
@@ -44,7 +43,7 @@ class _DataManufacturableDummyPluginManufacturer(
 ):
     @override
     @classmethod
-    def type(cls) -> builtins.type[_DataManufacturableDummyPluginDefinition]:
+    def plugin_type(cls) -> type[_DataManufacturableDummyPluginDefinition]:
         return _DataManufacturableDummyPluginDefinition
 
 

--- a/betty/tests/service/test_plugin.py
+++ b/betty/tests/service/test_plugin.py
@@ -1,4 +1,3 @@
-import builtins
 from collections.abc import Iterable, Iterator, Mapping
 from importlib.metadata import EntryPoint, EntryPoints
 from typing import override
@@ -14,7 +13,6 @@ from betty.plugin.discovery import ResolvableDiscovery
 from betty.plugin.error import PluginNotFound
 from betty.plugin.factory import PluginManufacturer
 from betty.plugin.ordered import OrderedPluginDefinition
-from betty.requirement import ServicePluginRequirement
 from betty.service.level import ServiceLevel
 from betty.service.level.universe import UNIVERSE
 from betty.service.plugin import (
@@ -22,7 +20,7 @@ from betty.service.plugin import (
     PluginManager,
     ServicePluginDefinition,
     ServicePluginManager,
-    ServicePluginManufacturers,
+    ServicePlugins,
 )
 from betty.string import kebab_case_to_snake_case
 from betty.test_utils.locale.localizable import DUMMY_COUNTABLE_LOCALIZABLE
@@ -32,6 +30,12 @@ from betty.test_utils.plugin import (
     DummyPluginOne,
     DummyPluginThree,
     DummyPluginTwo,
+)
+from betty.test_utils.service.plugin import (
+    DummyServicePlugin,
+    DummyServicePluginDefinition,
+    DummyServicePluginManufacturer,
+    DummyServicePluginOne,
 )
 
 
@@ -201,53 +205,15 @@ class TestPluginManager:
 
 
 class TestServicePluginDefinition:
-    def test_requires(self) -> None:
-        requires = list(
-            ServicePluginDefinition(
-                "my-first-plugin-id", requires={DummyServicePluginIsolated}
-            ).requires
-        )
-        assert len(requires) == 1
-        assert isinstance(requires[0], ServicePluginRequirement)
-        assert requires[0].plugin is DummyServicePluginIsolated
-
     def test_auto(self) -> None:
         assert ServicePluginDefinition("my-first-plugin-id", auto=True).auto
         assert not ServicePluginDefinition("my-first-plugin-id", auto=False).auto
 
 
-class DummyServicePlugin(Plugin["DummyServicePluginDefinition"]):
-    pass
-
-
-@PluginTypeDefinition(
-    "dummy-service-plugin",
-    label="dummy service plugin",
-    label_plural="dummy service plugin",
-    label_countable=DUMMY_COUNTABLE_LOCALIZABLE,
-)
-class DummyServicePluginDefinition(ServicePluginDefinition[DummyServicePlugin]):
-    pass
-
-
-class DummyServicePluginManufacturer(
-    PluginManufacturer[DummyServicePluginDefinition, DummyServicePlugin]
-):
-    @override
-    @classmethod
-    def type(cls) -> builtins.type[DummyServicePluginDefinition]:
-        return DummyServicePluginDefinition
-
-
-@DummyServicePluginDefinition("dummy-service-plugin-isolated")
-class DummyServicePluginIsolated(DummyServicePlugin):
-    pass
-
-
 @DummyServicePluginDefinition(
-    "dummy-service-plugin-requires-isolated", requires={DummyServicePluginIsolated}
+    "dummy-service-plugin-requires-isolated", requires={DummyServicePluginOne}
 )
-class DummyServicePluginRequiresIsolated(DummyServicePlugin):
+class DummyServicePluginRequiresOne(DummyServicePlugin):
     pass
 
 
@@ -274,13 +240,13 @@ class DummyServicePluginRequirementManufacturer(
 ):
     @override
     @classmethod
-    def type(cls) -> builtins.type[DummyServicePluginRequirementDefinition]:
+    def plugin_type(cls) -> type[DummyServicePluginRequirementDefinition]:
         return DummyServicePluginRequirementDefinition
 
 
 @DummyServicePluginRequirementDefinition(
     "dummy-service-plugin-requirement-requires-requires-isolated",
-    requires={DummyServicePluginRequiresIsolated},
+    requires={DummyServicePluginRequiresOne},
 )
 class DummyServicePluginRequirementRequiresRequiresIsolated(
     DummyServicePluginRequirement
@@ -309,7 +275,7 @@ class DummyServicePluginOrderedManufacturer(
 ):
     @override
     @classmethod
-    def type(cls) -> builtins.type[DummyServicePluginOrderedDefinition]:
+    def plugin_type(cls) -> type[DummyServicePluginOrderedDefinition]:
         return DummyServicePluginOrderedDefinition
 
 
@@ -353,7 +319,7 @@ class DummyServicePluginAutoManufacturer(
 ):
     @override
     @classmethod
-    def type(cls) -> builtins.type[DummyServicePluginAutoDefinition]:
+    def plugin_type(cls) -> type[DummyServicePluginAutoDefinition]:
         return DummyServicePluginAutoDefinition
 
 
@@ -372,29 +338,23 @@ class TestServicePluginManager:
     )
     async def test___getitem__(self, key: type[ServicePluginDefinition] | str) -> None:
         async with ServicePluginManager(
-            {
-                DummyServicePluginDefinition: [
-                    DummyServicePluginManufacturer(DummyServicePluginIsolated)
-                ]
-            },
+            plugin_types={DummyServicePluginDefinition},
+            plugin_manufacturers=[DummyServicePluginOne],
             services=ServiceLevel(
-                plugins={DummyServicePluginDefinition: [DummyServicePluginIsolated]}
+                plugins={DummyServicePluginDefinition: [DummyServicePluginOne]}
             ),
         ) as sut:
             assert isinstance(
-                sut[key][DummyServicePluginIsolated],
-                DummyServicePluginIsolated,
+                sut[key][DummyServicePluginOne],
+                DummyServicePluginOne,
             )
 
     async def test___iter__(self) -> None:
         async with ServicePluginManager(
-            {
-                DummyServicePluginDefinition: [
-                    DummyServicePluginManufacturer(DummyServicePluginIsolated)
-                ]
-            },
+            plugin_types={DummyServicePluginDefinition},
+            plugin_manufacturers=[DummyServicePluginOne],
             services=ServiceLevel(
-                plugins={DummyServicePluginDefinition: [DummyServicePluginIsolated]}
+                plugins={DummyServicePluginDefinition: [DummyServicePluginOne]}
             ),
         ) as sut:
             assert list(iter(sut)) == [DummyServicePluginDefinition]
@@ -406,69 +366,53 @@ class TestServicePluginManager:
             ({}, None, None),
             # A single, isolated service plugin.
             (
-                {
-                    DummyServicePluginDefinition: [
-                        DummyServicePluginIsolated.plugin().id
-                    ]
-                },
-                {DummyServicePluginDefinition: [DummyServicePluginIsolated]},
-                {
-                    DummyServicePluginDefinition: [
-                        DummyServicePluginManufacturer(DummyServicePluginIsolated)
-                    ]
-                },
+                {DummyServicePluginDefinition: [DummyServicePluginOne.plugin().id]},
+                {DummyServicePluginDefinition: [DummyServicePluginOne]},
+                [DummyServicePluginOne],
             ),
             # Two explicitly enabled service plugins of the same type, one dependent on the other.
             (
                 {
                     DummyServicePluginDefinition: [
-                        DummyServicePluginIsolated.plugin().id,
-                        DummyServicePluginRequiresIsolated.plugin().id,
+                        DummyServicePluginOne.plugin().id,
+                        DummyServicePluginRequiresOne.plugin().id,
                     ]
                 },
                 {
                     DummyServicePluginDefinition: [
-                        DummyServicePluginIsolated,
-                        DummyServicePluginRequiresIsolated,
+                        DummyServicePluginOne,
+                        DummyServicePluginRequiresOne,
                     ]
                 },
-                {
-                    DummyServicePluginDefinition: [
-                        DummyServicePluginManufacturer(DummyServicePluginIsolated),
-                        DummyServicePluginManufacturer(
-                            DummyServicePluginRequiresIsolated
-                        ),
-                    ]
-                },
+                [
+                    DummyServicePluginOne,
+                    DummyServicePluginManufacturer(DummyServicePluginRequiresOne),
+                ],
             ),
             # One explicitly enabled service plugin, dependent on another of the same type.
             (
                 {
                     DummyServicePluginDefinition: [
-                        DummyServicePluginIsolated.plugin().id,
-                        DummyServicePluginRequiresIsolated.plugin().id,
+                        DummyServicePluginOne.plugin().id,
+                        DummyServicePluginRequiresOne.plugin().id,
                     ]
                 },
                 {
                     DummyServicePluginDefinition: [
-                        DummyServicePluginIsolated,
-                        DummyServicePluginRequiresIsolated,
+                        DummyServicePluginOne,
+                        DummyServicePluginRequiresOne,
                     ]
                 },
-                {
-                    DummyServicePluginDefinition: [
-                        DummyServicePluginManufacturer(
-                            DummyServicePluginRequiresIsolated
-                        ),
-                    ]
-                },
+                [
+                    DummyServicePluginManufacturer(DummyServicePluginRequiresOne),
+                ],
             ),
             # One explicitly enabled service plugin, with nested dependencies across different plugin types.
             (
                 {
                     DummyServicePluginDefinition: [
-                        DummyServicePluginIsolated.plugin().id,
-                        DummyServicePluginRequiresIsolated.plugin().id,
+                        DummyServicePluginOne.plugin().id,
+                        DummyServicePluginRequiresOne.plugin().id,
                     ],
                     DummyServicePluginRequirementDefinition: [
                         DummyServicePluginRequirementRequiresRequiresIsolated.plugin().id,
@@ -476,20 +420,18 @@ class TestServicePluginManager:
                 },
                 {
                     DummyServicePluginDefinition: [
-                        DummyServicePluginIsolated,
-                        DummyServicePluginRequiresIsolated,
+                        DummyServicePluginOne,
+                        DummyServicePluginRequiresOne,
                     ],
                     DummyServicePluginRequirementDefinition: [
                         DummyServicePluginRequirementRequiresRequiresIsolated,
                     ],
                 },
-                {
-                    DummyServicePluginRequirementDefinition: [
-                        DummyServicePluginRequirementManufacturer(
-                            DummyServicePluginRequirementRequiresRequiresIsolated
-                        ),
-                    ]
-                },
+                [
+                    DummyServicePluginRequirementManufacturer(
+                        DummyServicePluginRequirementRequiresRequiresIsolated
+                    ),
+                ],
             ),
             # Ordered plugins.
             (
@@ -507,19 +449,17 @@ class TestServicePluginManager:
                         DummyServicePluginOrderedBeforeIsolated,
                     ],
                 },
-                {
-                    DummyServicePluginOrderedDefinition: [
-                        DummyServicePluginOrderedManufacturer(
-                            DummyServicePluginOrderedAfterIsolated
-                        ),
-                        DummyServicePluginOrderedManufacturer(
-                            DummyServicePluginOrderedIsolated
-                        ),
-                        DummyServicePluginOrderedManufacturer(
-                            DummyServicePluginOrderedBeforeIsolated
-                        ),
-                    ]
-                },
+                [
+                    DummyServicePluginOrderedManufacturer(
+                        DummyServicePluginOrderedAfterIsolated
+                    ),
+                    DummyServicePluginOrderedManufacturer(
+                        DummyServicePluginOrderedIsolated
+                    ),
+                    DummyServicePluginOrderedManufacturer(
+                        DummyServicePluginOrderedBeforeIsolated
+                    ),
+                ],
             ),
             # Auto service plugins.
             (
@@ -533,9 +473,7 @@ class TestServicePluginManager:
                         DummyServicePluginAutoIsolated,
                     ],
                 },
-                {
-                    DummyServicePluginAutoDefinition: [],
-                },
+                (),
             ),
         ],
     )
@@ -546,11 +484,19 @@ class TestServicePluginManager:
             type[PluginDefinition], Iterable[ResolvableDiscovery[PluginDefinition]]
         ]
         | None,
-        service_plugins: ServicePluginManufacturers,
+        service_plugins: ServicePlugins,
         isolated_app: App,
     ) -> None:
         async with ServicePluginManager(
-            service_plugins, services=ServiceLevel(plugins=plugins)
+            plugin_types=()
+            if plugins is None
+            else [
+                plugin
+                for plugin in plugins
+                if issubclass(plugin, ServicePluginDefinition)
+            ],
+            plugin_manufacturers=service_plugins,
+            services=ServiceLevel(plugins=plugins),
         ) as sut:
             assert set(sut) == set(expected)
             for plugin_type in expected:

--- a/betty/tests/test_requirement.py
+++ b/betty/tests/test_requirement.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Any, override
+from collections.abc import Awaitable, Callable, Collection
+from typing import Any, override
 
 import pytest
 
@@ -18,17 +18,14 @@ from betty.service.level import ChainedServiceLevel, ServiceLevel
 from betty.service.plugin import (
     ServicePluginDefinition,
     ServicePluginManager,
-    ServicePluginManufacturers,
     ServicePluginProvider,
+    ServicePlugins,
 )
 from betty.service.provider import service
 from betty.test_utils.locale.localizable import (
     DUMMY_COUNTABLE_LOCALIZABLE,
     DUMMY_LOCALIZABLE,
 )
-
-if TYPE_CHECKING:
-    import builtins
 
 
 class _ServiceLevel(ServiceLevel):
@@ -42,18 +39,21 @@ class _ChainedServiceLevel(ChainedServiceLevel):
 class _ServicePluginProvider(ServiceLevel, ServicePluginProvider):
     def __init__(
         self,
-        service_plugin_manufacturers: ServicePluginManufacturers | None = None,
         *args: Any,
+        service_plugin_types: Collection[type[ServicePluginDefinition]],
+        service_plugin_manufacturers: ServicePlugins | None = None,
         **kwargs: Any,
     ):
         super().__init__(*args, **kwargs)
+        self._service_plugin_types = service_plugin_types
         self._service_plugin_manufacturers = service_plugin_manufacturers
 
     @override
     @service
     async def service_plugins(self) -> ServicePluginManager:
         service_plugins = ServicePluginManager(
-            self._service_plugin_manufacturers,
+            plugin_types=self._service_plugin_types,
+            plugin_manufacturers=self._service_plugin_manufacturers,
             services=self,
         )
         await service_plugins.bootstrap()
@@ -84,7 +84,7 @@ class _ServicePluginManufacturer(
 ):
     @override
     @classmethod
-    def type(cls) -> builtins.type[_ServicePluginDefinition]:
+    def plugin_type(cls) -> type[_ServicePluginDefinition]:
         return _ServicePluginDefinition
 
 
@@ -227,14 +227,20 @@ class TestServicePluginRequirement:
         self,
     ) -> None:
         sut = ServicePluginRequirement(_ServicePluginOne)
-        async with _ServicePluginProvider(plugins=self._PLUGINS) as services:
+        async with _ServicePluginProvider(
+            service_plugin_types=(),
+            service_plugin_manufacturers=(),
+            plugins=self._PLUGINS,
+        ) as services:
             with pytest.raises(UnmetRequirement):
                 await sut(services)
 
     async def test___call____services_unmet_because_no_service_plugin(self) -> None:
         sut = ServicePluginRequirement(_ServicePluginOne)
         async with _ServicePluginProvider(
-            {_ServicePluginDefinition: ()}, plugins=self._PLUGINS
+            service_plugin_types={_ServicePluginDefinition},
+            service_plugin_manufacturers=(),
+            plugins=self._PLUGINS,
         ) as services:
             with pytest.raises(UnmetRequirement):
                 await sut(services)
@@ -242,7 +248,10 @@ class TestServicePluginRequirement:
     async def test___call____services_met(self) -> None:
         sut = ServicePluginRequirement(_ServicePluginOne)
         async with _ServicePluginProvider(
-            {_ServicePluginDefinition: {_ServicePluginManufacturer(_ServicePluginOne)}},
+            service_plugin_types={_ServicePluginDefinition},
+            service_plugin_manufacturers={
+                _ServicePluginManufacturer(_ServicePluginOne)
+            },
             plugins=self._PLUGINS,
         ) as services:
             assert isinstance(await sut(services), _ServicePluginOne)
@@ -259,7 +268,10 @@ class TestServicePluginRequirement:
     ) -> None:
         sut = ServicePluginRequirement(_ServicePluginOne)
         async with _ServicePluginProvider(
-            {_ServicePluginDefinition: {_ServicePluginManufacturer(_ServicePluginOne)}},
+            service_plugin_types={_ServicePluginDefinition},
+            service_plugin_manufacturers={
+                _ServicePluginManufacturer(_ServicePluginOne)
+            },
             plugins=self._PLUGINS,
         ) as upstream:
             services = _ChainedServiceLevel(upstream=upstream)
@@ -271,15 +283,15 @@ class TestServicePluginRequirement:
         sut = ServicePluginRequirement(_ServicePluginOne)
         async with (
             _ServicePluginProvider(
-                {
-                    _ServicePluginDefinition: {
-                        _ServicePluginManufacturer(_ServicePluginOne)
-                    }
+                service_plugin_types={_ServicePluginDefinition},
+                service_plugin_manufacturers={
+                    _ServicePluginManufacturer(_ServicePluginOne)
                 },
                 plugins=self._PLUGINS,
             ) as upstream,
             _ChainedServicePluginProvider(
-                {},
+                service_plugin_types={},
+                service_plugin_manufacturers={},
                 plugins=self._PLUGINS,
                 upstream=upstream,
             ) as services,
@@ -292,15 +304,15 @@ class TestServicePluginRequirement:
         sut = ServicePluginRequirement(_ServicePluginOne)
         async with (
             _ServicePluginProvider(
-                {
-                    _ServicePluginDefinition: {
-                        _ServicePluginManufacturer(_ServicePluginOne)
-                    }
+                service_plugin_types={_ServicePluginDefinition},
+                service_plugin_manufacturers={
+                    _ServicePluginManufacturer(_ServicePluginOne)
                 },
                 plugins=self._PLUGINS,
             ) as upstream,
             _ChainedServicePluginProvider(
-                {_ServicePluginDefinition: ()},
+                service_plugin_types={_ServicePluginDefinition},
+                service_plugin_manufacturers=(),
                 plugins=self._PLUGINS,
                 upstream=upstream,
             ) as services,


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/3979

## Thoughts
- Is this even doable at all? All use cases use `PluginManufacturer` which is inherently unable to produce a plugin's `Data` object without a service level (`ServiceLevel.plugins` is needed to get the plugin class, which exposes the data class, which we can then initialize using the portable data. Only at this point can we check if that data is `HasRequirements`.
- Even if we cannot automatically enable requirements for non-service plugins, declaring them does allow us auto enabling in tests and to automatically provide detailed error reporting.
- Consider extracting individual improvements from this PR into separate PRs and closing this one.


## To do
- Add an API for `Data` classes to expose requirements and a reusable implementation to do this for configured plugins.