### PR TITLE
Automatically localize `Localizable`s before printing them in Jinja templates

### DIFF
--- a/betty/html/attributes.py
+++ b/betty/html/attributes.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, MutableMapping, MutableSequence, Sequence
 from typing import (
+    TYPE_CHECKING,
     Any,
     Final,
     NotRequired,
@@ -19,7 +20,12 @@ from typing import (
     override,
 )
 
+from betty.localizable import Localizable, ResolvableLocalizable
+from betty.localizer import default_localizer
 from betty.string import kebab_case_to_snake_case, snake_case_to_kebab_case
+
+if TYPE_CHECKING:
+    from betty.localizer import Localizer
 
 
 class _Attribute[AttributeGetT, AttributeSetT](ABC):
@@ -68,7 +74,7 @@ class _Attribute[AttributeGetT, AttributeSetT](ABC):
         pass
 
     @abstractmethod
-    def format(self, value: AttributeGetT) -> str:
+    def format(self, value: AttributeGetT, /, *, localizer: Localizer) -> str:
         """
         Format the attribute to a string.
         """
@@ -80,7 +86,7 @@ class _BooleanAttribute(_Attribute[bool, bool]):
         instance._attributes[self._attr_name] = value
 
     @override
-    def format(self, value: bool) -> str:
+    def format(self, value: bool, /, *, localizer: Localizer) -> str:
         return self._html_name
 
     @override
@@ -94,8 +100,8 @@ class _StringAttribute(_Attribute[str, str]):
         instance._attributes[self._attr_name] = value
 
     @override
-    def format(self, value: str) -> str:
-        return f'{self._html_name}="{value}"'
+    def format(self, value: str, /, *, localizer: Localizer) -> str:
+        return f'{self._html_name}="{value.localize(localizer) if isinstance(value, Localizable) else value}"'
 
     @override
     def _new_default(self) -> str:
@@ -114,8 +120,8 @@ class _MultipleStringAttribute(_Attribute[MutableSequence[str], Sequence[str]]):
         sequence.extend(value)
 
     @override
-    def format(self, value: Sequence[str]) -> str:
-        return f'{self._html_name}="{self._separator.join(value)}"'
+    def format(self, values: Sequence[str], /, *, localizer: Localizer) -> str:
+        return f'{self._html_name}="{self._separator.join(value.localize(localizer) if isinstance(value, Localizable) else value for value in values)}"'
 
     @override
     def _new_default(self) -> MutableSequence[str]:
@@ -128,130 +134,134 @@ class _BooleanOrStringAttribute(_Attribute[bool | str, bool | str]):
         instance._attributes[self._attr_name] = value
 
     @override
-    def format(self, value: bool | str) -> str:
+    def format(self, value: bool | str, /, *, localizer: Localizer) -> str:
         if isinstance(value, bool):
             return self._html_name
-        return f'{self._html_name}="{value}"'
+        return f'{self._html_name}="{value.localize(localizer) if isinstance(value, Localizable) else value}"'
 
     @override
     def _new_default(self) -> bool | str:
         return False
 
 
-class _AttributesKwargs(TypedDict):
-    html_accept: NotRequired[Sequence[str]]
-    html_accept_charset: NotRequired[str]
-    html_accesskey: NotRequired[str]
-    html_action: NotRequired[str]
-    html_allow: NotRequired[str]
-    html_alt: NotRequired[str]
-    html_aria_controls: NotRequired[Sequence[str]]
+class AttributesKwargs(TypedDict):
+    """
+    HTML attributes as keyword arguments.
+    """
+
+    html_accept: NotRequired[Sequence[ResolvableLocalizable]]
+    html_accept_charset: NotRequired[ResolvableLocalizable]
+    html_accesskey: NotRequired[ResolvableLocalizable]
+    html_action: NotRequired[ResolvableLocalizable]
+    html_allow: NotRequired[ResolvableLocalizable]
+    html_alt: NotRequired[ResolvableLocalizable]
+    html_aria_controls: NotRequired[Sequence[ResolvableLocalizable]]
     html_aria_expanded: NotRequired[bool]
-    html_as: NotRequired[str]
+    html_as: NotRequired[ResolvableLocalizable]
     html_async: NotRequired[bool]
-    html_autocapitalize: NotRequired[str]
-    html_autocomplete: NotRequired[str]
+    html_autocapitalize: NotRequired[ResolvableLocalizable]
+    html_autocomplete: NotRequired[ResolvableLocalizable]
     html_autoplay: NotRequired[bool]
-    html_capture: NotRequired[str]
-    html_charset: NotRequired[str]
+    html_capture: NotRequired[ResolvableLocalizable]
+    html_charset: NotRequired[ResolvableLocalizable]
     html_checked: NotRequired[bool]
-    html_cite: NotRequired[str]
-    html_class: NotRequired[Sequence[str]]
-    html_cols: NotRequired[str]
-    html_colspan: NotRequired[str]
-    html_content: NotRequired[str]
-    html_contenteditable: NotRequired[str]
+    html_cite: NotRequired[ResolvableLocalizable]
+    html_class: NotRequired[Sequence[ResolvableLocalizable]]
+    html_cols: NotRequired[ResolvableLocalizable]
+    html_colspan: NotRequired[ResolvableLocalizable]
+    html_content: NotRequired[ResolvableLocalizable]
+    html_contenteditable: NotRequired[ResolvableLocalizable]
     html_controls: NotRequired[bool]
-    html_coords: NotRequired[str]
-    html_crossorigin: NotRequired[str]
-    html_data: NotRequired[str]
-    html_datetime: NotRequired[str]
-    html_decoding: NotRequired[str]
+    html_coords: NotRequired[ResolvableLocalizable]
+    html_crossorigin: NotRequired[ResolvableLocalizable]
+    html_data: NotRequired[ResolvableLocalizable]
+    html_datetime: NotRequired[ResolvableLocalizable]
+    html_decoding: NotRequired[ResolvableLocalizable]
     html_default: NotRequired[bool]
     html_defer: NotRequired[bool]
-    html_dir: NotRequired[str]
-    html_dirname: NotRequired[str]
+    html_dir: NotRequired[ResolvableLocalizable]
+    html_dirname: NotRequired[ResolvableLocalizable]
     html_disabled: NotRequired[bool]
     html_download: NotRequired[bool | str]
-    html_draggable: NotRequired[str]
-    html_enctype: NotRequired[str]
-    html_enterkeyhint: NotRequired[str]
-    html_for: NotRequired[str]
-    html_formaction: NotRequired[str]
-    html_formenctype: NotRequired[str]
-    html_formmethod: NotRequired[str]
+    html_draggable: NotRequired[ResolvableLocalizable]
+    html_enctype: NotRequired[ResolvableLocalizable]
+    html_enterkeyhint: NotRequired[ResolvableLocalizable]
+    html_for: NotRequired[ResolvableLocalizable]
+    html_formaction: NotRequired[ResolvableLocalizable]
+    html_formenctype: NotRequired[ResolvableLocalizable]
+    html_formmethod: NotRequired[ResolvableLocalizable]
     html_formnovalidate: NotRequired[bool]
-    html_formtarget: NotRequired[str]
-    html_headers: NotRequired[Sequence[str]]
-    html_height: NotRequired[str]
-    html_hidden: NotRequired[str]
-    html_high: NotRequired[str]
-    html_href: NotRequired[str]
-    html_hreflang: NotRequired[str]
-    html_http_equiv: NotRequired[str]
-    html_id: NotRequired[str]
-    html_integrity: NotRequired[str]
-    html_inputmode: NotRequired[str]
+    html_formtarget: NotRequired[ResolvableLocalizable]
+    html_headers: NotRequired[Sequence[ResolvableLocalizable]]
+    html_height: NotRequired[ResolvableLocalizable]
+    html_hidden: NotRequired[ResolvableLocalizable]
+    html_high: NotRequired[ResolvableLocalizable]
+    html_href: NotRequired[ResolvableLocalizable]
+    html_hreflang: NotRequired[ResolvableLocalizable]
+    html_http_equiv: NotRequired[ResolvableLocalizable]
+    html_id: NotRequired[ResolvableLocalizable]
+    html_integrity: NotRequired[ResolvableLocalizable]
+    html_inputmode: NotRequired[ResolvableLocalizable]
     html_ismap: NotRequired[bool]
-    html_itemprop: NotRequired[str]
-    html_kind: NotRequired[str]
-    html_label: NotRequired[str]
-    html_lang: NotRequired[str]
-    html_loading: NotRequired[str]
-    html_list: NotRequired[str]
+    html_itemprop: NotRequired[ResolvableLocalizable]
+    html_kind: NotRequired[ResolvableLocalizable]
+    html_label: NotRequired[ResolvableLocalizable]
+    html_lang: NotRequired[ResolvableLocalizable]
+    html_loading: NotRequired[ResolvableLocalizable]
+    html_list: NotRequired[ResolvableLocalizable]
     html_loop: NotRequired[bool]
-    html_low: NotRequired[str]
-    html_max: NotRequired[str]
-    html_maxlength: NotRequired[str]
-    html_minlength: NotRequired[str]
-    html_media: NotRequired[str]
-    html_method: NotRequired[str]
-    html_min: NotRequired[str]
+    html_low: NotRequired[ResolvableLocalizable]
+    html_max: NotRequired[ResolvableLocalizable]
+    html_maxlength: NotRequired[ResolvableLocalizable]
+    html_minlength: NotRequired[ResolvableLocalizable]
+    html_media: NotRequired[ResolvableLocalizable]
+    html_method: NotRequired[ResolvableLocalizable]
+    html_min: NotRequired[ResolvableLocalizable]
     html_multiple: NotRequired[bool]
     html_muted: NotRequired[bool]
-    html_name: NotRequired[str]
+    html_name: NotRequired[ResolvableLocalizable]
     html_novalidate: NotRequired[bool]
     html_open: NotRequired[bool]
-    html_optimum: NotRequired[str]
-    html_pattern: NotRequired[str]
-    html_ping: NotRequired[Sequence[str]]
-    html_placeholder: NotRequired[str]
+    html_optimum: NotRequired[ResolvableLocalizable]
+    html_pattern: NotRequired[ResolvableLocalizable]
+    html_ping: NotRequired[Sequence[ResolvableLocalizable]]
+    html_placeholder: NotRequired[ResolvableLocalizable]
     html_playsinline: NotRequired[bool]
-    html_poster: NotRequired[str]
-    html_preload: NotRequired[str]
+    html_poster: NotRequired[ResolvableLocalizable]
+    html_preload: NotRequired[ResolvableLocalizable]
     html_readonly: NotRequired[bool]
-    html_referrerpolicy: NotRequired[str]
-    html_rel: NotRequired[str]
+    html_referrerpolicy: NotRequired[ResolvableLocalizable]
+    html_rel: NotRequired[ResolvableLocalizable]
     html_required: NotRequired[bool]
     html_reversed: NotRequired[bool]
-    html_role: NotRequired[str]
-    html_rows: NotRequired[str]
-    html_rowspan: NotRequired[str]
-    html_sandbox: NotRequired[Sequence[str]]
-    html_scope: NotRequired[str]
+    html_role: NotRequired[ResolvableLocalizable]
+    html_rows: NotRequired[ResolvableLocalizable]
+    html_rowspan: NotRequired[ResolvableLocalizable]
+    html_sandbox: NotRequired[Sequence[ResolvableLocalizable]]
+    html_scope: NotRequired[ResolvableLocalizable]
     html_selected: NotRequired[bool]
-    html_shape: NotRequired[str]
-    html_size: NotRequired[str]
-    html_sizes: NotRequired[str]
-    html_slot: NotRequired[str]
-    html_span: NotRequired[str]
-    html_spellcheck: NotRequired[str]
-    html_src: NotRequired[str]
-    html_srcdoc: NotRequired[str]
-    html_srclang: NotRequired[str]
-    html_srcset: NotRequired[Sequence[str]]
-    html_start: NotRequired[str]
-    html_step: NotRequired[str]
-    html_style: NotRequired[str]
-    html_tabindex: NotRequired[str]
-    html_target: NotRequired[str]
-    html_title: NotRequired[str]
-    html_translate: NotRequired[str]
-    html_type: NotRequired[str]
-    html_usemap: NotRequired[str]
-    html_value: NotRequired[str]
-    html_width: NotRequired[str]
-    html_wrap: NotRequired[str]
+    html_shape: NotRequired[ResolvableLocalizable]
+    html_size: NotRequired[ResolvableLocalizable]
+    html_sizes: NotRequired[ResolvableLocalizable]
+    html_slot: NotRequired[ResolvableLocalizable]
+    html_span: NotRequired[ResolvableLocalizable]
+    html_spellcheck: NotRequired[ResolvableLocalizable]
+    html_src: NotRequired[ResolvableLocalizable]
+    html_srcdoc: NotRequired[ResolvableLocalizable]
+    html_srclang: NotRequired[ResolvableLocalizable]
+    html_srcset: NotRequired[Sequence[ResolvableLocalizable]]
+    html_start: NotRequired[ResolvableLocalizable]
+    html_step: NotRequired[ResolvableLocalizable]
+    html_style: NotRequired[ResolvableLocalizable]
+    html_tabindex: NotRequired[ResolvableLocalizable]
+    html_target: NotRequired[ResolvableLocalizable]
+    html_title: NotRequired[ResolvableLocalizable]
+    html_translate: NotRequired[ResolvableLocalizable]
+    html_type: NotRequired[ResolvableLocalizable]
+    html_usemap: NotRequired[ResolvableLocalizable]
+    html_value: NotRequired[ResolvableLocalizable]
+    html_width: NotRequired[ResolvableLocalizable]
+    html_wrap: NotRequired[ResolvableLocalizable]
 
 
 @final
@@ -260,7 +270,7 @@ class Attributes:
     Manage attributes for an HTML element.
     """
 
-    __slots__ = ("_attributes", "_data_attributes")
+    __slots__ = ("_attributes", "_data_attributes", "_localizer")
 
     # Based on https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes.
     html_accept = _MultipleStringAttribute("accept", ", ")
@@ -387,30 +397,33 @@ class Attributes:
         if attr_name.startswith("html_")
     }
 
-    def __init__(self, **kwargs: Unpack[_AttributesKwargs]):
+    def __init__(self, *, localizer: Localizer = default_localizer):
         self._attributes: MutableMapping[str, Any] = {}
         self._data_attributes: MutableMapping[str, str] = {}
-        self.set(**kwargs)
+        self._localizer = localizer
 
-    def set(self, **attributes: Unpack[_AttributesKwargs]) -> None:
+    def set(self, **attributes: Unpack[AttributesKwargs]) -> Self:
         """
         Set values for the given HTML attributes.
         """
         for attribute_name, attribute_value in attributes.items():
             self.__attributes[attribute_name].set(self, attribute_value)
+        return self
 
-    def setdefault(self, **attributes: Unpack[_AttributesKwargs]) -> None:
+    def setdefault(self, **attributes: Unpack[AttributesKwargs]) -> Self:
         """
         Set values for the given HTML attributes, but only for those attributes that do not already have a value set.
         """
         for attribute_name, attribute_value in attributes.items():
             self.__attributes[attribute_name].setdefault(self, attribute_value)
+        return self
 
-    def set_data(self, **attributes: str) -> None:
+    def set_data(self, **attributes: str) -> Self:
         """
         Set values for the given HTML data attributes.
         """
         self._data_attributes.update(attributes)
+        return self
 
     def get_data(self, attribute_name: str) -> str | None:
         """
@@ -429,7 +442,9 @@ class Attributes:
             *(
                 formatted_attribute
                 for formatted_attribute in (
-                    self.__attributes[attr_name].format(attr_value)
+                    self.__attributes[attr_name].format(
+                        attr_value, localizer=self._localizer
+                    )
                     for attr_name, attr_value in self._attributes.items()
                 )
                 if formatted_attribute
@@ -445,4 +460,7 @@ class Attributes:
         return self.format()
 
     def __html__(self) -> str:
-        return self.format()
+        formatted = self.format()
+        if formatted:
+            return " " + formatted
+        return ""

--- a/betty/jinja/__init__.py
+++ b/betty/jinja/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import datetime
 from asyncio import to_thread
-from collections.abc import Awaitable, Callable, Iterable
+from collections.abc import Awaitable, Callable, Iterable, Mapping
 from os import makedirs
 from pathlib import Path
 from shutil import copy2
@@ -29,6 +29,7 @@ from betty.locale import default_locale, to_language_tag
 from betty.localizable import Localizable, ResolvableLocalizable
 from betty.localizables.gettext import gettext, ngettext, npgettext, pgettext
 from betty.localizables.markup import JoinAnd, JoinOr
+from betty.localized import LocalizedStr
 from betty.machine_name import MachineName
 from betty.media_type import (
     ResolvableMediaType,
@@ -36,6 +37,7 @@ from betty.media_type import (
     match_extension,
     resolve_media_type,
 )
+from betty.media_types.html import HTML
 from betty.media_types.jinja import JINJA
 from betty.pathlib import resolve_path
 from betty.store import StoreItem
@@ -244,6 +246,11 @@ class _CacheTagExtension(Extension):
 
 @final
 class _CodeGenerator(CodeGenerator):
+    _character_order_to_html_lang_map: Final[Mapping[str, str]] = {
+        "left-to-right": "ltr",
+        "right-to-left": "rtl",
+    }
+
     @override
     def visit_Template(self, node: Template, frame: Frame | None = None) -> None:
         self.writeline("from betty.jinja import _CodeGenerator")
@@ -264,10 +271,44 @@ class _CodeGenerator(CodeGenerator):
         super()._output_child_post(node, frame, finalize)
 
     @classmethod
-    def _output_child(cls, ctx: Context, value: Any, /) -> Any:
+    def _output_child(cls, context: Context, value: Any, /) -> Any:
         if isinstance(value, Localizable):
-            return value.localize(context_document(ctx).localizer)
+            value = cls._output_localizable(context, value)
+        if isinstance(value, LocalizedStr):
+            value = cls._output_localized_str(context, value)
         return value
+
+    @classmethod
+    def _output_localizable(
+        cls, context: Context, value: Localizable, /
+    ) -> LocalizedStr:
+        return value.localize(context_document(context).localizer)
+
+    @classmethod
+    def _output_localized_str(cls, context: Context, value: LocalizedStr, /) -> str:
+        output: str = value
+        document = context_document(context)
+        if document.media_type != HTML:
+            return output
+        localizer = document.localizer
+        if value.locale != localizer.locale:
+            localizer_dir = cls._character_order_to_html_lang_map[
+                localizer.locale.character_order
+            ]
+            if value.locale is None:
+                has_locale_dir = "auto"
+            else:
+                has_locale_dir = cls._character_order_to_html_lang_map[
+                    value.locale.character_order
+                ]
+            dir_attribute = (
+                f' dir="{has_locale_dir}"' if has_locale_dir != localizer_dir else ""
+            )
+            output = f'<span lang="{to_language_tag(value.locale)}"{dir_attribute}>{value}</span>'
+        # @todo Do we need this?
+        if context.eval_ctx.autoescape:
+            output = Markup(output)
+        return output
 
 
 @pass_context

--- a/betty/jinja/__init__.py
+++ b/betty/jinja/__init__.py
@@ -10,21 +10,24 @@ from collections.abc import Awaitable, Callable, Iterable
 from os import makedirs
 from pathlib import Path
 from shutil import copy2
-from typing import TYPE_CHECKING, Final, cast, override
+from typing import TYPE_CHECKING, Any, Final, Unpack, cast, final, override
 
 from jinja2 import Environment, FileSystemLoader, pass_context, select_autoescape
 from jinja2.async_utils import auto_await
+from jinja2.compiler import CodeGenerator, Frame
 from jinja2.ext import Extension
-from jinja2.nodes import CallBlock, ContextReference, Node
-from jinja2.runtime import Context as JinjaContext
-from jinja2.runtime import DebugUndefined, StrictUndefined
+from jinja2.nodes import CallBlock, ContextReference, Expr, Node, Template
+from jinja2.runtime import Context, DebugUndefined, StrictUndefined
 from jinja2.utils import missing
+from markupsafe import Markup
 
 from betty import about
 from betty.date import Date
 from betty.file import read, write
-from betty.html.attributes import Attributes
-from betty.locale import default_locale
+from betty.html.attributes import Attributes, AttributesKwargs
+from betty.locale import default_locale, to_language_tag
+from betty.localizable import Localizable, ResolvableLocalizable
+from betty.localizables.gettext import gettext, ngettext, npgettext, pgettext
 from betty.localizables.markup import JoinAnd, JoinOr
 from betty.machine_name import MachineName
 from betty.media_type import (
@@ -50,7 +53,7 @@ if TYPE_CHECKING:
 type CopyFunction = Callable[[Path, Path], Awaitable[None]]
 
 
-def context_document(context: JinjaContext) -> Document:
+def context_document(context: Context) -> Document:
     """
     Get the current document from the Jinja2 context.
     """
@@ -60,6 +63,20 @@ def context_document(context: JinjaContext) -> Document:
             "No `document` context variable exists in this Jinja2 template."
         ) from None
     return document
+
+
+@final
+class _GlobalGettext[*Ts]:
+    def __init__(self, factory: Callable[[*Ts], Localizable]):
+        self._factory = factory
+
+    def __call__(
+        self, *args: *Ts, **format_kwargs: ResolvableLocalizable
+    ) -> Localizable:
+        localizable = self._factory(*args)
+        if format_kwargs:
+            return localizable.format(**format_kwargs)
+        return localizable
 
 
 async def new_environment(project: Project, /) -> Environment:
@@ -84,15 +101,16 @@ async def new_environment(project: Project, /) -> Environment:
             _CacheTagExtension,
         ],
     )
+    environment.code_generator_class = _CodeGenerator
     if project.debug:
         environment.add_extension("jinja2.ext.debug")
-    environment.install_gettext_callables(  # ty:ignore[unresolved-attribute]
-        gettext=_gettext,
-        ngettext=_ngettext,
-        pgettext=_pgettext,
-        npgettext=_npgettext,
-        newstyle=True,
+    environment.globals.update(
+        gettext=_GlobalGettext(gettext),  # ty:ignore[invalid-argument-type]
+        ngettext=_GlobalGettext(ngettext),  # ty:ignore[invalid-argument-type]
+        pgettext=_GlobalGettext(pgettext),  # ty:ignore[invalid-argument-type]
+        npgettext=_GlobalGettext(npgettext),  # ty:ignore[invalid-argument-type]
     )
+    environment.newstyle_gettext = True  # ty:ignore[unresolved-attribute]
     environment.policies["ext.i18n.trimmed"] = True
 
     environment.globals.update({
@@ -107,7 +125,7 @@ async def new_environment(project: Project, /) -> Environment:
         "localizable_join_and": JoinAnd,
         "localizable_join_or": JoinOr,
         "machine_name": MachineName,
-        "new_attributes": Attributes,
+        "new_attributes": _new_html_attributes,
         "project": project,
         "primary_navigation_links": [
             link.link for link in project.links if link.primary
@@ -117,6 +135,7 @@ async def new_environment(project: Project, /) -> Environment:
         "secondary_navigation_links": [
             link.link for link in project.links if not link.primary
         ],
+        "tag": _html_tag,
         "today": Date(today.year, today.month, today.day),
     })  # ty:ignore[no-matching-overload]
     environment.filters.update({
@@ -130,38 +149,6 @@ async def new_environment(project: Project, /) -> Environment:
         if (test := await awaitable_test)
     })
     return environment
-
-
-@pass_context
-def _gettext(context: JinjaContext, message: str) -> str:
-    return context_document(context).localizer.gettext(message)
-
-
-@pass_context
-def _ngettext(
-    context: JinjaContext, message_singular: str, message_plural: str, n: int
-) -> str:
-    return context_document(context).localizer.ngettext(
-        message_singular, message_plural, n
-    )
-
-
-@pass_context
-def _pgettext(context: JinjaContext, gettext_context: str, message: str) -> str:
-    return context_document(context).localizer.pgettext(gettext_context, message)
-
-
-@pass_context
-def _npgettext(
-    context: JinjaContext,
-    gettext_context: str,
-    message_singular: str,
-    message_plural: str,
-    n: int,
-) -> str:
-    return context_document(context).localizer.npgettext(
-        gettext_context, message_singular, message_plural, n
-    )
 
 
 def make_copy_function(
@@ -239,7 +226,7 @@ class _CacheTagExtension(Extension):
         ).set_lineno(lineno)
 
     async def _cache(
-        self, cache_key: str, context: JinjaContext, caller: Callable[[], str]
+        self, cache_key: str, context: Context, caller: Callable[[], str]
     ) -> str:
         try:
             job_context = context_document(context).context
@@ -253,3 +240,51 @@ class _CacheTagExtension(Extension):
             rendered = await auto_await(caller())
             await result(rendered)
             return rendered
+
+
+@final
+class _CodeGenerator(CodeGenerator):
+    @override
+    def visit_Template(self, node: Template, frame: Frame | None = None) -> None:
+        self.writeline("from betty.jinja import _CodeGenerator")
+        super().visit_Template(node, frame)
+
+    @override
+    def _output_child_pre(
+        self, node: Expr, frame: Frame, finalize: CodeGenerator._FinalizeInfo
+    ) -> None:
+        super()._output_child_pre(node, frame, finalize)
+        self.write("_CodeGenerator._output_child(context, ")
+
+    @override
+    def _output_child_post(
+        self, node: Expr, frame: Frame, finalize: CodeGenerator._FinalizeInfo
+    ) -> None:
+        self.write(")")
+        super()._output_child_post(node, frame, finalize)
+
+    @classmethod
+    def _output_child(cls, ctx: Context, value: Any, /) -> Any:
+        if isinstance(value, Localizable):
+            return value.localize(context_document(ctx).localizer)
+        return value
+
+
+@pass_context
+def _new_html_attributes(
+    context: Context, **attributes: Unpack[AttributesKwargs]
+) -> Attributes:
+    return Attributes(localizer=context_document(context).localizer).set(**attributes)
+
+
+@pass_context
+def _html_tag(
+    context: Context, name: str, body: Any, /, **attributes: Unpack[AttributesKwargs]
+) -> str:
+    localizer = context_document(context).localizer
+    if isinstance(body, Localizable):
+        body = body.localize(localizer)
+        attributes["html_lang"] = to_language_tag(body.locale)
+    return Markup(
+        f"<{name}{Attributes(localizer=context_document(context).localizer).set(**attributes)}>{body}</{name}>"
+    )

--- a/betty/jinja_filters/url.py
+++ b/betty/jinja_filters/url.py
@@ -11,6 +11,7 @@ from jinja2 import pass_context
 from betty.factory import Manufacturable
 from betty.jinja import context_document
 from betty.jinja.filter import JinjaFilter, JinjaFilterDefinition
+from betty.localizable import Localizable
 from betty.media_type import MediaType
 from betty.media_types.html import HTML
 from betty.project import Project
@@ -49,9 +50,12 @@ class Url(JinjaFilter, Manufacturable):
         media_type: str | None = None,
         **kwargs: Any,
     ) -> str:
+        localizer = context_document(context).localizer
+        if isinstance(resource, Localizable):
+            resource = resource.localize(localizer)
         return self._url_generator.generate(
             resource,
             media_type=MediaType(media_type) if media_type else HTML,
-            locale=locale or context_document(context).localizer.locale,
+            locale=locale or localizer.locale,
             **kwargs,
         )

--- a/betty/tests/asset_directories/raspberry_mint/templates/component/test_accordion.py
+++ b/betty/tests/asset_directories/raspberry_mint/templates/component/test_accordion.py
@@ -49,7 +49,7 @@ async def test_with_html_attributes(assert_template_file: AssertTemplateFile) ->
                     "body": Markup("<p>Lorem ipsum dolor sit amet</p>"),
                 },
             ],
-            "attributes": Attributes(html_class=[html_class]),
+            "attributes": Attributes().set(html_class=[html_class]),
         },
         assets={raspberry_mint},
         template="component/accordion.html.j2",

--- a/betty/tests/asset_directories/raspberry_mint/templates/component/test_button.py
+++ b/betty/tests/asset_directories/raspberry_mint/templates/component/test_button.py
@@ -34,7 +34,7 @@ async def test_with_html_attribute(assert_template_file: AssertTemplateFile) -> 
     async with assert_template_file(
         data={
             "button_label": "Hit me, I am a button!",
-            "attributes": Attributes(html_id=html_id),
+            "attributes": Attributes().set(html_id=html_id),
         },
         assets={raspberry_mint},
         template="component/button.html.j2",

--- a/betty/tests/asset_directories/raspberry_mint/templates/component/test_button_close.py
+++ b/betty/tests/asset_directories/raspberry_mint/templates/component/test_button_close.py
@@ -15,7 +15,7 @@ async def test_with_html_attribute(assert_template_file: AssertTemplateFile) -> 
     html_id = "my-first-id"
     async with assert_template_file(
         data={
-            "attributes": Attributes(html_id=html_id),
+            "attributes": Attributes().set(html_id=html_id),
         },
         assets={raspberry_mint},
         template="component/button-close.html.j2",

--- a/betty/tests/asset_directories/raspberry_mint/templates/component/test_button_full_screen.py
+++ b/betty/tests/asset_directories/raspberry_mint/templates/component/test_button_full_screen.py
@@ -15,7 +15,7 @@ async def test_with_html_attribute(assert_template_file: AssertTemplateFile) -> 
     html_id = "my-first-id"
     async with assert_template_file(
         data={
-            "attributes": Attributes(html_id=html_id),
+            "attributes": Attributes().set(html_id=html_id),
         },
         assets={raspberry_mint},
         template="component/button-full-screen.html.j2",

--- a/betty/tests/asset_directories/raspberry_mint/templates/component/test_button_icon.py
+++ b/betty/tests/asset_directories/raspberry_mint/templates/component/test_button_icon.py
@@ -20,7 +20,7 @@ async def test_with_html_attribute(assert_template_file: AssertTemplateFile) -> 
     html_id = "my-first-id"
     async with assert_template_file(
         data={
-            "attributes": Attributes(html_id=html_id),
+            "attributes": Attributes().set(html_id=html_id),
         },
         assets={raspberry_mint},
         template="component/button-icon.html.j2",

--- a/betty/tests/asset_directories/raspberry_mint/templates/component/test_button_language.py
+++ b/betty/tests/asset_directories/raspberry_mint/templates/component/test_button_language.py
@@ -15,7 +15,7 @@ async def test_with_html_attribute(assert_template_file: AssertTemplateFile) -> 
     html_id = "my-first-id"
     async with assert_template_file(
         data={
-            "attributes": Attributes(html_id=html_id),
+            "attributes": Attributes().set(html_id=html_id),
         },
         assets={raspberry_mint},
         template="component/button-language.html.j2",

--- a/betty/tests/asset_directories/raspberry_mint/templates/component/test_button_menu.py
+++ b/betty/tests/asset_directories/raspberry_mint/templates/component/test_button_menu.py
@@ -15,7 +15,7 @@ async def test_with_html_attribute(assert_template_file: AssertTemplateFile) -> 
     html_id = "my-first-id"
     async with assert_template_file(
         data={
-            "attributes": Attributes(html_id=html_id),
+            "attributes": Attributes().set(html_id=html_id),
         },
         assets={raspberry_mint},
         template="component/button-menu.html.j2",

--- a/betty/tests/asset_directories/raspberry_mint/templates/component/test_button_search.py
+++ b/betty/tests/asset_directories/raspberry_mint/templates/component/test_button_search.py
@@ -15,7 +15,7 @@ async def test_with_html_attribute(assert_template_file: AssertTemplateFile) -> 
     html_id = "my-first-id"
     async with assert_template_file(
         data={
-            "attributes": Attributes(html_id=html_id),
+            "attributes": Attributes().set(html_id=html_id),
         },
         assets={raspberry_mint},
         template="component/button-search.html.j2",

--- a/betty/tests/asset_directories/raspberry_mint/templates/component/test_button_zoom_in.py
+++ b/betty/tests/asset_directories/raspberry_mint/templates/component/test_button_zoom_in.py
@@ -15,7 +15,7 @@ async def test_with_html_attribute(assert_template_file: AssertTemplateFile) -> 
     html_id = "my-first-id"
     async with assert_template_file(
         data={
-            "attributes": Attributes(html_id=html_id),
+            "attributes": Attributes().set(html_id=html_id),
         },
         assets={raspberry_mint},
         template="component/button-zoom-in.html.j2",

--- a/betty/tests/asset_directories/raspberry_mint/templates/component/test_button_zoom_out.py
+++ b/betty/tests/asset_directories/raspberry_mint/templates/component/test_button_zoom_out.py
@@ -15,7 +15,7 @@ async def test_with_html_attribute(assert_template_file: AssertTemplateFile) -> 
     html_id = "my-first-id"
     async with assert_template_file(
         data={
-            "attributes": Attributes(html_id=html_id),
+            "attributes": Attributes().set(html_id=html_id),
         },
         assets={raspberry_mint},
         template="component/button-zoom-out.html.j2",

--- a/betty/tests/asset_directories/raspberry_mint/templates/component/test_checkbox.py
+++ b/betty/tests/asset_directories/raspberry_mint/templates/component/test_checkbox.py
@@ -25,7 +25,7 @@ async def test_with_html_attributes(assert_template_file: AssertTemplateFile) ->
     async with assert_template_file(
         data={
             "checkbox_label": "Check me out!",
-            "attributes": Attributes(html_id=html_id),
+            "attributes": Attributes().set(html_id=html_id),
         },
         assets={raspberry_mint},
         template="component/checkbox.html.j2",

--- a/betty/tests/asset_directories/raspberry_mint/templates/component/test_checkboxes.py
+++ b/betty/tests/asset_directories/raspberry_mint/templates/component/test_checkboxes.py
@@ -58,7 +58,7 @@ async def test_with_full_items(assert_template_file: AssertTemplateFile) -> None
                 {
                     "label": "Check me out!",
                     "value": "Look at this treasure",
-                    "attributes": Attributes(html_id=html_id),
+                    "attributes": Attributes().set(html_id=html_id),
                 }
             ],
             "checkboxes_label": "Check these out!",

--- a/betty/tests/asset_directories/raspberry_mint/templates/component/test_submit.py
+++ b/betty/tests/asset_directories/raspberry_mint/templates/component/test_submit.py
@@ -35,7 +35,7 @@ async def test_with_html_attributes(assert_template_file: AssertTemplateFile) ->
     async with assert_template_file(
         data={
             "button_label": "Hit me, I am a button!",
-            "attributes": Attributes(html_id=html_id),
+            "attributes": Attributes().set(html_id=html_id),
         },
         assets={raspberry_mint},
         template="component/submit.html.j2",

--- a/betty/tests/html/test_attributes.py
+++ b/betty/tests/html/test_attributes.py
@@ -2,17 +2,17 @@ from __future__ import annotations
 
 from inspect import getmembers
 
-from betty.html.attributes import Attributes, _Attribute, _AttributesKwargs
+from betty.html.attributes import Attributes, AttributesKwargs, _Attribute
 
 
 class TestAttributes:
     def test_against_descriptors_against_kwargs(self) -> None:
         for attr_name, attr_value in getmembers(Attributes):
             if isinstance(attr_value, _Attribute):
-                assert attr_name in _AttributesKwargs.__required_keys__
+                assert attr_name in AttributesKwargs.__required_keys__
 
     def test_kwargs_against_descriptors(self) -> None:
-        for attr_name in _AttributesKwargs.__required_keys__:
+        for attr_name in AttributesKwargs.__required_keys__:
             assert isinstance(getattr(Attributes, attr_name), _Attribute)
 
     def test___str__(self) -> None:
@@ -28,27 +28,27 @@ class TestAttributes:
         assert sut.format() == ""
 
     def test_format__with_values(self) -> None:
-        sut = Attributes(html_class=["my-first-class"], html_id="my-first-id")
+        sut = Attributes().set(html_class=["my-first-class"], html_id="my-first-id")
         assert sut.format() == 'class="my-first-class" id="my-first-id"'
 
     def test_format__with_boolean_attribute(self) -> None:
-        sut = Attributes(html_checked=True)
+        sut = Attributes().set(html_checked=True)
         assert sut.format() == "checked"
 
     def test_format__with_string_attribute(self) -> None:
-        sut = Attributes(html_id="my-first-id")
+        sut = Attributes().set(html_id="my-first-id")
         assert sut.format() == 'id="my-first-id"'
 
     def test_format__with_multiple_string_attribute(self) -> None:
-        sut = Attributes(html_class=["my-first-class", "my-second-class"])
+        sut = Attributes().set(html_class=["my-first-class", "my-second-class"])
         assert sut.format() == 'class="my-first-class my-second-class"'
 
     def test_format__with_boolean_or_string_attribute_with_boolean_value(self) -> None:
-        sut = Attributes(html_download=True)
+        sut = Attributes().set(html_download=True)
         assert sut.format() == "download"
 
     def test_format__with_boolean_or_string_attribute_with_string_value(self) -> None:
-        sut = Attributes(html_download="my-first-file")
+        sut = Attributes().set(html_download="my-first-file")
         assert sut.format() == 'download="my-first-file"'
 
     def test_set__with_boolean_attribute(self) -> None:

--- a/data/asset/builtin/public/localized/index.html.j2
+++ b/data/asset/builtin/public/localized/index.html.j2
@@ -1,6 +1,6 @@
 {% extends 'base.html.j2' %}
 {% set page_title %}
-    {% trans project_title=project.title | localize -%}
+    {% trans project_title=project.title -%}
         Welcome to {{ project_title }}
     {%- endtrans %}
 {% endset %}

--- a/data/asset/builtin/public/static/index.html.j2
+++ b/data/asset/builtin/public/static/index.html.j2
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-    <title>{{ project.title | localize }}</title>
+    <title>{{ project.title }}</title>
     <meta http-equiv="refresh" content="0; url={{ 'betty:///index.html' | url(locale=project.default_locale.locale) }}">
 </head>
 <body>

--- a/data/asset/builtin/templates/head.html.j2
+++ b/data/asset/builtin/templates/head.html.j2
@@ -1,12 +1,12 @@
-<title>{% if page_title is defined %}{{ page_title | striptags }} - {% endif %}{{ project.title | localize }}</title>
+<title>{% if page_title is defined %}{{ page_title | striptags }} - {% endif %}{{ project.title }}</title>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="generator" content="Betty {{ about_version_major }} ({{ about_url }})">
 {% if project.author %}
-    <meta name="author" content="{{ project.author | localize }}">
+    <meta name="author" content="{{ project.author }}">
 {% endif %}
 <meta name="og:title" content="{{ page_title | default(project.title | localize) | striptags }}">
-<meta name="og:site_name" content="{{ project.title | localize }}">
+<meta name="og:site_name" content="{{ project.title }}">
 <meta name="twitter:title" content="{{ page_title | default(project.title | localize) | striptags }}">
 <meta name="twitter:card" content="summary_large_image">
 {% if document.resource %}
@@ -19,8 +19,8 @@
             <meta name="og:image:type" content="{{ page_image.media_type }}">
             <meta name="twitter:image" content="{{ page_image_url }}">
             {% if page_image.description %}
-                <meta name="og:image:description" content="{{ page_image.description | localize }}">
-                <meta name="twitter:image:alt" content="{{ page_image.description | localize }}">
+                <meta name="og:image:description" content="{{ page_image.description }}">
+                <meta name="twitter:image:alt" content="{{ page_image.description }}">
             {% endif %}
         {% endif %}
     {% endif %}

--- a/data/asset/http-api-doc/public/static/api/index.html.j2
+++ b/data/asset/http-api-doc/public/static/api/index.html.j2
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html lang="en-US">
 <head>
-    <title>{% trans %}API documentation{% endtrans %} - {{ project.title | localize }}</title>
+    <title>{% trans %}API documentation{% endtrans %} - {{ project.title }}</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>

--- a/data/asset/raspberry-mint/templates/base.html.j2
+++ b/data/asset/raspberry-mint/templates/base.html.j2
@@ -16,7 +16,7 @@
         <div class="row row-gap-3">
             <div class="col col-12 col-sm-9">
                 {% include 'component/breadcrumbs.html.j2' %}
-                <h1 class="page-intro-title">{{ page_title | default(project.title | localize) | html_lang }}</h1>
+                {{ tag('h1', page_title | default(project.title), html_class = ['page-intro-title']) }}
                 {% block page_summary %}
                     {% if document.resource is entity_plugin %}
                         {% with entity = document.resource %}
@@ -31,7 +31,7 @@
                 {% if page_image_reference is defined %}
                     <div class="align-items-center col-12 col-sm-3 d-flex justify-content-center">
                         <a href="{{ page_image_reference.file | url }}" class="image-link page-intro-image-link rounded-circle">
-                            <img src="{{ page_image_reference | image_resize_cover((500, 500)) | url }}" class="image page-intro-image rounded-circle" alt="{{ page_image_reference.file.label | localize }}">
+                            <img src="{{ page_image_reference | image_resize_cover((500, 500)) | url }}" class="image page-intro-image rounded-circle" alt="{{ page_image_reference.file.label }}">
                         </a>
                     </div>
                 {% endif %}

--- a/data/asset/raspberry-mint/templates/component/accordion.html.j2
+++ b/data/asset/raspberry-mint/templates/component/accordion.html.j2
@@ -2,7 +2,7 @@
 {% do attributes.setdefault(html_id=machine_name()) %}
 {% do attributes.html_class.append('accordion') %}
 {% if accordion_items | length > 0 %}
-    <div {{ attributes }}>
+    <div{{ attributes }}>
         {% for item in accordion_items %}
             <div class="accordion-item">
                 <{{ accordion_heading_element }} class="accordion-header{% if accordion_heading_class is defined %} {{ accordion_heading_class }}{% endif %}">

--- a/data/asset/raspberry-mint/templates/component/button.html.j2
+++ b/data/asset/raspberry-mint/templates/component/button.html.j2
@@ -2,5 +2,5 @@
     {% do attributes.set(html_type='button') %}
     {% do attributes.html_class.append('button') %}
     {% do attributes.html_class.append('button-secondary' if button_secondary | default(false) else 'button-primary') %}
-    <button {{ attributes }}>{{ button_label }}</button>
+    <button{{ attributes }}>{{ button_label }}</button>
 {% endwith %}

--- a/data/asset/raspberry-mint/templates/component/checkbox.html.j2
+++ b/data/asset/raspberry-mint/templates/component/checkbox.html.j2
@@ -3,6 +3,6 @@
 {% set form_control_attributes = form_control_attributes | default(new_attributes()) %}
 {% do form_control_attributes.html_class.append("form-check") %}
 <div {{ form_control_attributes }}>
-    <input class="form-check-input" type="checkbox" value="{{ checkbox_value }}" {{ attributes }}>
+    <input class="form-check-input" type="checkbox" value="{{ checkbox_value }}"{{ attributes }}>
     <label class="form-check-label" for="{{ attributes.html_id }}">{{ checkbox_label }}</label>
 </div>

--- a/data/asset/raspberry-mint/templates/component/maps/selected-place-preview.html.j2
+++ b/data/asset/raspberry-mint/templates/component/maps/selected-place-preview.html.j2
@@ -9,6 +9,6 @@
     {% if place_image_reference is defined %}
         <img src="{{ place_image_reference | image_resize_cover((100, 100)) | url }}"
              class="image map-selected-place-preview-image rounded-circle"
-             alt="{{ place_image_reference.file.label | localize }}">
+             alt="{{ place_image_reference.file.label }}">
     {% endif %}
 </div>

--- a/data/asset/raspberry-mint/templates/component/modal.html.j2
+++ b/data/asset/raspberry-mint/templates/component/modal.html.j2
@@ -2,7 +2,7 @@
 {% do attributes.html_class.append("modal") %}
 {% set dialog_attributes = dialog_attributes | default(new_attributes()) %}
 {% do dialog_attributes.html_class.append("modal-dialog") %}
-<div {{ attributes }}>
+<div{{ attributes }}>
     <div {{ dialog_attributes }}>
         <div class="modal-content">
             <div class="modal-header">

--- a/data/asset/raspberry-mint/templates/component/raspberry-mint/links.html.j2
+++ b/data/asset/raspberry-mint/templates/component/raspberry-mint/links.html.j2
@@ -9,9 +9,9 @@
                    hreflang="{{ localized_link_url.locale | to_language_tag }}"{% endif %}
                         {% if link.relationship is not none %} rel="{{ link.relationship }}"{% endif %}
                         {% if link.media_type is not none %}
-                   type="{{ link.media_type }}"{% endif %}>{{ link.label | localize or generated_link_url }}</a>
+                   type="{{ link.media_type }}"{% endif %}>{{ link.label or generated_link_url }}</a>
                 {% if link.description %}
-                    <p class="small">{{ link.description | localize }}</p>
+                    <p class="small">{{ link.description }}</p>
                 {% endif %}
             </li>
         {% endfor %}

--- a/data/asset/raspberry-mint/templates/component/raspberry-mint/media-gallery.html.j2
+++ b/data/asset/raspberry-mint/templates/component/raspberry-mint/media-gallery.html.j2
@@ -8,7 +8,7 @@
                         <figure>
                             <picture>
                                 <source srcset="{{ file_reference | image_resize_cover((900, 900)) | url }}" media="(min-width: 500px)">
-                                <img src="{{ file_reference | image_resize_cover((500, 500)) | url }}" alt="{{ file_reference.file.label | localize }}" class="image" loading="lazy">
+                                <img src="{{ file_reference | image_resize_cover((500, 500)) | url }}" alt="{{ file_reference.file.label }}" class="image" loading="lazy">
                             </picture>
                             <figcaption class="mt-1 small text-truncate">{{ file_reference.file.label | localize | html_lang }}</figcaption>
                         </figure>

--- a/data/asset/raspberry-mint/templates/component/raspberry-mint/media.html.j2
+++ b/data/asset/raspberry-mint/templates/component/raspberry-mint/media.html.j2
@@ -9,10 +9,10 @@
                                 {% for size, breakpoint in [(1300, 900), (900, 500)] %}
                                     <source srcset="{{ file | image_resize_cover((size, size)) | url }}" media="(min-width: {{ breakpoint }}px)">
                                 {% endfor %}
-                                <img src="{{ file | image_resize_cover((500, 500)) | url }}" alt="{{ file.label | localize }}" class="image">
+                                <img src="{{ file | image_resize_cover((500, 500)) | url }}" alt="{{ file.label }}" class="image">
                             </picture>
                         </a>
-                        <figcaption class="mt-1">{{ file.label | localize }}</figcaption>
+                        <figcaption class="mt-1">{{ file.label }}</figcaption>
                     </figure>
                 </div>
             </div>
@@ -34,7 +34,7 @@
                         <h2>{% trans %}Copyright{% endtrans %}</h2>
                         <p>
                             {% if file.copyright_notice.url is not none %}
-                                <a href="{{ file.copyright_notice.url | localize }}">
+                                <a href="{{ file.copyright_notice.url }}">
                             {% endif %}
                             {{ file.copyright_notice.summary | localize | html_lang }}
                             {% if file.copyright_notice.url is not none %}
@@ -48,7 +48,7 @@
                         <h2>{% trans %}License{% endtrans %}</h2>
                         <p>
                             {% if file.license.url is not none %}
-                                <a href="{{ file.license.url | localize }}">
+                                <a href="{{ file.license.url }}">
                             {% endif %}
                             {{ file.license.summary | localize | html_lang }}
                             {% if file.license.url is not none %}

--- a/data/asset/raspberry-mint/templates/component/raspberry-mint/section.html.j2
+++ b/data/asset/raspberry-mint/templates/component/raspberry-mint/section.html.j2
@@ -4,7 +4,7 @@
             <div class="row">
                 <div class="col col-12">
                     <h2 class="section-heading{% if section_visually_hide_heading | default(false) %} visually-hidden{% endif %}">
-                        {{ section_heading | localize }}
+                        {{ section_heading }}
                         {% if section_name %}
                             {% with url = '#' ~ section_name %}
                                 {% include 'component/permalink.html.j2' %}

--- a/data/asset/raspberry-mint/templates/component/submit.html.j2
+++ b/data/asset/raspberry-mint/templates/component/submit.html.j2
@@ -2,4 +2,4 @@
 {% do attributes.set(html_type='submit') %}
 {% do attributes.html_class.append('button') %}
 {% do attributes.html_class.append('button-secondary' if button_secondary | default(false) else 'button-primary') %}
-<input value="{{ button_label }}" {{ attributes }}>
+<input value="{{ button_label }}"{{ attributes }}>

--- a/data/asset/raspberry-mint/templates/entity/card.html.j2
+++ b/data/asset/raspberry-mint/templates/entity/card.html.j2
@@ -15,7 +15,7 @@
     </div>
     {% block preview %}
         {% if entity_image_reference %}
-            <img src="{{ entity_image_reference | image_resize_cover((500, 500)) | url }}" alt="{{ entity_image_reference.file.label | localize }}" class="card-img-bottom" loading="lazy">
+            <img src="{{ entity_image_reference | image_resize_cover((500, 500)) | url }}" alt="{{ entity_image_reference.file.label }}" class="card-img-bottom" loading="lazy">
         {% endif %}
     {% endblock %}
 </div>

--- a/data/asset/raspberry-mint/templates/entity/details--citation.html.j2
+++ b/data/asset/raspberry-mint/templates/entity/details--citation.html.j2
@@ -5,7 +5,7 @@
                 {% trans %}Accessed{% endtrans %}
             </dt>
             <dd class="d-table-cell">
-                {{ entity.date | localize }}
+                {{ entity.date }}
             </dd>
         </div>
     </dl>

--- a/data/asset/raspberry-mint/templates/entity/details--source.html.j2
+++ b/data/asset/raspberry-mint/templates/entity/details--source.html.j2
@@ -6,7 +6,7 @@
                     {% trans %}Author{% endtrans %}
                 </dt>
                 <dd class="d-table-cell">
-                    {{ entity.author | localize }}
+                    {{ entity.author }}
                 </dd>
             </div>
         {% endif %}
@@ -16,7 +16,7 @@
                     {% trans %}Publisher{% endtrans %}
                 </dt>
                 <dd class="d-table-cell">
-                    {{ entity.publisher | localize }}
+                    {{ entity.publisher }}
                 </dd>
             </div>
         {% endif %}

--- a/data/asset/raspberry-mint/templates/entity/label--citation.html.j2
+++ b/data/asset/raspberry-mint/templates/entity/label--citation.html.j2
@@ -6,7 +6,7 @@
         <a href="{{ entity | url }}">
     {%- endif -%}
     {%- if entity.location -%}
-        {{ entity.location | localize }}
+        {{ entity.location }}
     {%- else -%}
         <i>{% trans %}Unknown{% endtrans %}</i>
     {%- endif -%}

--- a/data/asset/raspberry-mint/templates/footer.html.j2
+++ b/data/asset/raspberry-mint/templates/footer.html.j2
@@ -3,12 +3,8 @@
         <div class="container">
             <div class="row">
                 <div class="col col-12 col-lg-6 p-3">
-                    <p>
-                        {{ project.copyright_notice.summary | localize | html_lang }}
-                    </p>
-                    <p>
-                        {{ project.license.summary | localize | html_lang }}
-                    </p>
+                    {{ tag('p', project.copyright_notice.summary) }}
+                    {{ tag('p', project.license.summary) }}
                 </div>
                 <div class="col col-12 col-lg-6 p-3">
                     {% if document.context %}
@@ -20,7 +16,7 @@
                     {% endif %}
                     {% for link in secondary_navigation_links %}
                         <p>
-                            <a href="{{ link.url | localize | url }}">{{ link.label | localize | html_lang }}</a>
+                            {{ tag('a', link.label, html_href = link.url | url) }}
                         </p>
                     {% endfor %}
                 </div>

--- a/data/asset/raspberry-mint/templates/header.html.j2
+++ b/data/asset/raspberry-mint/templates/header.html.j2
@@ -6,7 +6,7 @@
             {% if entity_type_id == 'event' %}
                 {% trans %}Timeline{% endtrans %}
             {% else %}
-                {{ entity_type.label_plural | localize }}
+                {{ entity_type.label_plural }}
             {% endif %}
         {%- endset %}
         {% do ns.primary_navigation_links.update({entity_type | url: entity_type_label}) %}
@@ -19,7 +19,7 @@
                     <div class="d-flex gap-1">
                         <img src="{{ ('betty-static:///logo' ~ project.logo.suffix) | url }}" alt="{% trans project_title = project.title | localize %}The '{{ project_title }}' logo{% endtrans %}" class="header-site-logo">
                         <a class="flex-grow-1 header-site-title no-link" href="{{ 'betty:///index.html' | url }}" title="{% trans %}Go to the front page{% endtrans %}">
-                            {{ project.title | localize }}
+                            {{ project.title }}
                         </a>
                     </div>
                     <div class="d-none d-md-block">
@@ -31,7 +31,7 @@
                             {% endfor %}
                             {% for link in primary_navigation_links %}
                                 <li>
-                                    <a href="{{ link.url | localize | url }}">{{ link.label | localize | html_lang }}</a>
+                                    {{ tag('a', link.label, html_href = link.url | url) }}
                                 </li>
                             {% endfor %}
                         </ul>

--- a/data/asset/raspberry-mint/templates/search/result--file.html.j2
+++ b/data/asset/raspberry-mint/templates/search/result--file.html.j2
@@ -1,13 +1,13 @@
 {% set embedded=True %}
 <div class="flex-grow-1 search-result-description">
-    <span class="link">{{ entity.label | localize }}</span>
+    <span class="link">{{ entity.label }}</span>
     {% with entity = entity %}
         {% include 'entity/summary--file.html.j2' %}
     {% endwith %}
 </div>
 {% if entity.media_type and entity.media_type.type== 'image' %}
     <div class="search-result-preview">
-        <img src="{{ entity | image_resize_cover((100, 100)) | url }}" class="image rounded-circle"{% if entity.description %} alt="{{ entity.description | localize }}"{% endif %} loading="lazy">
+        <img src="{{ entity | image_resize_cover((100, 100)) | url }}" class="image rounded-circle"{% if entity.description %} alt="{{ entity.description }}"{% endif %} loading="lazy">
     </div>
     {% endif %}
 <a href="{{ entity | url }}" class="stretched-link"><span class="visually-hidden">View {{ entity.label | localize | html_lang }}</span></a>

--- a/data/asset/raspberry-mint/templates/search/result-with-image.html.j2
+++ b/data/asset/raspberry-mint/templates/search/result-with-image.html.j2
@@ -8,7 +8,7 @@
 {% set image_reference = entity.files | selectattr('file.public') | selectattr('file.media_type', 'image_media_type_supported') | first %}
 {% if image_reference is defined %}
     <div class="search-result-preview">
-        <img src="{{ image_reference | image_resize_cover((100, 100)) | url }}" class="image rounded-circle" alt="{{ image_reference.file.label | localize }}" loading="lazy">
+        <img src="{{ image_reference | image_resize_cover((100, 100)) | url }}" class="image rounded-circle" alt="{{ image_reference.file.label }}" loading="lazy">
     </div>
 {% endif %}
 <a href="{{ entity | url }}" class="stretched-link"><span class="visually-hidden">View {{ entity.label | localize | html_lang }}</span></a>

--- a/data/asset/raspberry-mint/templates/search/result.html.j2
+++ b/data/asset/raspberry-mint/templates/search/result.html.j2
@@ -3,4 +3,6 @@
     <span class="link">{% include ['entity/label--' + entity.plugin().id + '.html.j2', 'entity/label.html.j2'] %}</span>
     {% include 'entity/summary--' + entity.plugin().id + '.html.j2' ignore missing %}
 </div>
-<a href="{{ entity | url }}" class="stretched-link"><span class="visually-hidden">View {{ entity.label | localize | html_lang }}</span></a>
+<a href="{{ entity | url }}" class="stretched-link">
+    {{ tag('span', _('View {subject}', subject = entity.label), html_class = ['visually-hidden']) }}
+</a>

--- a/data/asset/wiki/templates/component/wiki/wikipedia-summary.html.j2
+++ b/data/asset/wiki/templates/component/wiki/wikipedia-summary.html.j2
@@ -1,3 +1,5 @@
 {{ wikipedia_summary.content | safe }}
 <p>{% trans url = wikipedia_summary.url %}Continue reading on <a href="{{ url }}">Wikipedia</a>.{% endtrans %}</p>
-<small><a href="{{ wikipedia_summary_copyright_notice.url | localize }}">{{ wikipedia_summary_copyright_notice.summary | localize | html_lang }}</a></small>
+<small>
+    {{ tag('a', wikipedia_summary_copyright_notice.summary, html_href = wikipedia_summary_copyright_notice.url) }}
+</small>


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty/issues/4587

## To do
- Remove `html_lang` entirely? The problem with this, is that it seems it may not be possible to reliably and automatically determine if and when a `LocalizedStr` needs to be printed in an HTML element, or when not.
- Remove as many `localize` calls from templates as possible.
- To do that, we may need to automate the application of the `html_lang` filter as well
- And to do **that**, we need to solve it not only for when printing on its own, but also when a localizable is printed as 1) the value of an HTML attribute (we cannot use our `<span>` trick then) and 2) the contents of an HTML tag that does not allow `<span>` inside of it.
- Consider `{% element %}` in addition to or instead of the newly introduced `element` global