### PR TITLE
Refactor the date API

### DIFF
--- a/betty/attrs/date.py
+++ b/betty/attrs/date.py
@@ -8,25 +8,25 @@ from typing import TYPE_CHECKING, Any, override
 
 from betty.attrs.owner import OwnerAttr
 from betty.attrs.privacy import HasPrivacy
-from betty.datas.date import AnyDateDefinition
-from betty.date import AnyDate, Date
-from betty.json_schemas.date import ResolvableDateSchema
+from betty.datas.date import DateExpressionDefinition
+from betty.date import Date, DateExpression
+from betty.json_schemas.date import DateExpressionSchema
 from betty.linked_data import JsonLdObject, LinkedDataDumpableWithSchemaJsonLdObject
 from betty.prop import HasProps
 
 if TYPE_CHECKING:
     from betty.portable import PortableMapping
     from betty.project import Project
-from betty.date import DateRange, _dump_date_iso8601
+from betty.date import DateRange
 from betty.linked_data import dump_context
 
 
-class HasAnyDate(LinkedDataDumpableWithSchemaJsonLdObject, HasProps):
+class HasDate(LinkedDataDumpableWithSchemaJsonLdObject, HasProps):
     """
-    A resource with date information.
+    A resource with a date.
     """
 
-    date = OwnerAttr(AnyDateDefinition()).optional
+    date = OwnerAttr(DateExpressionDefinition()).optional
     """
     The date.
     """
@@ -34,13 +34,13 @@ class HasAnyDate(LinkedDataDumpableWithSchemaJsonLdObject, HasProps):
     def __init__(
         self,
         *args: Any,
-        date: AnyDate | None = None,
+        date: DateExpression | None = None,
         **kwargs: Any,
     ):
         super().__init__(*args, **kwargs)
         self.date = date
 
-    def has_any_date_linked_data_contexts(
+    def has_date_linked_data_contexts(
         self,
     ) -> tuple[str | None, str | None, str | None]:
         """
@@ -58,7 +58,7 @@ class HasAnyDate(LinkedDataDumpableWithSchemaJsonLdObject, HasProps):
                 schema_org_date_definition,
                 schema_org_start_date_definition,
                 schema_org_end_date_definition,
-            ) = self.has_any_date_linked_data_contexts()
+            ) = self.has_date_linked_data_contexts()
             if isinstance(self.date, Date):
                 portable["date"] = _dump_linked_data_for_date(
                     self.date, context_definition=schema_org_date_definition
@@ -75,7 +75,7 @@ class HasAnyDate(LinkedDataDumpableWithSchemaJsonLdObject, HasProps):
     @classmethod
     async def linked_data_schema(cls, project: Project, /) -> JsonLdObject:
         schema = await super().linked_data_schema(project)
-        schema.add_property("date", ResolvableDateSchema(), False)
+        schema.add_property("date", DateExpressionSchema(), False)
         return schema
 
 
@@ -83,7 +83,7 @@ def _dump_linked_data_for_date(
     date: Date, *, context_definition: str | None = None
 ) -> PortableMapping:
     portable: PortableMapping = {
-        "fuzzy": date.fuzzy,
+        "imprecise": date.imprecise,
     }
     if date.year:
         portable["year"] = date.year
@@ -91,12 +91,14 @@ def _dump_linked_data_for_date(
         portable["month"] = date.month
     if date.day:
         portable["day"] = date.day
-    if date.comparable:
-        portable["iso8601"] = _dump_date_iso8601(date)
+    if date.year and date.month and date.day:
+        portable["date"] = (
+            f"{'-' if date.year < 0 else '-'}{date.year:04d}-{date.month:02d}-{date.day:02d}"
+        )
         # Set a single term definition because JSON-LD does not let us apply multiple
         # for the same term (key).
         if context_definition:
-            dump_context(portable, iso8601=context_definition)
+            dump_context(portable, date=context_definition)
     return portable
 
 

--- a/betty/calendar.py
+++ b/betty/calendar.py
@@ -1,0 +1,138 @@
+"""
+The calendar API.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, final
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from betty.localizable import Localizable
+    from betty.machine_name import MachineName
+
+
+class Calendar(ABC):
+    """
+    A calendar.
+    """
+
+    @final
+    def __init_subclass__(cls, **kwargs: Any):
+        assert cls.__module__.startswith("betty.calendars."), (
+            "Third-party calendars are not supported."
+        )
+        super().__init_subclass__(**kwargs)
+
+    @classmethod
+    @abstractmethod
+    def id(cls) -> MachineName:
+        """
+        The unique calendar ID.
+        """
+
+    @classmethod
+    @abstractmethod
+    def label(cls) -> Localizable:
+        """
+        The human-readable calendar label.
+        """
+
+    @classmethod
+    @abstractmethod
+    def public_label(cls) -> Localizable:
+        """
+        The human-readable public calendar label.
+        """
+
+    @classmethod
+    @abstractmethod
+    def years(cls) -> Sequence[int]:
+        """
+        Get the years on this calendar.
+        """
+
+    @classmethod
+    @abstractmethod
+    def months(cls) -> int:
+        """
+        Get the number of months in a year.
+        """
+
+    @classmethod
+    @abstractmethod
+    def days(cls, year: int | None, month: int | None, /) -> int:
+        """
+        Get the number of days for the given month, or the maximum number of days any month could have.
+        """
+
+    # @todo Should we be using this at all? It's too simplistic, because it cannot handle the new year not
+    # @todo being on the first day of the frst month.
+    # @todo
+    # @todo Can we refactor this using cls.earliest() and cls.latest()?
+    # @todo
+    @classmethod
+    def validate(
+        cls, year: int | None, month: int | None, day: int | None, /
+    ) -> bool | None:
+        """
+        Validate the given date against this calendar.
+
+        Return ``True`` if all date parts are present and valid. Return ``False`` if any date part is invalid. Return
+        ``None`` otherwise, indicating that any given date was valid, but not all data was given.
+        """
+        if year is not None and year not in cls.years():
+            return False
+        if month is not None:
+            if month < 1:
+                return False
+            if month > cls.months():
+                return False
+        if day is not None:
+            if day < 1:
+                return False
+            if day > cls.days(year, month):
+                return False
+        if year is None:
+            return None
+        if month is None:
+            return None
+        if day is None:
+            return None
+        return True
+
+    @classmethod
+    @abstractmethod
+    def to_proleptic_iso8601(
+        cls, year: int, month: int, day: int, /
+    ) -> tuple[int, int, int]:
+        """
+        Convert a date on this calendar to one on the :py:class:`proleptic ISO 8601 calendar <betty.calendars.iso8601.ProlepticIso8601>`.
+        """
+
+    @classmethod
+    def earliest(
+        cls, year: int | None, month: int | None, day: int | None, /
+    ) -> tuple[int | None, int | None, int | None]:
+        """
+        Try to fill in the missing date parts with the earliest possible values.
+        """
+        return year, month, day
+
+    @classmethod
+    def latest(
+        cls, year: int | None, month: int | None, day: int | None, /
+    ) -> tuple[int | None, int | None, int | None]:
+        """
+        Try to fill in the missing date parts with the latest possible values.
+        """
+        return year, month, day
+
+
+def to_year_zero(year: int, /) -> int:
+    """
+    Convert a year from a numbering without year zero to a numbering with year zero.
+    """
+    raise NotImplementedError

--- a/betty/calendars/__init__.py
+++ b/betty/calendars/__init__.py
@@ -1,0 +1,58 @@
+"""
+Reusable calendars.
+"""
+
+from collections.abc import Iterable, Mapping
+from typing import Final, final
+
+from betty.calendar import Calendar
+from betty.calendars.gregorian import Gregorian, ProlepticGregorian
+from betty.calendars.iso8601 import Iso8601, ProlepticIso8601
+from betty.calendars.julian import Julian, ProlepticJulian
+from betty.exception import HumanFacingException
+from betty.localizables.gettext import _
+from betty.localizables.markup import Paragraph, do_you_mean
+from betty.machine_name import MachineName
+
+calendars: Final[Iterable[type[Calendar]]] = (
+    Gregorian,
+    Iso8601,
+    Julian,
+    ProlepticGregorian,
+    ProlepticIso8601,
+    ProlepticJulian,
+)
+"""
+The available calendars. 
+"""
+
+_calendars: Final[Mapping[MachineName, type[Calendar]]] = {
+    calendar.id(): calendar for calendar in calendars
+}
+
+
+def get(calendar: MachineName, /) -> type[Calendar]:
+    """
+    Get a calendar by its ID.
+
+    :raises CalendarNotFound:
+    """
+    try:
+        return _calendars[calendar]
+    except KeyError:
+        raise CalendarNotFound(calendar) from None
+
+
+@final
+class CalendarNotFound(HumanFacingException, ValueError):
+    """
+    Raised when a calendar cannot be found.
+    """
+
+    def __init__(self, calendar: MachineName, /):
+        super().__init__(
+            Paragraph(
+                _('Cannot find the "{calendar}" calendar.').format(calendar=calendar),
+                do_you_mean(calendar.id() for calendar in calendars),
+            )
+        )

--- a/betty/calendars/_base.py
+++ b/betty/calendars/_base.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, final, override
+
+from betty.calendar import Calendar
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from betty.localizable import Localizable
+    from betty.machine_name import MachineName
+
+
+class _CalendarBase(Calendar):
+    _id: MachineName
+    _label: Localizable
+    _public_label: Localizable
+    _years: Sequence[int]
+
+    @final
+    @override
+    @classmethod
+    def id(cls) -> MachineName:
+        return cls._id
+
+    @final
+    @override
+    @classmethod
+    def label(cls) -> Localizable:
+        return cls._label
+
+    @final
+    @override
+    @classmethod
+    def public_label(cls) -> Localizable:
+        return cls._public_label
+
+    @final
+    @override
+    @classmethod
+    def years(cls) -> Sequence[int]:
+        return cls._years

--- a/betty/calendars/gregorian.py
+++ b/betty/calendars/gregorian.py
@@ -1,0 +1,68 @@
+"""
+Gregorian calendars.
+"""
+
+from __future__ import annotations
+
+from typing import final, override
+
+from convertdate.gregorian import monthrange
+
+from betty.calendar import to_year_zero
+from betty.calendars._base import _CalendarBase
+from betty.localizables.gettext import _
+from betty.machine_name import MachineName
+
+
+class _GregorianCalendarBase(_CalendarBase):
+    @final
+    @override
+    @classmethod
+    def months(cls) -> int:
+        return 12
+
+    @final
+    @override
+    @classmethod
+    def days(cls, year: int | None, month: int | None, /) -> int:
+        if year is None or month is None:
+            return 31
+        return monthrange(year, month)[1]
+
+
+@final
+class Gregorian(_GregorianCalendarBase):
+    """
+    The Gregorian calendar.
+    """
+
+    _id = MachineName("gregorian")
+    _label = _("Gregorian")
+    _public_label = _label
+    _years = tuple(range(1582, 9999))
+
+    @override
+    @classmethod
+    def to_proleptic_iso8601(
+        cls, year: int, month: int, day: int, /
+    ) -> tuple[int, int, int]:
+        return year, month, day
+
+
+@final
+class ProlepticGregorian(_GregorianCalendarBase):
+    """
+    The proleptic Gregorian calendar, classic, without year zero.
+    """
+
+    _id = MachineName("gregorian-proleptic")
+    _label = _("Gregorian (proleptic)")
+    _public_label = _("Gregorian")
+    _years = (*range(-9999, -1), *range(1, 9999))
+
+    @override
+    @classmethod
+    def to_proleptic_iso8601(
+        cls, year: int, month: int, day: int, /
+    ) -> tuple[int, int, int]:
+        return to_year_zero(year), month, day

--- a/betty/calendars/iso8601.py
+++ b/betty/calendars/iso8601.py
@@ -1,0 +1,77 @@
+"""
+ISO 8601 calendars.
+"""
+
+from __future__ import annotations
+
+from typing import final, override
+
+from betty.calendars.gregorian import _GregorianCalendarBase
+from betty.localizables.gettext import _
+from betty.machine_name import MachineName
+
+
+class _Iso8601CalendarBase(_GregorianCalendarBase):
+    @final
+    @override
+    @classmethod
+    def earliest(
+        cls, year: int | None, month: int | None, day: int | None, /
+    ) -> tuple[int | None, int | None, int | None]:
+        return (
+            cls.years()[0] if year is None else year,
+            1 if month is None else month,
+            1 if day is None else month,
+        )
+
+    @final
+    @override
+    @classmethod
+    def latest(
+        cls, year: int | None, month: int | None, day: int | None, /
+    ) -> tuple[int | None, int | None, int | None]:
+        if year is None:
+            year = cls.years()[-1]
+        if month is None:
+            month = 12
+        if day is None:
+            day = cls.days(year, month)
+        return (year, month, day)
+
+
+@final
+class Iso8601(_Iso8601CalendarBase):
+    """
+    The ISO 8601 calendar.
+    """
+
+    _id = MachineName("iso8601")
+    _label = _("ISO 8601")
+    _public_label = _label
+    _years = tuple(range(9999))
+
+    @override
+    @classmethod
+    def to_proleptic_iso8601(
+        cls, year: int, month: int, day: int, /
+    ) -> tuple[int, int, int]:
+        return year, month, day
+
+
+@final
+class ProlepticIso8601(_Iso8601CalendarBase):
+    """
+    The proleptic ISO 8601 calendar, with year zero.
+    """
+
+    _id = MachineName("iso8601-proleptic")
+    _label = _("ISO 8601 (proleptic)")
+    _public_label = _("ISO 8601")
+    _years = tuple(range(-9999, 9999))
+
+    @override
+    @classmethod
+    def to_proleptic_iso8601(
+        cls, year: int, month: int, day: int, /
+    ) -> tuple[int, int, int]:
+        return year, month, day

--- a/betty/calendars/julian.py
+++ b/betty/calendars/julian.py
@@ -1,0 +1,68 @@
+"""
+Julian calendars.
+"""
+
+from __future__ import annotations
+
+from typing import final, override
+
+from convertdate.julian import month_length, to_gregorian
+
+from betty.calendar import to_year_zero
+from betty.calendars._base import _CalendarBase
+from betty.localizables.gettext import _
+from betty.machine_name import MachineName
+
+
+class _JulianCalendarBase(_CalendarBase):
+    @final
+    @override
+    @classmethod
+    def months(cls) -> int:
+        return 12
+
+    @final
+    @override
+    @classmethod
+    def days(cls, year: int | None, month: int | None, /) -> int:
+        if year is None or month is None:
+            return 31
+        return month_length(year, month)
+
+
+@final
+class Julian(_JulianCalendarBase):
+    """
+    The Julian calendar.
+    """
+
+    _id = MachineName("julian")
+    _label = _("Julian")
+    _public_label = _("Julian")
+    _years = tuple(range(8, 9999))
+
+    @override
+    @classmethod
+    def to_proleptic_iso8601(
+        cls, year: int, month: int, day: int, /
+    ) -> tuple[int, int, int]:
+        return to_gregorian(year, month, day)
+
+
+@final
+class ProlepticJulian(_JulianCalendarBase):
+    """
+    The proleptic Julian calendar, classic, without year zero.
+    """
+
+    _id = MachineName("julian-proleptic")
+    _label = _("Julian (proleptic)")
+    _public_label = _("Julian")
+    _years = (*range(-9999, -1), *range(1, 9999))
+
+    @override
+    @classmethod
+    def to_proleptic_iso8601(
+        cls, year: int, month: int, day: int, /
+    ) -> tuple[int, int, int]:
+        return to_gregorian(to_year_zero(year), month, day)

--- a/betty/datas/aggregate/record/__init__.py
+++ b/betty/datas/aggregate/record/__init__.py
@@ -188,7 +188,8 @@ class RecordDefinition[
         from betty.porters.fields import FieldsPorter
 
         self._factory = factory
-        self._fields: MutableMapping[ElementT, FieldDefinition[DataT, Any]] = (
+        self._factory = factory
+        self._fields: Final[MutableMapping[ElementT, FieldDefinition[DataT, Any]]] = (
             {}
             if fields is None
             else {
@@ -196,7 +197,6 @@ class RecordDefinition[
                 for element, field in fields.items()
             }
         )
-
         super().__init__(
             *args,
             cls=cls,

--- a/betty/datas/aggregate/record/object.py
+++ b/betty/datas/aggregate/record/object.py
@@ -4,13 +4,21 @@ Object data types.
 
 from __future__ import annotations
 
-from typing import override
+from typing import TYPE_CHECKING, Any, Self, override
 
 from betty.attr import Attr
-from betty.datas.aggregate.record import RecordDefinition
+from betty.datas.aggregate.record import FieldDefinition, RecordDefinition
 from betty.indicator.selector import Attr as AttrElement
 from betty.portable import Porter
 from betty.prop import HasProps
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Mapping
+
+    from betty.data import ResolvableDataDefinitionFeature
+    from betty.localizable import ResolvableLocalizable
+    from betty.sample import Sample, Samples
+    from betty.typing import Intersection
 
 
 class ObjectDefinition[DataT, PorterT: Porter = Porter](
@@ -21,6 +29,38 @@ class ObjectDefinition[DataT, PorterT: Porter = Porter](
 
     Use :py:class:`betty.attr.Attr` to define fields inline, or in superclasses so they can be inherited.
     """
+
+    def __init__(
+        self,
+        *args: Any,
+        cls: type[DataT] | None = None,
+        label: ResolvableLocalizable,
+        fields: Mapping[AttrElement | str, FieldDefinition[DataT, Any]] | None = None,
+        description: ResolvableLocalizable | None = None,
+        samples: Iterable[Callable[[], Sample[DataT]] | Samples] = (),
+        factory: Callable[..., DataT] | None = None,
+        porter: ResolvableDataDefinitionFeature[
+            Intersection[PorterT, Porter[DataT]], Self, DataT
+        ]
+        | None = None,
+        **kwargs: Any,
+    ):
+        super().__init__(
+            *args,
+            cls=cls,
+            label=label,
+            description=description,
+            factory=factory,
+            fields=None
+            if fields is None
+            else {
+                name if isinstance(name, AttrElement) else AttrElement(name): field
+                for name, field in fields.items()
+            },
+            samples=samples,
+            porter=porter,
+            **kwargs,
+        )
 
     @override
     def _set_cls(self, cls: type[DataT], /) -> None:

--- a/betty/datas/date.py
+++ b/betty/datas/date.py
@@ -7,18 +7,20 @@ from __future__ import annotations
 from typing import final
 
 from betty.data import DataDefinition
-from betty.date import AnyDate, Date, DateRange
+from betty.date import Date, DateExpression, DateRange
 from betty.localizables.gettext import _
-from betty.porters.date import AnyDatePorter
+from betty.porters.date import DateExpressionPorter
 
 
 @final
-class AnyDateDefinition(DataDefinition[AnyDate]):
+class DateExpressionDefinition(DataDefinition[DateExpression]):
     """
-    The data definition for a date or a date range.
+    The data definition for a date expression.
     """
 
     def __init__(self):
         super().__init__(
-            label=_("Date"), porter=AnyDatePorter(), samples=[Date, DateRange]
+            label=_("Date"),
+            porter=DateExpressionPorter(),
+            samples=[Date, DateRange],
         )

--- a/betty/datas/optional.py
+++ b/betty/datas/optional.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import final
 
-from betty.data import DataDefinition
+from betty.data import DataDefinition, ResolvableDataDefinition, resolve_data_definition
 from betty.portable import Porter
 from betty.porters.data_proxy import DataDefinitionProxyPorter
 from betty.porters.optional import OptionalPorter
@@ -19,7 +19,8 @@ class OptionalDefinition[DataT](DataDefinition[DataT | None, Porter[DataT | None
     Wrap another data definition to make it optional, e.g. allow ``None``.
     """
 
-    def __init__(self, proxied: DataDefinition[DataT, Porter[DataT]], /):
+    def __init__(self, proxied: ResolvableDataDefinition[DataDefinition[DataT]], /):
+        proxied = resolve_data_definition(proxied)
         super().__init__(
             label=proxied.label,
             description=proxied.description,

--- a/betty/date.py
+++ b/betty/date.py
@@ -1,459 +1,493 @@
 """
-Localize dates.
+The date API.
 """
 
 from __future__ import annotations
 
-import calendar
 import datetime
-import operator
-from contextlib import suppress
-from functools import total_ordering
-from typing import TYPE_CHECKING, Any, final, override
+from abc import ABC, abstractmethod
+from operator import not_
+from typing import TYPE_CHECKING, Any, Final, Self, TypeGuard, final, overload, override
 
 from babel import dates
 
-from betty.attrs.owner import OwnerAttr
-from betty.data import Data
+from betty import calendars
+from betty.calendars import ProlepticIso8601
+from betty.data import Data, DataDefinition
+from betty.datas.aggregate.record import FieldDefinition
 from betty.datas.aggregate.record.object import ObjectDefinition
 from betty.datas.bool import BoolDefinition
 from betty.datas.int import IntDefinition
+from betty.datas.optional import OptionalDefinition
+from betty.exception import HumanFacingException
 from betty.localizable import Localizable
-from betty.localizables.gettext import _
-from betty.prop import HasProps
+from betty.localizables.gettext import _, pgettext
+from betty.localized import LocalizedStr
+from betty.machine_name import MachineName
+from betty.porters.callback import CallbackPorter
+from betty.porters.omit_field import OmitFieldPorter
 from betty.sample import Sample, Size
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
-    from types import NotImplementedType
+    from collections.abc import Mapping
 
-    from betty.localized import LocalizedStr
+    from betty.calendar import Calendar
     from betty.localizer import Localizer
 
 
+type DateParts = (
+    tuple[int, int | None, int | None]
+    | tuple[int | None, int, int | None]
+    | tuple[int | None, int | None, int]
+)
+
+
+def validate_date_parts(
+    parts: tuple[int | None, int | None, int | None], /
+) -> TypeGuard[DateParts]:
+    """
+    Validate date parts to ensue they are not all empty.
+    """
+    return parts != (None, None, None)
+
+
 @final
-class IncompleteDateError(ValueError):
+class InvalidDate(HumanFacingException, ValueError):
     """
-    Raised when a date-like was unexpectedly incomplete.
+    Raised when a date is invalid.
     """
 
+    def __init__(
+        self,
+        year: int | None,
+        month: int | None,
+        day: int | None,
+        calendar: type[Calendar],
+        /,
+    ):
+        super().__init__(
+            _("Invalid date {year}-{month}-{day} on the {calendar} calendar.").format(
+                year="...." if year is None else str(year),
+                month=".." if month is None else str(month),
+                day=".." if day is None else str(day),
+                calendar=calendar.label(),
+            )
+        )
 
-_LOCALIZE_DATE_PART_FORMATS: Mapping[tuple[bool, bool, bool], Localizable] = {
-    (True, True, True): _("MMMM d, y"),
-    (True, True, False): _("MMMM, y"),
-    (True, False, False): _("y"),
-    (False, True, True): _("MMMM d"),
-    (False, True, False): _("MMMM"),
-}
 
+class DateExpression(Localizable, Data[ObjectDefinition], ABC):
+    """
+    A date-like expression.
+    """
 
-def _localize_date_parts(localizer: Localizer, date: Date | None, /) -> str:
-    if date is None:
-        raise IncompleteDateError("This date is None.")
-    try:
-        date_parts_format = _LOCALIZE_DATE_PART_FORMATS[
-            (date.year is not None, date.month is not None, date.day is not None)
-        ].localize(localizer)
-    except KeyError:
-        raise IncompleteDateError(
-            "This date does not have enough parts to be rendered."
-        ) from None
-    parts = (1 if x is None else x for x in date.parts)
-    return dates.format_date(datetime.date(*parts), date_parts_format, localizer.locale)
+    @final
+    def __init_subclass__(cls, **kwargs: Any):
+        assert cls.__module__ == "betty.date", (
+            "Third-party date expressions are not supported."
+        )
+        super().__init_subclass__(**kwargs)
+
+    @final
+    def __truediv__[OtherT: DateExpression](self, other: OtherT) -> Self | OtherT:
+        """
+        Return the earliest of the two date expressions, or return the left operand if no comparison was possible.
+
+        This operation may be lossy.
+        """
+        return self if self <= other else other
+
+    @final
+    def __mul__[OtherT: DateExpression](self, other: OtherT) -> Self | OtherT:
+        """
+        Return the latest of the two date expressions, or return the left operand if no comparison was possible.
+
+        This operation may be lossy.
+        """
+        return self if self >= other else other
+
+    @abstractmethod
+    def __contains__(self, other: DateExpression) -> bool:
+        pass
 
 
 @final
 @ObjectDefinition(
     label=_("Date"),
+    fields={
+        "year": FieldDefinition(
+            OptionalDefinition(IntDefinition(label=_("Year"))),
+            optional=True,
+            porter=OmitFieldPorter.new(lambda data: data is None),
+        ),
+        "month": FieldDefinition(
+            OptionalDefinition(IntDefinition(label=_("Month"))),
+            optional=True,
+            porter=OmitFieldPorter.new(lambda data: data is None),
+        ),
+        "day": FieldDefinition(
+            OptionalDefinition(IntDefinition(label=_("Day"))),
+            optional=True,
+            porter=OmitFieldPorter.new(lambda data: data is None),
+        ),
+        "calendar": FieldDefinition(
+            DataDefinition(
+                label=_("Calendar"),
+                porter=CallbackPorter(
+                    lambda data: calendars.get(MachineName.data().porter.load(data)),
+                    lambda data: MachineName.data().porter.dump(data.id()),
+                ),
+            ),
+            optional=True,
+            porter=OmitFieldPorter.new(lambda data: data is ProlepticIso8601),
+        ),
+        "imprecise": FieldDefinition(
+            BoolDefinition(label=_("Imprecise")),
+            optional=True,
+            porter=OmitFieldPorter.new(not_),
+        ),
+    },
+    factory=lambda *, year, month, day, imprecise: Date(
+        year, month, day, imprecise=imprecise
+    ),
     samples=[
-        lambda: Sample(Date(), label="Minimal", size=Size.MINIMAL),
-        lambda: Sample(Date(1970, 1, 1, fuzzy=True), label="Full", size=Size.FULL),
+        lambda: Sample(Date(1), label="Minimal", size=Size.MINIMAL),
+        lambda: Sample(Date(1970, 1, 1, imprecise=True), label="Full", size=Size.FULL),
     ],
 )
-class Date(Localizable, Data, HasProps):
+class Date(DateExpression):
     """
-    A (Gregorian) date.
+    A single date.
     """
 
-    _LOCALIZE_FORMATS: Mapping[tuple[bool | None], Localizable] = {
-        (True,): _("around {date}"),
-        (False,): _("{date}"),
+    __slots__ = (
+        "calendar",
+        "year",
+        "month",
+        "day",
+        "imprecise",
+    )
+
+    _format_date_patterns: Final[dict[tuple[bool, bool, bool], Localizable]] = {
+        (True, True, True): pgettext("date", "MMMM d, y"),
+        (True, True, False): pgettext("date", "MMMM, y"),
+        (True, False, True): pgettext("date", "'day' d 'of the month,' y"),
+        (True, False, False): pgettext("date", "y"),
+        (False, True, True): pgettext("date", "MMMM d"),
+        (False, True, False): pgettext("date", "MMMM"),
+        (False, False, True): pgettext("date", "'day' d 'of the month'"),
     }
 
-    year = OwnerAttr(IntDefinition(label=_("Year"))).optional
-    month = OwnerAttr(IntDefinition(label=_("Month"))).optional
-    day = OwnerAttr(IntDefinition(label=_("Day"))).optional
-    fuzzy = OwnerAttr(BoolDefinition(label=_("Fuzzy"))).default(lambda: False)
+    @overload
+    def __init__(
+        self,
+        year: int,
+        month: int | None = None,
+        day: int | None = None,
+        /,
+        *,
+        calendar: type[Calendar] = ProlepticIso8601,
+        imprecise: bool = False,
+    ):
+        pass
+
+    @overload
+    def __init__(
+        self,
+        year: int | None,
+        month: int,
+        day: int | None = None,
+        /,
+        *,
+        calendar: type[Calendar] = ProlepticIso8601,
+        imprecise: bool = False,
+    ):
+        pass
+
+    @overload
+    def __init__(
+        self,
+        year: int | None,
+        month: int | None,
+        day: int,
+        /,
+        *,
+        calendar: type[Calendar] = ProlepticIso8601,
+        imprecise: bool = False,
+    ):
+        pass
 
     def __init__(
         self,
-        year: int | None = None,
-        month: int | None = None,
-        day: int | None = None,
+        year,
+        month=None,
+        day=None,
+        /,
         *,
-        fuzzy: bool = False,
+        calendar=ProlepticIso8601,
+        imprecise=False,
     ):
+        if calendar.validate(year, month, day) is False:
+            raise InvalidDate(year, month, day, calendar)
         super().__init__()
-        self.year = year
-        self.month = month
-        self.day = day
-        self.fuzzy = fuzzy
+        self.calendar: Final[type[Calendar]] = calendar
+        """
+        The calendar on which the date is expressed.
+        """
 
-    @override
-    def localize(self, localizer: Localizer, /) -> LocalizedStr:
-        try:
-            return (
-                self
-                ._LOCALIZE_FORMATS[(self.fuzzy,)]
-                .format(
-                    date=_localize_date_parts(localizer, self),
-                )
-                .localize(localizer)
-            )
-        except IncompleteDateError:
-            return _("unknown date").localize(localizer)
+        self.year: Final[int | None] = year
+        """
+        The year.
+        """
 
-    @property
-    def comparable(self) -> bool:
+        self.month: Final[int | None] = month
         """
-        If this date is comparable to other date-likes.
+        The month.
         """
-        return self.year is not None
 
-    @property
-    def complete(self) -> bool:
+        self.day: Final[int | None] = day
         """
-        Whether this date is complete.
+        The day.
         """
-        return self.year is not None and self.month is not None and self.day is not None
 
-    @property
-    def parts(self) -> tuple[int | None, int | None, int | None]:
+        self.imprecise: Final[bool] = imprecise
         """
-        The date parts: a 3-tuple of the year, month, and day.
+        Whether the year, month, and/or day are imprecise, e.g. not exactly known. 
         """
-        return self.year, self.month, self.day
 
-    def to_range(self) -> DateRange:
-        """
-        Convert this date to a date range.
-        """
-        if not self.comparable:
-            raise ValueError(
-                f"Cannot convert non-comparable date {self!r} to a date range."
-            )
-        assert self.year is not None
-        if self.month is None:
-            month_start = 1
-            month_end = 12
-        else:
-            month_start = month_end = self.month
-        if self.day is None:
-            day_start = 1
-            day_end = calendar.monthrange(self.year, month_end)[1]
-        else:
-            day_start = day_end = self.day
-        return DateRange(
-            Date(self.year, month_start, day_start), Date(self.year, month_end, day_end)
+        # @todo Can we skip some calculations for complete dates?
+        self._earliest = calendar.earliest(year, month, day)
+        self._latest = calendar.latest(year, month, day)
+        self._earliest_proleptic_iso8601 = (
+            self._earliest
+            if calendar is ProlepticIso8601
+            else calendar.to_proleptic_iso8601(*self._earliest)
+        )
+        self._latest_proleptic_iso8601 = (
+            self._latest
+            if calendar is ProlepticIso8601
+            else calendar.to_proleptic_iso8601(*self._latest)
         )
 
-    def _compare(
-        self, other: Any, comparator: Callable[[Any, Any], bool], /
-    ) -> bool | NotImplementedType:
-        if not isinstance(other, Date):
-            return NotImplemented
-        selfish = self
-        if not selfish.comparable or not other.comparable:
-            return NotImplemented
-        if selfish.complete and other.complete:
-            return comparator(selfish.parts, other.parts)
-        if not other.complete:
-            other = other.to_range()
-        if not selfish.complete:
-            selfish = selfish.to_range()
-        return comparator(selfish, other)
-
-    def __contains__(self, other: AnyDate) -> bool:
-        if isinstance(other, Date):
-            return self == other
-        return self in other
+    def __hash__(self):
+        return hash((type(self), self.year, self.month, self.day, self.imprecise))
 
     def __lt__(self, other: Any) -> bool:
-        return self._compare(other, operator.lt)
+        if not isinstance(other, Date):
+            return NotImplemented
+        # @todo Date parts can be None...
+        if self.calendar is other.calendar:
+            return self._latest < other._earliest
+        return self._latest_proleptic_iso8601 < other._earliest_proleptic_iso8601
 
     def __le__(self, other: Any) -> bool:
-        return self._compare(other, operator.le)
+        return self < other or self == other
 
-    @override
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Date):
             return NotImplemented
-        return self.parts == other.parts
+        return (self.year, self.month, self.day, self.imprecise) == (
+            other.year,
+            other.month,
+            other.day,
+            other.imprecise,
+        )
 
     def __ge__(self, other: Any) -> bool:
-        return self._compare(other, operator.ge)
+        return self > other or self == other
 
     def __gt__(self, other: Any) -> bool:
-        return self._compare(other, operator.gt)
-
-    @classmethod
-    def _load_date(cls, value: str) -> tuple[int | None, int | None, int | None]:
+        if not isinstance(other, Date):
+            return NotImplemented
         raise NotImplementedError
 
+    def __contains__(self, other: Any) -> bool:
+        if not isinstance(other, Date):
+            return False
+        return self == other
 
-def _dump_date_iso8601(date: Date, /) -> str | None:
-    if not date.complete:
-        return None
-    assert date.year
-    assert date.month
-    assert date.day
-    return f"{date.year:04d}-{date.month:02d}-{date.day:02d}"
+    def __repr__(self):
+        return f"<Date: year={self.year}, month={self.month}, day={self.day}, imprecise={self.imprecise}, calendar={self.calendar.id()}>"
+
+    @override
+    def localize(self, localizer: Localizer, /) -> LocalizedStr:
+        pattern = self._format_date_patterns[
+            (self.year is not None, self.month is not None, self.day is not None)
+        ].localize(localizer)
+        localized = LocalizedStr(
+            dates.format_date(
+                datetime.date(
+                    1 if self.year is None else self.year,
+                    1 if self.month is None else self.month,
+                    1 if self.day is None else self.day,
+                ),
+                pattern,
+                pattern.locale,
+            ),
+            locale=pattern.locale,
+        )
+        if self.imprecise:
+            localized = _("around {date}").format(date=localized).localize(localizer)
+        if self.calendar is not ProlepticIso8601:
+            localized = (
+                _("{date} ({calendar})")
+                .format(date=localized, calendar=self.calendar.public_label())
+                .localize(localizer)
+            )
+        return localized
 
 
 @final
-@total_ordering
-@ObjectDefinition(label=_("Date range"))
-class DateRange(Localizable, Data, HasProps):
+@ObjectDefinition(
+    label=_("Date range"),
+    fields={
+        "start": FieldDefinition(
+            OptionalDefinition(Date),
+            label=_("Start date"),
+            optional=True,
+            porter=OmitFieldPorter.new(lambda data: data is None),
+        ),
+        "start_is_boundary": FieldDefinition(
+            BoolDefinition(label=_("Start date is a boundary")),
+            optional=True,
+            porter=OmitFieldPorter.new(not_),
+        ),
+        "end": FieldDefinition(
+            OptionalDefinition(Date),
+            label=_("End date"),
+            optional=True,
+            porter=OmitFieldPorter.new(lambda data: data is None),
+        ),
+        "end_is_boundary": FieldDefinition(
+            BoolDefinition(label=_("End date is a boundary")),
+            optional=True,
+            porter=OmitFieldPorter.new(not_),
+        ),
+    },
+    factory=lambda *, start, end, start_is_boundary, end_is_boundary: DateRange(
+        start, end, start_is_boundary=start_is_boundary, end_is_boundary=end_is_boundary
+    ),
+    samples=[
+        lambda: Sample(
+            DateRange(Date.data().samples.get(Size.MINIMAL).subject),
+            label="Minimal",
+            size=Size.MINIMAL,
+        ),
+        lambda: Sample(
+            DateRange(None, Date.data().samples.get(Size.MINIMAL).subject),
+            label="Minimal",
+            size=Size.MINIMAL,
+        ),
+        lambda: Sample(
+            DateRange(
+                Date.data().samples.get(Size.FULL).subject,
+                DateRange.data().samples.get(Size.FULL).subject,
+            ),
+            label="Full",
+            size=Size.FULL,
+        ),
+    ],
+)
+class DateRange(DateExpression):
     """
     A date range can describe a period of time between, before, after, or around start and/or end dates.
     """
 
-    _LOCALIZE_FORMATS: Mapping[
-        tuple[bool | None, bool | None, bool | None, bool | None], Localizable
-    ] = {
-        (False, False, False, False): _("from {start_date} until {end_date}"),
-        (False, False, False, True): _(
-            "from {start_date} until sometime before {end_date}"
-        ),
-        (False, False, True, False): _("from {start_date} until around {end_date}"),
-        (False, False, True, True): _(
-            "from {start_date} until sometime before around {end_date}"
-        ),
-        (False, True, False, False): _(
-            "from sometime after {start_date} until {end_date}"
-        ),
-        (False, True, False, True): _("sometime between {start_date} and {end_date}"),
-        (False, True, True, False): _(
-            "from sometime after {start_date} until around {end_date}"
-        ),
-        (False, True, True, True): _(
-            "sometime between {start_date} and around {end_date}"
-        ),
-        (True, False, False, False): _("from around {start_date} until {end_date}"),
-        (True, False, False, True): _(
-            "from around {start_date} until sometime before {end_date}"
-        ),
-        (True, False, True, False): _(
-            "from around {start_date} until around {end_date}"
-        ),
-        (True, False, True, True): _(
-            "from around {start_date} until sometime before around {end_date}"
-        ),
-        (True, True, False, False): _(
-            "from sometime after around {start_date} until {end_date}"
-        ),
-        (True, True, False, True): _(
-            "sometime between around {start_date} and {end_date}"
-        ),
-        (True, True, True, False): _(
-            "from sometime after around {start_date} until around {end_date}"
-        ),
-        (True, True, True, True): _(
-            "sometime between around {start_date} and around {end_date}"
-        ),
-        (False, False, None, None): _("from {start_date}"),
-        (False, True, None, None): _("sometime after {start_date}"),
-        (True, False, None, None): _("from around {start_date}"),
-        (True, True, None, None): _("sometime after around {start_date}"),
-        (None, None, False, False): _("until {end_date}"),
-        (None, None, False, True): _("sometime before {end_date}"),
-        (None, None, True, False): _("until around {end_date}"),
-        (None, None, True, True): _("sometime before around {end_date}"),
+    __slots__ = ("start", "start_is_boundary", "end", "end_is_boundary")
+
+    _localizables: Final[Mapping[tuple[bool | None, bool | None], Localizable]] = {
+        (False, False): _("from {start_date} until {end_date}"),
+        (False, True): _("from {start_date} until sometime before {end_date}"),
+        (True, False): _("from sometime after {start_date} until {end_date}"),
+        (True, True): _("sometime between {start_date} and {end_date}"),
+        (False, None): _("from {start_date}"),
+        (True, None): _("sometime after {start_date}"),
+        (None, False): _("until {end_date}"),
+        (None, True): _("sometime before {end_date}"),
     }
 
-    start = OwnerAttr(Date).optional
-    start_is_boundary = OwnerAttr(
-        BoolDefinition(label=_("Start date is a boundary"))
-    ).default(lambda: False)
-    end = OwnerAttr(Date).optional
-    end_is_boundary = OwnerAttr(
-        BoolDefinition(label=_("End date is a boundary"))
-    ).default(lambda: False)
-
+    @overload
     def __init__(
         self,
-        start: Date | None = None,
-        end: Date | None = None,
+        start: Date,
+        end: Date,
+        /,
         *,
         start_is_boundary: bool = False,
         end_is_boundary: bool = False,
     ):
+        pass
+
+    @overload
+    def __init__(
+        self,
+        start: Date | None,
+        end: Date,
+        /,
+        *,
+        start_is_boundary: bool = False,
+        end_is_boundary: bool = False,
+    ):
+        pass
+
+    @overload
+    def __init__(
+        self,
+        start: Date,
+        end: Date | None = None,
+        /,
+        *,
+        start_is_boundary: bool = False,
+        end_is_boundary: bool = False,
+    ):
+        pass
+
+    def __init__(
+        self, start, end=None, /, *, start_is_boundary=False, end_is_boundary=False
+    ):
         super().__init__()
-        self.start = start
-        self.start_is_boundary = start_is_boundary
-        self.end = end
-        self.end_is_boundary = end_is_boundary
+        self.start: Final[Date | None] = start
+        self.start_is_boundary: Final[bool] = start_is_boundary
+        self.end: Final[Date | None] = end
+        self.end_is_boundary: Final[bool] = end_is_boundary
+
+    def __hash__(self):
+        return hash((
+            type(self),
+            self.start,
+            self.end,
+            self.start_is_boundary,
+            self.end_is_boundary,
+        ))
+
+    @override
+    def __contains__(self, other: DateExpression) -> bool:
+        raise NotImplementedError
+
+    def __repr__(self):
+        return f"<DateRange: start={repr(self.start)}, start_is_boundary={self.start_is_boundary}, end={repr(self.end)}, end_is_boundary={self.end_is_boundary}>"
 
     @override
     def localize(self, localizer: Localizer, /) -> LocalizedStr:
-        formatter_configuration: tuple[
-            bool | None, bool | None, bool | None, bool | None
-        ] = (None, None, None, None)
-        formatter_arguments = {}
+        localizable_key: tuple[bool | None, bool | None] = (None, None)
+        localizable_args = {}
 
-        with suppress(IncompleteDateError):
-            formatter_arguments["start_date"] = _localize_date_parts(
-                localizer, self.start
-            )
-            formatter_configuration = (
-                None if self.start is None else self.start.fuzzy,
+        if self.start:
+            localizable_args["start_date"] = self.start.localize(localizer)
+            localizable_key = (
                 self.start_is_boundary,
-                formatter_configuration[2],
-                formatter_configuration[3],
+                localizable_key[1],
             )
 
-        with suppress(IncompleteDateError):
-            formatter_arguments["end_date"] = _localize_date_parts(localizer, self.end)
-            formatter_configuration = (
-                formatter_configuration[0],
-                formatter_configuration[1],
-                None if self.end is None else self.end.fuzzy,
+        if self.end:
+            localizable_args["end_date"] = self.end.localize(localizer)
+            localizable_key = (
+                localizable_key[0],
                 self.end_is_boundary,
-            )
-
-        if not formatter_arguments:
-            raise IncompleteDateError(
-                "This date range does not have enough parts to be rendered."
             )
 
         return (
             self
-            ._LOCALIZE_FORMATS[formatter_configuration]
-            .format(**formatter_arguments)
+            ._localizables[localizable_key]
+            .format(**localizable_args)
             .localize(localizer)
         )
-
-    @property
-    def comparable(self) -> bool:
-        """
-        If this date is comparable to other date-likes.
-        """
-        return (
-            self.start is not None
-            and self.start.comparable
-            or self.end is not None
-            and self.end.comparable
-        )
-
-    def __contains__(self, other: AnyDate) -> bool:
-        if not self.comparable:
-            return False
-
-        if isinstance(other, Date):
-            others = [other]
-        else:
-            if not other.comparable:
-                return False
-            others = []
-            if other.start is not None and other.start.comparable:
-                others.append(other.start)
-            if other.end is not None and other.end.comparable:
-                others.append(other.end)
-
-        if self.start is not None and self.end is not None:
-            if isinstance(other, DateRange) and (
-                other.start is None or other.end is None
-            ):
-                if other.start is None:
-                    return self.start <= other.end or self.end <= other.end
-                if other.end is None:
-                    return self.start >= other.start or self.end >= other.start
-            for another in others:
-                if self.start <= another <= self.end:
-                    return True
-            if isinstance(other, DateRange):
-                for selfdate in [self.start, self.end]:
-                    if other.start <= selfdate <= other.end:
-                        return True
-
-        elif self.start is not None:
-            # Two date ranges with start dates only always overlap.
-            if isinstance(other, DateRange) and other.end is None:
-                return True
-
-            for another in others:
-                if self.start <= another:
-                    return True
-        elif self.end is not None:
-            # Two date ranges with end dates only always overlap.
-            if isinstance(other, DateRange) and other.start is None:
-                return True
-
-            for another in others:
-                if another <= self.end:
-                    return True
-        return False
-
-    def _get_comparable_date(self, date: Date | None, /) -> Date | None:
-        if date and date.comparable:
-            return date
-        return None
-
-    def __lt__(self, other: Any) -> bool:
-        if not isinstance(other, Date | DateRange):
-            return NotImplemented
-
-        self_start = self._get_comparable_date(self.start)
-        self_end = self._get_comparable_date(self.end)
-        if isinstance(other, DateRange):
-            other_start = self._get_comparable_date(other.start)
-            other_end = self._get_comparable_date(other.end)
-            if self_start is None:
-                if self_end is None:
-                    return NotImplemented
-                if other_start is None:
-                    if other_end is None:
-                        return NotImplemented
-                    return self_end < other_end
-                if other_end is None:
-                    return self_end <= other_start
-                return self_end <= other_start
-            if self_end is None:
-                if other_start is None:
-                    if other_end is None:
-                        return NotImplemented
-                    return self_start < other_end
-                if other_end is None:
-                    return self_start < other_start
-                return self_start < other_start
-            if other_start is None:
-                if other_end is None:
-                    return NotImplemented
-                return self_start < other_end or self_end <= other_end
-            if other_end is None:
-                return self_start <= other_start
-            return self_start < other_start
-        if self_start is None:
-            if self_end is None:
-                return NotImplemented
-            return self_end <= other
-        if self_end is None:
-            return self_start < other
-        return self_start < other
-
-    @override
-    def __eq__(self, other: object) -> bool:
-        if isinstance(other, Date):
-            return False
-
-        if not isinstance(other, DateRange):
-            return NotImplemented
-        return (self.start, self.end, self.start_is_boundary, self.end_is_boundary) == (
-            other.start,
-            other.end,
-            other.start_is_boundary,
-            other.end_is_boundary,
-        )
-
-
-type AnyDate = Date | DateRange

--- a/betty/deriver.py
+++ b/betty/deriver.py
@@ -219,8 +219,8 @@ class _DateDeriver(ABC):
         reference_events = _get_reference_events(
             person, reference_event_types, derivable_event.event_type.plugin()
         )
-        reference_events_dates: Iterable[tuple[Event, Date]] = filter(
-            lambda x: x[1].comparable, cls._get_events_dates(reference_events)
+        reference_events_dates: Iterable[tuple[Event, Date]] = cls._get_events_dates(
+            reference_events
         )
         if derivable_event.date is not None:
             reference_events_dates = filter(
@@ -233,15 +233,11 @@ class _DateDeriver(ABC):
         except IndexError:
             return False
 
-        if derivable_event.date is None:
-            derivable_event.date = DateRange()
-        cls._set(
-            cast(DateRange, derivable_event.date),
+        derivable_event.date = cls._set(
+            derivable_event.date,
             Date(
-                reference_date.year,
-                reference_date.month,
-                reference_date.day,
-                fuzzy=reference_date.fuzzy,
+                *reference_date.parts,
+                imprecise=reference_date.imprecise,
             ),
         )
         derivable_event.citations.add(*reference_event.citations)
@@ -276,7 +272,7 @@ class _DateDeriver(ABC):
 
     @classmethod
     @abstractmethod
-    def _set(cls, derivable_date: DateRange, derived_date: Date) -> None:
+    def _set(cls, derivable_date: DateRange | None, derived_date: Date) -> DateRange:
         pass
 
 
@@ -304,9 +300,15 @@ class _ComesBeforeDateDeriver(_DateDeriver):
 
     @override
     @classmethod
-    def _set(cls, derivable_date: DateRange, derived_date: Date) -> None:
-        derivable_date.end = derived_date
-        derivable_date.end_is_boundary = True
+    def _set(cls, derivable_date: DateRange | None, derived_date: Date) -> DateRange:
+        return DateRange(
+            derivable_date.start if derivable_date else None,
+            derived_date,
+            start_is_boundary=derivable_date.start_is_boundary
+            if derivable_date
+            else False,
+            end_is_boundary=True,
+        )
 
 
 @final
@@ -333,9 +335,13 @@ class _ComesAfterDateDeriver(_DateDeriver):
 
     @override
     @classmethod
-    def _set(cls, derivable_date: DateRange, derived_date: Date) -> None:
-        derivable_date.start = derived_date
-        derivable_date.start_is_boundary = True
+    def _set(cls, derivable_date: DateRange | None, derived_date: Date) -> DateRange:
+        return DateRange(
+            derived_date,
+            derivable_date.end if derivable_date else None,
+            start_is_boundary=True,
+            end_is_boundary=derivable_date.end_is_boundary if derivable_date else False,
+        )
 
 
 def _get_derivable_events(
@@ -379,7 +385,7 @@ def _get_reference_events(
                 reference_date = reference_event.date.end
             if reference_date is None:
                 continue
-            if reference_date.fuzzy:
+            if reference_date.imprecise:
                 continue
 
         # Ignore reference events of the wrong type.

--- a/betty/entities/citation.py
+++ b/betty/entities/citation.py
@@ -11,7 +11,7 @@ from betty.associations.has_file_references import HasFileReferences
 from betty.associations.has_links import HasLinks
 from betty.associations.to_many import ToMany, ToManyAssociates
 from betty.associations.to_one import ToOne, ToOneAssociate
-from betty.attrs.date import HasAnyDate
+from betty.attrs.date import HasDate
 from betty.attrs.localizable import new_localizable_attr
 from betty.entities.source import Source
 from betty.entity import EntityDefinition
@@ -22,7 +22,7 @@ from betty.privacy import Privacy
 from betty.privacy.resolve import merge_secondary_privacies
 
 if TYPE_CHECKING:
-    from betty.date import AnyDate
+    from betty.date import DateExpression
     from betty.entities.file_reference import FileReference
     from betty.entities.link import Link
     from betty.linked_data import JsonLdObject
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     label_plural=_("Citations"),
     label_countable=ngettext("{count} citation", "{count} citations"),
 )
-class Citation(HasAnyDate, HasFileReferences, HasLinks):
+class Citation(HasDate, HasFileReferences, HasLinks):
     """
     .. plugin:: entity:citation.
     """
@@ -78,7 +78,7 @@ class Citation(HasAnyDate, HasFileReferences, HasLinks):
         facts: ToManyAssociates[Self, HasCitations] = (),
         id: ResolvableMachineName | None = None,  # noqa: A002
         location: ResolvableLocalizable | None = None,
-        date: AnyDate | None = None,
+        date: DateExpression | None = None,
         files: ToManyAssociates[Self, FileReference] = (),
         links: ToManyAssociates[Self, Link] = (),
         privacy: Privacy = Privacy.UNDETERMINED,

--- a/betty/entities/enclosure.py
+++ b/betty/entities/enclosure.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Self, final
 
 from betty.associations.has_citations import HasCitations
 from betty.associations.to_one import ToOne, ToOneAssociate
-from betty.attrs.date import HasAnyDate
+from betty.attrs.date import HasDate
 from betty.entity import Entity, EntityDefinition
 from betty.localizables.gettext import _, ngettext
 
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     label_countable=ngettext("{count} enclosure", "{count} enclosures"),
     public_facing=False,
 )
-class Enclosure(HasAnyDate, HasCitations, Entity):
+class Enclosure(HasDate, HasCitations, Entity):
     """
     .. plugin:: entity:enclosure.
     """

--- a/betty/entities/event.py
+++ b/betty/entities/event.py
@@ -12,7 +12,7 @@ from betty.associations.has_links import HasLinks
 from betty.associations.has_notes import HasNotes
 from betty.associations.to_many import ToMany, ToManyAssociates
 from betty.associations.to_one import ToOne
-from betty.attrs.date import HasAnyDate
+from betty.attrs.date import HasDate
 from betty.attrs.description import HasDescription
 from betty.attrs.localizable import new_localizable_attr
 from betty.entities.place import Place
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
 
     from betty.association import Associate
-    from betty.date import AnyDate
+    from betty.date import DateExpression
     from betty.entities.citation import Citation
     from betty.entities.file_reference import FileReference
     from betty.entities.note import Note
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
     label_countable=ngettext("{count} event", "{count} events"),
 )
 class Event(
-    HasAnyDate, HasFileReferences, HasCitations, HasNotes, HasDescription, HasLinks
+    HasDate, HasFileReferences, HasCitations, HasNotes, HasDescription, HasLinks
 ):
     """
     .. plugin:: entity:event.
@@ -88,7 +88,7 @@ class Event(
         *,
         id: ResolvableMachineName | None = None,  # noqa: A002
         event_type: EventType | None = None,
-        date: AnyDate | None = None,
+        date: DateExpression | None = None,
         files: ToManyAssociates[Self, FileReference] = (),
         citations: ToManyAssociates[Self, Citation] = (),
         notes: ToManyAssociates[Self, Note] = (),
@@ -116,7 +116,7 @@ class Event(
         self.name = name
 
     @override
-    def has_any_date_linked_data_contexts(
+    def has_date_linked_data_contexts(
         self,
     ) -> tuple[str | None, str | None, str | None]:
         return (

--- a/betty/entities/place_name.py
+++ b/betty/entities/place_name.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, final, override
 
-from betty.attrs.date import HasAnyDate
+from betty.attrs.date import HasDate
 from betty.attrs.localizable import new_localizable_attr
 from betty.entity import Entity, EntityDefinition
 from betty.json_schemas.static_translations import StaticTranslationsSchema
@@ -14,7 +14,7 @@ from betty.localizable.linked_data import dump_linked_data
 from betty.localizables.gettext import _, ngettext
 
 if TYPE_CHECKING:
-    from betty.date import AnyDate
+    from betty.date import DateExpression
     from betty.linked_data import JsonLdObject
     from betty.localizable import ResolvableLocalizable
     from betty.machine_name import ResolvableMachineName
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     label_countable=ngettext("{count} place name", "{count} place names"),
     public_facing=False,
 )
-class PlaceName(HasAnyDate, Entity):
+class PlaceName(HasDate, Entity):
     """
     .. plugin:: entity:place-name.
     """
@@ -41,7 +41,7 @@ class PlaceName(HasAnyDate, Entity):
         self,
         name: ResolvableLocalizable,
         *,
-        date: AnyDate | None = None,
+        date: DateExpression | None = None,
         id: ResolvableMachineName | None = None,  # noqa: A002
     ):
         super().__init__(date=date, id=id)

--- a/betty/entities/source.py
+++ b/betty/entities/source.py
@@ -11,7 +11,7 @@ from betty.associations.has_links import HasLinks
 from betty.associations.has_notes import HasNotes
 from betty.associations.to_many import ToMany, ToManyAssociates
 from betty.associations.to_one import ToOne
-from betty.attrs.date import HasAnyDate
+from betty.attrs.date import HasDate
 from betty.attrs.localizable import new_localizable_attr
 from betty.entity import EntityDefinition
 from betty.json_schemas.static_translations import StaticTranslationsSchema
@@ -23,7 +23,7 @@ from betty.privacy.resolve import merge_privacies
 
 if TYPE_CHECKING:
     from betty.association import Associate
-    from betty.date import AnyDate
+    from betty.date import DateExpression
     from betty.entities.citation import Citation  # noqa: F401
     from betty.entities.file_reference import FileReference
     from betty.entities.link import Link
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
     label_plural=_("Sources"),
     label_countable=ngettext("{count} source", "{count} sources"),
 )
-class Source(HasAnyDate, HasFileReferences, HasNotes, HasLinks):
+class Source(HasDate, HasFileReferences, HasNotes, HasLinks):
     """
     .. plugin:: entity:source.
     """
@@ -101,7 +101,7 @@ class Source(HasAnyDate, HasFileReferences, HasNotes, HasLinks):
         contained_by: Associate[Self, Source] | None = None,
         contains: ToManyAssociates[Self, Source] = (),
         notes: ToManyAssociates[Self, Note] = (),
-        date: AnyDate | None = None,
+        date: DateExpression | None = None,
         files: ToManyAssociates[Self, FileReference] = (),
         links: ToManyAssociates[Self, Link] = (),
         privacy: Privacy = Privacy.UNDETERMINED,

--- a/betty/extensions/_theme/__init__.py
+++ b/betty/extensions/_theme/__init__.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import TYPE_CHECKING, cast
 
-from betty.date import AnyDate, Date
+from betty.date import Date, DateExpression
 from betty.entities.event import Event
 from betty.entities.person import Person
 from betty.entities.place import Place
@@ -31,7 +31,7 @@ def _is_person_timeline_presence(presence: Presence) -> bool:
         return False
     if not presence.event.date:
         return False
-    return presence.event.date.comparable
+    return presence.event.date.normalized is not None
 
 
 def person_timeline_events(person: Person, lifetime_threshold: int) -> Iterable[Event]:
@@ -121,7 +121,7 @@ def _person_timeline_events(person: Person, lifetime_threshold: int) -> Iterable
     if start_date is None and end_date is not None:
         if isinstance(end_date, Date):
             start_date_reference = end_date
-        elif end_date.end is not None and end_date.end.comparable:
+        elif end_date.end is not None:
             start_date_reference = end_date.end
         else:
             assert end_date.start is not None
@@ -131,7 +131,7 @@ def _person_timeline_events(person: Person, lifetime_threshold: int) -> Iterable
             start_date_reference.year - lifetime_threshold,
             start_date_reference.month,
             start_date_reference.day,
-            fuzzy=start_date_reference.fuzzy,
+            imprecise=start_date_reference.imprecise,
         )
 
     # If a start-of-life event exists, but no end-of-life event, create an end-of-life date based on the start date,
@@ -139,7 +139,7 @@ def _person_timeline_events(person: Person, lifetime_threshold: int) -> Iterable
     if end_date is None and start_date is not None:
         if isinstance(start_date, Date):
             end_date_reference = start_date
-        elif start_date.start and start_date.start.comparable:
+        elif start_date.start:
             end_date_reference = start_date.start
         else:
             assert start_date.end is not None
@@ -149,12 +149,12 @@ def _person_timeline_events(person: Person, lifetime_threshold: int) -> Iterable
             end_date_reference.year + lifetime_threshold,
             end_date_reference.month,
             end_date_reference.day,
-            fuzzy=end_date_reference.fuzzy,
+            imprecise=end_date_reference.imprecise,
         )
 
     if start_date is None or end_date is None:
         reference_dates = sorted(
-            cast(AnyDate, presence.event.date)
+            cast(DateExpression, presence.event.date)
             for presence in person.presences
             if _is_person_timeline_presence(presence)
         )

--- a/betty/gramps.py
+++ b/betty/gramps.py
@@ -27,8 +27,9 @@ from betty.associations.has_citations import HasCitations
 from betty.associations.has_links import HasLinks
 from betty.associations.has_notes import HasNotes
 from betty.attrs.privacy import HasPrivacy
+from betty.calendars import ProlepticIso8601, ProlepticJulian
 from betty.copyright_notice import CopyrightNoticeManufacturer
-from betty.date import AnyDate, Date, DateRange
+from betty.date import Date, DateExpression, DateRange, validate_date_parts
 from betty.entities.citation import Citation
 from betty.entities.enclosure import Enclosure
 from betty.entities.event import Event
@@ -128,6 +129,7 @@ if TYPE_CHECKING:
     from babel import Locale
 
     from betty.associations.has_file_references import HasFileReferences
+    from betty.calendar import Calendar
     from betty.event_type import EventType, EventTypeDefinition
     from betty.gender import Gender
     from betty.localizables.static import StaticTranslationsMapping
@@ -197,6 +199,17 @@ class GrampsEntityReference:
         return f"{self.entity_type.value} ({self.entity_id})"
 
 
+calendar_mapping: Final[Mapping[str | None, type[Calendar]]] = {
+    None: ProlepticIso8601,
+    "Gregorian": ProlepticIso8601,
+    "Julian": ProlepticJulian,
+    # @todo
+    # "Hebrew": None,
+    # "French Republican": None,
+    # "Persian": None,
+    # "Islamic": None,
+    # "Swedish": None,
+}
 DEFAULT_GENDER_MAPPING: Mapping[
     str, ResolvablePluginManufacturer[GenderDefinition, Gender]
 ] = {
@@ -672,70 +685,88 @@ class GrampsLoader:
             )
         return found_element
 
-    _date_pattern: Final[re.Pattern[str]] = re.compile(r"^.{4}((-.{2})?-.{2})?$")
-    _date_part_pattern: Final[re.Pattern[str]] = re.compile(r"^\d+$")
-
-    def _load_date(self, element: ElementTree.Element) -> AnyDate | None:
+    def _load_date(self, element: ElementTree.Element) -> DateExpression | None:
         with suppress(XPathError):
             dateval_element = self._xpath1(element, "./ns:dateval")
-            if dateval_element.get("cformat") is None:
-                dateval_type = dateval_element.get("type")
-                if dateval_type is None:
-                    return self._load_dateval(dateval_element, "val")
-                dateval_type = str(dateval_type)
-                if dateval_type == "about":
-                    date = self._load_dateval(dateval_element, "val")
-                    if date is None:
-                        return None
-                    date.fuzzy = True
-                    return date
-                if dateval_type == "before":
-                    return DateRange(
-                        None,
-                        self._load_dateval(dateval_element, "val"),
-                        end_is_boundary=True,
-                    )
-                if dateval_type == "after":
-                    return DateRange(
-                        self._load_dateval(dateval_element, "val"),
-                        start_is_boundary=True,
-                    )
+            calendar = calendar_mapping[dateval_element.get("cformat")]
+            dateval_type = dateval_element.get("type")
+            if dateval_type is None:
+                return self._load_dateval(dateval_element, "val", calendar=calendar)
+            dateval_type = str(dateval_type)
+            if dateval_type == "about":
+                return self._load_dateval(
+                    dateval_element, "val", calendar=calendar, imprecise=True
+                )
+            if dateval_type == "before":
+                end = self._load_dateval(dateval_element, "val", calendar=calendar)
+                # @todo Log an error
+                assert end
+                return DateRange(None, end, end_is_boundary=True)
+            if dateval_type == "after":
+                start = self._load_dateval(dateval_element, "val", calendar=calendar)
+                # @todo Log an error
+                assert start
+                return DateRange(start, start_is_boundary=True)
         with suppress(XPathError):
             datespan_element = self._xpath1(element, "./ns:datespan")
-            if datespan_element.get("cformat") is None:
-                return DateRange(
-                    self._load_dateval(datespan_element, "start"),
-                    self._load_dateval(datespan_element, "stop"),
-                )
+            calendar = calendar_mapping[datespan_element.get("cformat")]
+            start = self._load_dateval(datespan_element, "start", calendar=calendar)
+            end = self._load_dateval(datespan_element, "stop", calendar=calendar)
+            # @todo Log an error
+            assert start or end
+            return DateRange(
+                start,
+                end,
+            )  # ty:ignore[no-matching-overload]
         with suppress(XPathError):
             daterange_element = self._xpath1(element, "./ns:daterange")
-            if daterange_element.get("cformat") is None:
-                return DateRange(
-                    self._load_dateval(daterange_element, "start"),
-                    self._load_dateval(daterange_element, "stop"),
-                    start_is_boundary=True,
-                    end_is_boundary=True,
-                )
+            calendar = calendar_mapping[daterange_element.get("cformat")]
+            start = self._load_dateval(datespan_element, "start", calendar=calendar)
+            end = self._load_dateval(datespan_element, "stop", calendar=calendar)
+            # @todo Log an error
+            assert start or end
+            return DateRange(
+                start,
+                end,
+                start_is_boundary=True,
+                end_is_boundary=True,
+            )
         return None
 
+    # @todo Gramps only allows YYY-MM-DD, with any character being a digit.
+    # @todo We'd have to use text comments to properly support partial dates.
+    # @todo
+    _dateval_pattern: Final[re.Pattern[str]] = re.compile(
+        r"^(\d{4})(-(\d{2}))?(-(\d{2}))?$"
+    )
+
+    def _load_dateval_part(self, part: str, /) -> int | None:
+        if set(part) == {"."}:
+            return None
+        return int(part)
+
     def _load_dateval(
-        self, element: ElementTree.Element, value_attribute_name: str
+        self,
+        element: ElementTree.Element,
+        value_attribute_name: str,
+        *,
+        calendar: type[Calendar],
+        imprecise: bool | None = None,
     ) -> Date | None:
         dateval = str(element.get(value_attribute_name))
-        if self._date_pattern.fullmatch(dateval):
-            date_parts: Sequence[int | None] = [
-                (
-                    int(part)
-                    if self._date_part_pattern.fullmatch(part) and int(part) > 0
-                    else None
+        if dateval_match := self._dateval_pattern.fullmatch(dateval):
+            date_parts = (
+                self._load_dateval_part(dateval_match.group(1)),
+                self._load_dateval_part(dateval_match.group(3)),
+                self._load_dateval_part(dateval_match.group(5)),
+            )
+            if validate_date_parts(date_parts):
+                return Date(
+                    *date_parts,
+                    calendar=calendar,
+                    imprecise=imprecise or element.get("quality") == "estimated",
                 )
-                for part in dateval.split("-", 2)
-            ]
-            date = Date(*date_parts)
-            dateval_quality = element.get("quality")
-            if dateval_quality == "estimated":
-                date.fuzzy = True
-            return date
+        # @todo Log an error
         return None
 
     async def _load_notes(self, database: ElementTree.Element) -> None:

--- a/betty/jinja_filters/negotiate_has_dates.py
+++ b/betty/jinja_filters/negotiate_has_dates.py
@@ -17,8 +17,8 @@ if TYPE_CHECKING:
 
     from jinja2.runtime import Context
 
-    from betty.attrs.date import HasAnyDate
-    from betty.date import AnyDate
+    from betty.attrs.date import HasDate
+    from betty.date import DateExpression
 
 
 @final
@@ -36,10 +36,10 @@ class NegotiateHasDates(JinjaFilter):
     def __call__(
         self,
         context: Context,
-        has_dates: Iterable[HasAnyDate],
+        has_dates: Iterable[HasDate],
         /,
-        date: AnyDate | None,
-    ) -> HasAnyDate | None:
+        date: DateExpression | None,
+    ) -> HasDate | None:
         """
         :param date: A date to select by. If ``None``, then today's date is used.
         """

--- a/betty/jinja_filters/select_has_dates.py
+++ b/betty/jinja_filters/select_has_dates.py
@@ -15,8 +15,8 @@ if TYPE_CHECKING:
 
     from jinja2.runtime import Context
 
-    from betty.attrs.date import HasAnyDate
-    from betty.date import AnyDate
+    from betty.attrs.date import HasDate
+    from betty.date import DateExpression
 
 
 @final
@@ -32,18 +32,16 @@ class SelectHasDates(JinjaFilter):
     def __call__(
         self,
         context: Context,
-        has_dates: Iterable[HasAnyDate],
+        has_dates: Iterable[HasDate],
         /,
-        date: AnyDate | None,
-    ) -> Iterator[HasAnyDate]:
+        date: DateExpression | None,
+    ) -> Iterator[HasDate]:
         """
         :param date: A date to select by. If ``None``, then today's date is used.
         """
         if date is None:
             date = context.resolve_or_missing("today")
         return filter(
-            lambda dated: (
-                dated.date is None or dated.date.comparable and dated.date in date
-            ),
+            lambda dated: dated.date is None or dated.date | date,
             has_dates,
         )

--- a/betty/json_schemas/date.py
+++ b/betty/json_schemas/date.py
@@ -18,7 +18,7 @@ class DateSchema(JsonLdObject):
 
     def __init__(self):
         super().__init__(def_name="date", title="Date")
-        self.add_property("fuzzy", Boolean(title="Fuzzy"))
+        self.add_property("imprecise", Boolean(title="Imprecise"))
         self.add_property("year", Number(title="Year"), False)
         self.add_property("month", Number(title="Month"), False)
         self.add_property("day", Number(title="Day"), False)
@@ -46,15 +46,15 @@ class DateRangeSchema(JsonLdObject):
 
 
 @final
-class ResolvableDateSchema(OneOf):
+class DateExpressionSchema(OneOf):
     """
-    A JSON Schema for :py:type:`betty.date.AnyDate`.
+    A JSON Schema for :py:type:`betty.date.DateExpression`.
     """
 
     def __init__(self):
         super().__init__(
             DateSchema(),
             DateRangeSchema(),
-            def_name="dateLike",
-            title="Date or date range",
+            def_name="dateExpression",
+            title="A date, date range, or date series.",
         )

--- a/betty/localizable/__init__.py
+++ b/betty/localizable/__init__.py
@@ -18,6 +18,8 @@ from betty.localizer import Localizer, default_localizer
 
 
 class _Localizable[T](ABC):
+    __slots__ = ()
+
     @abstractmethod
     def format(self, **format_kwargs: ResolvableLocalizable) -> T:
         """
@@ -36,6 +38,8 @@ class Localizable(_Localizable["Localizable"]):
 
     Objects of this type can convert themselves to localized strings at the point of use.
     """
+
+    __slots__ = ()
 
     @abstractmethod
     def localize(self, localizer: Localizer, /) -> LocalizedStr:

--- a/betty/localized.py
+++ b/betty/localized.py
@@ -35,7 +35,7 @@ class LocalizedStr(Localized, str):
     _locale: Locale | None
 
     @override
-    def __new__(cls, string: str, *, locale: Locale | None = None):
+    def __new__(cls, string: str, /, *, locale: Locale | None = None):
         new = super().__new__(cls, string)
         new._locale = locale
         return new

--- a/betty/porters/date.py
+++ b/betty/porters/date.py
@@ -7,12 +7,12 @@ from __future__ import annotations
 from typing import final, override
 
 from betty.assertions.if_else import assert_if_else
-from betty.date import AnyDate, Date, DateRange
+from betty.date import Date, DateExpression, DateRange
 from betty.portable import PortableData, Porter
 
 
 @final
-class AnyDatePorter(Porter[AnyDate]):
+class DateExpressionPorter(Porter[DateExpression]):
     """
     Port a date or date range.
     """
@@ -25,5 +25,5 @@ class AnyDatePorter(Porter[AnyDate]):
     )
 
     @override
-    def dump(self, data: AnyDate, /) -> PortableData:
+    def dump(self, data: DateExpression, /) -> PortableData:
         return data.data().porter.dump(data)

--- a/betty/privacy/privatizer.py
+++ b/betty/privacy/privatizer.py
@@ -285,9 +285,8 @@ class Privatizer:
         date: Date,
         generations_ago: int,
     ) -> bool:
-        if not date.comparable:
+        if date.year is None:
             return False
-
         return date <= Date(
             datetime.now(tz=UTC).year - self._lifetime_threshold * generations_ago,
             datetime.now(tz=UTC).month,

--- a/betty/tests/attrs/test_date.py
+++ b/betty/tests/attrs/test_date.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, override
 
 import pytest
 
-from betty.attrs.date import HasAnyDate
+from betty.attrs.date import HasDate
 from betty.date import Date, DateRange
 
 if TYPE_CHECKING:
@@ -13,17 +13,17 @@ if TYPE_CHECKING:
     from betty.test_utils.conftest import AssertDumpsLinkedData
 
 
-class DummyHasDateWithContextDefinitions(HasAnyDate):
+class DummyHasDateWithContextDefinitions(HasDate):
     @override
-    def has_any_date_linked_data_contexts(
+    def has_date_linked_data_contexts(
         self,
     ) -> tuple[str | None, str | None, str | None]:
         return "single-date", "start-date", "end-date"
 
 
-class TestHasAnyDate:
+class TestHasDate:
     def test_date(self) -> None:
-        sut = HasAnyDate()
+        sut = HasDate()
         assert sut.date is None
 
     @pytest.mark.parametrize(
@@ -32,7 +32,7 @@ class TestHasAnyDate:
             # No date information.
             (
                 {},
-                HasAnyDate(),
+                HasDate(),
             ),
             (
                 {},
@@ -45,21 +45,21 @@ class TestHasAnyDate:
                         "year": 1970,
                         "month": 1,
                         "day": 1,
-                        "iso8601": "1970-01-01",
-                        "fuzzy": False,
+                        "date": "1970-01-01",
+                        "imprecise": False,
                     }
                 },
-                HasAnyDate(date=Date(1970, 1, 1)),
+                HasDate(date=Date(1970, 1, 1)),
             ),
             (
                 {
                     "date": {
-                        "@context": {"iso8601": "single-date"},
+                        "@context": {"date": "single-date"},
                         "year": 1970,
                         "month": 1,
                         "day": 1,
-                        "iso8601": "1970-01-01",
-                        "fuzzy": False,
+                        "date": "1970-01-01",
+                        "imprecise": False,
                     }
                 },
                 DummyHasDateWithContextDefinitions(date=Date(1970, 1, 1)),
@@ -72,24 +72,24 @@ class TestHasAnyDate:
                             "year": 1970,
                             "month": 1,
                             "day": 1,
-                            "iso8601": "1970-01-01",
-                            "fuzzy": False,
+                            "date": "1970-01-01",
+                            "imprecise": False,
                         },
                         "end": None,
                     },
                 },
-                HasAnyDate(date=DateRange(Date(1970, 1, 1))),
+                HasDate(date=DateRange(Date(1970, 1, 1))),
             ),
             (
                 {
                     "date": {
                         "start": {
-                            "@context": {"iso8601": "start-date"},
+                            "@context": {"date": "start-date"},
                             "year": 1970,
                             "month": 1,
                             "day": 1,
-                            "iso8601": "1970-01-01",
-                            "fuzzy": False,
+                            "date": "1970-01-01",
+                            "imprecise": False,
                         },
                         "end": None,
                     },
@@ -105,24 +105,24 @@ class TestHasAnyDate:
                             "year": 2000,
                             "month": 12,
                             "day": 31,
-                            "iso8601": "2000-12-31",
-                            "fuzzy": False,
+                            "date": "2000-12-31",
+                            "imprecise": False,
                         },
                     },
                 },
-                HasAnyDate(date=DateRange(None, Date(2000, 12, 31))),
+                HasDate(date=DateRange(None, Date(2000, 12, 31))),
             ),
             (
                 {
                     "date": {
                         "start": None,
                         "end": {
-                            "@context": {"iso8601": "end-date"},
+                            "@context": {"date": "end-date"},
                             "year": 2000,
                             "month": 12,
                             "day": 31,
-                            "iso8601": "2000-12-31",
-                            "fuzzy": False,
+                            "date": "2000-12-31",
+                            "imprecise": False,
                         },
                     },
                 },
@@ -138,38 +138,38 @@ class TestHasAnyDate:
                             "year": 1970,
                             "month": 1,
                             "day": 1,
-                            "iso8601": "1970-01-01",
-                            "fuzzy": False,
+                            "date": "1970-01-01",
+                            "imprecise": False,
                         },
                         "end": {
                             "year": 2000,
                             "month": 12,
                             "day": 31,
-                            "iso8601": "2000-12-31",
-                            "fuzzy": False,
+                            "date": "2000-12-31",
+                            "imprecise": False,
                         },
                     },
                 },
-                HasAnyDate(date=DateRange(Date(1970, 1, 1), Date(2000, 12, 31))),
+                HasDate(date=DateRange(Date(1970, 1, 1), Date(2000, 12, 31))),
             ),
             (
                 {
                     "date": {
                         "start": {
-                            "@context": {"iso8601": "start-date"},
+                            "@context": {"date": "start-date"},
                             "year": 1970,
                             "month": 1,
                             "day": 1,
-                            "iso8601": "1970-01-01",
-                            "fuzzy": False,
+                            "date": "1970-01-01",
+                            "imprecise": False,
                         },
                         "end": {
-                            "@context": {"iso8601": "end-date"},
+                            "@context": {"date": "end-date"},
                             "year": 2000,
                             "month": 12,
                             "day": 31,
-                            "iso8601": "2000-12-31",
-                            "fuzzy": False,
+                            "date": "2000-12-31",
+                            "imprecise": False,
                         },
                     },
                 },

--- a/betty/tests/coverage/test_coverage.py
+++ b/betty/tests/coverage/test_coverage.py
@@ -108,8 +108,8 @@ _BASELINE: Mapping[str, _ModuleIgnore] = {
         "CommonAttr": MissingReason.ABSTRACT,
     },
     "betty/attrs/date.py": {
-        "HasAnyDate": {
-            "has_any_date_linked_data_contexts": MissingReason.STATIC_CONTENT_ONLY,
+        "HasDate": {
+            "has_date_linked_data_contexts": MissingReason.STATIC_CONTENT_ONLY,
         },
     },
     "betty/attrs/privacy.py": {
@@ -207,7 +207,7 @@ _BASELINE: Mapping[str, _ModuleIgnore] = {
         "FieldPorter": MissingReason.ABSTRACT,
     },
     "betty/datas/date.py": {
-        "AnyDateDefinition": MissingReason.STATIC_CONTENT_ONLY,
+        "DateExpressionDefinition": MissingReason.STATIC_CONTENT_ONLY,
     },
     "betty/datas/plugin/definition/__init__.py": {
         "PluginDefinitionData": {
@@ -216,15 +216,6 @@ _BASELINE: Mapping[str, _ModuleIgnore] = {
     },
     "betty/datas/plugin/manufacturer/sequence.py": {
         "PluginManufacturerSequenceDefinition": MissingReason.SHOULD_BE_COVERED,
-    },
-    "betty/date.py": {
-        "DateRange": {
-            "end": MissingReason.INHERITED,
-            "end_is_boundary": MissingReason.INHERITED,
-            "start": MissingReason.INHERITED,
-            "start_is_boundary": MissingReason.INHERITED,
-        },
-        "IncompleteDateError": MissingReason.STATIC_CONTENT_ONLY,
     },
     "betty/deriver.py": {"Derivation": MissingReason.ENUM},
     "betty/dirs.py": MissingReason.STATIC_CONTENT_ONLY,
@@ -439,7 +430,7 @@ _BASELINE: Mapping[str, _ModuleIgnore] = {
     },
     "betty/entities/event.py": {
         "Event": {
-            "has_any_date_linked_data_contexts": MissingReason.STATIC_CONTENT_ONLY,
+            "has_date_linked_data_contexts": MissingReason.STATIC_CONTENT_ONLY,
         },
     },
     "betty/entity/__init__.py": {

--- a/betty/tests/entities/test_enclosure.py
+++ b/betty/tests/entities/test_enclosure.py
@@ -37,7 +37,7 @@ class TestEnclosure(EntityTestBase):
         encloses = Place()
         enclosed_by = Place()
         sut = Enclosure(encloses=encloses, enclosed_by=enclosed_by)
-        date = Date()
+        date = Date(1)
         assert sut.date is None
         sut.date = date
         assert sut.date is date

--- a/betty/tests/entities/test_event.py
+++ b/betty/tests/entities/test_event.py
@@ -97,7 +97,7 @@ class TestEvent(EntityTestBase):
     def test_date(self) -> None:
         sut = Event(event_type=UnknownEventType())
         assert sut.date is None
-        date = Date()
+        date = Date(1)
         sut.date = date
         assert sut.date == date
 
@@ -206,23 +206,23 @@ class TestEvent(EntityTestBase):
             "date": {
                 "start": {
                     "@context": {
-                        "iso8601": "https://schema.org/startDate",
+                        "date": "https://schema.org/startDate",
                     },
                     "year": 2000,
                     "month": 1,
                     "day": 1,
-                    "iso8601": "2000-01-01",
-                    "fuzzy": False,
+                    "date": "2000-01-01",
+                    "imprecise": False,
                 },
                 "end": {
                     "@context": {
-                        "iso8601": "https://schema.org/endDate",
+                        "date": "https://schema.org/endDate",
                     },
                     "year": 2019,
                     "month": 12,
                     "day": 31,
-                    "iso8601": "2019-12-31",
-                    "fuzzy": False,
+                    "date": "2019-12-31",
+                    "imprecise": False,
                 },
             },
             "place": "/place/my-first-place/index.json",

--- a/betty/tests/entities/test_place_name.py
+++ b/betty/tests/entities/test_place_name.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 class TestPlaceName:
     def test_date(self) -> None:
-        date = Date()
+        date = Date(1)
         sut = PlaceName(
             "Ikke",
             date=date,

--- a/betty/tests/entities/test_source.py
+++ b/betty/tests/entities/test_source.py
@@ -200,8 +200,8 @@ class TestSource(EntityTestBase):
                 "year": 2000,
                 "month": 1,
                 "day": 1,
-                "iso8601": "2000-01-01",
-                "fuzzy": False,
+                "date": "2000-01-01",
+                "imprecise": False,
             },
             "links": [
                 "/link/my-first-link/index.json",

--- a/betty/tests/extensions/test__theme.py
+++ b/betty/tests/extensions/test__theme.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Final
 
 import pytest
 
-from betty.date import AnyDate, Date, DateRange
+from betty.date import Date, DateExpression, DateRange
 from betty.entities.citation import Citation
 from betty.entities.event import Event
 from betty.entities.file import File
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from betty.role import Role
 
 __reference_date: Final[Date] = Date(1970, 1, 1)
-_reference_dates: Final[Sequence[AnyDate]] = (
+_reference_dates: Final[Sequence[DateExpression]] = (
     __reference_date,
     DateRange(__reference_date),
     DateRange(None, __reference_date),
@@ -50,10 +50,10 @@ def _parameterize_with_associated_events() -> Sequence[
         str | None,
         Privacy,
         EventType,
-        AnyDate | None,
+        DateExpression | None,
         Privacy,
         EventType,
-        AnyDate | None,
+        DateExpression | None,
     ]
 ]:
     return tuple(__parameterize_with_associated_events())
@@ -147,7 +147,7 @@ class TestPersonLifetimeEvents:
         expected: bool,
         event_id: str | None,
         event_privacy: Privacy,
-        event_date: AnyDate | None,
+        event_date: DateExpression | None,
     ) -> None:
         person = Person()
         event = Event(
@@ -181,10 +181,10 @@ class TestPersonLifetimeEvents:
         event_id: str | None,
         event_privacy: Privacy,
         event_type: EventType,
-        event_date: AnyDate | None,
+        event_date: DateExpression | None,
         person_reference_event_privacy: Privacy,
         person_reference_event_type: EventType,
-        person_reference_event_date: AnyDate | None,
+        person_reference_event_date: DateExpression | None,
     ) -> None:
         event_ids = 0
 

--- a/betty/tests/jinja_filters/test_negotiate_has_dates.py
+++ b/betty/tests/jinja_filters/test_negotiate_has_dates.py
@@ -3,13 +3,13 @@ from typing import Any, override
 
 import pytest
 
-from betty.attrs.date import HasAnyDate
-from betty.date import AnyDate, Date, DateRange
+from betty.attrs.date import HasDate
+from betty.date import Date, DateExpression, DateRange
 from betty.test_utils.conftest import AssertTemplateString
 
 
-class _DummyHasDate(HasAnyDate):
-    def __init__(self, value: str, date: AnyDate | None = None):
+class _DummyHasDate(HasDate):
+    def __init__(self, value: str, date: DateExpression | None = None):
         super().__init__(date=date)
         self.value = value
 
@@ -37,15 +37,6 @@ class TestNegotiateHasDates:
                     "has_dates": [
                         _DummyHasDate("Apple"),
                     ],
-                    "date": Date(),
-                },
-            ),
-            (
-                "Apple",
-                {
-                    "has_dates": [
-                        _DummyHasDate("Apple"),
-                    ],
                     "date": Date(1970, 1, 1),
                 },
             ),
@@ -56,15 +47,6 @@ class TestNegotiateHasDates:
                         _DummyHasDate("Apple", Date(1970, 1, 1)),
                     ],
                     "date": None,
-                },
-            ),
-            (
-                "",
-                {
-                    "has_dates": [
-                        _DummyHasDate("Apple", Date(1970, 1, 1)),
-                    ],
-                    "date": Date(),
                 },
             ),
             (

--- a/betty/tests/jinja_filters/test_select_has_dates.py
+++ b/betty/tests/jinja_filters/test_select_has_dates.py
@@ -3,13 +3,13 @@ from typing import Any, override
 
 import pytest
 
-from betty.attrs.date import HasAnyDate
-from betty.date import AnyDate, Date, DateRange
+from betty.attrs.date import HasDate
+from betty.date import Date, DateExpression, DateRange
 from betty.test_utils.conftest import AssertTemplateString
 
 
-class _DummyHasDate(HasAnyDate):
-    def __init__(self, value: str, date: AnyDate | None = None):
+class _DummyHasDate(HasDate):
+    def __init__(self, value: str, date: DateExpression | None = None):
         super().__init__(date=date)
         self.value = value
 
@@ -37,15 +37,6 @@ class TestSelectHasDates:
                     "has_dates": [
                         _DummyHasDate("Apple"),
                     ],
-                    "date": Date(),
-                },
-            ),
-            (
-                "Apple",
-                {
-                    "has_dates": [
-                        _DummyHasDate("Apple"),
-                    ],
                     "date": Date(1970, 1, 1),
                 },
             ),
@@ -56,15 +47,6 @@ class TestSelectHasDates:
                         _DummyHasDate("Apple", Date(1970, 1, 1)),
                     ],
                     "date": None,
-                },
-            ),
-            (
-                "",
-                {
-                    "has_dates": [
-                        _DummyHasDate("Apple", Date(1970, 1, 1)),
-                    ],
-                    "date": Date(),
                 },
             ),
             (

--- a/betty/tests/json_schemas/test_date.py
+++ b/betty/tests/json_schemas/test_date.py
@@ -4,12 +4,12 @@ from typing import override
 
 import pytest
 
-from betty.json_schemas.date import DateRangeSchema, DateSchema, ResolvableDateSchema
+from betty.json_schemas.date import DateExpressionSchema, DateRangeSchema, DateSchema
 from betty.test_utils.json_schema import SchemaTestBase, SchemaTestBaseSut
 from betty.tests.test_date import (
-    _DUMMY_DATE_DUMPS,
-    _DUMMY_DATE_RANGE_DUMPS,
-    _DUMMY_RESOLVABLE_DATE_DUMPS,
+    date_dumps,
+    dummy_date_expression_dumps,
+    dummy_date_range_dumps,
 )
 
 
@@ -17,18 +17,18 @@ class TestDateRangeSchema(SchemaTestBase):
     @override
     @pytest.fixture
     def sut_data(self) -> SchemaTestBaseSut:
-        return (DateRangeSchema(), *_DUMMY_DATE_RANGE_DUMPS)
+        return (DateRangeSchema(), *dummy_date_range_dumps)
 
 
 class TestDateSchema(SchemaTestBase):
     @override
     @pytest.fixture
     def sut_data(self) -> SchemaTestBaseSut:
-        return (DateSchema(), *_DUMMY_DATE_DUMPS)
+        return (DateSchema(), *date_dumps)
 
 
 class TestResolvableDateSchema(SchemaTestBase):
     @override
     @pytest.fixture
     def sut_data(self) -> SchemaTestBaseSut:
-        return (ResolvableDateSchema(), *_DUMMY_RESOLVABLE_DATE_DUMPS)
+        return (DateExpressionSchema(), *dummy_date_expression_dumps)

--- a/betty/tests/porters/test_date.py
+++ b/betty/tests/porters/test_date.py
@@ -1,26 +1,28 @@
 from betty.date import Date, DateRange
-from betty.porters.date import AnyDatePorter
+from betty.porters.date import DateExpressionPorter
 
 
-class TestAnyDatePorter:
+class TestDateExpressionPorter:
     def test_load__with_date(self) -> None:
-        assert isinstance(AnyDatePorter().load({}), Date)
+        assert isinstance(DateExpressionPorter().load({}), Date)
 
     def test_load__with_date_range(self) -> None:
         assert isinstance(
-            AnyDatePorter().load({"start": {}}),
+            DateExpressionPorter().load({"start": {}}),
             DateRange,
         )
 
     def test_dump__with_date(self) -> None:
-        assert AnyDatePorter().dump(Date(1970, 1, 1)) == {
+        assert DateExpressionPorter().dump(Date(1970, 1, 1)) == {
             "year": 1970,
             "month": 1,
             "day": 1,
         }
 
     def test_dump__with_date_range(self) -> None:
-        assert AnyDatePorter().dump(DateRange(Date(1970, 1, 1), Date(2002, 2, 2))) == {
+        assert DateExpressionPorter().dump(
+            DateRange(Date(1970, 1, 1), Date(2002, 2, 2))
+        ) == {
             "start": {
                 "year": 1970,
                 "month": 1,

--- a/betty/tests/privacy/test_privatizer.py
+++ b/betty/tests/privacy/test_privatizer.py
@@ -125,7 +125,7 @@ def _expand_person(generation: int) -> Sequence[tuple[bool, Privacy, Event | Non
             Privacy.UNDETERMINED,
             Event(
                 event_type=Birth(),
-                date=Date(),
+                date=Date(None, None, 1),
             ),
         ),
         (
@@ -133,7 +133,7 @@ def _expand_person(generation: int) -> Sequence[tuple[bool, Privacy, Event | Non
             Privacy.PRIVATE,
             Event(
                 event_type=Birth(),
-                date=Date(),
+                date=Date(None, None, 1),
             ),
         ),
         (
@@ -141,7 +141,7 @@ def _expand_person(generation: int) -> Sequence[tuple[bool, Privacy, Event | Non
             Privacy.PUBLIC,
             Event(
                 event_type=Birth(),
-                date=Date(),
+                date=Date(None, None, 1),
             ),
         ),
         # Regular events under the lifetime threshold do not affect privacy.

--- a/betty/tests/test_date.py
+++ b/betty/tests/test_date.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Final, cast
 
 import pytest
 
@@ -8,7 +8,7 @@ from betty.attrs.date import (
     _dump_linked_data_for_date,
     _dump_linked_data_for_date_range,
 )
-from betty.date import AnyDate, Date, DateRange, IncompleteDateError
+from betty.date import Date, DateExpression, DateRange
 from betty.json_schemas.date import DateRangeSchema, DateSchema
 from betty.localizer import default_localizer
 from betty.portable import PortableMapping
@@ -16,51 +16,158 @@ from betty.portable import PortableMapping
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from _pytest.mark.structures import MarkDecorator
+
     from betty.test_utils.conftest import AssertLinkedDataDump
 
-_DUMMY_DATE_DUMPS: tuple[
-    Sequence[PortableMapping],
-    Sequence[PortableMapping],
+
+type Pairs = Sequence[tuple[DateExpression, DateExpression]]
+lt: Final[Pairs] = (
+    # Both dates are full.
+    (Date(1970, 1, 1), Date(1970, 1, 2)),
+    (Date(1970, 1, 1), Date(1970, 2, 1)),
+    (Date(1970, 1, 1), Date(1971, 1, 1)),
+    # Left date is not full.
+    # @todo
+    # Right date is not full.
+    # @todo
+    # @todo
+    # Date dates
+    # Start date only.
+    (DateRange(Date(1970, 2, 2)), Date(1970, 2, 3)),
+    (DateRange(Date(1970, 2, 2)), DateRange(Date(1970, 2, 3))),
+    (DateRange(Date(1970, 2, 2)), DateRange(None, Date(1970, 2, 3))),
+    # End date only.
+    (DateRange(None, Date(1970, 2, 2)), Date(1970, 2, 2)),
+    (DateRange(None, Date(1970, 2, 2)), Date(1970, 2, 3)),
+    (DateRange(None, Date(1970, 2, 2)), DateRange(Date(1970, 2, 2))),
+    (DateRange(None, Date(1970, 2, 2)), DateRange(Date(1970, 2, 3))),
+    (
+        DateRange(None, Date(1970, 2, 2)),
+        DateRange(None, Date(1970, 2, 3)),
+    ),
+    (
+        DateRange(None, Date(1970, 2, 2)),
+        DateRange(Date(1970, 2, 2), Date(1970, 2, 3)),
+    ),
+    # Both dates.
+    (DateRange(Date(1970, 2, 1), Date(1970, 2, 3)), Date(1970, 2, 2)),
+    (DateRange(Date(1970, 2, 1), Date(1970, 2, 3)), Date(1970, 2, 3)),
+    (
+        DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
+        DateRange(Date(1970, 2, 1)),
+    ),
+    (
+        DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
+        DateRange(Date(1970, 2, 2)),
+    ),
+    (
+        DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
+        DateRange(Date(1970, 2, 3)),
+    ),
+    (
+        DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
+        DateRange(None, Date(1970, 2, 2)),
+    ),
+    (
+        DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
+        DateRange(None, Date(1970, 2, 3)),
+    ),
+    (
+        DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
+        DateRange(Date(1970, 2, 2), Date(1970, 2, 3)),
+    ),
+)
+
+eq: Final[Pairs] = (
+    (Date(1970, 1, 1), Date(1970, 1, 1)),
+    (DateRange(Date(1970, 2, 2)), DateRange(Date(1970, 2, 2))),
+)
+neq: Final[Pairs] = (
+    (Date(1970, 1, 1), Date(1970, 1, None)),
+    (Date(1970, 1, 1), Date(1970, None, 1)),
+    (Date(1970, 1, 1), Date(None, 1, 1)),
+    (Date(1970, 1, 1), Date(1970, None, None)),
+    (Date(1970, 1, 1), Date(None, 1, None)),
+    (Date(1970, 1, 1), Date(None, None, 1)),
+    (DateRange(Date(1970, 2, 2)), DateRange(Date(1970, 2, None))),
+    (DateRange(Date(1970, 2, 2)), DateRange(Date(1970, None, 2))),
+    (DateRange(Date(1970, 2, 2)), DateRange(Date(None, 2, 2))),
+    (DateRange(Date(1970, 2, 2)), DateRange(Date(1970, None, None))),
+    (DateRange(Date(1970, 2, 2)), DateRange(Date(None, 2, None))),
+    (DateRange(Date(1970, 2, 2)), DateRange(Date(None, None, 2))),
+)
+
+le: Final[Pairs] = (
+    *lt,
+    *eq,
+)
+
+gt: Final[Pairs] = ()
+
+ge: Final[Pairs] = (
+    *gt,
+    *eq,
+)
+
+
+def parameterize_pairs[DateExpressionT: DateExpression](
+    date: type[DateExpressionT], _pass: Pairs, fail: Pairs
+) -> MarkDecorator:
+    return pytest.mark.parametrize(
+        ("expected", "sut", "other"),
+        [
+            *((True, sut, other) for sut, other in _pass if isinstance(sut, date)),
+            *((False, sut, other) for sut, other in fail if isinstance(sut, date)),
+        ],
+    )
+
+
+date_dumps: Final[
+    tuple[
+        Sequence[PortableMapping],
+        Sequence[PortableMapping],
+    ]
 ] = (
     [
         {
             "year": 1970,
-            "fuzzy": False,
+            "imprecise": False,
         },
         {
             "month": 1,
-            "fuzzy": False,
+            "imprecise": False,
         },
         {
             "day": 1,
-            "fuzzy": False,
+            "imprecise": False,
         },
         {
             "year": 1970,
             "month": 1,
-            "fuzzy": False,
+            "imprecise": False,
         },
         {
             "year": 1970,
             "day": 1,
-            "fuzzy": False,
+            "imprecise": False,
         },
         {
             "month": 1,
             "day": 1,
-            "fuzzy": False,
-        },
-        {
-            "year": 1970,
-            "month": 1,
-            "day": 1,
-            "fuzzy": False,
+            "imprecise": False,
         },
         {
             "year": 1970,
             "month": 1,
             "day": 1,
-            "fuzzy": True,
+            "imprecise": False,
+        },
+        {
+            "year": 1970,
+            "month": 1,
+            "day": 1,
+            "imprecise": True,
         },
     ],
     [
@@ -74,227 +181,103 @@ _DUMMY_DATE_DUMPS: tuple[
             "day": 1,
         },
         {
-            "fuzzy": "true",
+            "imprecise": "true",
         },
     ],
 )
 
-_DUMMY_DATE_RANGE_DUMPS: tuple[
-    Sequence[PortableMapping],
-    Sequence[PortableMapping],
+dummy_date_range_dumps: Final[
+    tuple[
+        Sequence[PortableMapping],
+        Sequence[PortableMapping],
+    ]
 ] = (
     [
         *[
             cast(PortableMapping, {"start": start, "end": None})
-            for start in _DUMMY_DATE_DUMPS[0]
+            for start in date_dumps[0]
         ],
-        *[
-            cast(PortableMapping, {"start": None, "end": end})
-            for end in _DUMMY_DATE_DUMPS[0]
-        ],
+        *[cast(PortableMapping, {"start": None, "end": end}) for end in date_dumps[0]],
         *[
             cast(PortableMapping, {"start": start, "end": end})
-            for start in _DUMMY_DATE_DUMPS[0]
-            for end in _DUMMY_DATE_DUMPS[0]
+            for start in date_dumps[0]
+            for end in date_dumps[0]
         ],
     ],
     [],
 )
 
-_DUMMY_RESOLVABLE_DATE_DUMPS: tuple[
-    Sequence[PortableMapping],
-    Sequence[PortableMapping],
+dummy_date_expression_dumps: Final[
+    tuple[
+        Sequence[PortableMapping],
+        Sequence[PortableMapping],
+    ]
 ] = (
-    [*_DUMMY_DATE_DUMPS[0], *_DUMMY_DATE_RANGE_DUMPS[0]],
-    [*_DUMMY_DATE_DUMPS[1], *_DUMMY_DATE_RANGE_DUMPS[1]],
+    [*date_dumps[0], *dummy_date_range_dumps[0]],
+    [*date_dumps[1], *dummy_date_range_dumps[1]],
 )
 
 
 class TestDate:
     def test_year(self) -> None:
         year = 1970
-        sut = Date(year=year)
+        sut = Date(year)
         assert sut.year == year
 
     def test_month(self) -> None:
         month = 1
-        sut = Date(month=month)
+        sut = Date(None, month)
         assert sut.month == month
 
     def test_day(self) -> None:
         day = 1
-        sut = Date(day=day)
+        sut = Date(None, None, day)
         assert sut.day == day
 
-    def test_fuzzy(self) -> None:
-        fuzzy = True
-        sut = Date()
-        sut.fuzzy = fuzzy
-        assert sut.fuzzy == fuzzy
+    def test_imprecise(self) -> None:
+        assert Date(1, imprecise=True).imprecise
+        assert not Date(1, imprecise=False).imprecise
 
-    @pytest.mark.parametrize(
-        ("expected", "year", "month", "day"),
-        [
-            (True, 1970, 1, 1),
-            (False, None, 1, 1),
-            (True, 1970, None, 1),
-            (True, 1970, 1, None),
-            (False, None, None, 1),
-            (True, 1970, None, None),
-            (False, None, None, None),
-        ],
-    )
-    def test_comparable(
-        self, expected: bool, year: int | None, month: int | None, day: int | None
-    ) -> None:
-        sut = Date(year, month, day)
-        assert sut.comparable == expected
+    @parameterize_pairs(Date, lt, ge)
+    def test___lt__(self, expected: bool, sut: Date, other: DateExpression) -> None:
+        assert (sut < other) is expected
 
-    @pytest.mark.parametrize(
-        ("expected", "year", "month", "day"),
-        [
-            (True, 1970, 1, 1),
-            (False, None, 1, 1),
-            (False, 1970, None, 1),
-            (False, 1970, 1, None),
-            (False, None, None, 1),
-            (False, 1970, None, None),
-            (False, None, None, None),
-        ],
-    )
-    def test_complete(
-        self, expected: bool, year: int | None, month: int | None, day: int | None
-    ) -> None:
-        sut = Date(year, month, day)
-        assert sut.complete == expected
+    @parameterize_pairs(Date, le, gt)
+    def test___le__(self, expected: bool, sut: Date, other: DateExpression) -> None:
+        assert (sut <= other) is expected
 
-    def test_to_range__when_incomparable_should_raise(self) -> None:
-        with pytest.raises(ValueError):  # noqa: PT011
-            Date(None, 1, 1).to_range()
+    @parameterize_pairs(Date, eq, neq)
+    def test___eq__(self, expected: bool, sut: Date, other: DateExpression) -> None:
+        assert (sut == other) is expected
 
-    @pytest.mark.parametrize(
-        ("year", "month", "day"),
-        [
-            (1970, 1, 1),
-            (None, None, None),
-        ],
-    )
-    def test_parts(self, year: int | None, month: int | None, day: int | None) -> None:
-        assert (year, month, day) == Date(year, month, day).parts
+    @parameterize_pairs(Date, ge, lt)
+    def test___ge__(self, expected: bool, sut: Date, other: DateExpression) -> None:
+        assert (sut >= other) is expected
 
-    @pytest.mark.parametrize(
-        ("expected", "other"),
-        [
-            (False, Date(1970, 2, 1)),
-            (True, Date(1970, 2, 2)),
-            (False, Date(1970, 2, 3)),
-            (False, DateRange()),
-        ],
-    )
-    def test___contains__(self, expected: bool, other: AnyDate) -> None:
-        assert (other in Date(1970, 2, 2)) == expected
-
-    @pytest.mark.parametrize(
-        ("expected", "sut", "other"),
-        [
-            (False, Date(1970, 2, 2), Date(1970, 2, 1)),
-            (False, Date(1970, 2, 2), Date(1970, 2, 2)),
-            (True, Date(1970, 2, 2), Date(1970, 2, 3)),
-            (False, Date(1970, 2, 2), Date(1970)),
-            (False, Date(1970, 2, 2), Date(1970, 2)),
-            (True, Date(1970, 2, 2), Date(1971)),
-            (True, Date(1970, 2, 2), Date(1970, 3)),
-        ],
-    )
-    def test___lt__(self, expected: bool, sut: Date, other: AnyDate) -> None:
-        assert (sut < other) == expected
-
-    @pytest.mark.parametrize(
-        ("expected", "sut", "other"),
-        [
-            (False, Date(1970, 2, 2), Date(1970, 2, 1)),
-            (True, Date(1970, 2, 2), Date(1970, 2, 2)),
-            (True, Date(1970, 2, 2), Date(1970, 2, 3)),
-            (False, Date(1970, 2, 2), Date(1970)),
-            (False, Date(1970, 2, 2), Date(1970, 2)),
-            (True, Date(1970, 2, 2), Date(1971)),
-            (True, Date(1970, 2, 2), Date(1970, 3)),
-        ],
-    )
-    def test___le__(self, expected: bool, sut: Date, other: AnyDate) -> None:
-        assert (sut <= other) == expected
-
-    @pytest.mark.parametrize(
-        ("expected", "other"),
-        [
-            (True, Date(1970, 1, 1)),
-            (False, Date(1970, 1, None)),
-            (False, Date(1970, None, 1)),
-            (False, Date(None, 1, 1)),
-            (False, Date(1970, None, None)),
-            (False, Date(None, 1, None)),
-            (False, Date(None, None, 1)),
-            (False, None),
-        ],
-    )
-    def test___eq__(self, expected: bool, other: AnyDate) -> None:
-        assert (Date(1970, 1, 1) == other) == expected
-        assert (other == Date(1970, 1, 1)) == expected
-
-    @pytest.mark.parametrize(
-        ("expected", "sut", "other"),
-        [
-            (True, Date(1970, 2, 2), Date(1970, 2, 1)),
-            (True, Date(1970, 2, 2), Date(1970, 2, 2)),
-            (False, Date(1970, 2, 2), Date(1970, 2, 3)),
-            (True, Date(1970, 2, 2), Date(1970)),
-            (True, Date(1970, 2, 2), Date(1970, 2)),
-            (False, Date(1970, 2, 2), Date(1971)),
-            (False, Date(1970, 2, 2), Date(1970, 3)),
-        ],
-    )
-    def test___ge__(self, expected: bool, sut: Date, other: AnyDate) -> None:
-        assert (sut >= other) == expected
-
-    @pytest.mark.parametrize(
-        ("expected", "sut", "other"),
-        [
-            (True, Date(1970, 2, 2), Date(1970, 2, 1)),
-            (False, Date(1970, 2, 2), Date(1970, 2, 2)),
-            (False, Date(1970, 2, 2), Date(1970, 2, 3)),
-            (True, Date(1970, 2, 2), Date(1970)),
-            (True, Date(1970, 2, 2), Date(1970, 2)),
-            (False, Date(1970, 2, 2), Date(1971)),
-            (False, Date(1970, 2, 2), Date(1970, 3)),
-        ],
-    )
-    def test___gt__(self, expected: bool, sut: Date, other: AnyDate) -> None:
-        assert (sut > other) == expected
+    @parameterize_pairs(Date, gt, le)
+    def test___gt__(self, expected: bool, sut: Date, other: DateExpression) -> None:
+        assert (sut > other) is expected
 
     @pytest.mark.parametrize(
         ("expected", "sut"),
         [
             # Dates that cannot be formatted.
-            ("unknown date", Date()),
-            ("unknown date", Date(None, None, 1)),
+            ("day 1 of the month", Date(None, None, 1)),
             # Single dates.
             ("January", Date(None, 1, None)),
-            ("around January", Date(None, 1, None, fuzzy=True)),
+            ("around January", Date(None, 1, None, imprecise=True)),
             ("1970", Date(1970, None, None)),
-            ("around 1970", Date(1970, None, None, fuzzy=True)),
+            ("around 1970", Date(1970, None, None, imprecise=True)),
             ("January, 1970", Date(1970, 1, None)),
-            ("around January, 1970", Date(1970, 1, None, fuzzy=True)),
+            ("around January, 1970", Date(1970, 1, None, imprecise=True)),
             ("January 1, 1970", Date(1970, 1, 1)),
-            ("around January 1, 1970", Date(1970, 1, 1, fuzzy=True)),
+            ("around January 1, 1970", Date(1970, 1, 1, imprecise=True)),
             ("January 1", Date(None, 1, 1)),
-            ("around January 1", Date(None, 1, 1, fuzzy=True)),
+            ("around January 1", Date(None, 1, 1, imprecise=True)),
         ],
     )
     async def test_localize(self, expected: str, sut: Date) -> None:
         assert sut.localize(default_localizer) == expected
-
-    def test_load__minimal(self) -> None:
-        Date.data().porter.load({})
 
     def test_load__with_year(self) -> None:
         assert Date.data().porter.load({"year": 9}).year == 9
@@ -305,536 +288,55 @@ class TestDate:
     def test_load__with_day(self) -> None:
         assert Date.data().porter.load({"day": 9}).day == 9
 
-    def test_load__with_fuzzy(self) -> None:
-        assert Date.data().porter.load({"fuzzy": True}).fuzzy
-
-    def test_dump__minimal(self) -> None:
-        assert Date.data().porter.dump(Date()) == {}
+    def test_load__with_imprecise(self) -> None:
+        assert Date.data().porter.load({"imprecise": True, "year": 9}).imprecise
 
     def test_dump__with_year(self) -> None:
-        assert Date.data().porter.dump(Date(year=9)) == {"year": 9}
+        assert Date.data().porter.dump(Date(9)) == {"year": 9}
 
     def test_dump__with_month(self) -> None:
-        assert Date.data().porter.dump(Date(month=9)) == {"month": 9}
+        assert Date.data().porter.dump(Date(None, 9)) == {"month": 9}
 
     def test_dump__with_day(self) -> None:
-        assert Date.data().porter.dump(Date(day=9)) == {"day": 9}
+        assert Date.data().porter.dump(Date(None, None, 9)) == {"day": 9}
 
-    def test_dump__with_fuzzy(self) -> None:
-        assert Date.data().porter.dump(Date(fuzzy=True)) == {"fuzzy": True}
+    def test_dump__with_imprecise(self) -> None:
+        assert Date.data().porter.dump(Date(9, imprecise=True)) == {
+            "imprecise": True,
+            "year": 9,
+        }
 
 
 class TestDateRange:
-    @pytest.mark.parametrize(
-        ("expected", "sut"),
-        [
-            (False, DateRange()),
-            (False, DateRange(Date(), None)),
-            (True, DateRange(Date(1970), None)),
-            (False, DateRange(Date(None, 1), None)),
-            (False, DateRange(Date(None, None, 1), None)),
-            (False, DateRange(None, Date())),
-            (True, DateRange(None, Date(1970))),
-            (False, DateRange(None, Date(None, 1))),
-            (False, DateRange(None, Date(None, None, 1))),
-            (False, DateRange(Date(), Date())),
-            (True, DateRange(Date(1970), Date())),
-            (True, DateRange(Date(), Date(1970))),
-        ],
-    )
-    def test_comparable(self, expected: bool, sut: DateRange) -> None:
-        assert sut.comparable == expected
-
-    _TEST_CONTAINS_PARAMETERS: Sequence[tuple[bool, AnyDate, AnyDate]] = [
-        (False, Date(1970, 2, 2), DateRange()),
-        (False, Date(1970, 2), DateRange()),
-        (False, Date(1970), DateRange()),
-        (False, Date(1970, 2, 1), DateRange(Date(1970, 2, 2))),
-        (True, Date(1970, 2, 2), DateRange(Date(1970, 2, 2))),
-        (True, Date(1970, 2, 3), DateRange(Date(1970, 2, 2))),
-        (True, Date(1970, 2, 1), DateRange(None, Date(1970, 2, 2))),
-        (True, Date(1970, 2, 2), DateRange(None, Date(1970, 2, 2))),
-        (False, Date(1970, 2, 3), DateRange(None, Date(1970, 2, 2))),
-        (False, Date(1969, 2, 1), DateRange(Date(1969, 2, 2), Date(1970, 2, 2))),
-        (True, Date(1970, 2, 1), DateRange(Date(1969, 2, 2), Date(1970, 2, 2))),
-        (False, Date(1971, 2, 1), DateRange(Date(1969, 2, 2), Date(1970, 2, 2))),
-        (True, DateRange(Date(1970, 2, 1)), DateRange(Date(1970, 2, 2))),
-        (True, DateRange(Date(1970, 2, 2)), DateRange(Date(1970, 2, 2))),
-        (True, DateRange(Date(1970, 2, 3)), DateRange(Date(1970, 2, 2))),
-        (False, DateRange(None, Date(1970, 2, 1)), DateRange(Date(1970, 2, 2))),
-        (True, DateRange(None, Date(1970, 2, 2)), DateRange(Date(1970, 2, 2))),
-        (True, DateRange(None, Date(1970, 2, 3)), DateRange(Date(1970, 2, 2))),
-        (True, DateRange(Date(1970, 2, 1)), DateRange(None, Date(1970, 2, 2))),
-        (True, DateRange(Date(1970, 2, 2)), DateRange(None, Date(1970, 2, 2))),
-        (False, DateRange(Date(1970, 2, 3)), DateRange(None, Date(1970, 2, 2))),
-        (True, DateRange(None, Date(1970, 2, 1)), DateRange(None, Date(1970, 2, 2))),
-        (True, DateRange(None, Date(1970, 2, 2)), DateRange(None, Date(1970, 2, 2))),
-        (True, DateRange(None, Date(1970, 2, 3)), DateRange(None, Date(1970, 2, 2))),
-        (
-            True,
-            DateRange(Date(1969, 2, 1)),
-            DateRange(Date(1969, 2, 2), Date(1970, 2, 2)),
-        ),
-        (
-            True,
-            DateRange(Date(1970, 2, 1)),
-            DateRange(Date(1969, 2, 2), Date(1970, 2, 2)),
-        ),
-        (
-            False,
-            DateRange(Date(1971, 2, 1)),
-            DateRange(Date(1969, 2, 2), Date(1970, 2, 2)),
-        ),
-        (
-            False,
-            DateRange(None, Date(1969, 2, 1)),
-            DateRange(Date(1969, 2, 2), Date(1970, 2, 2)),
-        ),
-        (
-            True,
-            DateRange(None, Date(1970, 2, 1)),
-            DateRange(Date(1969, 2, 2), Date(1970, 2, 2)),
-        ),
-        (
-            True,
-            DateRange(None, Date(1971, 2, 1)),
-            DateRange(Date(1969, 2, 2), Date(1970, 2, 2)),
-        ),
-        (
-            False,
-            DateRange(Date(1969, 2, 2), Date(1970, 2, 2)),
-            DateRange(Date(1971, 2, 2), Date(1972, 2, 2)),
-        ),
-        (
-            True,
-            DateRange(Date(1969, 2, 2), Date(1971, 2, 2)),
-            DateRange(Date(1970, 2, 2), Date(1972, 2, 2)),
-        ),
-        (
-            True,
-            DateRange(Date(1970, 2, 2), Date(1971, 2, 2)),
-            DateRange(Date(1969, 2, 2), Date(1972, 2, 2)),
-        ),
-    ]
-
-    # Mirror the arguments because we want the containment check to work in either direction.
-    @pytest.mark.parametrize(
-        ("expected", "other", "sut"),
-        _TEST_CONTAINS_PARAMETERS
-        + [(x[0], x[2], x[1]) for x in _TEST_CONTAINS_PARAMETERS],
-    )
-    def test___contains__(self, expected: bool, other: AnyDate, sut: AnyDate) -> None:
-        assert (other in sut) == expected
-
-    @pytest.mark.parametrize(
-        ("expected", "sut", "other"),
-        [
-            # Start date only.
-            (False, DateRange(Date(1970, 2, 2)), Date(1970, 2, 1)),
-            (False, DateRange(Date(1970, 2, 2)), Date(1970, 2, 2)),
-            (True, DateRange(Date(1970, 2, 2)), Date(1970, 2, 3)),
-            (False, DateRange(Date(1970, 2, 2)), DateRange(Date(1970, 2, 1))),
-            (False, DateRange(Date(1970, 2, 2)), DateRange(Date(1970, 2, 2))),
-            (True, DateRange(Date(1970, 2, 2)), DateRange(Date(1970, 2, 3))),
-            (False, DateRange(Date(1970, 2, 2)), DateRange(None, Date(1970, 2, 1))),
-            (False, DateRange(Date(1970, 2, 2)), DateRange(None, Date(1970, 2, 2))),
-            (True, DateRange(Date(1970, 2, 2)), DateRange(None, Date(1970, 2, 3))),
-            (
-                False,
-                DateRange(Date(1970, 2, 2)),
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 2)),
-            ),
-            (
-                False,
-                DateRange(Date(1970, 2, 2)),
-                DateRange(Date(1970, 2, 2), Date(1970, 2, 3)),
-            ),
-            (
-                False,
-                DateRange(Date(1970, 2, 2)),
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-            ),
-            # End date only.
-            (False, DateRange(None, Date(1970, 2, 2)), Date(1970, 2, 1)),
-            (True, DateRange(None, Date(1970, 2, 2)), Date(1970, 2, 2)),
-            (True, DateRange(None, Date(1970, 2, 2)), Date(1970, 2, 3)),
-            (False, DateRange(None, Date(1970, 2, 2)), DateRange(Date(1970, 2, 1))),
-            (True, DateRange(None, Date(1970, 2, 2)), DateRange(Date(1970, 2, 2))),
-            (True, DateRange(None, Date(1970, 2, 2)), DateRange(Date(1970, 2, 3))),
-            (
-                False,
-                DateRange(None, Date(1970, 2, 2)),
-                DateRange(None, Date(1970, 2, 1)),
-            ),
-            (
-                False,
-                DateRange(None, Date(1970, 2, 2)),
-                DateRange(None, Date(1970, 2, 2)),
-            ),
-            (
-                True,
-                DateRange(None, Date(1970, 2, 2)),
-                DateRange(None, Date(1970, 2, 3)),
-            ),
-            (
-                False,
-                DateRange(None, Date(1970, 2, 2)),
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 2)),
-            ),
-            (
-                True,
-                DateRange(None, Date(1970, 2, 2)),
-                DateRange(Date(1970, 2, 2), Date(1970, 2, 3)),
-            ),
-            (
-                False,
-                DateRange(None, Date(1970, 2, 2)),
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-            ),
-            # Both dates.
-            (False, DateRange(Date(1970, 2, 1), Date(1970, 2, 3)), Date(1970, 2, 1)),
-            (True, DateRange(Date(1970, 2, 1), Date(1970, 2, 3)), Date(1970, 2, 2)),
-            (True, DateRange(Date(1970, 2, 1), Date(1970, 2, 3)), Date(1970, 2, 3)),
-            (
-                False,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(Date(1970, 1, 1)),
-            ),
-            (
-                True,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(Date(1970, 2, 1)),
-            ),
-            (
-                True,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(Date(1970, 2, 2)),
-            ),
-            (
-                True,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(Date(1970, 2, 3)),
-            ),
-            (
-                False,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(None, Date(1970, 2, 1)),
-            ),
-            (
-                True,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(None, Date(1970, 2, 2)),
-            ),
-            (
-                True,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(None, Date(1970, 2, 3)),
-            ),
-            (
-                False,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 2)),
-            ),
-            (
-                True,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(Date(1970, 2, 2), Date(1970, 2, 3)),
-            ),
-            (
-                False,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-            ),
-        ],
-    )
-    def test___lt____with_both_dates(
-        self, expected: bool, sut: DateRange, other: AnyDate
+    @parameterize_pairs(DateRange, lt, ge)
+    def test___lt__(
+        self, expected: bool, sut: DateRange, other: DateExpression
     ) -> None:
-        assert (sut < other) == expected
+        assert (sut < other) is expected
 
-    @pytest.mark.parametrize(
-        ("expected", "sut", "other"),
-        [
-            # Start date only.
-            (False, DateRange(Date(1970, 2, 2)), Date(1970, 2, 1)),
-            (False, DateRange(Date(1970, 2, 2)), Date(1970, 2, 2)),
-            (True, DateRange(Date(1970, 2, 2)), Date(1970, 2, 3)),
-            (False, DateRange(Date(1970, 2, 2)), DateRange(Date(1970, 2, 1))),
-            (True, DateRange(Date(1970, 2, 2)), DateRange(Date(1970, 2, 2))),
-            (True, DateRange(Date(1970, 2, 2)), DateRange(Date(1970, 2, 3))),
-            (False, DateRange(Date(1970, 2, 2)), DateRange(None, Date(1970, 2, 1))),
-            (False, DateRange(Date(1970, 2, 2)), DateRange(None, Date(1970, 2, 2))),
-            (True, DateRange(Date(1970, 2, 2)), DateRange(None, Date(1970, 2, 3))),
-            (
-                False,
-                DateRange(Date(1970, 2, 2)),
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 2)),
-            ),
-            (
-                False,
-                DateRange(Date(1970, 2, 2)),
-                DateRange(Date(1970, 2, 2), Date(1970, 2, 3)),
-            ),
-            (
-                False,
-                DateRange(Date(1970, 2, 2)),
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-            ),
-            # End date only.
-            (False, DateRange(None, Date(1970, 2, 2)), Date(1970, 2, 1)),
-            (True, DateRange(None, Date(1970, 2, 2)), Date(1970, 2, 2)),
-            (True, DateRange(None, Date(1970, 2, 2)), Date(1970, 2, 3)),
-            (False, DateRange(None, Date(1970, 2, 2)), DateRange(Date(1970, 2, 1))),
-            (True, DateRange(None, Date(1970, 2, 2)), DateRange(Date(1970, 2, 2))),
-            (True, DateRange(None, Date(1970, 2, 2)), DateRange(Date(1970, 2, 3))),
-            (
-                False,
-                DateRange(None, Date(1970, 2, 2)),
-                DateRange(None, Date(1970, 2, 1)),
-            ),
-            (
-                True,
-                DateRange(None, Date(1970, 2, 2)),
-                DateRange(None, Date(1970, 2, 2)),
-            ),
-            (
-                True,
-                DateRange(None, Date(1970, 2, 2)),
-                DateRange(None, Date(1970, 2, 3)),
-            ),
-            (
-                False,
-                DateRange(None, Date(1970, 2, 2)),
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 2)),
-            ),
-            (
-                True,
-                DateRange(None, Date(1970, 2, 2)),
-                DateRange(Date(1970, 2, 2), Date(1970, 2, 3)),
-            ),
-            (
-                False,
-                DateRange(None, Date(1970, 2, 2)),
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-            ),
-            # Both dates.
-            (False, DateRange(Date(1970, 2, 1), Date(1970, 2, 3)), Date(1970, 2, 1)),
-            (True, DateRange(Date(1970, 2, 1), Date(1970, 2, 3)), Date(1970, 2, 2)),
-            (True, DateRange(Date(1970, 2, 1), Date(1970, 2, 3)), Date(1970, 2, 3)),
-            (
-                False,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(Date(1970, 1, 1)),
-            ),
-            (
-                True,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(Date(1970, 2, 1)),
-            ),
-            (
-                True,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(Date(1970, 2, 2)),
-            ),
-            (
-                True,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(Date(1970, 2, 3)),
-            ),
-            (
-                False,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(None, Date(1970, 2, 1)),
-            ),
-            (
-                True,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(None, Date(1970, 2, 2)),
-            ),
-            (
-                True,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(None, Date(1970, 2, 3)),
-            ),
-            (
-                False,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 2)),
-            ),
-            (
-                True,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(Date(1970, 2, 2), Date(1970, 2, 3)),
-            ),
-            (
-                True,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-            ),
-        ],
-    )
-    def test___le__(self, expected: bool, sut: DateRange, other: AnyDate) -> None:
-        assert (sut <= other) == expected
+    @parameterize_pairs(DateRange, le, gt)
+    def test___le__(
+        self, expected: bool, sut: DateRange, other: DateExpression
+    ) -> None:
+        assert (sut <= other) is expected
 
-    @pytest.mark.parametrize(
-        ("expected", "other"),
-        [
-            (True, DateRange(Date(1970, 2, 2))),
-            (False, DateRange(Date(1970, 2, None))),
-            (False, DateRange(Date(1970, None, 2))),
-            (False, DateRange(Date(None, 2, 2))),
-            (False, DateRange(Date(1970, None, None))),
-            (False, DateRange(Date(None, 2, None))),
-            (False, DateRange(Date(None, None, 2))),
-            (False, None),
-        ],
-    )
-    def test___eq__(self, expected: bool, other: AnyDate) -> None:
-        assert (DateRange(Date(1970, 2, 2)) == other) == expected
+    @parameterize_pairs(DateRange, eq, neq)
+    def test___eq__(
+        self, expected: bool, sut: DateRange, other: DateExpression
+    ) -> None:
+        assert (sut == other) is expected
 
-    @pytest.mark.parametrize(
-        ("expected", "sut", "other"),
-        [
-            # Start date only.
-            (True, DateRange(Date(1970, 2, 2)), Date(1970, 2, 1)),
-            (True, DateRange(Date(1970, 2, 2)), Date(1970, 2, 2)),
-            (False, DateRange(Date(1970, 2, 2)), Date(1970, 2, 3)),
-            (True, DateRange(Date(1970, 2, 2)), DateRange(Date(1970, 2, 1))),
-            (True, DateRange(Date(1970, 2, 2)), DateRange(Date(1970, 2, 2))),
-            (False, DateRange(Date(1970, 2, 2)), DateRange(Date(1970, 2, 3))),
-            (True, DateRange(Date(1970, 2, 2)), DateRange(None, Date(1970, 2, 1))),
-            (True, DateRange(Date(1970, 2, 2)), DateRange(None, Date(1970, 2, 2))),
-            (False, DateRange(Date(1970, 2, 2)), DateRange(None, Date(1970, 2, 3))),
-            (
-                True,
-                DateRange(Date(1970, 2, 2)),
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 2)),
-            ),
-            (
-                True,
-                DateRange(Date(1970, 2, 2)),
-                DateRange(Date(1970, 2, 2), Date(1970, 2, 3)),
-            ),
-            (
-                True,
-                DateRange(Date(1970, 2, 2)),
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-            ),
-            # End date only.
-            (True, DateRange(None, Date(1970, 2, 2)), Date(1970, 2, 1)),
-            (False, DateRange(None, Date(1970, 2, 2)), Date(1970, 2, 2)),
-            (False, DateRange(None, Date(1970, 2, 2)), Date(1970, 2, 3)),
-            (True, DateRange(None, Date(1970, 2, 2)), DateRange(Date(1970, 2, 1))),
-            (False, DateRange(None, Date(1970, 2, 2)), DateRange(Date(1970, 2, 2))),
-            (False, DateRange(None, Date(1970, 2, 2)), DateRange(Date(1970, 2, 3))),
-            (
-                True,
-                DateRange(None, Date(1970, 2, 2)),
-                DateRange(None, Date(1970, 2, 1)),
-            ),
-            (
-                True,
-                DateRange(None, Date(1970, 2, 2)),
-                DateRange(None, Date(1970, 2, 2)),
-            ),
-            (
-                False,
-                DateRange(None, Date(1970, 2, 2)),
-                DateRange(None, Date(1970, 2, 3)),
-            ),
-            (
-                True,
-                DateRange(None, Date(1970, 2, 2)),
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 2)),
-            ),
-            (
-                False,
-                DateRange(None, Date(1970, 2, 2)),
-                DateRange(Date(1970, 2, 2), Date(1970, 2, 3)),
-            ),
-            (
-                True,
-                DateRange(None, Date(1970, 2, 2)),
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-            ),
-            # Both dates.
-            (True, DateRange(Date(1970, 2, 1), Date(1970, 2, 3)), Date(1970, 2, 1)),
-            (False, DateRange(Date(1970, 2, 1), Date(1970, 2, 3)), Date(1970, 2, 2)),
-            (False, DateRange(Date(1970, 2, 1), Date(1970, 2, 3)), Date(1970, 2, 3)),
-            (
-                True,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(Date(1970, 1, 1)),
-            ),
-            (
-                False,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(Date(1970, 2, 1)),
-            ),
-            (
-                False,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(Date(1970, 2, 2)),
-            ),
-            (
-                False,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(Date(1970, 2, 3)),
-            ),
-            (
-                True,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(None, Date(1970, 2, 1)),
-            ),
-            (
-                False,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(None, Date(1970, 2, 2)),
-            ),
-            (
-                False,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(None, Date(1970, 2, 3)),
-            ),
-            (
-                True,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 2)),
-            ),
-            (
-                False,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(Date(1970, 2, 2), Date(1970, 2, 3)),
-            ),
-            (
-                True,
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-                DateRange(Date(1970, 2, 1), Date(1970, 2, 3)),
-            ),
-        ],
-    )
-    def test___ge__(self, expected: bool, sut: DateRange, other: AnyDate) -> None:
-        assert (sut >= other) == expected
+    @parameterize_pairs(DateRange, ge, lt)
+    def test___ge__(
+        self, expected: bool, sut: DateRange, other: DateExpression
+    ) -> None:
+        assert (sut >= other) is expected
 
-    @pytest.mark.parametrize(
-        ("expected", "other"),
-        [
-            (True, Date(1970, 2, 1)),
-            (True, Date(1970, 2, 2)),
-            (False, Date(1970, 2, 3)),
-            (True, DateRange(Date(1970, 2, 1))),
-            (False, DateRange(Date(1970, 2, 2))),
-            (False, DateRange(Date(1970, 2, 3))),
-            (True, DateRange(None, Date(1970, 2, 1))),
-            (True, DateRange(None, Date(1970, 2, 2))),
-            (False, DateRange(None, Date(1970, 2, 3))),
-            (True, DateRange(Date(1970, 2, 1), Date(1970, 2, 2))),
-            (True, DateRange(Date(1970, 2, 2), Date(1970, 2, 3))),
-            (True, DateRange(Date(1970, 2, 1), Date(1970, 2, 3))),
-        ],
-    )
-    def test___gt__(self, expected: bool, other: AnyDate) -> None:
-        assert (DateRange(Date(1970, 2, 2)) > other) == expected
+    @parameterize_pairs(DateRange, gt, le)
+    def test___gt__(
+        self, expected: bool, sut: DateRange, other: DateExpression
+    ) -> None:
+        assert (DateRange(Date(1970, 2, 2)) > other) is expected
 
     _FORMAT_DATE_RANGE_TEST_PARAMETERS: Sequence[tuple[str, DateRange]] = [
         (
@@ -847,12 +349,14 @@ class TestDateRange:
         ),
         (
             "from January 1, 1970 until around December 31, 1999",
-            DateRange(Date(1970, 1, 1), Date(1999, 12, 31, fuzzy=True)),
+            DateRange(Date(1970, 1, 1), Date(1999, 12, 31, imprecise=True)),
         ),
         (
             "from January 1, 1970 until sometime before around December 31, 1999",
             DateRange(
-                Date(1970, 1, 1), Date(1999, 12, 31, fuzzy=True), end_is_boundary=True
+                Date(1970, 1, 1),
+                Date(1999, 12, 31, imprecise=True),
+                end_is_boundary=True,
             ),
         ),
         (
@@ -871,50 +375,58 @@ class TestDateRange:
         (
             "from sometime after January 1, 1970 until around December 31, 1999",
             DateRange(
-                Date(1970, 1, 1), Date(1999, 12, 31, fuzzy=True), start_is_boundary=True
+                Date(1970, 1, 1),
+                Date(1999, 12, 31, imprecise=True),
+                start_is_boundary=True,
             ),
         ),
         (
             "sometime between January 1, 1970 and around December 31, 1999",
             DateRange(
                 Date(1970, 1, 1),
-                Date(1999, 12, 31, fuzzy=True),
+                Date(1999, 12, 31, imprecise=True),
                 start_is_boundary=True,
                 end_is_boundary=True,
             ),
         ),
         (
             "from around January 1, 1970 until December 31, 1999",
-            DateRange(Date(1970, 1, 1, fuzzy=True), Date(1999, 12, 31)),
+            DateRange(Date(1970, 1, 1, imprecise=True), Date(1999, 12, 31)),
         ),
         (
             "from around January 1, 1970 until sometime before December 31, 1999",
             DateRange(
-                Date(1970, 1, 1, fuzzy=True), Date(1999, 12, 31), end_is_boundary=True
+                Date(1970, 1, 1, imprecise=True),
+                Date(1999, 12, 31),
+                end_is_boundary=True,
             ),
         ),
         (
             "from around January 1, 1970 until around December 31, 1999",
-            DateRange(Date(1970, 1, 1, fuzzy=True), Date(1999, 12, 31, fuzzy=True)),
+            DateRange(
+                Date(1970, 1, 1, imprecise=True), Date(1999, 12, 31, imprecise=True)
+            ),
         ),
         (
             "from around January 1, 1970 until sometime before around December 31, 1999",
             DateRange(
-                Date(1970, 1, 1, fuzzy=True),
-                Date(1999, 12, 31, fuzzy=True),
+                Date(1970, 1, 1, imprecise=True),
+                Date(1999, 12, 31, imprecise=True),
                 end_is_boundary=True,
             ),
         ),
         (
             "from sometime after around January 1, 1970 until December 31, 1999",
             DateRange(
-                Date(1970, 1, 1, fuzzy=True), Date(1999, 12, 31), start_is_boundary=True
+                Date(1970, 1, 1, imprecise=True),
+                Date(1999, 12, 31),
+                start_is_boundary=True,
             ),
         ),
         (
             "sometime between around January 1, 1970 and December 31, 1999",
             DateRange(
-                Date(1970, 1, 1, fuzzy=True),
+                Date(1970, 1, 1, imprecise=True),
                 Date(1999, 12, 31),
                 start_is_boundary=True,
                 end_is_boundary=True,
@@ -923,16 +435,16 @@ class TestDateRange:
         (
             "from sometime after around January 1, 1970 until around December 31, 1999",
             DateRange(
-                Date(1970, 1, 1, fuzzy=True),
-                Date(1999, 12, 31, fuzzy=True),
+                Date(1970, 1, 1, imprecise=True),
+                Date(1999, 12, 31, imprecise=True),
                 start_is_boundary=True,
             ),
         ),
         (
             "sometime between around January 1, 1970 and around December 31, 1999",
             DateRange(
-                Date(1970, 1, 1, fuzzy=True),
-                Date(1999, 12, 31, fuzzy=True),
+                Date(1970, 1, 1, imprecise=True),
+                Date(1999, 12, 31, imprecise=True),
                 start_is_boundary=True,
                 end_is_boundary=True,
             ),
@@ -942,10 +454,10 @@ class TestDateRange:
             "sometime after January 1, 1970",
             DateRange(Date(1970, 1, 1), start_is_boundary=True),
         ),
-        ("from around January 1, 1970", DateRange(Date(1970, 1, 1, fuzzy=True))),
+        ("from around January 1, 1970", DateRange(Date(1970, 1, 1, imprecise=True))),
         (
             "sometime after around January 1, 1970",
-            DateRange(Date(1970, 1, 1, fuzzy=True), start_is_boundary=True),
+            DateRange(Date(1970, 1, 1, imprecise=True), start_is_boundary=True),
         ),
         ("until December 31, 1999", DateRange(None, Date(1999, 12, 31))),
         (
@@ -954,30 +466,17 @@ class TestDateRange:
         ),
         (
             "until around December 31, 1999",
-            DateRange(None, Date(1999, 12, 31, fuzzy=True)),
+            DateRange(None, Date(1999, 12, 31, imprecise=True)),
         ),
         (
             "sometime before around December 31, 1999",
-            DateRange(None, Date(1999, 12, 31, fuzzy=True), end_is_boundary=True),
+            DateRange(None, Date(1999, 12, 31, imprecise=True), end_is_boundary=True),
         ),
     ]
 
     @pytest.mark.parametrize(("expected", "sut"), _FORMAT_DATE_RANGE_TEST_PARAMETERS)
     async def test_localize(self, expected: str, sut: DateRange) -> None:
         assert sut.localize(default_localizer) == expected
-
-    @pytest.mark.parametrize(
-        "sut",
-        [
-            DateRange(),
-            DateRange(Date()),
-            DateRange(None, Date()),
-            DateRange(Date(), Date()),
-        ],
-    )
-    async def test_localize__with_incomplete_date_range(self, sut: DateRange) -> None:
-        with pytest.raises(IncompleteDateError):
-            assert sut.localize(default_localizer)
 
 
 @pytest.mark.parametrize(
@@ -988,16 +487,17 @@ class TestDateRange:
                 "year": 1970,
                 "month": 1,
                 "day": 1,
-                "iso8601": "1970-01-01",
-                "fuzzy": True,
+                "date": "1970-01-01",
+                "imprecise": True,
             },
-            Date(1970, 1, 1, fuzzy=True),
+            Date(1970, 1, 1, imprecise=True),
         ),
         (
             {
-                "fuzzy": True,
+                "year": 1970,
+                "imprecise": True,
             },
-            Date(None, None, None, fuzzy=True),
+            Date(1, None, None, imprecise=True),
         ),
     ],
 )
@@ -1019,8 +519,8 @@ async def test__dump_linked_data_for_date(
                     "year": 1970,
                     "month": 1,
                     "day": 1,
-                    "iso8601": "1970-01-01",
-                    "fuzzy": False,
+                    "date": "1970-01-01",
+                    "imprecise": False,
                 },
                 "end": None,
             },
@@ -1033,8 +533,8 @@ async def test__dump_linked_data_for_date(
                     "year": 2000,
                     "month": 12,
                     "day": 31,
-                    "iso8601": "2000-12-31",
-                    "fuzzy": False,
+                    "date": "2000-12-31",
+                    "imprecise": False,
                 },
             },
             DateRange(None, Date(2000, 12, 31)),
@@ -1045,15 +545,15 @@ async def test__dump_linked_data_for_date(
                     "year": 1970,
                     "month": 1,
                     "day": 1,
-                    "iso8601": "1970-01-01",
-                    "fuzzy": False,
+                    "date": "1970-01-01",
+                    "imprecise": False,
                 },
                 "end": {
                     "year": 2000,
                     "month": 12,
                     "day": 31,
-                    "iso8601": "2000-12-31",
-                    "fuzzy": False,
+                    "date": "2000-12-31",
+                    "imprecise": False,
                 },
             },
             DateRange(Date(1970, 1, 1), Date(2000, 12, 31)),

--- a/betty/tests/test_deriver.py
+++ b/betty/tests/test_deriver.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, final, override
 
 import pytest
 
-from betty.date import AnyDate, Date, DateRange
+from betty.date import Date, DateExpression, DateRange
 from betty.deriver import Deriver
 from betty.entities.event import Event
 from betty.entities.person import Person
@@ -460,9 +460,9 @@ class TestDeriver:
     )
     async def test_derive__update_comes_before(
         self,
-        expected_date: AnyDate | None,
-        before_date: AnyDate | None,
-        derivable_date: AnyDate | None,
+        expected_date: DateExpression | None,
+        before_date: DateExpression | None,
+        derivable_date: DateExpression | None,
         new_project: NewProject,
     ) -> None:
         async with new_project({
@@ -512,16 +512,12 @@ class TestDeriver:
                 Date(1970, 1, 1),
             ),
             (
-                None,
-                DateRange(None, None),
-            ),
-            (
                 DateRange(None, Date(1970, 1, 1), end_is_boundary=True),
                 DateRange(Date(1970, 1, 1)),
             ),
             (
                 None,
-                DateRange(Date(1970, 1, 1, fuzzy=True)),
+                DateRange(Date(1970, 1, 1, imprecise=True)),
             ),
             (
                 None,
@@ -535,8 +531,8 @@ class TestDeriver:
     )
     async def test_derive__create_comes_before(
         self,
-        expected_date: AnyDate | None,
-        before_date: AnyDate | None,
+        expected_date: DateExpression | None,
+        before_date: DateExpression | None,
         new_project: NewProject,
     ) -> None:
         async with new_project({
@@ -770,9 +766,9 @@ class TestDeriver:
     )
     async def test_derive__update_comes_after(
         self,
-        expected_date: AnyDate | None,
-        after_date: AnyDate | None,
-        derivable_date: AnyDate | None,
+        expected_date: DateExpression | None,
+        after_date: DateExpression | None,
+        derivable_date: DateExpression | None,
         new_project: NewProject,
     ) -> None:
         async with new_project({
@@ -814,14 +810,13 @@ class TestDeriver:
         ("expected_date", "after_date"),
         [
             (None, None),
-            (None, Date()),
             (DateRange(Date(1970, 1, 1), start_is_boundary=True), Date(1970, 1, 1)),
             (None, DateRange(Date(1970, 1, 1))),
             (
                 DateRange(Date(1999, 12, 31), start_is_boundary=True),
                 DateRange(None, Date(1999, 12, 31)),
             ),
-            (None, DateRange(None, Date(1999, 12, 31, fuzzy=True))),
+            (None, DateRange(None, Date(1999, 12, 31, imprecise=True))),
             (
                 DateRange(Date(1999, 12, 31), start_is_boundary=True),
                 DateRange(Date(1970, 1, 1), Date(1999, 12, 31)),
@@ -834,8 +829,8 @@ class TestDeriver:
     )
     async def test_derive__create_comes_after(
         self,
-        expected_date: AnyDate | None,
-        after_date: AnyDate | None,
+        expected_date: DateExpression | None,
+        after_date: DateExpression | None,
         new_project: NewProject,
     ) -> None:
         async with new_project({
@@ -885,7 +880,6 @@ class TestDeriver:
         "after_date",
         [
             None,
-            Date(),
             Date(1970, 1, 1),
             DateRange(Date(1970, 1, 1)),
             DateRange(None, Date(1999, 12, 31)),
@@ -894,7 +888,7 @@ class TestDeriver:
         ],
     )
     async def test_derive__should_not_exist(
-        self, after_date: AnyDate | None, new_project: NewProject
+        self, after_date: DateExpression | None, new_project: NewProject
     ) -> None:
         async with new_project({
             ComesBeforeReference,

--- a/betty/tests/test_gramps.py
+++ b/betty/tests/test_gramps.py
@@ -1111,7 +1111,6 @@ class TestGrampsLoader:
     @pytest.mark.parametrize(
         ("expected", "dateval_val"),
         [
-            (Date(), "0000-00-00"),
             (Date(None, None, 1), "0000-00-01"),
             (Date(None, 1), "0000-01-00"),
             (Date(None, 1, 1), "0000-01-01"),
@@ -1170,7 +1169,7 @@ class TestGrampsLoader:
         assert date.end.month == 1
         assert date.end.day == 1
         assert date.end_is_boundary
-        assert not date.end.fuzzy
+        assert not date.end.imprecise
 
     async def test_date_should_load_after(self, load_partial: LoadPartial) -> None:
         ancestry = await load_partial(
@@ -1191,7 +1190,7 @@ class TestGrampsLoader:
         assert date.start.month == 1
         assert date.start.day == 1
         assert date.start_is_boundary
-        assert not date.start.fuzzy
+        assert not date.start.imprecise
 
     async def test_date_should_load_calculated(self, load_partial: LoadPartial) -> None:
         ancestry = await load_partial(
@@ -1209,7 +1208,7 @@ class TestGrampsLoader:
         assert date.year == 1970
         assert date.month == 1
         assert date.day == 1
-        assert not date.fuzzy
+        assert not date.imprecise
 
     async def test_date_should_load_estimated(self, load_partial: LoadPartial) -> None:
         ancestry = await load_partial(
@@ -1227,7 +1226,7 @@ class TestGrampsLoader:
         assert date.year == 1970
         assert date.month == 1
         assert date.day == 1
-        assert date.fuzzy
+        assert date.imprecise
 
     async def test_date_should_load_about(self, load_partial: LoadPartial) -> None:
         ancestry = await load_partial(
@@ -1245,7 +1244,7 @@ class TestGrampsLoader:
         assert date.year == 1970
         assert date.month == 1
         assert date.day == 1
-        assert date.fuzzy
+        assert date.imprecise
 
     async def test_daterange_should_load(self, load_partial: LoadPartial) -> None:
         ancestry = await load_partial(
@@ -1267,13 +1266,13 @@ class TestGrampsLoader:
         assert start.year == 1970
         assert start.month == 1
         assert start.day == 1
-        assert not start.fuzzy
+        assert not start.imprecise
         assert date.start_is_boundary
         assert end.year == 1999
         assert end.month == 12
         assert end.day == 31
         assert date.end_is_boundary
-        assert not end.fuzzy
+        assert not end.imprecise
 
     async def test_daterange_should_load_calculated(
         self, load_partial: LoadPartial
@@ -1292,10 +1291,10 @@ class TestGrampsLoader:
         assert isinstance(date, DateRange)
         start = date.start
         assert isinstance(start, Date)
-        assert not start.fuzzy
+        assert not start.imprecise
         end = date.end
         assert isinstance(end, Date)
-        assert not end.fuzzy
+        assert not end.imprecise
 
     async def test_daterange_should_load_estimated(
         self, load_partial: LoadPartial
@@ -1314,10 +1313,10 @@ class TestGrampsLoader:
         assert isinstance(date, DateRange)
         start = date.start
         assert isinstance(start, Date)
-        assert start.fuzzy
+        assert start.imprecise
         end = date.end
         assert isinstance(end, Date)
-        assert end.fuzzy
+        assert end.imprecise
 
     async def test_datespan_should_load(self, load_partial: LoadPartial) -> None:
         ancestry = await load_partial(
@@ -1339,11 +1338,11 @@ class TestGrampsLoader:
         assert start.year == 1970
         assert start.month == 1
         assert start.day == 1
-        assert not start.fuzzy
+        assert not start.imprecise
         assert end.year == 1999
         assert end.month == 12
         assert end.day == 31
-        assert not end.fuzzy
+        assert not end.imprecise
 
     async def test_datespan_should_load_calculated(
         self, load_partial: LoadPartial
@@ -1362,10 +1361,10 @@ class TestGrampsLoader:
         assert isinstance(date, DateRange)
         start = date.start
         assert isinstance(start, Date)
-        assert not start.fuzzy
+        assert not start.imprecise
         end = date.end
         assert isinstance(end, Date)
-        assert not end.fuzzy
+        assert not end.imprecise
 
     async def test_datespan_should_load_estimated(
         self, load_partial: LoadPartial
@@ -1384,10 +1383,10 @@ class TestGrampsLoader:
         assert isinstance(date, DateRange)
         start = date.start
         assert isinstance(start, Date)
-        assert start.fuzzy
+        assert start.imprecise
         end = date.end
         assert isinstance(end, Date)
-        assert end.fuzzy
+        assert end.imprecise
 
     async def test_source_from_repository_should_include_name(
         self, load_partial: LoadPartial

--- a/documentation/usage/ancestry/date.rst
+++ b/documentation/usage/ancestry/date.rst
@@ -1,32 +1,5 @@
 Dates
 =====
 
-Dates can be expressed in three different ways: :py:class:`Date <betty.date.Date>`,
-:py:class:`DateRange <betty.date.DateRange>`, and
-:py:class:`ResolvableDate <betty.date.AnyDate>` (which are either dates or date ranges).
-
-Dates
------
-Fields
-^^^^^^
-``year`` (optional ``int``)
-    The date's year as a four-digit number.
-``month`` (optional ``int``)
-    The date's month as a two-digit number.
-``day`` (optional ``int``)
-    The date's day as a two-digit number.
-``fuzzy`` (``bool``)
-    Whether or not the date is fuzzy.
-
-Date ranges
------------
-Fields
-^^^^^^
-``start`` (optional date)
-    The range's start date.
-``start_is_boundary`` (``bool``)
-    Whether the start date is a boundary.
-``end`` (optional date)
-    The range's end date.
-``end_is_boundary`` (``bool``)
-    Whether the end date is a boundary.
+Dates can be expressed in three different ways: :py:class:`a single date <betty.date.Date>`,
+:py:class:`a date range <betty.date.DateRange>`, or :py:class:`a date series <betty.date.DateSeries>`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     'aiohttp-client-cache ~= 0.14',
     'aiosqlite ~= 0.21',
     'babel ~= 2.16',
+    'convertdate ~= 2.4',
     'docutils ~= 0.21',
     'geopy ~= 2.4',
     'jinja2 ~= 3.1',


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/4451

## To do
- Add `DateExpressionFormatter` that is completely agnostic of `betty.date` Can this replace `FormatDatetimeDatetime` as well? Ideally we'd have (overloaded) methods for non-`Localizable` types.
- Add `Localizer.date: DateExpressionFormatter`
- Calculating the earliest and latest possible variants of an incomplete date requires knowledge of which date the given new year started in. For some calendars we can set a reasonable default. For others, this is a specific bit of 'locale' information that goes with the date, because historically, whatever was the New Year's day in a given place in a given year changed a lot. Gramps also addresses this by allowing dates to specify their own New Year's day (we would need a month and a day: `Date.new_years_day: tuple[int, int] | None`).
- Can we use this, and a new `AnyDateSeries` (a series of dates, one or more of which may be applicable), to encode dual-dated dates when parsing them from Gramps?
- When compiling comparison date parts, do so in ISO 8601 **as well as** the date's original calendar, so the date can at least be compared to other dates on the same calendar.
- What to do with dates on different calendars that cannot be compared? We don't want to exclude them anywhere.
- Always include dates with missing parts when sorting. Just decide whether to put them at the start, or at the end.
- In `Date._get_comparable_start()` we assume that the start of the new year is on the first day of the first month, but that is absolutely not a given thing. We should delegate this to `Calendar` implementations, but bar the ISO 8601 ones, we may not be able to fill in missing months, only missing days.
- Define the `date` linked data field in terms of ISO 8601 but with the caveat that we allow four OR MORE year digits and that years are ALWAYS prefixed with a plus or minus sign
- Consider adding support for multiple date formatting variants: short, medium, long (with day of the week)?
- Ensure Gramps can load dates on any of the other calendars we now support. Also support loading dual-dated dates!
- Speaking of, which other calendars to add besides Julian? Gramps supports Gregorian, Hebrew, French Republican, Julian, Islamic, Persian, and Swedish. Just all of the calendars supported by convertdate?
- Fix `@todo`s