### PR TITLE
Add `@Property.getter`, `@Property.setter`, and `@Property.default`

### DIFF
--- a/betty/date/__init__.py
+++ b/betty/date/__init__.py
@@ -19,7 +19,7 @@ from betty.datas.bool import BoolDefinition
 from betty.datas.int import IntDefinition
 from betty.locale.localizable import Localizable
 from betty.locale.localizable.gettext import _
-from betty.property import Optional, Property
+from betty.property import AttrProperty, Optional
 from betty.sample import Sample, Size
 
 if TYPE_CHECKING:
@@ -80,10 +80,10 @@ class Date(Localizable, Data):
         (False,): _("{date}"),
     }
 
-    year = Optional(Property(IntDefinition(label=_("Year"))))
-    month = Optional(Property(IntDefinition(label=_("Month"))))
-    day = Optional(Property(IntDefinition(label=_("Day"))))
-    fuzzy = Property(
+    year = Optional(AttrProperty(IntDefinition(label=_("Year"))))
+    month = Optional(AttrProperty(IntDefinition(label=_("Month"))))
+    day = Optional(AttrProperty(IntDefinition(label=_("Day"))))
+    fuzzy = AttrProperty(
         BoolDefinition(label=_("Fuzzy")),
         omit_load=True,
         omit_dump=lambda data: data is False,
@@ -274,14 +274,14 @@ class DateRange(Localizable, Data):
         (None, None, True, True): _("sometime before around {end_date}"),
     }
 
-    start = Optional(Property(Date))
-    start_is_boundary = Property(
+    start = Optional(AttrProperty(Date))
+    start_is_boundary = AttrProperty(
         BoolDefinition(label=_("Start date is a boundary")),
         omit_load=True,
         omit_dump=lambda data: data is False,
     )
-    end = Optional(Property(Date))
-    end_is_boundary = Property(
+    end = Optional(AttrProperty(Date))
+    end_is_boundary = AttrProperty(
         BoolDefinition(label=_("End date is a boundary")),
         omit_load=True,
         omit_dump=lambda data: data is False,

--- a/betty/entity/reference.py
+++ b/betty/entity/reference.py
@@ -12,7 +12,7 @@ from betty.datas.str import StrDefinition
 from betty.locale.localizable.gettext import _
 from betty.plugin.resolve import resolve_plugin_id
 from betty.properties.machine_name import MachineNameProperty
-from betty.property import Property
+from betty.property import AttrProperty
 
 if TYPE_CHECKING:
     from betty.entity import EntityDefinition
@@ -38,7 +38,7 @@ class EntityReference(Data):
     The type of the referenced entity. 
     """
 
-    id = Property(StrDefinition(label=_("Entity ID")))
+    id = AttrProperty(StrDefinition(label=_("Entity ID")))
     """
     The ID of the referenced entity.
     """

--- a/betty/plugins/content/box.py
+++ b/betty/plugins/content/box.py
@@ -19,7 +19,7 @@ from betty.project import Project
 from betty.properties.plugin_manufacturer_sequence import (
     PluginManufacturerSequenceProperty,
 )
-from betty.property import Optional, Property
+from betty.property import AttrProperty, Optional
 from betty.sample import Sample, Size
 
 if TYPE_CHECKING:
@@ -64,12 +64,12 @@ class BoxData(Data):
     The content within this box.
     """
 
-    min_height = Optional(Property(StrDefinition(label=_("Minimum height"))))
-    max_height = Optional(Property(StrDefinition(label=_("Maximum height"))))
-    height = Optional(Property(StrDefinition(label=_("Height"))))
-    min_width = Optional(Property(StrDefinition(label=_("Minimum width"))))
-    max_width = Optional(Property(StrDefinition(label=_("Maximum width"))))
-    width = Optional(Property(StrDefinition(label=_("Width"))))
+    min_height = Optional(AttrProperty(StrDefinition(label=_("Minimum height"))))
+    max_height = Optional(AttrProperty(StrDefinition(label=_("Maximum height"))))
+    height = Optional(AttrProperty(StrDefinition(label=_("Height"))))
+    min_width = Optional(AttrProperty(StrDefinition(label=_("Minimum width"))))
+    max_width = Optional(AttrProperty(StrDefinition(label=_("Maximum width"))))
+    width = Optional(AttrProperty(StrDefinition(label=_("Width"))))
 
     def __init__(
         self,

--- a/betty/plugins/content/raspberry_mint_color_style.py
+++ b/betty/plugins/content/raspberry_mint_color_style.py
@@ -20,7 +20,7 @@ from betty.project import Project
 from betty.properties.plugin_manufacturer_sequence import (
     PluginManufacturerSequenceProperty,
 )
-from betty.property import Property
+from betty.property import AttrProperty
 from betty.sample import Sample
 
 if TYPE_CHECKING:
@@ -55,7 +55,7 @@ class ColorStyleData(Data):
     The content within this color style.
     """
 
-    style = Property(EnumDefinition(cls=RaspberryMintColorStyle, label=_("Style")))
+    style = AttrProperty(EnumDefinition(cls=RaspberryMintColorStyle, label=_("Style")))
     """
     The style.
     """

--- a/betty/plugins/content/raspberry_mint_columns.py
+++ b/betty/plugins/content/raspberry_mint_columns.py
@@ -33,7 +33,7 @@ from betty.plugins.content.template import Template, TemplateBuild
 from betty.plugins.extension.raspberry_mint import Breakpoint, JustifyContent
 from betty.portable import CallbackPorter
 from betty.project import Project
-from betty.property import Optional, Property
+from betty.property import AttrProperty, Optional
 from betty.sample import Sample, Size
 
 if TYPE_CHECKING:
@@ -123,7 +123,7 @@ class ColumnsData(Data):
     _DEFAULT_WIDTH: ClassVar[ColumnsWidth] = {Breakpoint.XS: [12]}
     _width: ColumnsWidth
 
-    content = Property(
+    content = AttrProperty(
         SequenceDefinition(
             cls=list,
             value=PluginManufacturerSequenceDefinition(
@@ -137,13 +137,13 @@ class ColumnsData(Data):
     """
 
     justify_content = Optional(
-        Property(EnumDefinition(cls=JustifyContent, label=_("Justify content")))
+        AttrProperty(EnumDefinition(cls=JustifyContent, label=_("Justify content")))
     )
     """
     If and how to justify content.
     """
 
-    width = Property(
+    width = AttrProperty(
         MappingDefinition(
             cls=dict,
             key=EnumDefinition(

--- a/betty/plugins/content/raspberry_mint_presences.py
+++ b/betty/plugins/content/raspberry_mint_presences.py
@@ -18,7 +18,7 @@ from betty.plugins.asset_directory.raspberry_mint import RASPBERRY_MINT
 from betty.plugins.content.template import Template, TemplateBuild
 from betty.plugins.entity.event import Event
 from betty.project import Project
-from betty.property import Optional, Property
+from betty.property import AttrProperty, Optional
 from betty.role import RoleDefinition
 from betty.sample import Sample, Size
 
@@ -54,14 +54,18 @@ class PresencesData(Data):
     """
 
     exclude = Optional(
-        Property(SequenceDefinition(cls=list, value=MachineName, label=_("Exclude")))
+        AttrProperty(
+            SequenceDefinition(cls=list, value=MachineName, label=_("Exclude"))
+        )
     )
     """
     The presence roles for which to exclude presences.
     """
 
     include = Optional(
-        Property(SequenceDefinition(cls=list, value=MachineName, label=_("Include")))
+        AttrProperty(
+            SequenceDefinition(cls=list, value=MachineName, label=_("Include"))
+        )
     )
     """
     The presence roles for which to include presences.

--- a/betty/plugins/content/raspberry_mint_section.py
+++ b/betty/plugins/content/raspberry_mint_section.py
@@ -21,7 +21,7 @@ from betty.properties.machine_name import MachineNameProperty
 from betty.properties.plugin_manufacturer_sequence import (
     PluginManufacturerSequenceProperty,
 )
-from betty.property import Optional, Property
+from betty.property import AttrProperty, Optional
 from betty.sample import Sample, Size
 from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
 
@@ -74,7 +74,7 @@ class SectionData(Data):
     """
 
     visually_hide_heading = Optional(
-        Property(
+        AttrProperty(
             BoolDefinition(label=_("Visually hide heading")),
             omit_load=True,
             omit_dump=lambda data: data is False,

--- a/betty/plugins/enricher/wiki/__init__.py
+++ b/betty/plugins/enricher/wiki/__init__.py
@@ -14,7 +14,7 @@ from betty.plugins.enricher.populate_links import PopulateLinks
 from betty.plugins.enricher.wiki.jobs import PopulateEntity
 from betty.plugins.extension.wiki import Wiki as WikiExtension
 from betty.project import Project
-from betty.property import Optional, Property
+from betty.property import AttrProperty, Optional
 from betty.sample import Sample, Size
 
 if TYPE_CHECKING:
@@ -37,7 +37,7 @@ class WikiData(Data):
     """
 
     populate_images = Optional(
-        Property(
+        AttrProperty(
             BoolDefinition(
                 label=_("Populate images"),
                 description=_(

--- a/betty/plugins/entity/link.py
+++ b/betty/plugins/entity/link.py
@@ -43,8 +43,7 @@ class Link(LinkType, HasMediaType, HasDescription, HasPrivacy, Entity):
     .. plugin:: entity:link.
     """
 
-    _url = LocalizableProperty(label=_("URL"))
-    _label = Optional(LocalizableProperty(label=_("Label")))
+    url = LocalizableProperty(label=_("URL"))
 
     relationship: str | None
     """
@@ -74,33 +73,16 @@ class Link(LinkType, HasMediaType, HasDescription, HasPrivacy, Entity):
         super().__init__(
             media_type=media_type, description=description, privacy=privacy
         )
-        self._url = url
-        self._label = label
+        self.url = url
+        self.label = label
         self.relationship = relationship
         if owner is not None:
             self.owner = owner
 
     @override
-    @property
-    def url(self) -> Localizable:
-        return self._url
-
-    @url.setter
-    def url(self, url: ResolvableLocalizable) -> None:
-        self._url = url
-
-    @override
-    @property
-    def label(self) -> Localizable:
-        return self.url if self._label is None else self._label
-
-    @label.setter
-    def label(self, label: ResolvableLocalizable | None) -> None:
-        self._label = label
-
-    @label.deleter
-    def label(self) -> None:
-        del self._label
+    @Optional(LocalizableProperty(label=_("Label")))
+    def label(self, label: Localizable | None, /) -> Localizable:
+        return self.url if label is None else label
 
     @property
     def has_label(self) -> bool:
@@ -115,10 +97,9 @@ class Link(LinkType, HasMediaType, HasDescription, HasPrivacy, Entity):
         portable = await super().dump_linked_data(project)
         if self.public:
             portable["url"] = dump_linked_data(self.url, localizers=public_localizers)
-            if self._label is not None:
-                portable["label"] = dump_linked_data(
-                    self._label, localizers=public_localizers
-                )
+            portable["label"] = dump_linked_data(
+                self.label, localizers=public_localizers
+            )
             if self.relationship is not None:
                 portable["relationship"] = self.relationship
         return portable

--- a/betty/plugins/extension/raspberry_mint/__init__.py
+++ b/betty/plugins/extension/raspberry_mint/__init__.py
@@ -38,7 +38,7 @@ from betty.plugins.extension.webpack.build import EntryPointProvider
 from betty.project import Project
 from betty.project.generate import Generator
 from betty.properties.collection.mapping import MappingProperty
-from betty.property import Optional, Property
+from betty.property import AttrProperty, Optional
 from betty.sample import Sample, Size
 from betty.service import ServiceProvider
 from betty.service.simple import service
@@ -91,17 +91,21 @@ class RaspberryMintData(Data):
     .. data:: betty.plugins.extension.raspberry_mint:RaspberryMintData
     """
 
-    primary_color = Optional(Property(ColorDefinition(), label=_("Primary color")))
+    primary_color = Optional(AttrProperty(ColorDefinition(), label=_("Primary color")))
     """
     The primary color.
     """
 
-    secondary_color = Optional(Property(ColorDefinition(), label=_("Secondary color")))
+    secondary_color = Optional(
+        AttrProperty(ColorDefinition(), label=_("Secondary color"))
+    )
     """
     The secondary color.
     """
 
-    tertiary_color = Optional(Property(ColorDefinition(), label=_("Tertiary color")))
+    tertiary_color = Optional(
+        AttrProperty(ColorDefinition(), label=_("Tertiary color"))
+    )
     """
     The tertiary color.
     """

--- a/betty/plugins/loader/gramps/__init__.py
+++ b/betty/plugins/loader/gramps/__init__.py
@@ -35,7 +35,7 @@ from betty.plugins.loader.gramps.jobs import LoadAncestry
 from betty.project import Project
 from betty.properties.collection.mapping import MappingProperty
 from betty.properties.collection.sequence import SequenceProperty
-from betty.property import Optional, Property
+from betty.property import AttrProperty, Optional
 from betty.role import Role, RoleDefinition, RoleManufacturer
 from betty.sample import Sample, Size
 
@@ -121,12 +121,12 @@ class FamilyTree(Data):
     How to map event types.
     """
 
-    file = Optional(Property(PathDefinition(), label=_("File")))
+    file = Optional(AttrProperty(PathDefinition(), label=_("File")))
     """
     The path to a Gramps family tree file.
     """
 
-    name = Optional(Property(StrDefinition(label=_("Name"))))
+    name = Optional(AttrProperty(StrDefinition(label=_("Name"))))
     """
     The family tree's name in Gramps.
     """
@@ -255,7 +255,7 @@ class GrampsData(Data):
     The Gramps family trees to load.
     """
 
-    executable = Optional(Property(PathDefinition()))
+    executable = Optional(AttrProperty(PathDefinition()))
     """
     The path to a specific Gramps executable.
 

--- a/betty/project/__init__.py
+++ b/betty/project/__init__.py
@@ -98,7 +98,7 @@ from betty.properties.collection.sequence import SequenceProperty
 from betty.properties.localizable import LocalizableProperty
 from betty.properties.machine_name import MachineNameProperty
 from betty.properties.plugin_definitions import PluginDefinitionDatasProperty
-from betty.property import Optional, Property
+from betty.property import AttrProperty, Optional
 from betty.render import RenderDispatcher, RendererDefinition
 from betty.role import RoleDefinition
 from betty.sample import Sample, Size
@@ -773,7 +773,7 @@ class ProjectData(Data):
     The project's author.
     """
 
-    clean_urls = Property(
+    clean_urls = AttrProperty(
         BoolDefinition(
             label=_("Clean URLs"),
             description=_(
@@ -788,7 +788,7 @@ class ProjectData(Data):
     """
 
     copyright_notice = Optional(
-        Property(
+        AttrProperty(
             CopyrightNoticeManufacturer,
             omit_load=True,
             omit_dump=lambda data: data == ProjectData._default_copyright_notice(),
@@ -807,7 +807,7 @@ class ProjectData(Data):
     The :py:class:`betty.copyright_notice.CopyrightNotice` plugins created by this project.
     """
 
-    debug = Property(
+    debug = AttrProperty(
         BoolDefinition(
             label=_("Debugging mode"),
             description=_(
@@ -886,7 +886,7 @@ class ProjectData(Data):
     """
 
     license = Optional(
-        Property(
+        AttrProperty(
             LicenseManufacturer,
             omit_load=True,
             omit_dump=lambda data: data == ProjectData._default_license(),
@@ -903,7 +903,7 @@ class ProjectData(Data):
     The :py:class:`betty.license.License` plugins created by this project.
     """
 
-    lifetime_threshold = Property(
+    lifetime_threshold = AttrProperty(
         IntDefinition(
             label=_("Lifetime threshold"),
             description=_(
@@ -960,7 +960,7 @@ class ProjectData(Data):
     The configured locales.
     """
 
-    logo = Optional(Property(PathDefinition(), label=_("Logo")))
+    logo = Optional(AttrProperty(PathDefinition(), label=_("Logo")))
     """
     The project logo.
     """
@@ -987,7 +987,7 @@ class ProjectData(Data):
     The human-readable project title.
     """
 
-    url = Property(
+    url = AttrProperty(
         StrDefinition(
             label=_("URL"),
             description=_(

--- a/betty/properties/collection/keyed.py
+++ b/betty/properties/collection/keyed.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, final, override
 
 from betty.collection.keyed import MutableKeyedCollection
 from betty.functools import passthrough
-from betty.property import Property
+from betty.property import AttrProperty
 
 if TYPE_CHECKING:
     from betty.data import Data
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 class KeyedCollectionProperty[
     MutableKeyedCollectionT: MutableKeyedCollection,
     ValueSetT,
-](Property[MutableKeyedCollectionT, Iterable[ValueSetT]]):
+](AttrProperty[MutableKeyedCollectionT, Iterable[ValueSetT]]):
     """
     A property that contains an :py:class:`betty.collection.keyed.KeyedCollection`.
     """

--- a/betty/properties/collection/mapping.py
+++ b/betty/properties/collection/mapping.py
@@ -8,7 +8,7 @@ from collections.abc import Mapping, MutableMapping
 from typing import TYPE_CHECKING, Any, final, override
 
 from betty.functools import passthrough
-from betty.property import Property
+from betty.property import AttrProperty
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -24,7 +24,7 @@ class MappingProperty[
     KeyGetT,
     ItemGetT,
     ValueSetT,
-](Property[MutableMappingT, ValueSetT]):
+](AttrProperty[MutableMappingT, ValueSetT]):
     """
     A property that contains a :py:class:`collections.abc.MutableMapping`.
     """

--- a/betty/properties/collection/sequence.py
+++ b/betty/properties/collection/sequence.py
@@ -8,7 +8,7 @@ from collections.abc import Iterable, MutableSequence
 from typing import TYPE_CHECKING, Any, final, override
 
 from betty.functools import passthrough
-from betty.property import Property
+from betty.property import AttrProperty
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 
 class SequenceProperty[MutableSequenceT: MutableSequence[Any], ItemGetT, ValueSetT](
-    Property[MutableSequenceT, ValueSetT]
+    AttrProperty[MutableSequenceT, ValueSetT]
 ):
     """
     A property that contains a :py:class:`collections.abc.MutableSequence`.

--- a/betty/properties/countable_localizable.py
+++ b/betty/properties/countable_localizable.py
@@ -13,12 +13,12 @@ from betty.locale.localizable import (
     ResolvableLocalizable,
     resolve_countable_localizable,
 )
-from betty.property import Property
+from betty.property import AttrProperty
 
 
 @final
 class CountableLocalizableProperty(
-    Property[CountableLocalizable, ResolvableCountableLocalizable]
+    AttrProperty[CountableLocalizable, ResolvableCountableLocalizable]
 ):
     """
     A property containing a :py:class:`betty.locale.localizable.CountableLocalizable`.

--- a/betty/properties/date.py
+++ b/betty/properties/date.py
@@ -15,7 +15,7 @@ from betty.date.linked_data import (
 from betty.date.schema import ResolvableDateSchema
 from betty.linked_data import JsonLdObject, LinkedDataDumpableWithSchemaJsonLdObject
 from betty.privacy.resolve import is_public
-from betty.property import Optional, Property
+from betty.property import AttrProperty, Optional
 
 if TYPE_CHECKING:
     from betty.portable import PortableMapping
@@ -27,7 +27,7 @@ class HasAnyDate(LinkedDataDumpableWithSchemaJsonLdObject):
     A resource with date information.
     """
 
-    date = Optional(Property(AnyDateDefinition()))
+    date = Optional(AttrProperty(AnyDateDefinition()))
     """
     The date.
     """

--- a/betty/properties/locale.py
+++ b/betty/properties/locale.py
@@ -12,7 +12,7 @@ from betty.linked_data import JsonLdObject, LinkedDataDumpableWithSchemaJsonLdOb
 from betty.locale import Localized, ResolvableLocale, resolve_locale, to_language_tag
 from betty.locale.schema import LocaleSchema
 from betty.privacy.resolve import is_public
-from betty.property import Optional, Property
+from betty.property import AttrProperty, Optional
 
 if TYPE_CHECKING:
     from betty.locale.localizable import ResolvableLocalizable
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 
 @final
-class LocaleProperty(Property):
+class LocaleProperty(AttrProperty):
     """
     A property containing a locale.
     """

--- a/betty/properties/localizable.py
+++ b/betty/properties/localizable.py
@@ -12,11 +12,11 @@ from betty.locale.localizable import (
     ResolvableLocalizable,
     resolve_localizable,
 )
-from betty.property import Property
+from betty.property import AttrProperty
 
 
 @final
-class LocalizableProperty(Property[Localizable, ResolvableLocalizable]):
+class LocalizableProperty(AttrProperty[Localizable, ResolvableLocalizable]):
     """
     A property containing a :py:class:`betty.locale.localizable.Localizable`.
     """

--- a/betty/properties/machine_name.py
+++ b/betty/properties/machine_name.py
@@ -8,14 +8,14 @@ from typing import TYPE_CHECKING, final
 
 from betty.locale.localizable.gettext import _
 from betty.machine_name import _MACHINE_NAME_DESCRIPTION, MachineName
-from betty.property import Property
+from betty.property import AttrProperty
 
 if TYPE_CHECKING:
     from betty.locale.localizable import ResolvableLocalizable
 
 
 @final
-class MachineNameProperty(Property):
+class MachineNameProperty(AttrProperty):
     """
     A property containing a machine name.
     """

--- a/betty/properties/media_type.py
+++ b/betty/properties/media_type.py
@@ -10,7 +10,7 @@ from betty.linked_data import JsonLdObject, LinkedDataDumpableWithSchemaJsonLdOb
 from betty.media_type import MediaType, ResolvableMediaType, resolve_media_type
 from betty.media_type.schema import MediaTypeSchema
 from betty.privacy.resolve import is_public
-from betty.property import Optional, Property
+from betty.property import AttrProperty, Optional
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 
 @final
-class MediaTypeProperty(Property[MediaType, ResolvableMediaType]):
+class MediaTypeProperty(AttrProperty[MediaType, ResolvableMediaType]):
     """
     A property containing a media type.
     """

--- a/betty/properties/privacy.py
+++ b/betty/properties/privacy.py
@@ -11,14 +11,14 @@ from betty.linked_data import LinkedDataDumper
 from betty.locale.localizable.gettext import _
 from betty.privacy import Privacy
 from betty.privacy.schema import PrivacySchema
-from betty.property import Property
+from betty.property import AttrProperty
 
 if TYPE_CHECKING:
     from betty.project import Project
 
 
 @final
-class PrivacyProperty(Property, LinkedDataDumper[object, PrivacySchema, bool]):
+class PrivacyProperty(AttrProperty, LinkedDataDumper[object, PrivacySchema, bool]):
     """
     A property containing a privacy.
     """

--- a/betty/property.py
+++ b/betty/property.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any, Self, cast, final, overload, override
 
 from betty.data import OptionalDefinition
 from betty.datas.aggregate.record.object import Attr, AttrDefinition
-from betty.functools import passthrough
 from betty.importlib import fully_qualified_name
 from betty.typing import Void
 
@@ -20,26 +19,32 @@ if TYPE_CHECKING:
     from betty.locale.localizable import ResolvableLocalizable
 
 
-class _Property[ValueGetT, ValueSetT](Attr[ValueGetT], ABC):
-    _attr_name: str
+class Property[ValueGetT, ValueSetT](Attr[ValueGetT], ABC):
+    """
+    An instance property backed by a data definition.
+    """
 
-    def __init__(
-        self,
-        attr: AttrDefinition[ValueGetT],
-        *,
-        resolver: Callable[[ValueSetT | ValueGetT], ValueGetT] = passthrough,
-    ):
-        self._attr = attr
-        self._resolver = resolver
+    __name: str
+
+    def __init__(self, attr: AttrDefinition[ValueGetT], /):
+        self.__attr = attr
 
     def __set_name__(self, owner: type[Any], name: str) -> None:
-        self._attr_name = f"_{name}"
+        self.__name = f"_{name}"
 
     @final
     @override
     @property
     def attr(self) -> AttrDefinition[ValueGetT]:
-        return self._attr
+        return self.__attr
+
+    @final
+    @property
+    def name(self) -> str:
+        """
+        The property/attribute name.
+        """
+        return self.__name
 
     @overload
     def __get__(self, instance: None, owner: type[object], /) -> Self:
@@ -49,11 +54,13 @@ class _Property[ValueGetT, ValueSetT](Attr[ValueGetT], ABC):
     def __get__(self, instance: Any, owner: type[Any] | None = None, /) -> ValueGetT:
         pass
 
+    @final
     def __get__(self, instance, owner=None, /):
         if instance is None:
             return self
         return self.get(instance)
 
+    @final
     def __set__(self, instance: Any, value: ValueSetT | ValueGetT) -> None:
         self.set(instance, value)
 
@@ -63,18 +70,143 @@ class _Property[ValueGetT, ValueSetT](Attr[ValueGetT], ABC):
         Get the property value from the instance.
         """
 
+    @abstractmethod
     def set(self, instance: Any, value: ValueSetT, /) -> ValueGetT:
         """
         Set the value on the instance.
         """
-        resolved_value = self._resolver(value)
-        setattr(instance, self._attr_name, resolved_value)
-        return resolved_value
+
+    @final
+    def getter[GetterValueGetT](
+        self, getter: Callable[[Any, ValueGetT], GetterValueGetT], /
+    ) -> Property[GetterValueGetT, ValueSetT]:
+        """
+        Return a new property with the given getter.
+        """
+        return GetterProperty(self, getter)
+
+    @final
+    def __call__[GetterValueGetT](
+        self, getter: Callable[[Any, ValueGetT], GetterValueGetT], /
+    ) -> Property[GetterValueGetT, ValueSetT]:
+        """
+        Return a new property with the given getter.
+        """
+        return self.getter(getter)
+
+    @final
+    def setter[SetterValueSetT](
+        self, setter: Callable[[Any, ValueSetT], SetterValueSetT], /
+    ) -> Property[ValueGetT, SetterValueSetT]:
+        """
+        Return a new property with the given setter.
+        """
+        return SetterProperty(self, setter)
+
+    @final
+    def default(
+        self, default: Callable[[Any], ValueSetT], /
+    ) -> Property[ValueGetT, ValueSetT]:
+        """
+        Return a new property with the given default value factory.
+        """
+        return DefaultProperty(self, default)
 
 
-class Property[ValueGetT, ValueSetT](_Property[ValueGetT, ValueSetT]):
+class ProxyProperty[ValueGetT, ValueSetT](Property[ValueGetT, ValueSetT]):
     """
-    An object attribute with a definition.
+    A property that proxies everything to another wrapped property.
+    """
+
+    def __init__(self, wrapped: Property[ValueGetT, ValueSetT], /):
+        super().__init__(wrapped.attr)
+        self._wrapped = wrapped
+
+    @override
+    def __set_name__(self, owner: type[Any], name: str) -> None:
+        super().__set_name__(owner, name)
+        self._wrapped.__set_name__(owner, name)
+
+    @override
+    def get(self, instance: Any, /) -> ValueGetT:
+        return self._wrapped.get(instance)
+
+    @override
+    def set(self, instance: Any, value: ValueSetT, /) -> ValueGetT:
+        return self._wrapped.set(instance, value)
+
+
+@final
+class GetterProperty[ValueGetT, ValueSetT](ProxyProperty[ValueGetT, ValueSetT]):
+    """
+    Decorate a property with a getter callable.
+    """
+
+    def __init__[WrappedValueGetT](
+        self,
+        wrapped: Property[WrappedValueGetT, ValueSetT],
+        getter: Callable[[Any, WrappedValueGetT], ValueGetT],
+        /,
+    ):
+        super().__init__(wrapped)
+        self._getter = getter
+
+    @override
+    def get(self, instance: Any, /) -> ValueGetT:
+        return self._getter(instance, self._wrapped.get(instance))
+
+
+@final
+class SetterProperty[ValueGetT, ValueSetT](ProxyProperty[ValueGetT, ValueSetT]):
+    """
+    Decorate a property with a setter callable.
+    """
+
+    def __init__[WrappedValueSetT](
+        self,
+        wrapped: Property[ValueGetT, WrappedValueSetT],
+        setter: Callable[[Any, ValueSetT], WrappedValueSetT],
+        /,
+    ):
+        super().__init__(wrapped)
+        self._setter = setter
+
+    @override
+    def set(self, instance: Any, value: ValueSetT, /) -> ValueGetT:
+        return self._wrapped.set(instance, self._setter(instance, value))
+
+
+@final
+class DefaultProperty[ValueGetT, ValueSetT](ProxyProperty[ValueGetT, ValueSetT]):
+    """
+    Decorate a property with a default value factory.
+    """
+
+    def __init__(
+        self,
+        wrapped: Property[ValueGetT, ValueSetT],
+        default: Callable[[Any], ValueGetT],
+        /,
+    ):
+        super().__init__(wrapped)
+        self._default = default
+
+    @override
+    def get(self, instance: Any, /) -> ValueGetT:
+        # @todo This needs locking!!!
+        # @todo Use LazyReCallable? NO! Because that caches the result, and we must proxy!
+        # @todo
+        try:
+            return self._wrapped.get(instance)
+        except PropertyNotInitialized:
+            value = self._default(instance)
+            setattr(instance, self.name, value)
+        return value
+
+
+class AttrProperty[ValueGetT, ValueSetT](Property[ValueGetT, ValueSetT]):
+    """
+    A property that stores its value in an instance attribute.
     """
 
     def __init__(
@@ -85,8 +217,6 @@ class Property[ValueGetT, ValueSetT](_Property[ValueGetT, ValueSetT]):
         description: ResolvableLocalizable | None = None,
         omit_load: bool | None = None,
         omit_dump: Callable[[ValueGetT], bool] | None = None,
-        resolver: Callable[[ValueSetT], ValueGetT] = passthrough,
-        default: Callable[[], ValueGetT] | None = None,
     ):
         super().__init__(
             AttrDefinition(
@@ -95,30 +225,27 @@ class Property[ValueGetT, ValueSetT](_Property[ValueGetT, ValueSetT]):
                 description=description,
                 omit_load=omit_load,
                 omit_dump=omit_dump,
-            ),
-            resolver=resolver,
+            )
         )
         self._data = data
-        self._label = label
-        self._description = description
-        self._default = default
 
-    @final
     @override
     def get(self, instance: Any, /) -> ValueGetT:
         value = cast(
             ValueGetT | Void,
-            getattr(instance, self._attr_name, Void),
+            getattr(instance, self.name, Void),
         )
         if value is Void:
-            if self._default is None:
-                instance_name = fully_qualified_name(type(instance))
-                raise PropertyNotInitialized(
-                    f"{instance_name}.{self._attr_name[1:]} was never initialized. Either provide a default when initializing the property, or make {instance_name}.__init__() set a value."
-                )
-            value = self._default()
-            setattr(instance, self._attr_name, value)
+            instance_name = fully_qualified_name(type(instance))
+            raise PropertyNotInitialized(
+                f"{instance_name}.{self.name[1:]} was never initialized."
+            )
         return value  # ty:ignore[invalid-return-type]
+
+    @override
+    def set(self, instance: Any, value: ValueSetT, /) -> ValueGetT:
+        setattr(instance, self.name, value)
+        return value
 
 
 @final
@@ -129,7 +256,7 @@ class PropertyNotInitialized(ValueError):
 
 
 @final
-class Optional[ValueGetT, ValueSetT](_Property[ValueGetT | None, ValueSetT | None]):
+class Optional[ValueGetT, ValueSetT](Property[ValueGetT | None, ValueSetT | None]):
     """
     Make another property optional, e.g. allow ``None``.
     """

--- a/betty/test_utils/data.py
+++ b/betty/test_utils/data.py
@@ -12,7 +12,7 @@ from betty.datas.str import StrDefinition
 from betty.importlib import fully_qualified_name
 from betty.locale.localizable.plain import Plain
 from betty.locale.localize import DEFAULT_LOCALIZER
-from betty.property import Optional, Property
+from betty.property import AttrProperty, Optional
 
 
 class DataTestBase[DataT: Data]:
@@ -121,7 +121,7 @@ class DummyData(Data):
     A dummy :py:class:`betty.data.Data` implementation.
     """
 
-    value = Optional(Property(StrDefinition(label="Value")))
+    value = Optional(AttrProperty(StrDefinition(label="Value")))
 
     def __init__(self, /, value: str | None = None):
         self.value = value

--- a/betty/tests/test_property.py
+++ b/betty/tests/test_property.py
@@ -6,8 +6,9 @@ from betty.datas.str import StrDefinition
 from betty.functools import passthrough
 from betty.portable import CallbackPorter
 from betty.property import (
+    AttrProperty,
+    GetterProperty,
     Optional,
-    Property,
     PropertyNotInitialized,
 )
 from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
@@ -16,7 +17,7 @@ from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
 class TestProperty:
     def test___get__(self) -> None:
         class _Owner:
-            my_first_property = Property(StrDefinition(label=DUMMY_LOCALIZABLE))
+            my_first_property = AttrProperty(StrDefinition(label=DUMMY_LOCALIZABLE))
 
         owner = _Owner()
         with pytest.raises(PropertyNotInitialized):
@@ -24,7 +25,7 @@ class TestProperty:
 
     def test_get(self) -> None:
         class _Owner:
-            my_first_property = Property(StrDefinition(label=DUMMY_LOCALIZABLE))
+            my_first_property = AttrProperty(StrDefinition(label=DUMMY_LOCALIZABLE))
 
         owner = _Owner()
         with pytest.raises(PropertyNotInitialized):
@@ -32,7 +33,7 @@ class TestProperty:
 
     def test___set__(self) -> None:
         class _Owner:
-            my_first_property = Property(StrDefinition(label=DUMMY_LOCALIZABLE))
+            my_first_property = AttrProperty(StrDefinition(label=DUMMY_LOCALIZABLE))
 
         owner = _Owner()
         owner.my_first_property = "my-first-value"
@@ -40,7 +41,7 @@ class TestProperty:
 
     def test___set____with_resolver(self) -> None:
         class _Owner:
-            my_first_property = Property[str, str | bool](
+            my_first_property = AttrProperty[str, str | bool](
                 StrDefinition(label=DUMMY_LOCALIZABLE), resolver=str
             )
 
@@ -50,7 +51,7 @@ class TestProperty:
 
     def test___set_name__(self) -> None:
         class _Owner:
-            my_first_property = Property(StrDefinition(label=DUMMY_LOCALIZABLE))
+            my_first_property = AttrProperty(StrDefinition(label=DUMMY_LOCALIZABLE))
 
         assert _Owner.my_first_property._attr_name == "_my_first_property"
 
@@ -58,7 +59,7 @@ class TestProperty:
         data = StrDefinition(label=DUMMY_LOCALIZABLE)
 
         class _Owner:
-            my_first_property = Property(data)
+            my_first_property = AttrProperty(data)
 
         assert _Owner.my_first_property.attr.field("my_first_property").data is data
 
@@ -66,7 +67,7 @@ class TestProperty:
 class TestOptional:
     class _Owner:
         my_first_property = Optional(
-            Property(
+            AttrProperty(
                 DataDefinition(
                     cls=str,
                     label=DUMMY_LOCALIZABLE,
@@ -109,7 +110,7 @@ class TestOptional:
         assert owner.my_first_property is None
 
     def test___set_name__(self) -> None:
-        required_property = Property(StrDefinition(label=DUMMY_LOCALIZABLE))
+        required_property = AttrProperty(StrDefinition(label=DUMMY_LOCALIZABLE))
 
         class _Owner:
             my_first_property = Optional(required_property)
@@ -121,8 +122,26 @@ class TestOptional:
         data = StrDefinition(label=DUMMY_LOCALIZABLE)
 
         class _Owner:
-            my_first_property = Optional(Property(data))
+            my_first_property = Optional(AttrProperty(data))
 
         optional_data = _Owner.my_first_property.attr.data
         assert isinstance(optional_data, OptionalDefinition)
         assert optional_data.wrapped is data
+
+
+class TestGetterProperty:
+    def test_get(self) -> None:
+        class _Owner:
+            my_first_property = GetterProperty(
+                AttrProperty(StrDefinition(label=DUMMY_LOCALIZABLE)),
+                lambda instance, value: value.upper(),
+            )
+
+        owner = _Owner()
+        owner.my_first_property = "Helly, world!"
+        assert owner.my_first_property == "HELLO,WORLD!"
+
+
+class TestSetterProperty:
+    def test_set(self) -> None:
+        raise NotImplementedError


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/4189

## To do
- For getters and setters, if they change the value type, they MUST provide an updated data definition. However, we have no way of creating (modified) copies of data definitions. This really applies to any decorator that changes one of the types.
- Solve the `DefaultProperty` racing problem or find another approach that does not have race conditions, e.g. require an instance's `__init__()` to set a value. We could use locks but with properties being used on entities, of which thousands may exist, we may want to **hook into the instance's `__init__()` instead. Can we extract this functionality from service managers into a new descriptor API?** actually, we cannot use locks because we can't create a unique one for each instance before we have to acquire it.
  - Add getter, setter, and default support to the descriptor API? Allow the getter API to only provide getters that return the same type. Add `AnyGetterDescriptor(Descriptor)` to add getters that change the return type.
  - Add `HasDescriptors` and move `ServiceProvider`'s descriptor init code there.
  - Let's also add something like `BootstrappableDescriptor` and `HasBootstrappableDescriptors` to home the init code currently in `PluginServiceProvider`.
  - Add `GetterDescriptor`, `AnyGetterDescriptor`, `SetterDescriptor`, `DeleterDescriptor`, and `DefaultDescriptor`, all subclasses of `Descriptor` (or even `BootstrappableDescriptor`?
  - How do we handle `BootstrappableDescriptor.getter()` et al returning descriptors that are not bootstrappable? Should they be bootstrappable descriptors as well that just proxy if their upstream is bootstrappable?
- Add an API to get the underlying value? Useful for `Link.has_label` as well as testing.