### PR TITLE
Make subclassing `Plugin` optional for classed plugins

### DIFF
--- a/betty/plugin/cls.py
+++ b/betty/plugin/cls.py
@@ -15,6 +15,8 @@ from betty.plugin import PluginDefinition
 class Plugin[PluginClsDefinitionT: PluginClsDefinition]:
     """
     A plugin class.
+
+    Classed plugins may optionally subclass this class to expose their plugin definitions.
     """
 
     @classmethod
@@ -27,15 +29,16 @@ class Plugin[PluginClsDefinitionT: PluginClsDefinition]:
         )
 
 
-_PluginCoT = TypeVar("_PluginCoT", default=Plugin, covariant=True)
+_PluginClsCoT = TypeVar("_PluginClsCoT", covariant=True)
 
 
-class PluginClsDefinition(PluginDefinition, ClsDefinition[_PluginCoT]):
+class PluginClsDefinition(PluginDefinition, ClsDefinition[_PluginClsCoT]):
     """
     A classed plugin definition.
     """
 
     @override
-    def _set_cls(self, cls: type[_PluginCoT], /) -> None:
+    def _set_cls(self, cls: type[_PluginClsCoT], /) -> None:
         super()._set_cls(cls)
-        cls.plugin = staticmethod(update_wrapper(lambda: self, cls.plugin))  # ty:ignore[unresolved-attribute]
+        if issubclass(cls, Plugin):
+            cls.plugin = staticmethod(update_wrapper(lambda: self, cls.plugin))  # ty:ignore[invalid-assignment]

--- a/betty/tests/coverage/test_coverage.py
+++ b/betty/tests/coverage/test_coverage.py
@@ -474,7 +474,6 @@ _BASELINE: Mapping[str, _ModuleIgnore] = {
     },
     "betty/plugin/cls.py": {
         "Plugin": MissingReason.ABSTRACT,
-        "PluginClsDefinition": MissingReason.SHOULD_BE_COVERED,
     },
     "betty/plugin/data/__init__.py": {
         "PluginDefinitionConfiguration": {"new_plugin": MissingReason.ABSTRACT},

--- a/betty/tests/plugin/test_cls.py
+++ b/betty/tests/plugin/test_cls.py
@@ -1,0 +1,21 @@
+from betty.plugin.cls import Plugin, PluginClsDefinition
+
+
+class TestPluginClsDefinition:
+    def test__set_cls__without_plugin_class(self) -> None:
+        class _Plugin:
+            pass
+
+        sut = PluginClsDefinition("-")
+        sut(_Plugin)
+        assert sut.cls is _Plugin
+        assert not hasattr(_Plugin, "plugin")
+
+    def test__set_cls__with_plugin_class(self) -> None:
+        class _Plugin(Plugin):
+            pass
+
+        sut = PluginClsDefinition("-")
+        sut(_Plugin)
+        assert sut.cls is _Plugin
+        assert _Plugin.plugin() is sut


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/4049