### PR TITLE
Add a property (descriptor) API

### DIFF
--- a/betty/attr.py
+++ b/betty/attr.py
@@ -4,15 +4,18 @@ Object attributes.
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Self, cast, final, overload, override
+from typing import TYPE_CHECKING, Final, final, override
 
 from betty.data import OptionalDefinition
 from betty.datas.aggregate.record.object import Attr as DataAttr
 from betty.datas.aggregate.record.object import AttrDefinition
-from betty.functools import passthrough
-from betty.importlib import fully_qualified_name
-from betty.typing import Void
+from betty.descriptor import (
+    DeletableDescriptor,
+    DeletableDescriptorProxy,
+    HasDescriptors,
+    SettableDescriptor,
+    SettableDescriptorProxy,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -21,73 +24,52 @@ if TYPE_CHECKING:
     from betty.locale.localizable import ResolvableLocalizable
 
 
-class _Attr[ValueGetT, ValueSetT](DataAttr[ValueGetT], ABC):
-    _attr_name: str
+class Attr[OwnerT: HasDescriptors, GetT, SetT](
+    DataAttr[GetT], SettableDescriptor[OwnerT, GetT, SetT]
+):
+    """
+    An object attribute with a data definition.
+    """
 
-    def __init__(
-        self,
-        attr: AttrDefinition[ValueGetT],
-        *,
-        resolver: Callable[[ValueSetT | ValueGetT], ValueGetT] = passthrough,
-    ):
-        self._attr = attr
-        self._resolver = resolver
-
-    def __set_name__(self, owner: type[Any], name: str) -> None:
-        self._attr_name = f"_{name}"
+    def __init__(self, attr: AttrDefinition[GetT], /):
+        self.__attr = attr
+        self.__owner_attr: Final[str] = f"_{self.descriptor_name}"
 
     @final
     @override
     @property
-    def attr(self) -> AttrDefinition[ValueGetT]:
-        return self._attr
+    def attr(self) -> AttrDefinition[GetT]:
+        return self.__attr
 
-    @overload
-    def __get__(self, instance: None, owner: type[object], /) -> Self:
-        pass
+    @final
+    def _get(self, owner: OwnerT, /) -> GetT:
+        return getattr(owner, self.__owner_attr)
 
-    @overload
-    def __get__(self, instance: Any, owner: type[Any] | None = None, /) -> ValueGetT:
-        pass
+    @final
+    def _set(self, owner: OwnerT, value: SetT, /) -> None:
+        setattr(owner, self.__owner_attr, value)
 
-    def __get__(self, instance, owner=None, /):
-        if instance is None:
-            return self
-        return self.get(instance)
-
-    def __set__(self, instance: Any, value: ValueSetT | ValueGetT) -> None:
-        self.set(instance, value)
-
-    @abstractmethod
-    def get(self, instance: Any, /) -> ValueGetT:
+    @final
+    def default(self, default: Callable[[OwnerT], SetT], /) -> Attr[OwnerT, GetT, SetT]:
         """
-        Get the attribute value from the instance.
+        Return a new attribute with the given default value.
         """
-
-    def set(self, instance: Any, value: ValueSetT, /) -> ValueGetT:
-        """
-        Set the value on the instance.
-        """
-        resolved_value = self._resolver(value)
-        setattr(instance, self._attr_name, resolved_value)
-        return resolved_value
+        return DefaultProperty(self, default)
 
 
-class Attr[ValueGetT, ValueSetT](_Attr[ValueGetT, ValueSetT]):
+class AttrProperty[OwnerT: HasDescriptors, T](Attr[OwnerT, T, T]):
     """
-    An object attribute with a definition.
+    A property value stored in an object attribute.
     """
 
     def __init__(
         self,
-        data: DataDefinition[ValueGetT] | type[Data[DataDefinition[ValueGetT]]],
+        data: DataDefinition[T] | type[Data[DataDefinition[T]]],
         *,
         label: ResolvableLocalizable | None = None,
         description: ResolvableLocalizable | None = None,
         omit_load: bool | None = None,
-        omit_dump: Callable[[ValueGetT], bool] | None = None,
-        resolver: Callable[[ValueSetT], ValueGetT] = passthrough,
-        default: Callable[[], ValueGetT] | None = None,
+        omit_dump: Callable[[T], bool] | None = None,
     ):
         super().__init__(
             AttrDefinition(
@@ -96,32 +78,50 @@ class Attr[ValueGetT, ValueSetT](_Attr[ValueGetT, ValueSetT]):
                 description=description,
                 omit_load=omit_load,
                 omit_dump=omit_dump,
-            ),
-            resolver=resolver,
+            )
         )
-        self._data = data
-        self._label = label
-        self._description = description
-        self._default = default
 
     @final
     @override
-    def get(self, instance: Any, /) -> ValueGetT:
-        value = cast(
-            ValueGetT | Void,
-            getattr(instance, self._attr_name, Void),
-        )
-        if value is Void:
-            if self._default is None:
-                instance_name = fully_qualified_name(type(instance))
-                raise AttrNotInitialized(
-                    f"{instance_name}.{self._attr_name[1:]} was never initialized. Either provide a default when initializing the attribute, or make {instance_name}.__init__() set a value."
-                )
-            value = self._default()
-            setattr(instance, self._attr_name, value)
-        return value  # ty:ignore[invalid-return-type]
+    def get(self, owner: OwnerT, /) -> T:
+        return self._get(owner)
+
+    @override
+    def set(self, owner: OwnerT, value: T, /) -> None:
+        self._set(owner, value)
 
 
+# @todo A property with a default value is not necessarily settable.
+# @todo Examples of this:
+# @todo - collections
+# @todo - read-only properties
+# @todo - computed properties
+# @todo
+@final
+class DefaultProperty[OwnerT: HasDescriptors, GetT, SetT](
+    SettableDescriptorProxy[OwnerT, GetT, SetT],
+    DeletableDescriptorProxy[OwnerT, GetT],
+    Attr[OwnerT, GetT, SetT],
+):
+    """
+    A property with a default value.
+    """
+
+    def __init__(
+        self,
+        proxied: Attr[OwnerT, GetT, SetT],
+        default: Callable[[OwnerT], SetT],
+        /,
+    ):
+        super().__init__(proxied)
+        self._default = default
+
+    @override
+    def init_descriptor(self, owner: OwnerT, /) -> None:
+        self._set(owner, self._default(owner))
+
+
+# @todo This should be refactored into an internal exception for AttrProperty only
 @final
 class AttrNotInitialized(ValueError):
     """
@@ -130,52 +130,39 @@ class AttrNotInitialized(ValueError):
 
 
 @final
-class Optional[ValueGetT, ValueSetT](_Attr[ValueGetT | None, ValueSetT | None]):
+class Optional[OwnerT: HasDescriptors, GetT, SetT](
+    SettableDescriptorProxy[OwnerT, GetT | None, SetT | None],
+    DeletableDescriptor[OwnerT, GetT | None],
+    Attr[OwnerT, GetT | None, SetT | None],
+):
     """
     Make another attribute optional, e.g. allow ``None``.
     """
 
-    def __init__(self, required_attr: Attr[ValueGetT, ValueSetT], /):
-        def _omit_dump(data: ValueGetT | None) -> bool:
+    def __init__(self, proxied: Attr[OwnerT, GetT, SetT], /):
+        def _omit_dump(data: GetT | None) -> bool:
             if data is None:
                 return True
-            if required_attr.attr.omit_dump is None:
+            if proxied.attr.omit_dump is None:
                 return False
-            return required_attr.attr.omit_dump(data)
+            return proxied.attr.omit_dump(data)
 
         super().__init__(
+            proxied,
             AttrDefinition(
-                OptionalDefinition(required_attr.attr.data),
-                label=required_attr.attr.label,
-                description=required_attr.attr.description,
-                omit_load=required_attr.attr.omit_load,
+                OptionalDefinition(proxied.attr.data),
+                label=proxied.attr.label,
+                description=proxied.attr.description,
+                omit_load=proxied.attr.omit_load,
                 omit_dump=_omit_dump,
-            )
+            ),
         )
-        self._required_attr = required_attr
-
-    def __set_name__(self, owner: type[Any], name: str) -> None:
-        super().__set_name__(owner, name)
-        self._required_attr.__set_name__(owner, name)
 
     @override
-    def get(self, instance: Any, /) -> ValueGetT | None:
-        try:
-            return self._required_attr.get(instance)
-        except AttrNotInitialized:
-            return self.set(instance, None)
+    def init_descriptor(self, owner: OwnerT, /) -> None:
+        super().init_descriptor(owner)
+        self._set(owner, None)
 
     @override
-    def set(self, instance: Any, value: ValueSetT | None, /) -> ValueGetT | None:
-        if value is None:
-            return super().set(instance, value)
-        return self._required_attr.set(instance, value)
-
-    def __delete__(self, instance: Any) -> None:
-        self.delete(instance)
-
-    def delete(self, instance: Any, /) -> None:
-        """
-        Delete the value from the instance.
-        """
-        self.set(instance, None)
+    def delete(self, owner: OwnerT, /) -> None:
+        self.set(owner, None)

--- a/betty/attrs/collection/keyed.py
+++ b/betty/attrs/collection/keyed.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any, final, override
 
-from betty.attr import Attr
+from betty.attr import AttrProperty
 from betty.collection.keyed import MutableKeyedCollection
+from betty.descriptor import HasDescriptors
 from betty.functools import passthrough
 
 if TYPE_CHECKING:
@@ -20,7 +21,7 @@ if TYPE_CHECKING:
 class KeyedCollectionAttr[
     MutableKeyedCollectionT: MutableKeyedCollection,
     ValueSetT,
-](Attr[MutableKeyedCollectionT, Iterable[ValueSetT]]):
+](AttrProperty[HasDescriptors, MutableKeyedCollectionT, Iterable[ValueSetT]]):
     """
     An attribute that contains an :py:class:`betty.collection.keyed.KeyedCollection`.
     """
@@ -60,10 +61,8 @@ class KeyedCollectionAttr[
 
     @final
     @override
-    def set(
-        self, instance: Any, value: Iterable[ValueSetT], /
-    ) -> MutableKeyedCollectionT:
-        data = self.get(instance)
+    def set(self, owner: Any, value: Iterable[ValueSetT], /) -> MutableKeyedCollectionT:
+        data = self.get(owner)
         data.clear()
         data.add(*self._values_resolver(value))
         return data

--- a/betty/attrs/collection/mapping.py
+++ b/betty/attrs/collection/mapping.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 from collections.abc import Mapping, MutableMapping
 from typing import TYPE_CHECKING, Any, final, override
 
-from betty.attr import Attr
+from betty.attr import AttrProperty
+from betty.descriptor import HasDescriptors
 from betty.functools import passthrough
 
 if TYPE_CHECKING:
@@ -24,7 +25,7 @@ class MappingAttr[
     KeyGetT,
     ItemGetT,
     ValueSetT,
-](Attr[MutableMappingT, ValueSetT]):
+](AttrProperty[HasDescriptors, MutableMappingT, ValueSetT]):
     """
     An attribute that contains a :py:class:`collections.abc.MutableMapping`.
     """
@@ -71,8 +72,8 @@ class MappingAttr[
 
     @final
     @override
-    def set(self, instance: Any, value: ValueSetT, /) -> MutableMappingT:
-        data = self.get(instance)
+    def set(self, owner: Any, value: ValueSetT, /) -> MutableMappingT:
+        data = self.get(owner)
         data.clear()
         data.update(self._mapping_resolver(value))
         return data

--- a/betty/attrs/collection/sequence.py
+++ b/betty/attrs/collection/sequence.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 from collections.abc import Iterable, MutableSequence
 from typing import TYPE_CHECKING, Any, final, override
 
-from betty.attr import Attr
+from betty.attr import AttrProperty
+from betty.descriptor import HasDescriptors
 from betty.functools import passthrough
 
 if TYPE_CHECKING:
@@ -19,8 +20,8 @@ if TYPE_CHECKING:
     from betty.typing import Intersection
 
 
-class SequenceAttr[MutableSequenceT: MutableSequence[Any], ItemGetT, ValueSetT](
-    Attr[MutableSequenceT, ValueSetT]
+class SequenceProperty[MutableSequenceT: MutableSequence[Any], ItemGetT, ValueSetT](
+    AttrProperty[HasDescriptors, MutableSequenceT, ValueSetT]
 ):
     """
     An attribute that contains a :py:class:`collections.abc.MutableSequence`.
@@ -68,8 +69,8 @@ class SequenceAttr[MutableSequenceT: MutableSequence[Any], ItemGetT, ValueSetT](
 
     @final
     @override
-    def set(self, instance: Any, value: ValueSetT, /) -> MutableSequenceT:
-        data = self.get(instance)
+    def set(self, owner: Any, value: ValueSetT, /) -> MutableSequenceT:
+        data = self.get(owner)
         data.clear()
         data.extend(self._sequence_resolver(value))
         return data

--- a/betty/attrs/countable_localizable.py
+++ b/betty/attrs/countable_localizable.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 
 from typing import final
 
-from betty.attr import Attr
+from betty.attr import AttrProperty
 from betty.datas.countable_localizable import CountableLocalizableDefinition
+from betty.descriptor import HasDescriptors
 from betty.locale.localizable import (
     CountableLocalizable,
     ResolvableCountableLocalizable,
@@ -17,8 +18,8 @@ from betty.locale.localizable import (
 
 
 @final
-class CountableLocalizableAttr(
-    Attr[CountableLocalizable, ResolvableCountableLocalizable]
+class CountableLocalizableProperty(
+    AttrProperty[HasDescriptors, CountableLocalizable, ResolvableCountableLocalizable]
 ):
     """
     An attribute containing a :py:class:`betty.locale.localizable.CountableLocalizable`.

--- a/betty/attrs/date.py
+++ b/betty/attrs/date.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, override
 
-from betty.attr import Attr, Optional
+from betty.attr import AttrProperty, Optional
 from betty.datas.date import AnyDateDefinition
 from betty.date import AnyDate, Date
 from betty.date.linked_data import (
@@ -14,6 +14,7 @@ from betty.date.linked_data import (
     dump_linked_data_for_date_range,
 )
 from betty.date.schema import ResolvableDateSchema
+from betty.descriptor import HasDescriptors
 from betty.linked_data import JsonLdObject, LinkedDataDumpableWithSchemaJsonLdObject
 from betty.privacy.resolve import is_public
 
@@ -22,12 +23,12 @@ if TYPE_CHECKING:
     from betty.project import Project
 
 
-class HasAnyDate(LinkedDataDumpableWithSchemaJsonLdObject):
+class HasAnyDate(LinkedDataDumpableWithSchemaJsonLdObject, HasDescriptors):
     """
     A resource with date information.
     """
 
-    date = Optional(Attr(AnyDateDefinition()))
+    date = Optional(AttrProperty(AnyDateDefinition()))
     """
     The date.
     """

--- a/betty/attrs/description.py
+++ b/betty/attrs/description.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, override
 
 from betty.attr import Optional
 from betty.attrs.localizable import LocalizableAttr
+from betty.descriptor import HasDescriptors
 from betty.linked_data import (
     JsonLdObject,
     LinkedDataDumpableWithSchemaJsonLdObject,
@@ -24,7 +25,7 @@ if TYPE_CHECKING:
     from betty.project import Project
 
 
-class HasDescription(LinkedDataDumpableWithSchemaJsonLdObject):
+class HasDescription(LinkedDataDumpableWithSchemaJsonLdObject, HasDescriptors):
     """
     Data with a description.
     """

--- a/betty/attrs/locale.py
+++ b/betty/attrs/locale.py
@@ -6,8 +6,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, final, override
 
-from betty.attr import Attr, Optional
+from babel import Locale
+
+from betty.attr import AttrProperty, Optional
 from betty.datas.locale import LocaleDefinition
+from betty.descriptor import HasDescriptors
 from betty.json_schema import Null, OneOf
 from betty.linked_data import JsonLdObject, LinkedDataDumpableWithSchemaJsonLdObject
 from betty.locale import Localized, ResolvableLocale, resolve_locale, to_language_tag
@@ -21,7 +24,7 @@ if TYPE_CHECKING:
 
 
 @final
-class LocaleAttr(Attr):
+class LocaleAttr(AttrProperty[HasDescriptors, Locale, ResolvableLocale]):
     """
     An attribute containing a locale.
     """
@@ -40,7 +43,7 @@ class LocaleAttr(Attr):
         )
 
 
-class HasLocale(Localized, LinkedDataDumpableWithSchemaJsonLdObject):
+class HasLocale(Localized, LinkedDataDumpableWithSchemaJsonLdObject, HasDescriptors):
     """
     A resource that is localized, e.g. contains information in a specific locale.
     """

--- a/betty/attrs/localizable.py
+++ b/betty/attrs/localizable.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 
 from typing import final
 
-from betty.attr import Attr
+from betty.attr import AttrProperty
 from betty.datas.localizable import LocalizableDefinition
+from betty.descriptor import HasDescriptors
 from betty.locale.localizable import (
     Localizable,
     ResolvableLocalizable,
@@ -16,7 +17,9 @@ from betty.locale.localizable import (
 
 
 @final
-class LocalizableAttr(Attr[Localizable, ResolvableLocalizable]):
+class LocalizableProperty(
+    AttrProperty[HasDescriptors, Localizable, ResolvableLocalizable]
+):
     """
     An attribute containing a :py:class:`betty.locale.localizable.Localizable`.
     """

--- a/betty/attrs/machine_name.py
+++ b/betty/attrs/machine_name.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, final
 
-from betty.attr import Attr
+from betty.attr import AttrProperty
 from betty.locale.localizable.gettext import _
 from betty.machine_name import _MACHINE_NAME_DESCRIPTION, MachineName
 
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 @final
-class MachineNameAttr(Attr):
+class MachineNameProperty(AttrProperty):
     """
     An attribute containing a machine name.
     """

--- a/betty/attrs/media_type.py
+++ b/betty/attrs/media_type.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, final, override
 
-from betty.attr import Attr, Optional
+from betty.attr import AttrProperty, Optional
+from betty.descriptor import HasDescriptors
 from betty.linked_data import JsonLdObject, LinkedDataDumpableWithSchemaJsonLdObject
 from betty.media_type import MediaType, ResolvableMediaType, resolve_media_type
 from betty.media_type.schema import MediaTypeSchema
@@ -21,7 +22,7 @@ if TYPE_CHECKING:
 
 
 @final
-class MediaTypeAttr(Attr[MediaType, ResolvableMediaType]):
+class MediaTypeAttr(AttrProperty[HasDescriptors, MediaType, ResolvableMediaType]):
     """
     An attribute containing a media type.
     """
@@ -46,7 +47,7 @@ class MediaTypeAttr(Attr[MediaType, ResolvableMediaType]):
         )
 
 
-class HasMediaType(LinkedDataDumpableWithSchemaJsonLdObject):
+class HasMediaType(LinkedDataDumpableWithSchemaJsonLdObject, HasDescriptors):
     """
     A resource with an `IANA media type <https://www.iana.org/assignments/media-types/media-types.xhtml>`_.
     """

--- a/betty/attrs/privacy.py
+++ b/betty/attrs/privacy.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Literal, final, override
 
-from betty.attr import Attr
+from betty.attr import AttrProperty
 from betty.datas.enum import EnumDefinition
+from betty.descriptor import HasDescriptors
 from betty.linked_data import LinkedDataDumper
 from betty.locale.localizable.gettext import _
 from betty.privacy import Privacy
@@ -18,7 +19,10 @@ if TYPE_CHECKING:
 
 
 @final
-class PrivacyAttr(Attr, LinkedDataDumper[object, PrivacySchema, bool]):
+class PrivacyAttr(
+    AttrProperty[HasDescriptors, Privacy],
+    LinkedDataDumper[HasDescriptors, PrivacySchema, bool],
+):
     """
     An attribute containing a privacy.
     """
@@ -31,15 +35,13 @@ class PrivacyAttr(Attr, LinkedDataDumper[object, PrivacySchema, bool]):
         return PrivacySchema()
 
     @override
-    async def dump_linked_data_for(self, project: Project, target: object, /) -> bool:
-        if isinstance(target, HasPrivacy):
-            privacy = target.privacy
-        else:
-            privacy = getattr(target, self._attr_name)
-        return privacy is Privacy.PRIVATE
+    async def dump_linked_data_for(
+        self, project: Project, target: HasDescriptors, /
+    ) -> bool:
+        return self.get(target) is Privacy.PRIVATE
 
 
-class HasPrivacy:
+class HasPrivacy(HasDescriptors):
     """
     A resource that has privacy.
     """

--- a/betty/date/__init__.py
+++ b/betty/date/__init__.py
@@ -13,7 +13,8 @@ from typing import TYPE_CHECKING, Any, final, override
 
 from babel import dates
 
-from betty.attr import Attr, Optional
+from betty.attr import Attr as Attr
+from betty.attr import AttrProperty, Optional
 from betty.data import Data
 from betty.datas.aggregate.record.object import ObjectDefinition
 from betty.datas.bool import BoolDefinition
@@ -80,10 +81,10 @@ class Date(Localizable, Data):
         (False,): _("{date}"),
     }
 
-    year = Optional(Attr(IntDefinition(label=_("Year"))))
-    month = Optional(Attr(IntDefinition(label=_("Month"))))
-    day = Optional(Attr(IntDefinition(label=_("Day"))))
-    fuzzy = Attr(
+    year = Optional(AttrProperty(IntDefinition(label=_("Year"))))
+    month = Optional(AttrProperty(IntDefinition(label=_("Month"))))
+    day = Optional(AttrProperty(IntDefinition(label=_("Day"))))
+    fuzzy = AttrProperty(
         BoolDefinition(label=_("Fuzzy")),
         omit_load=True,
         omit_dump=lambda data: data is False,
@@ -274,14 +275,14 @@ class DateRange(Localizable, Data):
         (None, None, True, True): _("sometime before around {end_date}"),
     }
 
-    start = Optional(Attr(Date))
-    start_is_boundary = Attr(
+    start = Optional(AttrProperty(Date))
+    start_is_boundary = AttrProperty(
         BoolDefinition(label=_("Start date is a boundary")),
         omit_load=True,
         omit_dump=lambda data: data is False,
     )
-    end = Optional(Attr(Date))
-    end_is_boundary = Attr(
+    end = Optional(AttrProperty(Date))
+    end_is_boundary = AttrProperty(
         BoolDefinition(label=_("End date is a boundary")),
         omit_load=True,
         omit_dump=lambda data: data is False,

--- a/betty/descriptor.py
+++ b/betty/descriptor.py
@@ -1,0 +1,310 @@
+"""
+The descriptor API.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from inspect import getmembers
+from typing import TYPE_CHECKING, Any, Self, final, overload, override
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class HasDescriptors:
+    """
+    An object that has :py:class:`descriptors <betty.descriptor.Descriptors>`.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        # @todo Can we do this once per class? getmembers() is quite slow and we don't want this to impact entities negatively.
+        for _, member in getmembers(type(self)):
+            # @todo This can result in descriptors to be initialized with the wrong HasDescriptions subclass?
+            if isinstance(member, Descriptor):
+                member.init_descriptor(self)
+
+
+class Descriptor[OwnerT: HasDescriptors, GetT](ABC):
+    """
+    A `descriptor <https://docs.python.org/3/howto/descriptor.html>`_.
+    """
+
+    __name: str
+    __owner: type[OwnerT]
+
+    def __set_name__(self, owner: type[OwnerT], name: str) -> None:
+        self.__owner = owner
+        self.__name = name
+
+    @final
+    @property
+    def descriptor_owner(self) -> type[OwnerT]:
+        """
+        The descriptor owner.
+        """
+        return self.__owner
+
+    @final
+    @property
+    def descriptor_name(self) -> str:
+        """
+        The descriptor name.
+        """
+        return self.__name
+
+    def init_descriptor(self, owner: OwnerT, /) -> None:  # noqa: B027
+        """
+        Initialize the descriptor.
+        """
+
+    @overload
+    def __get__(self, instance: None, owner: type[OwnerT], /) -> Self:
+        pass
+
+    @overload
+    def __get__(self, instance: OwnerT, owner: type[OwnerT] | None = None, /) -> GetT:
+        pass
+
+    @final
+    def __get__(self, instance, owner=None, /):
+        if instance is None:
+            return self
+        return self.get(instance)
+
+    @abstractmethod
+    def get(self, owner: OwnerT, /) -> GetT:
+        """
+        Get the descriptor value from the owner.
+        """
+
+    def getter(
+        self, getter: Callable[[OwnerT, GetT], GetT], /
+    ) -> Descriptor[OwnerT, GetT]:
+        """
+        Return a new descriptor with the given getter.
+        """
+        return GetterDescriptor(self, getter)
+
+    def __call__(
+        self, getter: Callable[[OwnerT, GetT], GetT], /
+    ) -> Descriptor[OwnerT, GetT]:
+        """
+        Return a new descriptor with the given getter.
+        """
+        return self.getter(getter)
+
+
+class GettableDescriptor[OwnerT: HasDescriptors, GetT](Descriptor[OwnerT, GetT], ABC):
+    """
+    A descriptor that can get a value.
+    """
+
+    @overload
+    def getter(
+        self, getter: Callable[[OwnerT, GetT], GetT], /
+    ) -> Descriptor[OwnerT, GetT]:
+        pass
+
+    @overload
+    def getter[GetterGetT](
+        self, getter: Callable[[OwnerT, GetT], GetterGetT], /
+    ) -> GettableDescriptor[OwnerT, GetterGetT]:
+        pass
+
+    @override
+    def getter(self, getter, /):
+        return GetterDescriptor(self, getter)
+
+    @override
+    def __call__[GetterGetT](
+        self, getter: Callable[[OwnerT, GetT], GetterGetT], /
+    ) -> Descriptor[OwnerT, GetterGetT]:
+        return self.__call__(getter)
+
+
+class SettableDescriptor[OwnerT: HasDescriptors, GetT, SetT](
+    Descriptor[OwnerT, GetT], ABC
+):
+    """
+    A descriptor that can set a value.
+    """
+
+    @abstractmethod
+    def set(self, owner: OwnerT, value: SetT, /) -> None:
+        """
+        Set the value on the owner.
+
+        :raises AttributeError: Raised if the descriptor is not settable.
+        """
+
+    @final
+    def __set__(self, owner: OwnerT, value: SetT) -> None:
+        """
+        Set the value on the owner.
+
+        :raises AttributeError: Raised if the descriptor is not settable.
+        """
+        self.set(owner, value)
+
+    @final
+    def setter[SetterSetT](
+        self, setter: Callable[[OwnerT, SetterSetT], SetT], /
+    ) -> SetterDescriptor[OwnerT, GetT, SetterSetT]:
+        """
+        Return a new descriptor with the given setter.
+        """
+        return SetterDescriptor(self, setter)
+
+
+class DeletableDescriptor[OwnerT: HasDescriptors, GetT](Descriptor[OwnerT, GetT], ABC):
+    """
+    A descriptor that can delete a value.
+    """
+
+    @abstractmethod
+    def delete(self, owner: OwnerT, /) -> None:
+        """
+        Delete the value from the owner.
+
+        :raises AttributeError: Raised if the descriptor is not deletable.
+        """
+
+    @final
+    def __delete__(self, owner: OwnerT) -> None:
+        """
+        Delete the value from the owner.
+
+        :raises AttributeError: Raised if the descriptor is not deletable.
+        """
+        self.delete(owner)
+
+
+class DescriptorProxy[OwnerT: HasDescriptors, GetT](Descriptor[OwnerT, GetT]):
+    """
+    A descriptor proxy.
+    """
+
+    def __init__(self, proxied: Descriptor, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.__proxied = proxied
+
+    @override
+    def __set_name__(self, owner: type[OwnerT], name: str) -> None:
+        super().__set_name__(owner, name)
+        self.__proxied.__set_name__(owner, name)
+
+    @override
+    def get(self, owner: OwnerT, /) -> GetT:
+        return self.__proxied.get(owner)
+
+
+class SettableDescriptorProxy[OwnerT: HasDescriptors, GetT, SetT](
+    DescriptorProxy[OwnerT, GetT],
+    SettableDescriptor[OwnerT, GetT, SetT],
+):
+    """
+    A descriptor that proxies the setting of a value to another upstream descriptor.
+    """
+
+    def __init__(
+        self,
+        proxied: SettableDescriptor[OwnerT, GetT, SetT],
+        *args: Any,
+        **kwargs: Any,
+    ):
+        super().__init__(proxied, *args, **kwargs)
+        self.__settable_proxied = proxied
+
+    @final
+    @override
+    def set(self, owner: OwnerT, value: SetT, /) -> None:
+        self.__settable_proxied.set(owner, value)
+
+
+class DeletableDescriptorProxy[OwnerT: HasDescriptors, GetT](
+    DescriptorProxy[OwnerT, GetT], DeletableDescriptor[OwnerT, GetT]
+):
+    """
+    A descriptor that proxies the deletion of a value to another upstream descriptor.
+    """
+
+    def __init__(
+        self, proxied: DeletableDescriptor[OwnerT, GetT], *args: Any, **kwargs: Any
+    ):
+        super().__init__(proxied, *args, **kwargs)
+        self.__deletable_proxied = proxied
+
+    @final
+    @override
+    def delete(self, owner: OwnerT, /) -> None:
+        self.__deletable_proxied.delete(owner)
+
+
+class DataDescriptorProxy(SettableDescriptorProxy, DeletableDescriptorProxy):
+    """
+    A data descriptor that proxies to another upstream descriptor.
+    """
+
+
+@final
+class GetterDescriptor[OwnerT: HasDescriptors, GetT, SetT](
+    GettableDescriptor[OwnerT, GetT],
+    SettableDescriptorProxy[OwnerT, GetT, SetT],
+    DeletableDescriptorProxy[OwnerT, GetT],
+):
+    """
+    Decorate a descriptor with a getter callable.
+    """
+
+    def __init__[UpstreamGetT](
+        self,
+        proxied: Descriptor[OwnerT, UpstreamGetT],
+        getter: Callable[[OwnerT, UpstreamGetT], GetT],
+        /,
+    ):
+        super().__init__(
+            # @todo Can we type this better?
+            proxied,  # ty:ignore[invalid-argument-type]
+        )
+        self._proxied = proxied
+        self._getter = getter
+
+    @override
+    def get(self, owner: OwnerT, /) -> GetT:
+        return self._getter(owner, self._proxied.get(owner))
+
+
+@final
+class SetterDescriptor[OwnerT: HasDescriptors, GetT, SetT](
+    SettableDescriptor[OwnerT, GetT, SetT],
+    DeletableDescriptorProxy[OwnerT, GetT],
+):
+    """
+    Decorate a descriptor with a setter callable.
+    """
+
+    def __init__[UpstreamSetT](
+        self,
+        proxied: SettableDescriptor[OwnerT, GetT, UpstreamSetT],
+        setter: Callable[[OwnerT, SetT], UpstreamSetT],
+        /,
+    ):
+        super().__init__(
+            # @todo Can we type this better?
+            proxied,  # ty:ignore[invalid-argument-type]
+        )
+        self._proxied = proxied
+        self._setter = setter
+
+    @override
+    def set(self, owner: OwnerT, value: SetT, /) -> None:
+        return self._proxied.set(owner, self._setter(owner, value))
+
+
+@final
+class DescriptorNotInitialized(ValueError):
+    """
+    Raised when a class failed to initialize a value for a :py:class:`betty.descriptor.Descriptor`.
+    """

--- a/betty/entity/reference.py
+++ b/betty/entity/reference.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, final
 
-from betty.attr import Attr
+from betty.attr import AttrProperty
 from betty.attrs.machine_name import MachineNameAttr
 from betty.data import Data, Sample
 from betty.datas.aggregate.record.object import ObjectDefinition
@@ -38,7 +38,7 @@ class EntityReference(Data):
     The type of the referenced entity. 
     """
 
-    id = Attr(StrDefinition(label=_("Entity ID")))
+    id = AttrProperty(StrDefinition(label=_("Entity ID")))
     """
     The ID of the referenced entity.
     """

--- a/betty/plugins/content/box.py
+++ b/betty/plugins/content/box.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from asyncio import gather
 from typing import TYPE_CHECKING, Self, final, override
 
-from betty.attr import Attr, Optional
+from betty.attr import AttrProperty, Optional
 from betty.attrs.plugin_manufacturer_sequence import (
     PluginManufacturerSequenceAttr,
 )
@@ -64,12 +64,12 @@ class BoxData(Data):
     The content within this box.
     """
 
-    min_height = Optional(Attr(StrDefinition(label=_("Minimum height"))))
-    max_height = Optional(Attr(StrDefinition(label=_("Maximum height"))))
-    height = Optional(Attr(StrDefinition(label=_("Height"))))
-    min_width = Optional(Attr(StrDefinition(label=_("Minimum width"))))
-    max_width = Optional(Attr(StrDefinition(label=_("Maximum width"))))
-    width = Optional(Attr(StrDefinition(label=_("Width"))))
+    min_height = Optional(AttrProperty(StrDefinition(label=_("Minimum height"))))
+    max_height = Optional(AttrProperty(StrDefinition(label=_("Maximum height"))))
+    height = Optional(AttrProperty(StrDefinition(label=_("Height"))))
+    min_width = Optional(AttrProperty(StrDefinition(label=_("Minimum width"))))
+    max_width = Optional(AttrProperty(StrDefinition(label=_("Maximum width"))))
+    width = Optional(AttrProperty(StrDefinition(label=_("Width"))))
 
     def __init__(
         self,

--- a/betty/plugins/content/raspberry_mint_color_style.py
+++ b/betty/plugins/content/raspberry_mint_color_style.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from asyncio import gather
 from typing import TYPE_CHECKING, Self, final, override
 
-from betty.attr import Attr
+from betty.attr import AttrProperty
 from betty.attrs.plugin_manufacturer_sequence import (
     PluginManufacturerSequenceAttr,
 )
@@ -55,7 +55,7 @@ class ColorStyleData(Data):
     The content within this color style.
     """
 
-    style = Attr(EnumDefinition(cls=RaspberryMintColorStyle, label=_("Style")))
+    style = AttrProperty(EnumDefinition(cls=RaspberryMintColorStyle, label=_("Style")))
     """
     The style.
     """

--- a/betty/plugins/content/raspberry_mint_columns.py
+++ b/betty/plugins/content/raspberry_mint_columns.py
@@ -15,7 +15,7 @@ from betty.assertion import (
     assert_or,
     assert_sequence,
 )
-from betty.attr import Attr, Optional
+from betty.attr import AttrProperty, Optional
 from betty.content import Content, ContentDefinition, ContentManufacturer, build
 from betty.data import Data
 from betty.datas.aggregate.collection.mapping import MappingDefinition
@@ -123,7 +123,7 @@ class ColumnsData(Data):
     _DEFAULT_WIDTH: ClassVar[ColumnsWidth] = {Breakpoint.XS: [12]}
     _width: ColumnsWidth
 
-    content = Attr(
+    content = AttrProperty(
         SequenceDefinition(
             cls=list,
             value=PluginManufacturerSequenceDefinition(
@@ -137,13 +137,13 @@ class ColumnsData(Data):
     """
 
     justify_content = Optional(
-        Attr(EnumDefinition(cls=JustifyContent, label=_("Justify content")))
+        AttrProperty(EnumDefinition(cls=JustifyContent, label=_("Justify content")))
     )
     """
     If and how to justify content.
     """
 
-    width = Attr(
+    width = AttrProperty(
         MappingDefinition(
             cls=dict,
             key=EnumDefinition(

--- a/betty/plugins/content/raspberry_mint_presences.py
+++ b/betty/plugins/content/raspberry_mint_presences.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Self, final, override
 
-from betty.attr import Attr, Optional
+from betty.attr import AttrProperty, Optional
 from betty.content import ContentDefinition
 from betty.data import Data
 from betty.datas.aggregate.collection.sequence import SequenceDefinition
@@ -54,14 +54,18 @@ class PresencesData(Data):
     """
 
     exclude = Optional(
-        Attr(SequenceDefinition(cls=list, value=MachineName, label=_("Exclude")))
+        AttrProperty(
+            SequenceDefinition(cls=list, value=MachineName, label=_("Exclude"))
+        )
     )
     """
     The presence roles for which to exclude presences.
     """
 
     include = Optional(
-        Attr(SequenceDefinition(cls=list, value=MachineName, label=_("Include")))
+        AttrProperty(
+            SequenceDefinition(cls=list, value=MachineName, label=_("Include"))
+        )
     )
     """
     The presence roles for which to include presences.

--- a/betty/plugins/content/raspberry_mint_section.py
+++ b/betty/plugins/content/raspberry_mint_section.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from asyncio import gather
 from typing import TYPE_CHECKING, Self, final, override
 
-from betty.attr import Attr, Optional
+from betty.attr import AttrProperty, Optional
 from betty.attrs.localizable import LocalizableAttr
 from betty.attrs.machine_name import MachineNameAttr
 from betty.attrs.plugin_manufacturer_sequence import (
@@ -74,7 +74,7 @@ class SectionData(Data):
     """
 
     visually_hide_heading = Optional(
-        Attr(
+        AttrProperty(
             BoolDefinition(label=_("Visually hide heading")),
             omit_load=True,
             omit_dump=lambda data: data is False,

--- a/betty/plugins/enricher/wiki/__init__.py
+++ b/betty/plugins/enricher/wiki/__init__.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Self, final, override
 
-from betty.attr import Attr, Optional
+from betty.attr import Attr as Attr
+from betty.attr import AttrProperty, Optional
 from betty.data import Data
 from betty.datas.aggregate.record.object import ObjectDefinition
 from betty.datas.bool import BoolDefinition
@@ -37,7 +38,7 @@ class WikiData(Data):
     """
 
     populate_images = Optional(
-        Attr(
+        AttrProperty(
             BoolDefinition(
                 label=_("Populate images"),
                 description=_(

--- a/betty/plugins/extension/raspberry_mint/__init__.py
+++ b/betty/plugins/extension/raspberry_mint/__init__.py
@@ -9,7 +9,8 @@ from collections import defaultdict
 from enum import Enum
 from typing import TYPE_CHECKING, Final, Self, final, override
 
-from betty.attr import Attr, Optional
+from betty.attr import Attr as Attr
+from betty.attr import AttrProperty, Optional
 from betty.attrs.collection.mapping import MappingAttr
 from betty.collection.mapping import MutableResolvedMapping, ResolvedMapping
 from betty.collection.mapping.adapter import (
@@ -40,6 +41,7 @@ from betty.plugins.extension.webpack import Webpack
 from betty.plugins.extension.webpack.build import EntryPointProvider
 from betty.project import Project
 from betty.project.generate import Generator
+from betty.properties.collection.mapping import MappingProperty as MappingProperty
 from betty.sample import Sample, Size
 from betty.service import ServiceProvider
 from betty.service.simple import service
@@ -91,17 +93,21 @@ class RaspberryMintData(Data):
     .. data:: betty.plugins.extension.raspberry_mint:RaspberryMintData
     """
 
-    primary_color = Optional(Attr(ColorDefinition(), label=_("Primary color")))
+    primary_color = Optional(AttrProperty(ColorDefinition(), label=_("Primary color")))
     """
     The primary color.
     """
 
-    secondary_color = Optional(Attr(ColorDefinition(), label=_("Secondary color")))
+    secondary_color = Optional(
+        AttrProperty(ColorDefinition(), label=_("Secondary color"))
+    )
     """
     The secondary color.
     """
 
-    tertiary_color = Optional(Attr(ColorDefinition(), label=_("Tertiary color")))
+    tertiary_color = Optional(
+        AttrProperty(ColorDefinition(), label=_("Tertiary color"))
+    )
     """
     The tertiary color.
     """

--- a/betty/plugins/loader/gramps/__init__.py
+++ b/betty/plugins/loader/gramps/__init__.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 from collections.abc import Mapping, MutableMapping
 from typing import TYPE_CHECKING, Self, final, override
 
-from betty.attr import Attr, Optional
+from betty.attr import Attr as Attr
+from betty.attr import AttrProperty, Optional
 from betty.attrs.collection.mapping import MappingAttr
 from betty.attrs.collection.sequence import SequenceAttr
 from betty.collection.mapping import MutableResolvedMapping
@@ -36,6 +37,8 @@ from betty.plugin.cls import Plugin
 from betty.plugin.factory import PluginManufacturer, ResolvablePluginManufacturer
 from betty.plugins.loader.gramps.jobs import LoadAncestry
 from betty.project import Project
+from betty.properties.collection.mapping import MappingProperty as MappingProperty
+from betty.properties.collection.sequence import SequenceProperty as SequenceProperty
 from betty.role import Role, RoleDefinition, RoleManufacturer
 from betty.sample import Sample, Size
 
@@ -121,12 +124,12 @@ class FamilyTree(Data):
     How to map event types.
     """
 
-    file = Optional(Attr(PathDefinition(), label=_("File")))
+    file = Optional(AttrProperty(PathDefinition(), label=_("File")))
     """
     The path to a Gramps family tree file.
     """
 
-    name = Optional(Attr(StrDefinition(label=_("Name"))))
+    name = Optional(AttrProperty(StrDefinition(label=_("Name"))))
     """
     The family tree's name in Gramps.
     """
@@ -253,7 +256,7 @@ class GrampsData(Data):
     The Gramps family trees to load.
     """
 
-    executable = Optional(Attr(PathDefinition()))
+    executable = Optional(AttrProperty(PathDefinition()))
     """
     The path to a specific Gramps executable.
 

--- a/betty/project/__init__.py
+++ b/betty/project/__init__.py
@@ -22,7 +22,8 @@ from betty.about import VERSION_MAJOR
 from betty.app import App
 from betty.assertion import assert_number, assert_url
 from betty.asset import AssetRepositoryService
-from betty.attr import Attr, Optional
+from betty.attr import Attr as Attr
+from betty.attr import AttrProperty, Optional
 from betty.attrs.collection.keyed import KeyedCollectionAttr
 from betty.attrs.collection.sequence import SequenceAttr
 from betty.attrs.localizable import LocalizableAttr
@@ -56,6 +57,7 @@ from betty.datas.path import PathDefinition
 from betty.datas.place_type_definition import PlaceTypeDefinitionData
 from betty.datas.role_definition import RoleDefinitionData
 from betty.datas.str import StrDefinition
+from betty.descriptor import HasDescriptors
 from betty.dirs import BUILTIN_ASSET_DIRECTORY
 from betty.document import Document, DocumentProviderDefinition
 from betty.entity import EntityDefinition
@@ -99,6 +101,15 @@ from betty.plugin.resolve import (
     resolve_plugin_id,
 )
 from betty.privacy.privatizer import Privatizer
+from betty.properties.collection.keyed import (
+    KeyedCollectionProperty as KeyedCollectionProperty,
+)
+from betty.properties.collection.sequence import SequenceProperty as SequenceProperty
+from betty.properties.localizable import LocalizableProperty as LocalizableProperty
+from betty.properties.machine_name import MachineNameProperty as MachineNameProperty
+from betty.properties.plugin_definitions import (
+    PluginDefinitionDatasProperty as PluginDefinitionDatasProperty,
+)
 from betty.render import RenderDispatcher, RendererDefinition
 from betty.role import RoleDefinition
 from betty.sample import Sample, Size
@@ -761,7 +772,7 @@ class ProjectLocale(Data["ObjectDefinition"]):
         ),
     ],
 )
-class ProjectData(Data):
+class ProjectData(Data, HasDescriptors):
     """
     Configuration for a :py:class:`betty.project.Project`.
 
@@ -773,7 +784,7 @@ class ProjectData(Data):
     The project's author.
     """
 
-    clean_urls = Attr(
+    clean_urls = AttrProperty(
         BoolDefinition(
             label=_("Clean URLs"),
             description=_(
@@ -788,7 +799,7 @@ class ProjectData(Data):
     """
 
     copyright_notice = Optional(
-        Attr(
+        AttrProperty(
             CopyrightNoticeManufacturer,
             omit_load=True,
             omit_dump=lambda data: data == ProjectData._default_copyright_notice(),
@@ -807,7 +818,7 @@ class ProjectData(Data):
     The :py:class:`betty.copyright_notice.CopyrightNotice` plugins created by this project.
     """
 
-    debug = Attr(
+    debug = AttrProperty(
         BoolDefinition(
             label=_("Debugging mode"),
             description=_(
@@ -886,7 +897,7 @@ class ProjectData(Data):
     """
 
     license = Optional(
-        Attr(
+        AttrProperty(
             LicenseManufacturer,
             omit_load=True,
             omit_dump=lambda data: data == ProjectData._default_license(),
@@ -903,7 +914,7 @@ class ProjectData(Data):
     The :py:class:`betty.license.License` plugins created by this project.
     """
 
-    lifetime_threshold = Attr(
+    lifetime_threshold = AttrProperty(
         IntDefinition(
             label=_("Lifetime threshold"),
             description=_(
@@ -960,7 +971,7 @@ class ProjectData(Data):
     The configured locales.
     """
 
-    logo = Optional(Attr(PathDefinition(), label=_("Logo")))
+    logo = Optional(AttrProperty(PathDefinition(), label=_("Logo")))
     """
     The project logo.
     """
@@ -987,7 +998,7 @@ class ProjectData(Data):
     The human-readable project title.
     """
 
-    url = Attr(
+    url = AttrProperty(
         StrDefinition(
             label=_("URL"),
             description=_(

--- a/betty/service/__init__.py
+++ b/betty/service/__init__.py
@@ -4,11 +4,13 @@ An API for providing application-wide services.
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass
-from inspect import getmembers
-from typing import TYPE_CHECKING, Any, Self, final, overload
+from typing import TYPE_CHECKING, Any, final, override
+
+from betty.descriptor import Descriptor as Descriptor
+from betty.descriptor import GettableDescriptor, HasDescriptors
 
 if TYPE_CHECKING:
     from betty.service_level import ServiceLevel
@@ -28,7 +30,7 @@ type ServiceOrFactory[ServiceProviderT: ServiceProvider, ServiceT, FactoryServic
 )
 
 
-class ServiceProvider:
+class ServiceProvider(HasDescriptors):
     """
     A service provider.
     """
@@ -36,9 +38,6 @@ class ServiceProvider:
     def __init__(self, *args: Any, services: ServiceLevel, **kwargs: Any):
         super().__init__(*args, **kwargs)
         self.__services = services
-        for _, member in getmembers(type(self)):
-            if isinstance(member, ServiceManager):
-                member.init(self)
 
     @final
     @property
@@ -65,7 +64,7 @@ class ServiceManager[
     GetServiceT,
     GetterServiceT,
     FactoryServiceT,
-](ABC):
+](GettableDescriptor[ServiceProviderT, GetServiceT]):
     """
     Manage a single service for a service provider.
     """
@@ -76,62 +75,21 @@ class ServiceManager[
         self.__service_or_factory = factory
 
     @final
-    def __set_name__(self, owner: type[ServiceProviderT], name: str) -> None:
-        self.__owner = owner
-        self.__name = name
-
-    @final
-    @property
-    def owner(self) -> type[ServiceProviderT]:
-        """
-        The class this service is located on.
-        """
-        return self.__owner
-
-    @final
-    @property
-    def name(self) -> str:
-        """
-        The service name.
-        """
-        return self.__name
-
-    @final
     @property
     def id(self) -> str:
         """
         The global service ID.
         """
-        return f"{self.owner.__name__}.{self.name}"
+        return f"{self.descriptor_owner.__name__}.{self.descriptor_name}"
 
-    @overload
-    def __get__(self, instance: None, owner: type[ServiceProviderT], /) -> Self:
-        pass
-
-    @overload
-    def __get__(
-        self, instance: ServiceProviderT, owner: type[ServiceProviderT] | None = None, /
-    ) -> GetServiceT:
-        pass
-
-    @final
-    def __get__(
-        self,
-        instance: ServiceProviderT | None,
-        owner: type[ServiceProviderT] | None = None,
-        /,
-    ) -> GetServiceT | Self:
-        if instance is None:
-            return self
-
-        return self.get(instance)
-
-    def init(self, instance: ServiceProviderT, /) -> None:
-        """
-        Initialize the service.
-        """
+    @override
+    def init_descriptor(self, instance: ServiceProviderT, /) -> None:
         self._assert_service_not_initialized(instance)
-        setattr(instance, f"_service_{self.name}", self._new_service_getter(instance))
+        setattr(
+            instance,
+            f"_service_{self.descriptor_name}",
+            self._new_service_getter(instance),
+        )
 
     @abstractmethod
     def _new_service_getter(self, instance: ServiceProviderT, /) -> GetterServiceT:
@@ -145,11 +103,9 @@ class ServiceManager[
         """
 
     @final
+    @override
     def get(self, instance: ServiceProviderT, /) -> GetServiceT:
-        """
-        Get the service from an instance.
-        """
-        return self._get_service(getattr(instance, f"_service_{self.name}"))
+        return self._get_service(getattr(instance, f"_service_{self.descriptor_name}"))
 
     @abstractmethod
     def _get_service(self, service: GetterServiceT, /) -> GetServiceT:
@@ -162,14 +118,16 @@ class ServiceManager[
         self, instance: ServiceProviderT, /
     ) -> ServiceOrFactory[ServiceProviderT, ServiceT, FactoryServiceT]:
         return getattr(
-            instance, f"_service_{self.name}_or_factory", self.__service_or_factory
+            instance,
+            f"_service_{self.descriptor_name}_or_factory",
+            self.__service_or_factory,
         )
 
     @final
     def _assert_service_not_initialized(self, instance: ServiceProviderT, /) -> None:
-        if hasattr(instance, f"_service_{self.name}"):
+        if hasattr(instance, f"_service_{self.descriptor_name}"):
             raise ServiceAlreadyInitialized(
-                f"{instance}.{self.name} was initialized already."
+                f"{instance}.{self.descriptor_name} was initialized already."
             )
 
     @final
@@ -187,7 +145,7 @@ class ServiceManager[
         This MUST only be called from ``instance.__init__()``.
         """
         self._assert_service_not_initialized(instance)
-        setattr(instance, f"_service_{self.name}_or_factory", service)
+        setattr(instance, f"_service_{self.descriptor_name}_or_factory", service)
 
 
 class ServiceNotYetInitialized(ServiceError):

--- a/betty/service/plugin/__init__.py
+++ b/betty/service/plugin/__init__.py
@@ -116,9 +116,11 @@ class PluginServiceManager[
         return self.__auto
 
     @override
-    def init(self, service_provider: ServiceProviderT, /) -> None:
-        super().init(service_provider)
-        setattr(service_provider, f"_plugin_service_init_plugins_{self.name}", [])
+    def init_descriptor(self, service_provider: ServiceProviderT, /) -> None:
+        super().init_descriptor(service_provider)
+        setattr(
+            service_provider, f"_plugin_service_init_plugins_{self.descriptor_name}", []
+        )
 
     @final
     @override
@@ -142,7 +144,9 @@ class PluginServiceManager[
     def __get_init_plugins(
         self, service_provider: ServiceProviderT, /
     ) -> MutableSequence[InitT | ResolvablePluginDefinition[PluginDefinitionT]]:
-        return getattr(service_provider, f"_plugin_service_init_plugins_{self.name}")
+        return getattr(
+            service_provider, f"_plugin_service_init_plugins_{self.descriptor_name}"
+        )
 
     @final
     def get_init_plugins(
@@ -179,7 +183,7 @@ class PluginServiceManager[
         self.assert_plugins_not_initialized(service_provider)
         setattr(
             service_provider,
-            f"_plugin_service_plugins_{self.name}",
+            f"_plugin_service_plugins_{self.descriptor_name}",
             tuple(await self.prepare_plugins(service_provider, *plugins)),
         )
 
@@ -207,7 +211,9 @@ class PluginServiceManager[
         Get the initialized plugins.
         """
         self.assert_plugins_initialized(service_provider)
-        return getattr(service_provider, f"_plugin_service_plugins_{self.name}")
+        return getattr(
+            service_provider, f"_plugin_service_plugins_{self.descriptor_name}"
+        )
 
     @final
     def assert_plugins_not_initialized(
@@ -218,7 +224,7 @@ class PluginServiceManager[
 
         :raise ServiceAlreadyInitialized:
         """
-        if hasattr(service_provider, f"_plugin_service_plugins_{self.name}"):
+        if hasattr(service_provider, f"_plugin_service_plugins_{self.descriptor_name}"):
             raise ServiceAlreadyInitialized(
                 f"Service {self.id}'s plugins were initialized already."
             )
@@ -230,7 +236,9 @@ class PluginServiceManager[
 
         :raise ServiceNotYetInitialized:
         """
-        if not hasattr(service_provider, f"_plugin_service_plugins_{self.name}"):
+        if not hasattr(
+            service_provider, f"_plugin_service_plugins_{self.descriptor_name}"
+        ):
             raise ServiceNotYetInitialized(
                 f"Service {self.id}'s plugins were not yet initialized."
             )

--- a/betty/service/plugin/requirement.py
+++ b/betty/service/plugin/requirement.py
@@ -65,7 +65,7 @@ class PluginServiceRequirement[PluginDefinitionT: PluginDefinition, GetServiceT]
         """
         Check the requirement.
         """
-        if isinstance(services, self.service.owner):
+        if isinstance(services, self.service.descriptor_owner):
             service_plugins = list(
                 map(
                     self._service.resolve_init_plugin_id,

--- a/betty/service/simple/__init__.py
+++ b/betty/service/simple/__init__.py
@@ -54,7 +54,4 @@ def service(factory):
         if iscoroutinefunction(factory)
         else SynchronousServiceManager
     )
-    return update_wrapper(
-        service_manager_cls(factory),  # ty:ignore[invalid-argument-type]
-        factory,
-    )
+    return update_wrapper(service_manager_cls(factory), factory)

--- a/betty/test_utils/data.py
+++ b/betty/test_utils/data.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import pytest
 
-from betty.attr import Attr, Optional
+from betty.attr import AttrProperty, Optional
 from betty.data import Data
 from betty.datas.aggregate.record.object import ObjectDefinition
 from betty.datas.str import StrDefinition
@@ -121,7 +121,7 @@ class DummyData(Data):
     A dummy :py:class:`betty.data.Data` implementation.
     """
 
-    value = Optional(Attr(StrDefinition(label="Value")))
+    value = Optional(AttrProperty(StrDefinition(label="Value")))
 
     def __init__(self, /, value: str | None = None):
         self.value = value

--- a/betty/tests/service/plugin/test___init__.py
+++ b/betty/tests/service/plugin/test___init__.py
@@ -209,12 +209,6 @@ class _PluginServiceManagerTestServiceProvider(PluginServiceProvider):
 
 
 class TestPluginServiceManager:
-    def test___set_name__(self) -> None:
-        assert (
-            _PluginServiceManagerTestServiceProvider.my_first_service.name
-            == "my_first_service"
-        )
-
     def test_add_init_plugins(self) -> None:
         service_provider = _PluginServiceManagerTestServiceProvider(
             services=ServiceLevel()
@@ -312,7 +306,7 @@ class TestPluginServiceManager:
             )
         )
 
-    def test_init(self) -> None:
+    def test_init_descriptor(self) -> None:
         service_provider = _PluginServiceManagerTestServiceProvider(
             services=ServiceLevel()
         )

--- a/betty/tests/service/plugin/test_requirement.py
+++ b/betty/tests/service/plugin/test_requirement.py
@@ -17,11 +17,12 @@ from betty.test_utils.plugin import (
     DummyPluginThree,
     DummyPluginTwo,
 )
+from betty.typing import Intersection
 
 
 class _PluginServiceRequirementTestPluginServiceManager(
     PluginServiceManager[
-        PluginServiceProvider,
+        Intersection[PluginServiceProvider, ServiceLevel],
         DummyPluginDefinition,
         Sequence[DummyPluginDefinition],
         DummyPluginDefinition,
@@ -32,7 +33,7 @@ class _PluginServiceRequirementTestPluginServiceManager(
 
     @override
     def new_service(
-        self, service_provider: PluginServiceProvider, /
+        self, service_provider: Intersection[PluginServiceProvider, ServiceLevel], /
     ) -> Sequence[DummyPluginDefinition]:
         return tuple(
             map(resolve_plugin_definition, self.get_init_plugins(service_provider))

--- a/betty/tests/service/test___init__.py
+++ b/betty/tests/service/test___init__.py
@@ -36,39 +36,6 @@ class _DummyServiceManager[ServiceProviderT: ServiceProvider](
 
 
 class TestServiceManager:
-    def test___get____class(self) -> None:
-        class _ServiceProvider(ServiceProvider):
-            @_DummyServiceManager
-            def my_first_service(self) -> object:
-                raise NotImplementedError
-
-        assert isinstance(_ServiceProvider.my_first_service, _DummyServiceManager)
-        assert _ServiceProvider.my_first_service is _ServiceProvider.my_first_service
-
-    def test___get____instance(self) -> None:
-        service = object()
-
-        class _ServiceProvider(ServiceProvider):
-            @_DummyServiceManager
-            def my_first_service(self) -> object:
-                return service
-
-        assert _ServiceProvider(services=ServiceLevel()).my_first_service is service
-
-    def test___set_name__(self) -> None:
-        class _ServiceProvider(ServiceProvider):
-            @_DummyServiceManager
-            def my_first_service(self) -> object:
-                raise NotImplementedError
-
-    def test_owner(self) -> None:
-        class _ServiceProvider(ServiceProvider):
-            @_DummyServiceManager
-            def my_first_service(self) -> object:
-                raise NotImplementedError
-
-        assert _ServiceProvider.my_first_service.owner is _ServiceProvider
-
     def test_get(self) -> None:
         service = object()
 
@@ -94,7 +61,7 @@ class TestServiceManager:
             _ServiceProvider.my_first_service.id == "_ServiceProvider.my_first_service"
         )
 
-    def test_init__initialized_already(self) -> None:
+    def test_init_descriptor__initialized_already(self) -> None:
         class _ServiceProvider(ServiceProvider):
             @_DummyServiceManager
             def my_first_service(self) -> object:
@@ -102,15 +69,7 @@ class TestServiceManager:
 
         service_provider = _ServiceProvider(services=ServiceLevel())
         with pytest.raises(ServiceAlreadyInitialized):
-            _ServiceProvider.my_first_service.init(service_provider)
-
-    def test_name(self) -> None:
-        class _ServiceProvider(ServiceProvider):
-            @_DummyServiceManager
-            def my_first_service(self) -> object:
-                raise NotImplementedError
-
-        assert _ServiceProvider.my_first_service.name == "my_first_service"
+            _ServiceProvider.my_first_service.init_descriptor(service_provider)
 
     def test_override(self) -> None:
         class _ServiceProvider(ServiceProvider):

--- a/betty/tests/test_attr.py
+++ b/betty/tests/test_attr.py
@@ -1,7 +1,11 @@
 import pytest
 
 from betty.assertion import assert_str
-from betty.attr import Attr, AttrNotInitialized, Optional
+from betty.attr import (
+    AttrNotInitialized,
+    AttrProperty,
+    Optional,
+)
 from betty.data import DataDefinition, OptionalDefinition
 from betty.datas.str import StrDefinition
 from betty.functools import passthrough
@@ -12,7 +16,7 @@ from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
 class TestAttr:
     def test___get__(self) -> None:
         class _Owner:
-            my_first_property = Attr(StrDefinition(label=DUMMY_LOCALIZABLE))
+            my_first_property = AttrProperty(StrDefinition(label=DUMMY_LOCALIZABLE))
 
         owner = _Owner()
         with pytest.raises(AttrNotInitialized):
@@ -20,7 +24,7 @@ class TestAttr:
 
     def test_get(self) -> None:
         class _Owner:
-            my_first_property = Attr(StrDefinition(label=DUMMY_LOCALIZABLE))
+            my_first_property = AttrProperty(StrDefinition(label=DUMMY_LOCALIZABLE))
 
         owner = _Owner()
         with pytest.raises(AttrNotInitialized):
@@ -28,7 +32,7 @@ class TestAttr:
 
     def test___set__(self) -> None:
         class _Owner:
-            my_first_property = Attr(StrDefinition(label=DUMMY_LOCALIZABLE))
+            my_first_property = AttrProperty(StrDefinition(label=DUMMY_LOCALIZABLE))
 
         owner = _Owner()
         owner.my_first_property = "my-first-value"
@@ -36,7 +40,7 @@ class TestAttr:
 
     def test___set____with_resolver(self) -> None:
         class _Owner:
-            my_first_property = Attr[str, str | bool](
+            my_first_property = AttrProperty[str, str | bool](
                 StrDefinition(label=DUMMY_LOCALIZABLE), resolver=str
             )
 
@@ -46,15 +50,15 @@ class TestAttr:
 
     def test___set_name__(self) -> None:
         class _Owner:
-            my_first_property = Attr(StrDefinition(label=DUMMY_LOCALIZABLE))
+            my_first_property = AttrProperty(StrDefinition(label=DUMMY_LOCALIZABLE))
 
-        assert _Owner.my_first_property._attr_name == "_my_first_property"
+        assert _Owner.my_first_property.descriptor_name == "_my_first_property"
 
     def test_attr(self) -> None:
         data = StrDefinition(label=DUMMY_LOCALIZABLE)
 
         class _Owner:
-            my_first_property = Attr(data)
+            my_first_property = AttrProperty(data)
 
         assert _Owner.my_first_property.attr.field("my_first_property").data is data
 
@@ -62,7 +66,7 @@ class TestAttr:
 class TestOptional:
     class _Owner:
         my_first_property = Optional(
-            Attr(
+            AttrProperty(
                 DataDefinition(
                     cls=str,
                     label=DUMMY_LOCALIZABLE,
@@ -105,19 +109,19 @@ class TestOptional:
         assert owner.my_first_property is None
 
     def test___set_name__(self) -> None:
-        required_property = Attr(StrDefinition(label=DUMMY_LOCALIZABLE))
+        required_property = AttrProperty(StrDefinition(label=DUMMY_LOCALIZABLE))
 
         class _Owner:
             my_first_property = Optional(required_property)
 
-        assert _Owner.my_first_property._attr_name == "_my_first_property"
-        assert required_property._attr_name == "_my_first_property"
+        assert _Owner.my_first_property.descriptor_name == "_my_first_property"
+        assert required_property.descriptor_name == "_my_first_property"
 
     def test_attr(self) -> None:
         data = StrDefinition(label=DUMMY_LOCALIZABLE)
 
         class _Owner:
-            my_first_property = Optional(Attr(data))
+            my_first_property = Optional(AttrProperty(data))
 
         optional_data = _Owner.my_first_property.attr.data
         assert isinstance(optional_data, OptionalDefinition)

--- a/betty/tests/test_descriptor.py
+++ b/betty/tests/test_descriptor.py
@@ -1,0 +1,73 @@
+from typing import override
+
+from betty.descriptor import Descriptor, HasDescriptors
+
+
+class _DummyInstance(HasDescriptors):
+    """
+    A typed subclass to ensure descriptors are generic over an instance type.
+    """
+
+    def __init__(self):
+        self.init_descriptors = []
+        super().__init__()
+
+
+class _DummyDescriptorValue:
+    """
+    A typed descriptor value type.
+    """
+
+
+class _DummyDescriptor(
+    Descriptor[_DummyInstance, tuple[_DummyInstance, _DummyDescriptorValue]]
+):
+    def __init__(self, value: _DummyDescriptorValue, /):
+        self.__value = value
+
+    @override
+    def get(
+        self, instance: _DummyInstance, /
+    ) -> tuple[_DummyInstance, _DummyDescriptorValue]:
+        return instance, self.__value
+
+    @override
+    def init_descriptor(self, instance: _DummyInstance, /) -> None:
+        instance.init_descriptors.append(self)
+
+
+class TestDescriptor:
+    def test___get____class(self) -> None:
+        class _Instance(_DummyInstance):
+            my_first_descriptor = _DummyDescriptor(_DummyDescriptorValue())
+
+        assert isinstance(_Instance.my_first_descriptor, _DummyDescriptor)
+        assert _Instance.my_first_descriptor is _Instance.my_first_descriptor
+
+    def test___get____instance(self) -> None:
+        value = _DummyDescriptorValue()
+
+        class _Instance(_DummyInstance):
+            my_first_descriptor = _DummyDescriptor(value)
+
+        instance = _Instance()
+        assert instance.my_first_descriptor == (instance, value)
+
+    def test_owner(self) -> None:
+        class _Instance(_DummyInstance):
+            my_first_descriptor = _DummyDescriptor(_DummyDescriptorValue())
+
+        assert _Instance.my_first_descriptor.descriptor_owner is _Instance
+
+    def test_init_descriptor(self) -> None:
+        class _Instance(_DummyInstance):
+            my_first_descriptor = _DummyDescriptor(_DummyDescriptorValue())
+
+        instance = _Instance()
+        assert _Instance.my_first_descriptor in instance.init_descriptors
+
+    def test_name(self) -> None:
+        class _Instance(_DummyInstance):
+            my_first_descriptor = _DummyDescriptor(_DummyDescriptorValue())
+
+        assert _Instance.my_first_descriptor.descriptor_name == "my_first_descriptor"


### PR DESCRIPTION
**This is being replaced by several other PRs, and is kept as a reference while work on those other PRs is being completed.**

## To do
- Consider adding a barebones variant of this API first in a separate PR. Just base class, owner and name, init. Then expand functionality in follow-ups.
- That means we can have two variants of `GetterDescriptor`: one that is a data descriptor (for attrs) and one that isn't (for service managers) without having to add subclasses specific to either of those APIs, and they'd be reusable.
- Refactor `AssetRepositoryService` into a getter? Or could the asset repository class itself not only accept paths but also plugin definitions?
- Add `AnyGettableDescriptor` that allows the return value to be changed
- Implement for `ServiceManager`
  - we currently cache internally, but that is before getters. Can we cache the outermost getter instead? We may need to subclass `GetterDescriptor` or provide a custom implementation so only the outermost will cache, and call the uncached inner getters.
  - Refactor simple service managers using getters
- Implement for `Attr`
- Rename the descriptor API to the property API for consistency with `@property`