### PR TITLE
Add `Maybe` and `Result` to encapsulate (missing) values and/or errors

### DIFF
--- a/betty/association.py
+++ b/betty/association.py
@@ -15,13 +15,14 @@ from betty.entity.collection.multiple import MultipleTypesEntityCollection
 from betty.importlib import fully_qualified_name, import_any
 from betty.linked_data import LinkedDataDumper
 from betty.localizer import default_localizer
-from betty.typing import Intersection, Not, Void, VoidType
+from betty.maybe import Nothing, NothingType
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
 
     from betty.datas.aggregate.record import FieldDefinition
     from betty.project import Project
+    from betty.typing import Intersection, Not
 
 
 class Association[
@@ -60,8 +61,8 @@ class Association[
             else associate_attr
         )
         self.__associate_attr: (
-            Association[AssociateT, OwnerT, Any, Any] | None | VoidType
-        ) = associate_attr if isinstance(associate_attr, Association) else Void
+            Association[AssociateT, OwnerT, Any, Any] | None | NothingType
+        ) = associate_attr if isinstance(associate_attr, Association) else Nothing
 
     @final
     @property
@@ -71,7 +72,7 @@ class Association[
         """
         Get the inverse association, if this association is bidirectional.
         """
-        if self.__associate_attr is Void:
+        if self.__associate_attr is Nothing:
             if self.associate_attr_name is None:
                 self.__associate_attr = self._bi_associate_attr()
             else:

--- a/betty/collections/mapping/adapter.py
+++ b/betty/collections/mapping/adapter.py
@@ -18,7 +18,7 @@ from typing import Any, overload, override
 
 from betty.collection.mapping import MutableResolvedMapping, ResolvedMapping
 from betty.functools import passthrough
-from betty.typing import Void
+from betty.maybe import Nothing
 
 
 class ResolvedMappingAdapter[KeyT, ResolvableKeyT, ValueT](
@@ -138,10 +138,10 @@ class MutableResolvedMappingAdapter[KeyT, ResolvableKeyT, ValueT, ResolvableValu
         pass
 
     @override
-    def setdefault(self, key, default=Void):
+    def setdefault(self, key, default=Nothing):
         return self._proxied.setdefault(
             self._key_resolver(key),
-            None if default is Void else self._value_resolver(default),
+            None if default is Nothing else self._value_resolver(default),
         )  # ty:ignore[no-matching-overload]
 
     @overload
@@ -159,9 +159,9 @@ class MutableResolvedMappingAdapter[KeyT, ResolvableKeyT, ValueT, ResolvableValu
         pass
 
     @override
-    def pop(self, key, default=Void):
+    def pop(self, key, default=Nothing):
         key = self._key_resolver(key)
-        if default is Void:
+        if default is Nothing:
             return self._proxied.pop(key)
         return self._proxied.pop(key, default)
 

--- a/betty/commands/new.py
+++ b/betty/commands/new.py
@@ -23,9 +23,9 @@ from betty.locale import default_locale_tag, to_language_tag
 from betty.localizables.gettext import _
 from betty.localizables.static import StaticTranslations
 from betty.machine_name import MachineName
+from betty.maybe import Nothing
 from betty.project import ProjectData
 from betty.project.new import new
-from betty.typing import Void
 
 if TYPE_CHECKING:
     import argparse
@@ -97,12 +97,12 @@ class New(Manufacturable, Command):
             self._app.user, locales, _("What is your project called in {locale}?")
         )
 
+        default_machine_name = MachineName.machinify(
+            configuration.title.localize(localizers.get(default_locale))
+        )
         configuration.name = await self._app.user.ask_input(
             _("What is your project's machine name?"),
-            default=MachineName.machinify(
-                configuration.title.localize(localizers.get(default_locale))
-            )
-            or Void,
+            default=default_machine_name or Nothing,
         )
 
         configuration.author = await _user_input_static_translations(

--- a/betty/functools.py
+++ b/betty/functools.py
@@ -4,7 +4,6 @@ Provide functional programming utilities.
 
 from __future__ import annotations
 
-import contextlib
 import threading
 from asyncio import sleep
 from itertools import chain
@@ -20,8 +19,8 @@ from typing import (
 )
 
 from betty.asyncio import resolve_await
+from betty.maybe import Maybe, Nothing, Something
 from betty.threading import threadsafe
-from betty.typing import Void
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Iterable, Iterator
@@ -119,72 +118,6 @@ def passthrough[T](value: T, /) -> T:
     Return the value.
     """
     return value
-
-
-def suppress[**P, T](
-    target: Callable[P, T], *exceptions: type[BaseException]
-) -> Callable[P, T | type[Void]]:
-    """
-    Return the value, but suppress any errors.
-    """
-
-    def _suppress(*target_args: P.args, **target_kwargs: P.kwargs) -> T | type[Void]:
-        with contextlib.suppress(*exceptions):
-            return target(*target_args, **target_kwargs)
-        return Void
-
-    return _suppress
-
-
-class ResultUnavailable(RuntimeError):
-    """
-    A :py:attr:`betty.functools.Result.result` is unavailable.
-    """
-
-    def __init__(self):
-        super().__init__(
-            "The result is unavailable because the target has not been called yet."
-        )
-
-
-@final
-class Result[**P, T]:
-    """
-    Decorate a callable and store its return value or raised exception.
-    """
-
-    __slots__ = "_error", "_result", "_target"
-    _error: BaseException
-    _result: T
-
-    def __init__(self, target: Callable[P, T], /):
-        self._target = target
-
-    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T:
-        """
-        Call the target.
-        """
-        try:
-            self._result = self._target(*args, **kwargs)
-        except BaseException as error:
-            self._error = error
-            raise
-        else:
-            return self._result
-
-    def result(self) -> T:
-        """
-        Get the target's return value.
-
-        If the target raised an exception, calling this method will re-raise the exception.
-        """
-        try:
-            raise self._error
-        except AttributeError:
-            try:
-                return self._result
-            except AttributeError:
-                raise ResultUnavailable from None
 
 
 type DecoratorCallableType[
@@ -344,3 +277,35 @@ class Pipeline[ValueT, ReturnT]:
         Invoke the pipeline with a value.
         """
         return self._pipe(value)
+
+
+@final
+class Snapshot[**P, ReturnT]:
+    """
+    Decorate a callable to store a snapshot of the last call's return value.
+    """
+
+    __slots__ = "_function", "_snapshot"
+
+    def __init__(
+        self,
+        function: Callable[P, ReturnT],
+        /,
+    ):
+        self._function = function
+        self._snapshot: Maybe[ReturnT] = Nothing
+
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> ReturnT:
+        """
+        Call the function.
+        """
+        snapshot = self._function(*args, **kwargs)
+        self._snapshot = Something(snapshot)
+        return snapshot
+
+    @property
+    def snapshot(self) -> Maybe[ReturnT]:
+        """
+        The snapshot of the last call's return value.
+        """
+        return self._snapshot

--- a/betty/maybe.py
+++ b/betty/maybe.py
@@ -1,0 +1,157 @@
+"""
+Optional data types for when ``None`` is not sufficient.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Never, Self, final
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@final
+class IsNothing(ValueError):
+    """
+    Raise when performing operations on :py:class:`betty.maybe.Nothing`.
+    """
+
+    def __init__(self):
+        super().__init__(f"This <{Maybe.__name__}> value is {repr(Nothing)}.")
+
+
+@final
+class Something[SomethingT]:
+    """
+    A maybe value.
+    """
+
+    __slots__ = ("_something",)
+
+    def __init__(self, something: SomethingT, /):
+        self._something = something
+
+    @property
+    def something(self) -> SomethingT:
+        """
+        The something value.
+        """
+        return self._something
+
+    def __call__(self) -> SomethingT:
+        """
+        Get the something value.
+        """
+        return self.something
+
+    def map[NewSomethingT](
+        self, function: Callable[[SomethingT], Maybe[NewSomethingT]], /
+    ) -> Maybe[NewSomethingT]:
+        """
+        Apply a function to the value, and return its result.
+        """
+        return function(self._something)
+
+    __or__ = map  # noqa: A003
+
+    def map_from[NewSomethingT](
+        self, function: Callable[[SomethingT], NewSomethingT], /
+    ) -> Something[NewSomethingT]:
+        """
+        Apply a function to the value, and return its result wrapped in :py:class:`betty.maybe.Something`.
+        """
+        return Something(function(self._something))
+
+    __ior__ = map_from
+
+    def map_nothing(self, _: Callable[[], Maybe[Any]], /) -> Self:
+        """
+        Apply a function to the nothing, and return its result.
+        """
+        return self
+
+    __xor__ = map_nothing
+
+    def map_nothing_from(self, _: Callable[[], Any], /) -> Self:
+        """
+        Apply a function to the nothing, and return its result wrapped in :py:class:`betty.maybe.Something`.
+        """
+        return self
+
+    __ixor__ = map_nothing_from
+
+    def __repr__(self):
+        return f"<{type(self).__name__}: {repr(self._something)}>"
+
+
+class _NothingMeta(type):
+    @property
+    def something(self) -> Never:
+        """
+        The something value.
+
+        :raises IsNothing: Always raised because the value is :py:class:`betty.maybe.Nothing`.
+        """
+        raise IsNothing
+
+    def __call__(cls) -> Never:
+        """
+        Get the maybe value.
+
+        :raises IsNothing: Always raised because the value is :py:class:`betty.maybe.Nothing`.
+        """
+        raise IsNothing
+
+    def map(cls, _: Callable[[Any], Maybe[Any]], /) -> NothingType:
+        """
+        Apply a function to the value, and return its result.
+        """
+        return Nothing
+
+    __or__ = map  # noqa: A003
+
+    def map_from(cls, _: Callable[[Any], Any], /) -> NothingType:
+        """
+        Apply a function to the value, and return its result wrapped in :py:class:`betty.maybe.Something`.
+        """
+        return Nothing
+
+    __ior__ = map_from
+
+    def map_nothing[NewSomethingT](
+        self, function: Callable[[], Maybe[NewSomethingT]], /
+    ) -> Maybe[NewSomethingT]:
+        """
+        Apply a function to the nothing, and return its result.
+        """
+        return function()
+
+    __xor__ = map_nothing
+
+    def map_nothing_from[NewSomethingT](
+        self, function: Callable[[], NewSomethingT], /
+    ) -> Something[NewSomethingT]:
+        """
+        Apply a function to the nothing, and return its result wrapped in :py:class:`betty.maybe.Something`.
+        """
+        return Something(function())
+
+    __ixor__ = map_nothing_from
+
+    def __repr__(cls):
+        return f"<{Nothing.__name__}>"
+
+
+@final
+class Nothing(metaclass=_NothingMeta):
+    """
+    A missing maybe value.
+    """
+
+    def __new__(cls):  # noqa: D102
+        raise TypeError(f"{cls.__name__} cannot be initialized.")
+
+
+type NothingType = type[Nothing]
+
+type Maybe[SomethingT] = Something[SomethingT] | NothingType

--- a/betty/maybe.py
+++ b/betty/maybe.py
@@ -27,6 +27,7 @@ class Something[SomethingT]:
     """
 
     __slots__ = ("_something",)
+    __match_args__ = ("something",)
 
     def __init__(self, something: SomethingT, /):
         self._something = something

--- a/betty/plugin/factory.py
+++ b/betty/plugin/factory.py
@@ -24,13 +24,13 @@ from betty.importlib import fully_qualified_name
 from betty.indicator.selector import Attr
 from betty.localizables.gettext import _
 from betty.machine_name import MachineName
+from betty.maybe import Nothing, NothingType
 from betty.plugin import PluginDefinition
 from betty.plugin.cls import Plugin, PluginClsDefinition
 from betty.plugin.resolve import ResolvablePluginId, resolve_plugin_id
 from betty.portable import PortableData
 from betty.prop import HasProps
 from betty.sample import Samplable, Sample, Samples, Size
-from betty.typing import Void, VoidType
 
 if TYPE_CHECKING:
     from betty.service_level import ServiceLevel
@@ -67,7 +67,7 @@ class PluginManufacturer(
     """
 
     plugin_data = OwnerAttr(
-        DataDefinition[Data | PortableData | VoidType, PortableData](label=_("Data"))
+        DataDefinition[Data | PortableData | NothingType, PortableData](label=_("Data"))
     )
     """
     Get the plugin's own data.
@@ -77,7 +77,7 @@ class PluginManufacturer(
     def __init__(
         self,
         plugin: ResolvablePluginId[_PluginManufacturerPluginDefinitionT],
-        data: Data | PortableData | VoidType = Void,
+        data: Data | PortableData | NothingType = Nothing,
         /,
     ):
         super().__init__()
@@ -89,8 +89,8 @@ class PluginManufacturer(
         return hash((
             self.data().plugin_type,
             self.plugin_id,
-            Void
-            if self.plugin_data is Void
+            Nothing
+            if self.plugin_data is Nothing
             else dumps(
                 self.plugin_data.data().porter.dump(self.plugin_data)
                 if isinstance(self.plugin_data, Data)
@@ -116,7 +116,7 @@ class PluginManufacturer(
                 Field("data", optional=True),
             ),
         )(portable)
-        return cls(record["plugin"], record.get("data", Void))
+        return cls(record["plugin"], record.get("data", Nothing))
 
     @final
     @override
@@ -136,7 +136,7 @@ class PluginManufacturer(
     @override
     def dump(self) -> PortableData:
         data = self.plugin_data
-        if data is Void:
+        if data is Nothing:
             return self.plugin_id
         return {
             "plugin": self.plugin_id,
@@ -146,7 +146,7 @@ class PluginManufacturer(
     @final
     @override
     def dump_key(self, key: Attr, /) -> tuple[str, PortableData]:
-        return self.plugin_id, {} if self.plugin_data is Void else {
+        return self.plugin_id, {} if self.plugin_data is Nothing else {
             "data": self._dump_data(self.plugin_data)
         }
 
@@ -158,7 +158,7 @@ class PluginManufacturer(
         plugin_cls = (
             await services.plugins[self.data().plugin_type][self.plugin_id]
         ).cls  # ty:ignore[unresolved-attribute]
-        if self.plugin_data is Void:
+        if self.plugin_data is Nothing:
             return await services.factory.new(plugin_cls)
         if not issubclass(plugin_cls, DataManufacturable):
             raise PluginManufacturerError(

--- a/betty/result.py
+++ b/betty/result.py
@@ -133,6 +133,7 @@ class Ok[OkT, ErrorT: BaseException](_Result[OkT, ErrorT]):
     """
 
     __slots__ = ("_ok",)
+    __match_args__ = ("ok",)
 
     def __init__(self, ok: OkT, /):
         self._ok = ok
@@ -180,6 +181,7 @@ class Error[ErrorT: BaseException](_Result[Never, ErrorT]):
     """
 
     __slots__ = ("_error",)
+    __match_args__ = ("error",)
 
     def __init__(self, error: ErrorT, /):
         self._error = error

--- a/betty/result.py
+++ b/betty/result.py
@@ -1,0 +1,238 @@
+"""
+Data types to encapsulate errors as values.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, Never, Self, final, override
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+type ErrorType[ErrorT: BaseException = BaseException] = (
+    type[ErrorT] | tuple[type[ErrorT], ...]
+)
+
+
+class _Result[OkT, ErrorT: BaseException](ABC):
+    @property
+    @abstractmethod
+    def ok(self) -> OkT | Never:
+        """
+        The OK result value.
+
+        :raises ErrorT:
+        """
+
+    @property
+    @abstractmethod
+    def error(self) -> ErrorT | None:
+        """
+        The error, if there was any.
+        """
+
+    @final
+    def __call__(self) -> OkT:
+        """
+        Get the OK result value.
+        """
+        return self.ok
+
+    @abstractmethod
+    def map[MapOkT, MapErrorT: BaseException](
+        self, function: Callable[[OkT], Result[MapOkT, MapErrorT]], /
+    ) -> Result[MapOkT | OkT, MapErrorT | ErrorT]:
+        """
+        Apply a function to the OK value, and return its result.
+
+        If ``self`` is not OK (it is an error), this will return ``self``.
+        """
+
+    @final
+    def __or__[MapOkT, MapErrorT: BaseException](
+        self, function: Callable[[OkT], Result[MapOkT, MapErrorT]], /
+    ) -> Result[MapOkT | OkT, MapErrorT | ErrorT]:
+        """
+        An alias of :py:meth:`betty.result._Result.map`.
+        """
+        return self.map(function)
+
+    @abstractmethod
+    def map_from[MapOkT, MapErrorT: BaseException](
+        self, function: Callable[[OkT], MapOkT], error_type: ErrorType[MapErrorT], /
+    ) -> Result[MapOkT | OkT, MapErrorT | ErrorT]:
+        """
+        Apply a function to the OK value, and return its result wrapped in :py:class:`betty.result.Ok`.
+
+        If ``self`` is not OK (it is an error), this will return ``self``.
+
+        If ``function`` raises ``MapErrorT``, it will be caught, and returned wrapped in :py:class:`betty.result.Error`.
+        """
+
+    @final
+    def __ior__[MapOkT, MapErrorT: BaseException](
+        self,
+        function_and_error_type: tuple[Callable[[OkT], MapOkT], ErrorType[MapErrorT]],
+        /,
+    ) -> Result[MapOkT | OkT, MapErrorT | ErrorT]:
+        """
+        An alias of :py:meth:`betty.result._Result.map_from`.
+        """
+        return self.map_from(*function_and_error_type)
+
+    @abstractmethod
+    def map_error[MapOkT, MapErrorT: BaseException](
+        self, function: Callable[[ErrorT], Result[MapOkT, MapErrorT]], /
+    ) -> Result[MapOkT | OkT, MapErrorT | ErrorT]:
+        """
+        Apply a function to the error, and return its result.
+
+        If ``self`` is not an error (it is OK), this will return ``self``.
+        """
+
+    @final
+    def __xor__[MapOkT, MapErrorT: BaseException](
+        self, function: Callable[[ErrorT], Result[MapOkT, MapErrorT]], /
+    ) -> Result[MapOkT | OkT, MapErrorT | ErrorT]:
+        """
+        An alias of :py:meth:`betty.result._Result.map_error`.
+        """
+        return self.map_error(function)
+
+    @abstractmethod
+    def map_error_from[MapOkT, MapErrorT: BaseException](
+        self, function: Callable[[ErrorT], MapOkT], error_type: ErrorType[MapErrorT], /
+    ) -> Result[MapOkT | OkT, MapErrorT | ErrorT]:
+        """
+        Apply a function to the error, and return its result wrapped in :py:class:`betty.result.Ok`.
+
+        If ``self`` is not an error (it is OK), this will return ``self``.
+
+        If ``function`` raises ``MapErrorT``, it will be caught, and returned wrapped in :py:class:`betty.result.Error`.
+        """
+
+    @final
+    def _ixor__[MapOkT, MapErrorT: BaseException](
+        self,
+        function_and_error_type: tuple[
+            Callable[[ErrorT], MapOkT], ErrorType[MapErrorT]
+        ],
+        /,
+    ) -> Result[MapOkT | OkT, MapErrorT | ErrorT]:
+        """
+        An alias of :py:meth:`betty.result._Result.map_error_from`.
+        """
+        return self.map_error_from(*function_and_error_type)
+
+
+@final
+class Ok[OkT, ErrorT: BaseException](_Result[OkT, ErrorT]):
+    """
+    An OK result value.
+    """
+
+    __slots__ = ("_ok",)
+
+    def __init__(self, ok: OkT, /):
+        self._ok = ok
+
+    @override
+    @property
+    def ok(self) -> OkT:
+        return self._ok
+
+    @override
+    @property
+    def error(self) -> None:
+        return None
+
+    @override
+    def map[MapOkT, MapErrorT: BaseException](
+        self, function: Callable[[OkT], Result[MapOkT, MapErrorT]], /
+    ) -> Result[MapOkT, MapErrorT]:
+        return function(self._ok)
+
+    @override
+    def map_from[MapOkT, MapErrorT: BaseException](
+        self, function: Callable[[OkT], MapOkT], error_type: ErrorType[MapErrorT], /
+    ) -> Result[MapOkT, MapErrorT]:
+        return new_from(error_type, function, self._ok)
+
+    @override
+    def map_error(self, _: Callable[[ErrorT], Result], /) -> Self:
+        return self
+
+    @override
+    def map_error_from(
+        self, _: Callable[[ErrorT], Any], error_type: ErrorType, /
+    ) -> Self:
+        return self
+
+    def __repr__(self):
+        return f"<{type(self).__name__}: {repr(self._ok)}>"
+
+
+@final
+class Error[ErrorT: BaseException](_Result[Never, ErrorT]):
+    """
+    A result error.
+    """
+
+    __slots__ = ("_error",)
+
+    def __init__(self, error: ErrorT, /):
+        self._error = error
+
+    @override
+    @property
+    def ok(self) -> Never:
+        raise self._error
+
+    @override
+    @property
+    def error(self) -> ErrorT:
+        return self._error
+
+    @override
+    def map(self, _: Callable[[Any], Result], /) -> Self:
+        return self
+
+    @override
+    def map_from(self, _: Callable[[Any], Any], error_type: ErrorType, /) -> Self:
+        return self
+
+    @override
+    def map_error[MapOkT, MapErrorT: BaseException](
+        self, function: Callable[[ErrorT], Result[MapOkT, MapErrorT]], /
+    ) -> Result[MapOkT, MapErrorT]:
+        return function(self._error)
+
+    @override
+    def map_error_from[MapOkT, MapErrorT: BaseException](
+        self, function: Callable[[ErrorT], MapOkT], error_type: ErrorType[MapErrorT], /
+    ) -> Result[MapOkT, MapErrorT]:
+        return new_from(error_type, function, self._error)
+
+    def __repr__(self):
+        return f"<{type(self).__name__}: {repr(self._error)}>"
+
+
+type Result[OkT = Any, ErrorT: BaseException = BaseException] = (
+    Ok[OkT, ErrorT] | Error[ErrorT]
+)
+
+
+def new_from[**P, ReturnT, ErrorT: BaseException](
+    error_type: type[ErrorT] | tuple[type[ErrorT], ...],
+    function: Callable[P, ReturnT],
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> Result[ReturnT, ErrorT]:
+    """
+    Create a new result from a function call.
+    """
+    try:
+        return Ok(function(*args, **kwargs))
+    except error_type as error:
+        return Error(error)

--- a/betty/rich/user.py
+++ b/betty/rich/user.py
@@ -14,10 +14,10 @@ from rich.progress import Progress as _RichProgress
 from rich.prompt import Confirm, Prompt
 
 from betty.life_cycle.manage import ManagedLifeCycle
+from betty.maybe import Nothing, NothingType
 from betty.progresses.no_op import NoOpProgress
 from betty.progresses.rich import RichProgress
 from betty.rich import Theme
-from betty.typing import Void, VoidType
 from betty.user import User, Verbosity
 from betty.user.logging import UserHandler
 
@@ -177,7 +177,7 @@ class RichUser(ManagedLifeCycle, User):
         /,
         *,
         assertion: None = None,
-        default: str | VoidType = Void,
+        default: str | NothingType = Nothing,
         stdin: TextIO | None = None,
     ) -> str:
         pass
@@ -189,18 +189,24 @@ class RichUser(ManagedLifeCycle, User):
         /,
         *,
         assertion: Pipe[str, T],
-        default: str | VoidType = Void,
+        default: str | NothingType = Nothing,
         stdin: TextIO | None = None,
     ) -> T:
         pass
 
     @override
     async def ask_input(
-        self, question, /, *, assertion=None, default=Void, stdin: TextIO | None = None
+        self,
+        question,
+        /,
+        *,
+        assertion=None,
+        default=Nothing,
+        stdin: TextIO | None = None,
     ):
         self.assert_alive()
         ask_kwargs = {}
-        if default is not Void:
+        if default is not Nothing:
             ask_kwargs["default"] = default
         value = cast(
             str,

--- a/betty/sphinx/extension/betty.py
+++ b/betty/sphinx/extension/betty.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from asyncio import gather, run
 from collections.abc import Callable, Iterable, Mapping, MutableSequence, Sequence
-from functools import cmp_to_key
+from functools import cmp_to_key, partial
 from textwrap import indent
 from threading import Thread
 from typing import TYPE_CHECKING, override
@@ -21,13 +21,14 @@ from betty.datas.aggregate.record import RecordDefinition
 from betty.datas.optional import OptionalDefinition
 from betty.definition.human_facing import HumanFacingDefinition
 from betty.factory import DataManufacturable
-from betty.functools import Result
+from betty.functools import Snapshot
 from betty.importlib import import_any
 from betty.localizer import default_localizer
 from betty.machine_name import MachineName
 from betty.plugin.cls import PluginClsDefinition
 from betty.plugin.ordered import OrderedPluginDefinition
 from betty.project import Project
+from betty.result import new_from
 from betty.service_level import ServiceLevel
 
 if TYPE_CHECKING:
@@ -42,11 +43,11 @@ type NodesLike = nodes.Node | Iterable[nodes.Node] | None
 
 
 def _to_thread[T](target: Callable[[], T]) -> T:
-    result = Result(target)
+    result = Snapshot(partial(new_from, BaseException, target))
     thread = Thread(target=result)
     thread.start()
     thread.join()
-    return result.result()
+    return result.snapshot()()
 
 
 type _Plugins = Mapping[MachineName, Mapping[MachineName, PluginDefinition]]

--- a/betty/test_utils/user.py
+++ b/betty/test_utils/user.py
@@ -10,8 +10,8 @@ from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, overload, override
 
 from betty.localizer import default_localizer
+from betty.maybe import Nothing
 from betty.progresses.no_op import NoOpProgress
-from betty.typing import Void, VoidType
 from betty.user import User, UserTimeoutError, Verbosity
 
 if TYPE_CHECKING:
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
     from betty.functools import Pipe
     from betty.localizable import ResolvableLocalizable
+    from betty.maybe import NothingType
     from betty.progress import Progress
 
 
@@ -262,7 +263,7 @@ class StaticUser(User):
         /,
         *,
         assertion: None = None,
-        default: str | VoidType = Void,
+        default: str | NothingType = Nothing,
     ) -> str:
         pass
 
@@ -273,15 +274,15 @@ class StaticUser(User):
         /,
         *,
         assertion: Pipe[str, T],
-        default: str | VoidType = Void,
+        default: str | NothingType = Nothing,
     ) -> T:
         pass
 
     @override
-    async def ask_input(self, question, /, *, assertion=None, default=Void):
+    async def ask_input(self, question, /, *, assertion=None, default=Nothing):
         value = next(self._inputs)
         if value is None:
-            if default is Void:
+            if default is Nothing:
                 raise UserTimeoutError(
                     "Neither a predefined response nor a call default were provided."
                 )

--- a/betty/tests/commands/test_new.py
+++ b/betty/tests/commands/test_new.py
@@ -6,13 +6,13 @@ from betty.data import Data
 from betty.loaders.gramps import Gramps, GrampsData
 from betty.locale import default_locale_tag, to_language_tag
 from betty.localizer import default_localizer
+from betty.maybe import Nothing
 from betty.portable.file import assert_load_file
 from betty.project import ProjectData
 from betty.serializers.json import Json
 from betty.test_utils.conftest import IsolatedAppFactory
 from betty.test_utils.console import run
 from betty.test_utils.user import StaticUser
-from betty.typing import Void
 
 
 def _assert_new(configuration_file: Path) -> ProjectData:
@@ -191,7 +191,7 @@ class TestNew:
             configuration = _assert_new(configuration_file)
             assert Gramps in configuration.loaders
             portable_gramps_configuration = configuration.loaders[Gramps].plugin_data
-            assert portable_gramps_configuration is not Void
+            assert portable_gramps_configuration is not Nothing
             assert not isinstance(portable_gramps_configuration, Data)
             gramps_configuration = GrampsData.data().porter.load(
                 portable_gramps_configuration

--- a/betty/tests/coverage/test_coverage.py
+++ b/betty/tests/coverage/test_coverage.py
@@ -243,11 +243,6 @@ _BASELINE: Mapping[str, _ModuleIgnore] = {
         "Manufacturable": MissingReason.ABSTRACT,
         "UnsupportedTarget": MissingReason.ABSTRACT,
     },
-    "betty/functools.py": {
-        "Result": {
-            "result": MissingReason.COVERED_ELSEWHERE,
-        }
-    },
     "betty/genders/man.py": MissingReason.STATIC_CONTENT_ONLY,
     "betty/genders/non_binary.py": MissingReason.STATIC_CONTENT_ONLY,
     "betty/genders/unknown.py": MissingReason.STATIC_CONTENT_ONLY,
@@ -714,7 +709,6 @@ _BASELINE: Mapping[str, _ModuleIgnore] = {
     "betty/typing.py": {
         "Intersection": MissingReason.STATIC_CONTENT_ONLY,
         "Not": MissingReason.STATIC_CONTENT_ONLY,
-        "Void": MissingReason.STATIC_CONTENT_ONLY,
     },
     "betty/url_generator.py": {
         "GenerationError": MissingReason.ABSTRACT,

--- a/betty/tests/plugin/test_factory.py
+++ b/betty/tests/plugin/test_factory.py
@@ -5,6 +5,7 @@ import pytest
 from betty.exception import HumanFacingException
 from betty.factory import DataManufacturable, UnsupportedTarget
 from betty.indicator.selector import Attr
+from betty.maybe import Nothing
 from betty.plugin.factory import PluginManufacturer, PluginManufacturerError
 from betty.service_level import ServiceLevel
 from betty.test_utils.data import DummyData
@@ -14,7 +15,6 @@ from betty.test_utils.plugin import (
     DummyPluginManufacturer,
     DummyPluginOne,
 )
-from betty.typing import Void
 
 if TYPE_CHECKING:
     from betty.portable import PortableData
@@ -156,12 +156,12 @@ class TestPluginManufacturer:
     def test_load__minimal(self) -> None:
         sut = DummyPluginManufacturer.load({"plugin": DummyPluginOne.plugin().id})
         assert sut.plugin_id == DummyPluginOne.plugin().id
-        assert sut.plugin_data is Void
+        assert sut.plugin_data is Nothing
 
     def test_load__minimal_compact(self) -> None:
         sut = DummyPluginManufacturer.load(DummyPluginOne.plugin().id)
         assert sut.plugin_id == DummyPluginOne.plugin().id
-        assert sut.plugin_data is Void
+        assert sut.plugin_data is Nothing
 
     def test_load__with_configuration(self) -> None:
         configuration: PortableData = {
@@ -179,7 +179,7 @@ class TestPluginManufacturer:
             {}, Attr("plugin"), DummyPluginOne.plugin().id
         )
         assert sut.plugin_id == DummyPluginOne.plugin().id
-        assert sut.plugin_data is Void
+        assert sut.plugin_data is Nothing
 
     def test_load_key__with_configuration(self) -> None:
         configuration: PortableData = {

--- a/betty/tests/rich/test_user.py
+++ b/betty/tests/rich/test_user.py
@@ -303,5 +303,4 @@ class TestRichUser:
                 await sut.ask_input(
                     "", stdin=stdin, assertion=_assertion, default="123"
                 )
-                == 123
-            )
+            ) == 123

--- a/betty/tests/test_console.py
+++ b/betty/tests/test_console.py
@@ -1,6 +1,7 @@
 import argparse
 from asyncio import CancelledError
 from collections.abc import Awaitable, Callable
+from functools import partial
 from threading import Thread
 from typing import Any, override
 
@@ -11,7 +12,8 @@ from betty.app import App
 from betty.console import SystemExitCode, call_command_func, main_standalone
 from betty.console.command import Command, CommandDefinition
 from betty.exception import HumanFacingException
-from betty.functools import Result, suppress
+from betty.functools import Snapshot
+from betty.result import new_from
 from betty.test_utils.conftest import IsolatedAppFactory
 from betty.test_utils.console import run
 from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
@@ -115,13 +117,13 @@ async def test_main_standalone(
         main_standalone()
 
     # Run this in a thread so as not to conflict with pytest-playwright-asyncio's session-scoped event loop.
-    result = Result(_target)
-    thread = Thread(target=suppress(result, BaseException))
+    result = Snapshot(partial(new_from, BaseException, _target))
+    thread = Thread(target=result)
     thread.start()
     thread.join()
 
     with pytest.raises(SystemExit) as exc_info:
-        result.result()
+        result.snapshot()()
     assert exc_info.value.code is expected
 
 

--- a/betty/tests/test_functools.py
+++ b/betty/tests/test_functools.py
@@ -10,14 +10,10 @@ from betty.functools import (
     Do,
     LazyReCallable,
     Pipeline,
-    Result,
-    ResultUnavailable,
     map_suppress,
     passthrough,
-    suppress,
     unique,
 )
-from betty.typing import Void
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Iterable, Sequence
@@ -142,85 +138,6 @@ def test_map_suppress() -> None:
     assert list(
         map_suppress(_raising_map, ValueError, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
     ) == [0, 4, 8, 12, 16]
-
-
-class TestResult:
-    def test___call____and_result_with_return_value(self) -> None:
-        return_value = 123
-
-        def _target() -> int:
-            return return_value
-
-        sut = Result(_target)
-        assert sut() == return_value
-        assert sut.result() == return_value
-
-    def test___call____and_result_with_returned_exception(self) -> None:
-        return_value = RuntimeError()
-
-        def _target() -> BaseException:
-            return return_value
-
-        sut = Result(_target)
-        assert sut() == return_value
-        assert sut.result() == return_value
-
-    def test___call____and_result_with_raised_exception(self) -> None:
-        class _Exception(Exception):
-            pass
-
-        def _target() -> int:
-            raise _Exception
-
-        sut = Result(_target)
-        with pytest.raises(_Exception):
-            sut()
-        with pytest.raises(_Exception):
-            sut.result()
-
-    def test_result_without_call(self) -> None:
-        def _target() -> None:
-            pass  # pragma: nocover
-
-        sut = Result(_target)
-        with pytest.raises(ResultUnavailable):
-            sut.result()
-
-
-class TestResultUnavailable:
-    def test(self) -> None:
-        sut = ResultUnavailable()
-        assert str(sut)
-
-
-def test_suppress_with_return_value() -> None:
-    return_value = "Hello, world!"
-
-    def _target() -> Any:
-        return return_value
-
-    assert suppress(_target)() == return_value
-
-
-def test_suppress__with_suppressed_raised_exception() -> None:
-    class _Exception(Exception):
-        pass
-
-    def _target() -> Any:
-        raise _Exception
-
-    assert suppress(_target, _Exception)() is Void
-
-
-def test_suppress__with_unsuppressed_raised_exception() -> None:
-    class _Exception(Exception):
-        pass
-
-    def _target() -> Any:
-        raise _Exception
-
-    with pytest.raises(_Exception):
-        suppress(_target)()
 
 
 def _decorate(f: Callable[[int], int], /) -> Callable[[int], tuple[int, int]]:

--- a/betty/typing.py
+++ b/betty/typing.py
@@ -4,7 +4,7 @@ Providing typing utilities.
 
 from __future__ import annotations
 
-from typing import Any, final
+from typing import Any
 
 try:
     from ty_extensions import Intersection, Not
@@ -28,19 +28,3 @@ except ImportError:
 
 
 type Number = int | float
-
-
-@final
-class Void:
-    """
-    A sentinel that describes the absence of a value.
-
-    Using this sentinel allows for actual values to be ``None``. Like ``None``,
-    ``Void`` is only ever used through its type, and never instantiated.
-    """
-
-    def __new__():  # noqa: D102
-        raise NotImplementedError
-
-
-type VoidType = type[Void]

--- a/betty/user/__init__.py
+++ b/betty/user/__init__.py
@@ -9,7 +9,7 @@ from enum import IntEnum
 from typing import TYPE_CHECKING, overload
 
 from betty.localizer import default_localizer
-from betty.typing import Void, VoidType
+from betty.maybe import Nothing
 
 if TYPE_CHECKING:
     import logging
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from betty.functools import Pipe
     from betty.localizable import ResolvableLocalizable
     from betty.localizer import Localizer
+    from betty.maybe import NothingType
     from betty.progress import Progress
 
 
@@ -182,7 +183,7 @@ class User(ABC):
         /,
         *,
         assertion: None = None,
-        default: str | VoidType = Void,
+        default: str | NothingType = Nothing,
     ) -> str:
         pass
 
@@ -193,12 +194,12 @@ class User(ABC):
         /,
         *,
         assertion: Pipe[str, T],
-        default: str | VoidType = Void,
+        default: str | NothingType = Nothing,
     ) -> T:
         pass
 
     @abstractmethod
-    async def ask_input(self, question, /, *, assertion=None, default=Void):
+    async def ask_input(self, question, /, *, assertion=None, default=Nothing):
         """
         Ask the user to input text.
 

--- a/betty/user/logging.py
+++ b/betty/user/logging.py
@@ -19,8 +19,10 @@ from queue import Empty, Queue
 from time import sleep
 from typing import TYPE_CHECKING, final, override
 
-from betty.functools import Result, ResultUnavailable, suppress
+from betty.functools import Snapshot
 from betty.life_cycle.manage import ManagedLifeCycle
+from betty.maybe import IsNothing
+from betty.result import new_from
 
 if TYPE_CHECKING:
     from betty.user import User
@@ -35,9 +37,9 @@ class UserHandler(ManagedLifeCycle, logging.Handler):
     def __init__(self, user: User, /):
         super().__init__()
         self._user = user
-        self._result = Result(self._consume)
+        self._result = Snapshot(partial(new_from, BaseException, self._consume))
         self._thread = threading.Thread(
-            name=self.__class__.__name__, target=suppress(self._result, BaseException)
+            name=self.__class__.__name__, target=self._result
         )
         self.life_cycle.on((self._thread.start, self._shutdown_thread))
         self._queue = Queue[Callable[[], Coroutine[None, None, None]]]()
@@ -49,8 +51,8 @@ class UserHandler(ManagedLifeCycle, logging.Handler):
         with contextlib.suppress(CancelledError):
             await to_thread(self._thread.join)
         # If no log messages were recorded, there is no result.
-        with contextlib.suppress(ResultUnavailable):
-            self._result.result()
+        with contextlib.suppress(IsNothing):
+            self._result.snapshot()()
 
     def _consume(self) -> None:
         final_iteration = False

--- a/betty/user/no_op.py
+++ b/betty/user/no_op.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, final, overload, override
 
+from betty.maybe import Nothing
 from betty.progresses.no_op import NoOpProgress
-from betty.typing import Void, VoidType
 from betty.user import User, UserTimeoutError, Verbosity
 
 if TYPE_CHECKING:
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 
     from betty.functools import Pipe
     from betty.localizable import ResolvableLocalizable
+    from betty.maybe import NothingType
     from betty.progress import Progress
 
 
@@ -82,7 +83,7 @@ class NoOpUser(User):
         /,
         *,
         assertion: None = None,
-        default: str | VoidType = Void,
+        default: str | NothingType = Nothing,
     ) -> str:
         pass
 
@@ -93,10 +94,10 @@ class NoOpUser(User):
         /,
         *,
         assertion: Pipe[str, T],
-        default: str | VoidType = Void,
+        default: str | NothingType = Nothing,
     ) -> T:
         pass
 
     @override
-    async def ask_input(self, question, /, *, assertion=None, default=Void):
+    async def ask_input(self, question, /, *, assertion=None, default=Nothing):
         raise UserTimeoutError


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/4513

## To do
- Document the new types
  - `Maybe`
    - Why not just `Nothing` (like why not just `Void`?). Why three types instead of one? Give a concrete example.
    - `Nothing` is to `None` what `NothingType` is to `NoneType`
    - Similar to null-safe operators in other languages.
  - `Result`
    - performance (include benchmark stats)
    - type safety
    - useful for validation: reuse exceptions for the details they convey, but not to raise them if and until necessary 
    - Similar functionality to null-safe operators in other languages
- Add `Maybe.optional -> SomethingT | None` and `betty.maybe.from_optional(maybe: None | SomethingT) -> Maybe[SomethingT]`
- Test that `Maybe` and `Result` work with match statements. We'll need to implement `__match_args__`. For results to be matchable on their error **type**, we may need to add `Error.cls` and expose it as a match arg.
- Test that `Result` works with exception groups
- Benchmark error mapping
- Fix `@todo`s

## Follow-ups
- Rename assertions to validators
- Add `type betty.validator.Invalid = Intersection[HumanFacingException, ValueError]`
- Add `type betty.validator.Validator[InputT, OutputT, ErrorT: Invalid] = Callable[[InputT], Result[OutputT, ExceptionGroup[ErrorT]]]`

## Benchmark
```python
from time import perf_counter_ns
from typing import Never

from betty.result import Error, Ok, Result


def ____raise_error() -> Never:
    raise ValueError("Hello, world!")


def ___raise_error() -> None:
    ____raise_error()


def __raise_error() -> None:
    ___raise_error()


def _raise_error() -> None:
    __raise_error()


def test_raise() -> None:
    try:
        _raise_error()
    except ValueError as error:
        # Ensure we use the exception in case the interpreter somehow lazily binds it.
        error.args


def _map_error(error: BaseException) -> Result:
    return Ok(error)


def test_result() -> None:
    Error(ValueError("Hello, world!")) ^ _map_error


iterations = 999999
tests = [
    test_raise,
    test_result,
]


def test() -> None:
    for test in tests:
        start = perf_counter_ns()
        for _i in range(iterations):
            test()
        end = perf_counter_ns()
        end - start
        if iterations:
            pass


if __name__ == "__main__":
    test()

```
With this setup, `test_raise()` is ~50% slower than `test_result()`. Raising exceptions becomes slower as the the stack trace grows, as per expectations.