### PR TITLE
Data mutability

### DIFF
--- a/betty/data.py
+++ b/betty/data.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Self, override
 from betty.definition.cls import ClsDefinition
 from betty.definition.human_facing import HumanFacingDefinition
 from betty.importlib import fully_qualified_name
+from betty.mutable import Mutable
 from betty.portable import Portable, PortableData, PortablePorter, Porter
 from betty.portable.error import NotPortable
 from betty.sample import Samplable, Sample, Samples
@@ -77,7 +78,7 @@ class DataDefinition[DataClsT, PortableDataT: PortableData = PortableData](
         return Samples(self._samples)
 
 
-class Data[DataDefinitionT: DataDefinition = DataDefinition]:
+class Data[DataDefinitionT: DataDefinition = DataDefinition](Mutable):
     """
     A class that defines data for its instances.
     """

--- a/betty/media_type/__init__.py
+++ b/betty/media_type/__init__.py
@@ -50,6 +50,7 @@ class MediaType(Data, Portable):
     _suffix: str | None
 
     def __init__(self, media_type: str, *, extensions: Sequence[str] = ()):
+        super().__init__()
         self._str = media_type
         message = EmailMessage()
         message["Content-Type"] = media_type

--- a/betty/mutable.py
+++ b/betty/mutable.py
@@ -1,0 +1,62 @@
+"""
+The mutability API.
+
+This provides tools to mark objects as mutable or immutable, and to guard against mutations.
+"""
+
+from __future__ import annotations
+
+from typing import Any, final
+
+
+class MutabilityError(Exception):
+    """
+    A generic mutability API error.
+    """
+
+
+class MutableError(MutabilityError, RuntimeError):
+    """
+    Raised because something was unexpectedly mutable.
+    """
+
+
+class ImmutableError(MutabilityError, RuntimeError):
+    """
+    Raised because something was unexpectedly immutable.
+    """
+
+
+class Mutable:
+    """
+    A generic mutable type that can be marked immutable.
+    """
+
+    def __init__(self, *args: Any, mutable: bool = True, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.mutable = mutable
+        """
+        Whether the instance is mutable.
+        """
+
+    @final
+    def assert_mutable(self) -> None:
+        """
+        Assert that the instance is mutable.
+
+        :raise ImmutableError: if the instance is immutable.
+        """
+        if not self.mutable:
+            raise ImmutableError(
+                f"{self} was unexpectedly immutable, and cannot be modified."
+            )
+
+    @final
+    def assert_immutable(self) -> None:
+        """
+        Assert that the instance is immutable.
+
+        :raise MutableError: if the instance is mutable.
+        """
+        if self.mutable:
+            raise MutableError(f"{self} was unexpectedly mutable, and can be modified.")


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/4203

## To do
- Can we support the visitor pattern in the data API? Then we can use that to find all `Mutable` data within nested data, and mark all of those immutable.
- Use 0.4.x for inspiration: https://github.com/bartfeenstra/betty/blob/0.4.x/betty/mutability.py
- Add `betty.mutable.Mutable`
  - Add `betty.mutable.MutabilityError(Exception)` and `betty.attr.ImmutableAttr(MutabilityError, Owner error)`
  - `Mutable.mutable` is a `@property` whose setter only allows making the owner mutable, never immutable.
  - Add `Mutable.assert_mutable()` that raises `MutabilityError`
- Add `HasAttrs(HasProperties, Mutable, Data[ObjectDefinition])`
- In `OwnerAttr._set_owner_attr()`, call `owner.assert_mutable()` prior to making changes
- Add explicit `AttributeError` subclasses
- Make ancestries immutable in `betty.load.load()`
- Make configuration immutable once loaded, e.g. `AppData` and `ProjectData`
- Make our collection classes (im)mutable