### PR TITLE
Prevent sphinx-apidoc from being invoked twice during Read the Docs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,9 +3,6 @@ build:
   os: ubuntu-22.04
   tools:
     python: '3.14'
-  jobs:
-    pre_build:
-      - sphinx-apidoc --force --separate -d 999 -o documentation betty betty/tests
 sphinx:
   configuration: documentation/conf.py
   builder: dirhtml


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/3971