### PR TITLE
Add `ResolvableDataDefinition`

### DIFF
--- a/betty/attrs/attr.py
+++ b/betty/attrs/attr.py
@@ -13,7 +13,7 @@ from betty.property import HasProperties
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from betty.data import Data, DataDefinition
+    from betty.data import DataDefinition, ResolvableDataDefinition
     from betty.locale.localizable import ResolvableLocalizable
 
 
@@ -24,7 +24,7 @@ class AttrAttr[OwnerT: HasProperties, GetT, SetT](Attr[OwnerT, GetT, SetT]):
 
     def __init__(
         self,
-        data: DataDefinition[GetT] | type[Data[DataDefinition[GetT]]],
+        data: ResolvableDataDefinition[DataDefinition[GetT]],
         *,
         label: ResolvableLocalizable | None = None,
         description: ResolvableLocalizable | None = None,

--- a/betty/attrs/collection/keyed.py
+++ b/betty/attrs/collection/keyed.py
@@ -12,7 +12,7 @@ from betty.collection.keyed import MutableKeyedCollection
 from betty.property import HasProperties
 
 if TYPE_CHECKING:
-    from betty.data import Data
+    from betty.data import ResolvableDataDefinition
     from betty.datas.aggregate.collection.keyed import KeyedCollectionDefinition
     from betty.locale.localizable import ResolvableLocalizable
 
@@ -30,8 +30,9 @@ class KeyedCollectionAttr[
 
     def __init__(
         self,
-        data: KeyedCollectionDefinition[MutableKeyedCollectionT, ItemSetT]
-        | type[Data[KeyedCollectionDefinition[MutableKeyedCollectionT, ItemSetT]]],
+        data: ResolvableDataDefinition[
+            KeyedCollectionDefinition[MutableKeyedCollectionT, ItemSetT]
+        ],
         *,
         default: Callable[[], Iterable[ItemSetT]] = tuple,
         description: ResolvableLocalizable | None = None,

--- a/betty/attrs/collection/mapping.py
+++ b/betty/attrs/collection/mapping.py
@@ -13,7 +13,7 @@ from betty.property import HasProperties
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from betty.data import Data
+    from betty.data import ResolvableDataDefinition
     from betty.datas.aggregate.collection.mapping import MappingDefinition
     from betty.locale.localizable import ResolvableLocalizable
     from betty.typing import Intersection
@@ -33,16 +33,11 @@ class MappingAttr[
 
     def __init__(
         self,
-        data: MappingDefinition[
-            Intersection[MutableMappingT, MutableMapping[KeyT, ValueT]], KeyT, ValueT
-        ]
-        | type[
-            Data[
-                MappingDefinition[
-                    Intersection[MutableMappingT, MutableMapping[KeyT, ValueT]],
-                    KeyT,
-                    ValueT,
-                ]
+        data: ResolvableDataDefinition[
+            MappingDefinition[
+                Intersection[MutableMappingT, MutableMapping[KeyT, ValueT]],
+                KeyT,
+                ValueT,
             ]
         ],
         *,

--- a/betty/attrs/collection/sequence.py
+++ b/betty/attrs/collection/sequence.py
@@ -13,7 +13,7 @@ from betty.property import HasProperties
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from betty.data import Data
+    from betty.data import ResolvableDataDefinition
     from betty.datas.aggregate.collection.sequence import SequenceDefinition
     from betty.locale.localizable import ResolvableLocalizable
 
@@ -31,8 +31,7 @@ class SequenceAttr[
 
     def __init__(
         self,
-        data: SequenceDefinition[MutableSequenceT, ItemSetT]
-        | type[Data[SequenceDefinition[MutableSequenceT, ItemSetT]]],
+        data: ResolvableDataDefinition[SequenceDefinition[MutableSequenceT, ItemSetT]],
         *,
         default: Callable[[], Iterable[ItemSetT]] = tuple,
         description: ResolvableLocalizable | None = None,

--- a/betty/data.py
+++ b/betty/data.py
@@ -96,3 +96,19 @@ class Data[DataDefinitionT: DataDefinition = DataDefinition]:
             return NotImplemented
         porter = type(self).data().porter
         return porter.dump(self) == porter.dump(other)
+
+
+type ResolvableDataDefinition[DataDefinitionT: DataDefinition] = (
+    DataDefinitionT | type[Data[DataDefinitionT]]
+)
+
+
+def resolve_data_definition[DataDefinitionT: DataDefinition](
+    definition: ResolvableDataDefinition[DataDefinitionT],
+) -> DataDefinitionT:
+    """
+    Resolve a value to a data definition.
+    """
+    if isinstance(definition, DataDefinition):
+        return definition  # ty:ignore[invalid-return-type]
+    return definition.data()

--- a/betty/datas/aggregate/collection/__init__.py
+++ b/betty/datas/aggregate/collection/__init__.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Collection, Iterable
 from typing import TYPE_CHECKING, Any, final
 
-from betty.data import DataDefinition
+from betty.data import DataDefinition, resolve_data_definition
 from betty.datas.aggregate import AggregateDefinition
 from betty.indicator.selector import Element
 
@@ -39,7 +39,7 @@ class CollectionDefinition[
         factory: Callable[[], CollectionT] | None = None,
     ):
         super().__init__(cls=cls, label=label, description=description, porter=porter)
-        self._item = item if isinstance(item, DataDefinition) else item.data()
+        self._item = resolve_data_definition(item)
         self._factory = factory
 
     @final

--- a/betty/datas/aggregate/collection/__init__.py
+++ b/betty/datas/aggregate/collection/__init__.py
@@ -8,12 +8,12 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Collection, Iterable
 from typing import TYPE_CHECKING, Any, final
 
-from betty.data import DataDefinition, resolve_data_definition
+from betty.data import DataDefinition, ResolvableDataDefinition, resolve_data_definition
 from betty.datas.aggregate import AggregateDefinition
 from betty.indicator.selector import Element
 
 if TYPE_CHECKING:
-    from betty.data import Data
+    from betty.data import Data as Data
     from betty.locale.localizable import ResolvableLocalizable
     from betty.portable import Porter
 
@@ -32,7 +32,7 @@ class CollectionDefinition[
         /,
         cls: type[CollectionT] | None = None,
         *,
-        item: DataDefinition | type[Data],
+        item: ResolvableDataDefinition[DataDefinition],
         label: ResolvableLocalizable,
         description: ResolvableLocalizable | None = None,
         porter: Porter[CollectionT] | None = None,

--- a/betty/datas/aggregate/collection/keyed.py
+++ b/betty/datas/aggregate/collection/keyed.py
@@ -21,10 +21,9 @@ from betty.portable import (
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from betty.data import Data
+    from betty.data import ResolvableDataDefinition
     from betty.datas.aggregate.record import RecordDefinition
     from betty.locale.localizable import ResolvableLocalizable
-    from betty.typing import Intersection
 
 
 class KeyedCollectionDefinition[
@@ -43,8 +42,7 @@ class KeyedCollectionDefinition[
         /,
         cls: type[MutableKeyedCollection] | None = None,
         *,
-        value: RecordDefinition[ValueT, ElementT]
-        | type[Intersection[ValueT, Data[RecordDefinition[Any, ElementT]]]],
+        value: ResolvableDataDefinition[RecordDefinition[ValueT, ElementT]],
         key: ElementT,
         order_dump: bool = False,
         label: ResolvableLocalizable,

--- a/betty/datas/aggregate/collection/mapping.py
+++ b/betty/datas/aggregate/collection/mapping.py
@@ -7,13 +7,12 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping, MutableMapping
 from typing import TYPE_CHECKING, Any, final, override
 
-from betty.data import DataDefinition, resolve_data_definition
+from betty.data import DataDefinition, ResolvableDataDefinition, resolve_data_definition
 from betty.datas.aggregate.collection import CollectionDefinition
 from betty.indicator.selector import Key
 from betty.portable import CallbackPorter, PortableData, Porter
 
 if TYPE_CHECKING:
-    from betty.data import Data
     from betty.locale.localizable import ResolvableLocalizable
     from betty.typing import Intersection
 
@@ -31,8 +30,8 @@ class MappingDefinition[MutableMappingT: MutableMapping[Any, Any], KeyT, ValueT]
         cls: type[Intersection[MutableMappingT, MutableMapping[KeyT, ValueT]]]
         | None = None,
         *,
-        key: DataDefinition[KeyT, str] | type[Intersection[KeyT, Data]],
-        value: DataDefinition[ValueT] | type[Intersection[ValueT, Data]],
+        key: ResolvableDataDefinition[DataDefinition[KeyT, str]],
+        value: ResolvableDataDefinition[DataDefinition[ValueT]],
         label: ResolvableLocalizable,
         description: ResolvableLocalizable | None = None,
         factory: Callable[[], MutableMappingT] | None = None,

--- a/betty/datas/aggregate/collection/mapping.py
+++ b/betty/datas/aggregate/collection/mapping.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping, MutableMapping
 from typing import TYPE_CHECKING, Any, final, override
 
-from betty.data import DataDefinition
+from betty.data import DataDefinition, resolve_data_definition
 from betty.datas.aggregate.collection import CollectionDefinition
 from betty.indicator.selector import Key
 from betty.portable import CallbackPorter, PortableData, Porter
@@ -46,7 +46,7 @@ class MappingDefinition[MutableMappingT: MutableMapping[Any, Any], KeyT, ValueT]
             factory=factory,
             porter=CallbackPorter(self._load, self._dump) if porter is None else porter,
         )
-        self._value = value if isinstance(value, DataDefinition) else value.data()
+        self._value = resolve_data_definition(value)
 
     def _load(self, portable: PortableData, /) -> MutableMappingT:
         from betty.assertion import assert_mapping
@@ -61,7 +61,7 @@ class MappingDefinition[MutableMappingT: MutableMapping[Any, Any], KeyT, ValueT]
         return {
             self._item.porter.dump(key): self._value.porter.dump(item)
             for key, item in data.items()
-        }  # ty:ignore[invalid-return-type]
+        }
 
     @final
     @override

--- a/betty/datas/aggregate/collection/sequence.py
+++ b/betty/datas/aggregate/collection/sequence.py
@@ -12,7 +12,7 @@ from betty.indicator.selector import Index
 from betty.portable import CallbackPorter, PortableData
 
 if TYPE_CHECKING:
-    from betty.data import Data, DataDefinition
+    from betty.data import DataDefinition, ResolvableDataDefinition
     from betty.locale.localizable import ResolvableLocalizable
     from betty.typing import Intersection
 
@@ -30,7 +30,7 @@ class SequenceDefinition[MutableSequenceT: MutableSequence[Any], ValueT](
         cls: type[Intersection[MutableSequenceT, MutableSequence[ValueT]]]
         | None = None,
         *,
-        value: DataDefinition[ValueT] | type[Intersection[ValueT, Data]],
+        value: ResolvableDataDefinition[DataDefinition[ValueT]],
         label: ResolvableLocalizable,
         description: ResolvableLocalizable | None = None,
         factory: Callable[[], MutableSequenceT] | None = None,

--- a/betty/datas/aggregate/record/__init__.py
+++ b/betty/datas/aggregate/record/__init__.py
@@ -8,7 +8,13 @@ from abc import abstractmethod
 from typing import TYPE_CHECKING, Any, Self, TypeVar, final, override
 
 from betty.assertion import OptionalField, assert_mapping
-from betty.data import DataDefinition, Sample, Samples
+from betty.data import (
+    DataDefinition,
+    ResolvableDataDefinition,
+    Sample,
+    Samples,
+    resolve_data_definition,
+)
 from betty.datas.aggregate import AggregateDefinition
 from betty.datas.optional import OptionalDefinition
 from betty.indicator.selector import Element
@@ -18,7 +24,7 @@ from betty.portable import Portable, PortableData, PortablePorter, Porter
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, MutableSequence, Sequence
 
-    from betty.data import Data
+    from betty.data import Data as Data
     from betty.locale.localizable import Localizable, ResolvableLocalizable
     from betty.portable import PortableMapping
 
@@ -32,7 +38,7 @@ class FieldDefinition[ElementT: Element[Any] = Element[Any], DataClsT = Any]:
     def __init__(
         self,
         selector: ElementT,
-        data: DataDefinition[DataClsT] | type[Data[DataDefinition[DataClsT]]],
+        data: ResolvableDataDefinition[DataDefinition[DataClsT]],
         *,
         label: ResolvableLocalizable | None = None,
         description: ResolvableLocalizable | None = None,
@@ -40,7 +46,7 @@ class FieldDefinition[ElementT: Element[Any] = Element[Any], DataClsT = Any]:
         omit_dump: Callable[[DataClsT], bool] | None = None,
     ):
         self._selector = selector
-        self._data = data if isinstance(data, DataDefinition) else data.data()
+        self._data = resolve_data_definition(data)
         self._label = None if label is None else resolve_localizable(label)
         self._description = (
             None if description is None else resolve_localizable(description)

--- a/betty/datas/aggregate/record/object/__init__.py
+++ b/betty/datas/aggregate/record/object/__init__.py
@@ -10,7 +10,7 @@ from types import FunctionType
 from typing import TYPE_CHECKING, final, override
 
 from betty.attr import Attr
-from betty.data import DataDefinition
+from betty.data import DataDefinition, ResolvableDataDefinition, resolve_data_definition
 from betty.datas.aggregate.record import FieldDefinition, RecordDefinition
 from betty.importlib import fully_qualified_name
 from betty.indicator.selector import Attr as AttrElement
@@ -19,7 +19,7 @@ from betty.locale.localizable import resolve_localizable
 if TYPE_CHECKING:
     from collections.abc import Callable, MutableMapping
 
-    from betty.data import Data
+    from betty.data import Data as Data
     from betty.locale.localizable import Localizable, ResolvableLocalizable
 
 
@@ -45,14 +45,14 @@ class AttrDefinition[DataClsT]:
 
     def __init__(
         self,
-        data: DataDefinition[DataClsT] | type[Data[DataDefinition[DataClsT]]],
+        data: ResolvableDataDefinition[DataDefinition[DataClsT]],
         *,
         label: ResolvableLocalizable | None = None,
         description: ResolvableLocalizable | None = None,
         omit_load: bool | None = None,
         omit_dump: Callable[[DataClsT], bool] | None = None,
     ):
-        self._data = data if isinstance(data, DataDefinition) else data.data()
+        self._data = resolve_data_definition(data)
         self._label = None if label is None else resolve_localizable(label)
         self._description = (
             None if description is None else resolve_localizable(description)

--- a/betty/tests/attrs/collection/test_keyed.py
+++ b/betty/tests/attrs/collection/test_keyed.py
@@ -14,7 +14,7 @@ class TestKeyedCollectionAttr:
     @ObjectDefinition(label=DUMMY_LOCALIZABLE)
     class _Owner(Data, HasProperties):
         @ObjectDefinition(label=DUMMY_LOCALIZABLE)
-        class _Item(Data["ObjectDefinition"]):
+        class _Item(Data[ObjectDefinition]):
             attr: Any
 
         keyed_collection = KeyedCollectionAttr(

--- a/betty/tests/test_data.py
+++ b/betty/tests/test_data.py
@@ -5,7 +5,7 @@ from typing import Self, override
 import pytest
 
 from betty.assertion import assert_str
-from betty.data import Data, DataDefinition, Sample
+from betty.data import Data, DataDefinition, Sample, resolve_data_definition
 from betty.portable import CallbackPorter, Portable, PortableData
 from betty.portable.error import NotPortable
 from betty.sample import Samplable, Samples
@@ -99,3 +99,20 @@ class TestDataDefinition:
         sut = DataDefinition(cls=object, label=DUMMY_LOCALIZABLE)
         with pytest.raises(NotPortable):
             sut.porter.dump(None)
+
+
+def test_resolve_data_definition__with_definition() -> None:
+    definition = DataDefinition(label="-")
+    assert resolve_data_definition(definition) is definition
+
+
+def test_resolve_data_definition__with_data() -> None:
+    definition = DataDefinition(label="-")
+
+    class _Data(Data):
+        @override
+        @classmethod
+        def data(cls) -> DataDefinition:
+            return definition
+
+    assert resolve_data_definition(_Data) is definition


### PR DESCRIPTION
Scale/down reintroduce the changes if we cannot locate the root cause of the type failures. 