### PR TITLE
Add a capability API

### DIFF
--- a/betty/capability.py
+++ b/betty/capability.py
@@ -1,0 +1,175 @@
+"""
+The capability API.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, MutableMapping
+from typing import Any, Final, Never, Self, final
+
+from betty.collections import _empty_frozen_mapping
+from betty.importlib import fully_qualified_name
+from betty.nothing import Nothing
+from betty.typing import Intersection
+
+type CapabilityManufacturer[OwnerT, ManufacturableT] = Callable[
+    [OwnerT], ManufacturableT
+]
+
+type ResolvableCapability[OwnerT, ManufacturableT] = (
+    ManufacturableT | CapabilityManufacturer[OwnerT, ManufacturableT]
+)
+
+
+class Stage[OwnerT, ManufacturableT]:
+    """
+    A capability factory stage.
+    """
+
+    @final
+    def __init__(
+        self, manufacturer: CapabilityManufacturer[OwnerT, ManufacturableT], /
+    ):
+        self.manufacturer: Final[CapabilityManufacturer[OwnerT, ManufacturableT]] = (
+            manufacturer
+        )
+        """
+        The capability manufacturer.
+        """
+
+
+type StagedCapabilityManufacturer[OwnerT, ManufacturableT, StageT: Stage = Never] = (
+    Intersection[StageT, Stage[OwnerT, ManufacturableT]]
+)
+
+type ResolvableStagedCapability[OwnerT, ManufacturableT, StageT: Stage = Never] = (
+    ManufacturableT
+    | CapabilityManufacturer[OwnerT, ManufacturableT]
+    | StagedCapabilityManufacturer[OwnerT, ManufacturableT, StageT]
+)
+
+
+class CapabilityError(RuntimeError):
+    """
+    Raised for errors related to capabilities.
+    """
+
+
+@final
+class UnsupportedCapability(CapabilityError):
+    """
+    Raised when an object does not support the requested capability.
+    """
+
+    def __init__(self, owner: Capable, capability: str, /):
+        super().__init__(
+            f'{fully_qualified_name(type(owner))} does not support the "{capability}" capability.'
+        )
+
+
+@final
+class Incapable(CapabilityError):
+    """
+    Raised when an object does not have the requested capability.
+    """
+
+    def __init__(self, owner: Capable, capability: str, /):
+        super().__init__(
+            f'{fully_qualified_name(type(owner))} does not have a(n) "{capability}" capability.'
+        )
+
+
+@final
+class NotYetInitialized(CapabilityError):
+    """
+    Raised when an object's capability has not been initialized.
+    """
+
+    def __init__(self, owner: Capable, capability: str, stage: type[Stage], /):
+        super().__init__(
+            f'{fully_qualified_name(type(owner))}\'s "{capability}" capability was not yet initialized for stage {fully_qualified_name(stage)}.'
+        )
+
+
+class Capable[StageT: Stage = Never]:
+    """
+    An object that can be extended with arbitrary capabilities.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        capabilities: Mapping[
+            str, tuple[type, ResolvableStagedCapability[Self, Any, StageT]]
+        ] = _empty_frozen_mapping,
+        **kwargs: Any,
+    ):
+        self._capabilities: Final[
+            MutableMapping[str, ResolvableStagedCapability[Self, Any, StageT]]
+        ] = {}
+        super().__init__(*args, **kwargs)
+        if capabilities is not None:
+            for capability_name, (
+                capability_type,
+                capability_value,
+            ) in capabilities.items():
+                if capability_value is None or isinstance(
+                    capability_value, (capability_type, Stage)
+                ):
+                    self._capabilities[capability_name] = capability_value
+                else:
+                    self._capabilities[capability_name] = capability_value(self)  # ty:ignore[call-non-callable]
+
+    @final
+    def _init_staged_capabilities(self, stage: type[StageT], /) -> None:
+        for capability_name, capability_value in self._capabilities.items():
+            if isinstance(capability_value, stage):
+                self._capabilities[capability_name] = capability_value.manufacturer(
+                    self
+                )
+
+    @final
+    def _capability(self, name: str, /) -> Any:
+        """
+        Get a capability.
+
+        :raises betty.capability.CapabilityError:
+        """
+        capability = self._try_capability(name)
+        if capability is None:
+            raise Incapable(self, name)
+        return capability
+
+    @final
+    def _try_capability(self, name: str, /) -> Any | None:
+        """
+        Try to get a capability, or return ``None`` if it does not exist.
+        """
+        capability = self._capabilities.get(name, Nothing)
+        if capability is Nothing:
+            raise UnsupportedCapability(self, name)
+        if isinstance(capability, Stage):
+            raise NotYetInitialized(self, name, type(capability))
+        return capability
+
+
+class HasCapabilities[StageT: Stage = Never](Capable[StageT]):
+    """
+    An object that exposes its capabilities.
+    """
+
+    @final
+    def capability(self, name: str, /) -> Any:
+        """
+        Get a capability.
+
+        :raises betty.capability.CapabilityError:
+        """
+        return self._capability(name)
+
+    @final
+    def try_capability(self, name: str, /) -> Any | None:
+        """
+        Try to get a capability, or return ``None`` if it does not exist.
+        """
+        return self._try_capability(name)

--- a/betty/collections/__init__.py
+++ b/betty/collections/__init__.py
@@ -1,3 +1,23 @@
 """
 Reusable collections.
 """
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from typing import Final, final
+
+
+@final
+class _EmptyFrozenMapping[KeyT, ValueT](Mapping[KeyT, ValueT]):
+    def __getitem__(self, key: KeyT, /) -> ValueT:
+        raise KeyError
+
+    def __len__(self) -> int:
+        return 0
+
+    def __iter__(self) -> Iterator[KeyT]:
+        return iter(())
+
+
+_empty_frozen_mapping: Final[_EmptyFrozenMapping] = _EmptyFrozenMapping()

--- a/betty/data.py
+++ b/betty/data.py
@@ -4,43 +4,37 @@ Describe, access, and manipulate arbitrary data.
 
 from __future__ import annotations
 
-from inspect import signature
 from typing import TYPE_CHECKING, Any, Final, Self, final, override
 
-from betty.definition.cls import OptionalClsDefinition
+from betty.collections import _empty_frozen_mapping
+from betty.definition.cls import ClsDefinitionCapabilityStage, OptionalClsDefinition
 from betty.definition.human_facing import HumanFacingDefinition
 from betty.importlib import fully_qualified_name
 from betty.portable import Porter
-from betty.portable.error import NotPortable
 from betty.sample import Samplable, Sample, Samples
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Mapping, MutableMapping
 
+    from betty.capability import ResolvableCapability, ResolvableStagedCapability, Stage
     from betty.localizable import ResolvableLocalizable
     from betty.typing import Intersection
 
-type DataDefinitionFeatureManufacturer[
-    ManufacturableT,
-    DataDefinitionT: DataDefinition,
+
+type DataDefinitionCapabilityStage = ClsDefinitionCapabilityStage
+
+
+class DataDefinition[
     DataT,
-] = (
-    Callable[[DataDefinitionT], ManufacturableT]
-    | Callable[[DataDefinitionT, type[DataT]], ManufacturableT]
-)
-
-type ResolvableDataDefinitionFeature[
-    ManufacturableT,
-    DataDefinitionT: DataDefinition,
-    DataT,
-] = (
-    ManufacturableT
-    | DataDefinitionFeatureManufacturer[ManufacturableT, DataDefinitionT, DataT]
-)
-
-
-class DataDefinition[DataT, PorterT: Porter = Porter](
-    HumanFacingDefinition, OptionalClsDefinition[DataT]
+    PorterT: Porter = Porter,
+    StageT: Stage = DataDefinitionCapabilityStage,
+](
+    HumanFacingDefinition[
+        StageT | DataDefinitionCapabilityStage | ClsDefinitionCapabilityStage
+    ],
+    OptionalClsDefinition[
+        DataT, StageT | DataDefinitionCapabilityStage | ClsDefinitionCapabilityStage
+    ],
 ):
     """
     A data definition.
@@ -51,10 +45,17 @@ class DataDefinition[DataT, PorterT: Porter = Porter](
         *args: Any,
         cls: type[DataT] | None = None,
         label: ResolvableLocalizable,
+        capabilities: Mapping[
+            str,
+            tuple[
+                type,
+                ResolvableStagedCapability[
+                    Self, Any, StageT | DataDefinitionCapabilityStage
+                ],
+            ],
+        ] = _empty_frozen_mapping,
         description: ResolvableLocalizable | None = None,
-        porter: ResolvableDataDefinitionFeature[
-            Intersection[PorterT, Porter[DataT]], Self, DataT
-        ]
+        porter: ResolvableCapability[Self, Intersection[PorterT, Porter[DataT]]]
         | None = None,
         samples: Iterable[
             Callable[[], Sample[DataT]]
@@ -64,46 +65,25 @@ class DataDefinition[DataT, PorterT: Porter = Porter](
         **kwargs: Any,
     ):
         self.__samples = tuple(samples)
-        self._porter: Intersection[PorterT, Porter[DataT]] | None = None
-        self.__set_cls_feature_factories: MutableMapping[
-            str, Callable[[Self, type[DataT]], Any]
-        ] = {}
-        post_super_init_feature_factories = self.__init_features(
-            porter=(Porter, porter)
+        super().__init__(
+            *args,
+            cls=cls,
+            label=label,
+            description=description,
+            capabilities={
+                **capabilities,
+                "porter": (Porter, porter),
+            },
+            **kwargs,
         )
-        super().__init__(*args, cls=cls, label=label, description=description, **kwargs)
-        for feature_name, feature_factory in post_super_init_feature_factories.items():
-            setattr(self, f"_{feature_name}", feature_factory(self))
-
-    def __init_features(
-        self, **features: tuple[type, ResolvableDataDefinitionFeature]
-    ) -> Mapping[str, Any]:
-        post_super_init_feature_factories: MutableMapping[str, Any] = {}
-        for feature_name, (feature_type, feature_value) in features.items():
-            factory_signature: int | None = None
-            if feature_value is not None:
-                if isinstance(feature_value, feature_type):
-                    setattr(self, f"_{feature_name}", feature_value)
-                else:
-                    factory_signature = len(signature(feature_value).parameters)
-                    if factory_signature == 2:
-                        self.__set_cls_feature_factories[feature_name] = feature_value  # ty:ignore[invalid-assignment]
-
-            if factory_signature == 1:
-                post_super_init_feature_factories[feature_name] = feature_value
-        return post_super_init_feature_factories
 
     @final
     @property
     def porter(self) -> Intersection[PorterT, Porter[DataT]]:
         """
         The porter for the data.
-
-        :raises betty.portable.error.NotPortable:
         """
-        if not self._porter:
-            raise NotPortable("This data does not have a porter.")
-        return self._porter
+        return self.capability("porter")
 
     @final
     @property
@@ -111,18 +91,16 @@ class DataDefinition[DataT, PorterT: Porter = Porter](
         """
         The porter for the data, if it has one.
         """
-        return self._porter
+        return self.try_capability("porter")
 
     @override
     def _set_cls(self, cls: type[DataT], /) -> None:
-        super()._set_cls(cls)
         if issubclass(cls, Data):
             assert cls not in _datas, (
                 f"Found an existing data definition {_datas[cls]} when adding {self} for {cls}"
             )
             _datas[cls] = self
-        for feature_name, feature_factory in self.__set_cls_feature_factories.items():
-            setattr(self, f"_{feature_name}", feature_factory(self, cls))
+        super()._set_cls(cls)
 
     @final
     @property

--- a/betty/datas/aggregate/record/__init__.py
+++ b/betty/datas/aggregate/record/__init__.py
@@ -7,23 +7,25 @@ from __future__ import annotations
 from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING, Any, Final, Self, final
 
+from betty.capability import Stage
 from betty.data import (
     DataDefinition,
+    DataDefinitionCapabilityStage,
     ResolvableDataDefinition,
-    ResolvableDataDefinitionFeature,
     Sample,
     Samples,
     resolve_data_definition,
 )
+from betty.definition import Definition
+from betty.definition.cls import OnSetCls
 from betty.indicator.operator import Attr, Key
-from betty.indicator.operator import Operator as Operator
 from betty.localizable import resolve_localizable
 from betty.portable import PortableData, Porter
-from betty.portable.error import NotPortable
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Mapping, MutableMapping
 
+    from betty.capability import ResolvableCapability
     from betty.localizable import Localizable, ResolvableLocalizable
     from betty.nothing import NothingType
     from betty.typing import Intersection
@@ -50,22 +52,13 @@ class FieldPorter[OwnerT, DataT, FieldPorterLoadDataT = Any](metaclass=ABCMeta):
         """
 
 
-type FieldDefinitionFeatureManufacturer[ManufacturableT, OwnerT, DataT] = Callable[
-    [FieldDefinition[OwnerT, DataT]], ManufacturableT
-]
-
-type ResolvableFieldDefinitionFeature[ManufacturableT, OwnerT, DataT] = (
-    ManufacturableT | FieldDefinitionFeatureManufacturer[ManufacturableT, OwnerT, DataT]
-)
-
-
 @final
 class FieldDefinition[
     OwnerT,
     DataT,
     DataDefinitionT: DataDefinition = DataDefinition,
     FieldPorterT: FieldPorter = FieldPorter,
-]:
+](Definition):
     """
     A record field definition.
     """
@@ -79,8 +72,8 @@ class FieldDefinition[
         label: ResolvableLocalizable | None = None,
         description: ResolvableLocalizable | None = None,
         optional: bool = False,
-        porter: ResolvableFieldDefinitionFeature[
-            Intersection[FieldPorterT, FieldPorter[OwnerT, DataT]], OwnerT, DataT
+        porter: ResolvableCapability[
+            Self, Intersection[FieldPorterT, FieldPorter[OwnerT, DataT]]
         ]
         | None = None,
     ):
@@ -117,23 +110,24 @@ class FieldDefinition[
                 porter: FieldPorterT = PorterFieldPorter(data_porter)  # ty:ignore[invalid-assignment]
         elif not isinstance(porter, FieldPorter):
             porter: FieldPorterT = porter(self)
-        self.try_porter: Final[
-            Intersection[FieldPorterT, FieldPorter[OwnerT, DataT]] | None
-        ] = porter
-        """
-        The porter for field data, if it has one.
-        """
+
+        super().__init__(capabilities={"porter": (FieldPorter, porter)})
 
     @property
     def porter(self) -> Intersection[FieldPorterT, FieldPorter[OwnerT, DataT]]:
         """
         The porter for the data.
-
-        :raises betty.portable.error.NotPortable:
         """
-        if not self.try_porter:
-            raise NotPortable("This data does not have a porter.")
-        return self.try_porter
+        return self.capability("porter")
+
+    @property
+    def try_porter(
+        self,
+    ) -> Intersection[FieldPorterT, FieldPorter[OwnerT, DataT]] | None:
+        """
+        The porter for the data, if it has one.
+        """
+        return self.try_capability("porter")
 
 
 type ResolvableFieldDefinition[
@@ -163,9 +157,12 @@ def resolve_field_definition[
     return FieldDefinition(resolve_data_definition(field))
 
 
-class RecordDefinition[DataT, OperatorT: FieldOperator, PorterT: Porter = Porter](
-    DataDefinition[DataT, PorterT]
-):
+class RecordDefinition[
+    DataT,
+    OperatorT: FieldOperator,
+    PorterT: Porter = Porter,
+    StageT: Stage = DataDefinitionCapabilityStage,
+](DataDefinition[DataT, PorterT, StageT]):
     """
     A record data definition.
 
@@ -181,9 +178,7 @@ class RecordDefinition[DataT, OperatorT: FieldOperator, PorterT: Porter = Porter
         description: ResolvableLocalizable | None = None,
         samples: Iterable[Callable[[], Sample[DataT]] | Samples] = (),
         factory: Callable[..., DataT] | None = None,
-        porter: ResolvableDataDefinitionFeature[
-            Intersection[PorterT, Porter[DataT]], Self, DataT
-        ]
+        porter: ResolvableCapability[Self, Intersection[PorterT, Porter[DataT]]]
         | None = None,
         **kwargs: Any,
     ):
@@ -205,7 +200,7 @@ class RecordDefinition[DataT, OperatorT: FieldOperator, PorterT: Porter = Porter
             label=label,
             description=description,
             samples=samples,
-            porter=porter or (lambda record, __: FieldsPorter(record)),
+            porter=porter or OnSetCls(FieldsPorter),
             **kwargs,
         )
 

--- a/betty/datas/aggregate/record/object.py
+++ b/betty/datas/aggregate/record/object.py
@@ -7,15 +7,20 @@ from __future__ import annotations
 from typing import override
 
 from betty.attr import Attr
+from betty.capability import Stage
+from betty.data import DataDefinitionCapabilityStage
 from betty.datas.aggregate.record import RecordDefinition
+from betty.definition.cls import ClsDefinitionCapabilityStage
 from betty.indicator.operator import Attr as AttrOperator
 from betty.portable import Porter
 from betty.prop import HasProps
 
 
-class ObjectDefinition[DataT, PorterT: Porter = Porter](
-    RecordDefinition[DataT, AttrOperator, PorterT]
-):
+class ObjectDefinition[
+    DataT,
+    PorterT: Porter = Porter,
+    StageT: Stage = DataDefinitionCapabilityStage | ClsDefinitionCapabilityStage,
+](RecordDefinition[DataT, AttrOperator, PorterT, StageT]):
     """
     Define an object with attributes.
 

--- a/betty/datas/localizable.py
+++ b/betty/datas/localizable.py
@@ -20,7 +20,7 @@ from betty.localizables.gettext import _
 from betty.localizables.plain import Plain
 from betty.localizables.static import CountableStaticTranslations, StaticTranslations
 from betty.portable import Porter
-from betty.portable.error import NotPortable
+from betty.portable.error import NotDumpable
 
 if TYPE_CHECKING:
     from betty.portable import PortableData
@@ -54,7 +54,7 @@ class _LocalizablePorter(Porter[StaticTranslations]):
         if isinstance(data, Plain):
             data = StaticTranslations({data.locale: data.text})
         if not isinstance(data, StaticTranslations):
-            raise NotPortable(
+            raise NotDumpable(
                 Plain(
                     "Only static translations and plain text can be dumped to portable data, not `{localizable}` objects."
                 ).format(localizable=fully_qualified_name(type(data)))
@@ -99,7 +99,7 @@ class _CountableLocalizablePorter(Porter[CountableLocalizable]):
     @override
     def dump(self, data: CountableLocalizable) -> PortableData:
         if not isinstance(data, CountableStaticTranslations):
-            raise NotPortable(
+            raise NotDumpable(
                 Plain(
                     "Only static translations and plain text can be dumped to portable data, not `{localizable}` objects."
                 ).format(localizable=fully_qualified_name(type(data)))

--- a/betty/datas/plugin/definition/__init__.py
+++ b/betty/datas/plugin/definition/__init__.py
@@ -11,6 +11,7 @@ from betty.attrs.machine_name import new_machine_name_attr
 from betty.classtools import InitABCMeta
 from betty.data import Data
 from betty.datas.aggregate.record.object import ObjectDefinition
+from betty.definition.cls import OnSetCls
 from betty.definition.human_facing import HumanFacingDefinition
 from betty.localizables.gettext import _
 from betty.plugin import PluginDefinition
@@ -61,7 +62,9 @@ class PluginDefinitionDefinition[
             label=_("{plugin_type} configuration").format(
                 plugin_type=plugin_type.label
             ),
-            porter=lambda field, _: KeyedMappingPorter("id", FieldsPorter(field)),
+            porter=OnSetCls(
+                lambda definition: KeyedMappingPorter("id", FieldsPorter(definition))
+            ),
             samples=samples,
         )
 

--- a/betty/definition/__init__.py
+++ b/betty/definition/__init__.py
@@ -1,3 +1,15 @@
 """
 Tools to create definition classes.
 """
+
+from __future__ import annotations
+
+from typing import Never
+
+from betty.capability import HasCapabilities, Stage
+
+
+class Definition[StageT: Stage = Never](HasCapabilities[StageT]):
+    """
+    A definition.
+    """

--- a/betty/definition/cls.py
+++ b/betty/definition/cls.py
@@ -6,10 +6,24 @@ from __future__ import annotations
 
 from typing import Any, final
 
+from betty.capability import Stage
+from betty.definition import Definition
 from betty.importlib import fully_qualified_name
 
 
-class _ClsDefinition[BaseClsT = Any]:
+@final
+class OnSetCls(Stage):
+    """
+    The capability manufacturer stage for when a class is set on a definition.
+    """
+
+
+type ClsDefinitionCapabilityStage = OnSetCls
+
+
+class _ClsDefinition[BaseClsT = Any, StageT: Stage = ClsDefinitionCapabilityStage](
+    Definition[StageT | ClsDefinitionCapabilityStage]
+):
     def __init__(self, *args: Any, cls: type[BaseClsT] | None = None, **kwargs: Any):
         super().__init__(*args, **kwargs)
         self._cls: type[BaseClsT] | None = None
@@ -32,9 +46,12 @@ class _ClsDefinition[BaseClsT = Any]:
                 f"This definition already has a class: {fully_qualified_name(self._cls)}."
             )
         self._cls = cls
+        self._init_staged_capabilities(OnSetCls)
 
 
-class ClsDefinition[BaseClsT = Any](_ClsDefinition[BaseClsT]):
+class ClsDefinition[BaseClsT = Any, StageT: Stage = ClsDefinitionCapabilityStage](
+    _ClsDefinition[BaseClsT, StageT]
+):
     """
     A definition with a Python class.
     """
@@ -52,7 +69,10 @@ class ClsDefinition[BaseClsT = Any](_ClsDefinition[BaseClsT]):
         return self._cls
 
 
-class OptionalClsDefinition[BaseClsT = Any](_ClsDefinition[BaseClsT]):
+class OptionalClsDefinition[
+    BaseClsT = Any,
+    StageT: Stage = ClsDefinitionCapabilityStage,
+](_ClsDefinition[BaseClsT, StageT]):
     """
     A definition with an optional Python class.
     """

--- a/betty/definition/human_facing.py
+++ b/betty/definition/human_facing.py
@@ -4,8 +4,10 @@ Definitions that are human-facing and provide human-friendly information.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, Never
 
+from betty.capability import Stage
+from betty.definition import Definition
 from betty.localizable import resolve_localizable
 
 if TYPE_CHECKING:
@@ -16,7 +18,7 @@ if TYPE_CHECKING:
     )
 
 
-class HumanFacingDefinition:
+class HumanFacingDefinition[StageT: Stage = Never](Definition[StageT]):
     """
     A definition that is human-facing and provides human-friendly information.
     """
@@ -41,7 +43,9 @@ class HumanFacingDefinition:
         """
 
 
-class CountableHumanFacingDefinition(HumanFacingDefinition):
+class CountableHumanFacingDefinition[StageT: Stage = Never](
+    HumanFacingDefinition[StageT]
+):
     """
     A definition that is human-facing and provides countable human-friendly information.
     """

--- a/betty/entity/__init__.py
+++ b/betty/entity/__init__.py
@@ -9,7 +9,6 @@ from betty.association import HasAssociations
 from betty.attrs.machine_name import new_machine_name_attr
 from betty.attrs.privacy import HasPrivacy
 from betty.classtools import InitABCMeta
-from betty.datas.aggregate.record.object import ObjectDefinition
 from betty.definition.human_facing import CountableHumanFacingDefinition
 from betty.json_schema import JsonSchemaReference, String
 from betty.linked_data import JsonLdObject, LinkedDataDumpableWithSchemaJsonLdObject
@@ -121,7 +120,6 @@ class Entity(
 )
 class EntityDefinition[EntityT: Entity = Entity](
     CountableHumanFacingDefinition,
-    ObjectDefinition[EntityT],
     DataPluginDefinition[EntityT],
 ):
     """

--- a/betty/event_type.py
+++ b/betty/event_type.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING, final
 
+from betty.data import DataDefinitionCapabilityStage
+from betty.definition.cls import ClsDefinitionCapabilityStage
 from betty.definition.human_facing import CountableHumanFacingDefinition
 from betty.localizables.gettext import _, ngettext
 from betty.plugin import PluginTypeDefinition
@@ -16,6 +18,7 @@ from betty.plugin.ordered import (
     Order,
     OrderedPluginClsDefinition,
 )
+from betty.portable import Porter
 
 if TYPE_CHECKING:
     from betty.entities.person import Person
@@ -52,9 +55,13 @@ class ShouldExistEventType(EventType, metaclass=ABCMeta):
     label_countable=ngettext("{count} event type", "{count} event types"),
 )
 class EventTypeDefinition(
-    CountableHumanFacingDefinition,
-    OrderedPluginClsDefinition[EventType],
-    DataPluginDefinition[EventType],
+    CountableHumanFacingDefinition[
+        DataDefinitionCapabilityStage | ClsDefinitionCapabilityStage
+    ],
+    OrderedPluginClsDefinition[
+        EventType, DataDefinitionCapabilityStage | ClsDefinitionCapabilityStage
+    ],
+    DataPluginDefinition[EventType, Porter, DataDefinitionCapabilityStage],
 ):
     """
     .. plugin_type:: event-type.

--- a/betty/plugin/__init__.py
+++ b/betty/plugin/__init__.py
@@ -8,8 +8,10 @@ to Betty.
 from __future__ import annotations
 
 from functools import update_wrapper
-from typing import TYPE_CHECKING, Any, Final, Self, final, override
+from typing import TYPE_CHECKING, Any, Final, Never, Self, final, override
 
+from betty.capability import Stage
+from betty.definition import Definition
 from betty.definition.cls import ClsDefinition
 from betty.definition.human_facing import CountableHumanFacingDefinition
 from betty.importlib import fully_qualified_name
@@ -22,7 +24,7 @@ if TYPE_CHECKING:
     from betty.requirement import Requirement, Requires
 
 
-class PluginDefinition:
+class PluginDefinition[StageT: Stage = Never](Definition[StageT]):
     """
     A plugin definition.
     """

--- a/betty/plugin/cls.py
+++ b/betty/plugin/cls.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Final, TypeVar, final, override
 
-from betty.definition.cls import ClsDefinition
+from betty.capability import Stage
+from betty.definition.cls import ClsDefinition, ClsDefinitionCapabilityStage
 from betty.importlib import fully_qualified_name
 from betty.plugin import PluginDefinition
 
@@ -39,8 +40,15 @@ _PluginClsDefinitionPluginT = TypeVar(
     "_PluginClsDefinitionPluginT", covariant=True, default=Any
 )
 
+_PluginClsDefinitionStageT = TypeVar(
+    "_PluginClsDefinitionStageT", bound=Stage, default=ClsDefinitionCapabilityStage
+)
 
-class PluginClsDefinition(PluginDefinition, ClsDefinition[_PluginClsDefinitionPluginT]):
+
+class PluginClsDefinition(
+    ClsDefinition[_PluginClsDefinitionPluginT, _PluginClsDefinitionStageT],
+    PluginDefinition[_PluginClsDefinitionStageT | ClsDefinitionCapabilityStage],
+):
     """
     A classed plugin definition.
     """
@@ -52,4 +60,4 @@ class PluginClsDefinition(PluginDefinition, ClsDefinition[_PluginClsDefinitionPl
             _plugins[cls] = self
 
 
-_plugins: Final[MutableMapping[type, PluginClsDefinition]] = {}
+_plugins: Final[MutableMapping[type, PluginClsDefinition[Any, Any]]] = {}

--- a/betty/plugin/data.py
+++ b/betty/plugin/data.py
@@ -4,8 +4,12 @@ Data plugins.
 
 from __future__ import annotations
 
-from betty.data import Data, DataDefinition
+from betty.capability import Stage
+from betty.data import Data, DataDefinition, DataDefinitionCapabilityStage
+from betty.datas.aggregate.record.object import ObjectDefinition
+from betty.definition.cls import ClsDefinitionCapabilityStage
 from betty.plugin.cls import Plugin, PluginClsDefinition
+from betty.portable import Porter
 from betty.typing import Intersection
 
 
@@ -17,8 +21,19 @@ class DataPlugin[
     """
 
 
-class DataPluginDefinition[ClsT: Intersection[Data, Plugin]](
-    PluginClsDefinition[ClsT], DataDefinition[ClsT]
+class DataPluginDefinition[
+    ClsT: Intersection[Data, Plugin],
+    PorterT: Porter = Porter,
+    StageT: Stage = DataDefinitionCapabilityStage,
+](
+    PluginClsDefinition[
+        ClsT, StageT | DataDefinitionCapabilityStage | ClsDefinitionCapabilityStage
+    ],
+    ObjectDefinition[
+        ClsT,
+        PorterT,
+        StageT | DataDefinitionCapabilityStage | ClsDefinitionCapabilityStage,
+    ],
 ):
     """
     A data plugin definition.

--- a/betty/plugin/factory.py
+++ b/betty/plugin/factory.py
@@ -16,6 +16,7 @@ from betty.attrs.owner import OwnerAttr
 from betty.classtools import InitABCMeta
 from betty.data import Data, DataDefinition
 from betty.datas.aggregate.record.object import ObjectDefinition
+from betty.definition.cls import OnSetCls
 from betty.exception import HumanFacingException
 from betty.factory import DataManufacturable, FactoryError
 from betty.freezer import Frozen
@@ -261,7 +262,9 @@ class PluginManufacturerDefinition[PluginDefinitionT: PluginClsDefinition, Plugi
     ):
         super().__init__(
             label=plugin_type.type().label,
-            porter=lambda _, cls: PluginManufacturerPorter(cls),
+            porter=OnSetCls(
+                lambda definition: PluginManufacturerPorter(definition.cls)
+            ),
         )
         self.plugin_type: Final[type[PluginDefinition]] = plugin_type
 

--- a/betty/plugin/ordered.py
+++ b/betty/plugin/ordered.py
@@ -5,8 +5,11 @@ Plugins that can declare their order.
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, final
+from typing import TYPE_CHECKING, Any, Never, final
 
+from betty.capability import Stage
+from betty.data import DataDefinitionCapabilityStage
+from betty.definition.cls import ClsDefinitionCapabilityStage
 from betty.machine_name import MachineName, ResolvableMachineName
 from betty.plugin import PluginDefinition
 from betty.plugin.cls import PluginClsDefinition
@@ -18,7 +21,7 @@ if TYPE_CHECKING:
     from betty.requirement import Requires
 
 
-class OrderedPluginDefinition(PluginDefinition):
+class OrderedPluginDefinition[StageT: Stage = Never](PluginDefinition[StageT]):
     """
     A plugin definition that can declare its order with respect to other plugin definitions.
     """
@@ -58,8 +61,12 @@ class OrderedPluginDefinition(PluginDefinition):
         return self.__before(other)
 
 
-class OrderedPluginClsDefinition[BaseClsT](
-    OrderedPluginDefinition, PluginClsDefinition[BaseClsT]
+class OrderedPluginClsDefinition[
+    BaseClsT,
+    StageT: Stage = DataDefinitionCapabilityStage,
+](
+    OrderedPluginDefinition[StageT | ClsDefinitionCapabilityStage],
+    PluginClsDefinition[BaseClsT, StageT],
 ):
     """
     A definition of a classed plugin that can declare its order with respect to other plugins.

--- a/betty/portable/__init__.py
+++ b/betty/portable/__init__.py
@@ -75,5 +75,5 @@ class KeyedPorter[DataT](Porter[DataT]):
         """
         Dump the data to portable data and a portable primary key.
 
-        :raises betty.portable.error.NotPortable: Raised if any part of the data is not portable.
+        :raises betty.portable.error.NotDumpable: Raised if any part of the data is not portable.
         """

--- a/betty/portable/error.py
+++ b/betty/portable/error.py
@@ -10,7 +10,7 @@ from betty.exception import HumanFacingException
 
 
 @final
-class NotPortable(HumanFacingException):
+class NotDumpable(HumanFacingException):
     """
-    Raised when data is not portable.
+    Raised when data is not dumpable.
     """

--- a/betty/porters/omit_field.py
+++ b/betty/porters/omit_field.py
@@ -9,14 +9,11 @@ from inspect import signature
 from typing import TYPE_CHECKING, Any, final, override
 
 from betty.data import DataDefinition
-from betty.datas.aggregate.record import (
-    FieldDefinition,
-    FieldDefinitionFeatureManufacturer,
-    FieldPorter,
-)
+from betty.datas.aggregate.record import FieldDefinition, FieldPorter
 from betty.nothing import Nothing, NothingType
 
 if TYPE_CHECKING:
+    from betty.capability import CapabilityManufacturer
     from betty.portable import PortableData
 
 type OmitDump[OwnerT, DataT] = Callable[
@@ -56,11 +53,9 @@ class OmitFieldPorter[OwnerT, DataT](FieldPorter[OwnerT, DataT, DataT]):
     @classmethod
     def new[NewDataT](
         cls, omit_dump: Callable[[NewDataT], bool] | OmitDump[OwnerT, NewDataT], /
-    ) -> FieldDefinitionFeatureManufacturer[
-        OmitFieldPorter[OwnerT, NewDataT], Any, NewDataT
-    ]:
+    ) -> CapabilityManufacturer[Any, OmitFieldPorter[OwnerT, NewDataT]]:
         """
-        Create a field manufacturer to create a new porter.
+        Create a new capability manufacturer.
         """
         return lambda field: OmitFieldPorter[OwnerT, DataT](field, omit_dump)
 

--- a/betty/project/__init__.py
+++ b/betty/project/__init__.py
@@ -53,6 +53,7 @@ from betty.datas.plugin.definition.license import LicenseDefinitionData
 from betty.datas.plugin.definition.place_type import PlaceTypeDefinitionData
 from betty.datas.plugin.definition.role import RoleDefinitionData
 from betty.datas.str import StrDefinition
+from betty.definition.cls import OnSetCls
 from betty.dirs import builtin_asset_directory
 from betty.document import Document, DocumentProviderDefinition
 from betty.entity import EntityDefinition
@@ -641,7 +642,9 @@ class Project(DownstreamServiceLevel[App], RequirableServiceLevel, HasPluginServ
 @final
 @ObjectDefinition(
     label=_("Project locale"),
-    porter=lambda field, _: KeyedMappingPorter("locale", FieldsPorter(field)),
+    porter=OnSetCls(
+        lambda definition: KeyedMappingPorter("locale", FieldsPorter(definition))
+    ),
     samples=[
         lambda: Sample(
             ProjectLocale(Locale("nl", "NL")), label="Minimal", size=Size.MINIMAL

--- a/betty/tests/coverage/test_coverage.py
+++ b/betty/tests/coverage/test_coverage.py
@@ -124,6 +124,11 @@ _BASELINE: Mapping[str, _ModuleIgnore] = {
     "betty/babel.py": {
         "run_babel": MissingReason.SHOULD_BE_COVERED,
     },
+    "betty/capability.py": {
+        "CapabilityError": MissingReason.STATIC_CONTENT_ONLY,
+        "HasCapabilities": MissingReason.STATIC_CONTENT_ONLY,
+        "Stage": MissingReason.STATIC_CONTENT_ONLY,
+    },
     "betty/classtools.py": {
         "InitMeta": MissingReason.COVERED_ELSEWHERE,
         "InitABCMeta": MissingReason.STATIC_CONTENT_ONLY,
@@ -231,7 +236,15 @@ _BASELINE: Mapping[str, _ModuleIgnore] = {
         },
         "IncompleteDateError": MissingReason.STATIC_CONTENT_ONLY,
     },
-    "betty/deriver.py": {"Derivation": MissingReason.ENUM},
+    "betty/definition/__init__.py": {
+        "Definition": MissingReason.STATIC_CONTENT_ONLY,
+    },
+    "betty/definition/cls.py": {
+        "OnSetCls": MissingReason.STATIC_CONTENT_ONLY,
+    },
+    "betty/deriver.py": {
+        "Derivation": MissingReason.ENUM,
+    },
     "betty/dirs.py": MissingReason.STATIC_CONTENT_ONLY,
     "betty/error.py": {
         "FileNotFound": MissingReason.SHOULD_BE_COVERED,
@@ -538,7 +551,7 @@ _BASELINE: Mapping[str, _ModuleIgnore] = {
         "Porter": MissingReason.ABSTRACT,
     },
     "betty/portable/error.py": {
-        "NotPortable": MissingReason.STATIC_CONTENT_ONLY,
+        "NotDumpable": MissingReason.STATIC_CONTENT_ONLY,
     },
     "betty/role.py": {
         "Role": MissingReason.STATIC_CONTENT_ONLY,

--- a/betty/tests/datas/aggregate/collection/test_mapping.py
+++ b/betty/tests/datas/aggregate/collection/test_mapping.py
@@ -2,10 +2,10 @@ from collections.abc import Mapping
 
 import pytest
 
+from betty.capability import Incapable
 from betty.data import DataDefinition
 from betty.datas.aggregate.collection.mapping import MappingDefinition
 from betty.datas.str import StrDefinition
-from betty.portable.error import NotPortable
 
 
 class TestMappingDefinition:
@@ -50,14 +50,14 @@ class TestMappingDefinition:
         )
         assert isinstance(sut.porter.load({}), FactoryDict)
 
-    def test_load__with_item_not_loadable(self) -> None:
+    def test_load__with_item_without_porter(self) -> None:
         sut = MappingDefinition[dict[str, str], str, str](
             cls=dict,
             key=StrDefinition(label="-"),
             value=DataDefinition(cls=str, label="-"),
             label="-",
         )
-        with pytest.raises(NotPortable):
+        with pytest.raises(Incapable):
             sut.porter.load({"hello": "Hello, world!"})
 
     def test_dump__without_items(self) -> None:
@@ -78,14 +78,14 @@ class TestMappingDefinition:
         )
         assert sut.porter.dump({"hello": "Hello, world!"}) == {"hello": "Hello, world!"}
 
-    def test_dump__with_item_not_dumpable(self) -> None:
+    def test_dump__with_item_without_porter(self) -> None:
         sut = MappingDefinition[dict[str, str], str, str](
             cls=dict,
             key=StrDefinition(label="-"),
             value=DataDefinition(cls=str, label="-"),
             label="-",
         )
-        with pytest.raises(NotPortable):
+        with pytest.raises(Incapable):
             sut.porter.dump({"hello": "Hello, world!"})
 
     def test_clear(self) -> None:

--- a/betty/tests/datas/aggregate/collection/test_sequence.py
+++ b/betty/tests/datas/aggregate/collection/test_sequence.py
@@ -2,10 +2,10 @@ from collections.abc import Iterable
 
 import pytest
 
+from betty.capability import Incapable
 from betty.data import DataDefinition
 from betty.datas.aggregate.collection.sequence import SequenceDefinition
 from betty.datas.str import StrDefinition
-from betty.portable.error import NotPortable
 
 
 class TestSequenceDefinition:
@@ -46,13 +46,13 @@ class TestSequenceDefinition:
         )
         assert isinstance(sut.porter.load([]), FactoryList)
 
-    def test_porter__load__with_item_not_loadable(self) -> None:
+    def test_porter__load__with_item_without_porter(self) -> None:
         sut = SequenceDefinition[list[str], str](
             cls=list,
             value=DataDefinition(cls=str, label="-"),
             label="-",
         )
-        with pytest.raises(NotPortable):
+        with pytest.raises(Incapable):
             sut.porter.load(["Hello, world!"])
 
     def test_porter__dump__without_items(self) -> None:
@@ -71,13 +71,13 @@ class TestSequenceDefinition:
         )
         assert sut.porter.dump(["Hello, world!"]) == ["Hello, world!"]
 
-    def test_porter__dump__with_item_not_dumpable(self) -> None:
+    def test_porter__dump__with_item_without_porter(self) -> None:
         sut = SequenceDefinition[list[str], str](
             cls=list,
             value=DataDefinition(cls=str, label="-"),
             label="-",
         )
-        with pytest.raises(NotPortable):
+        with pytest.raises(Incapable):
             sut.porter.dump(["Hello, world!"])
 
     def test_clear(self) -> None:

--- a/betty/tests/datas/aggregate/test_record.py
+++ b/betty/tests/datas/aggregate/test_record.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 import pytest
 from pytest_mock import MockerFixture
 
+from betty.capability import Incapable
 from betty.data import DataDefinition
 from betty.datas.aggregate.record import (
     FieldDefinition,
@@ -17,7 +18,6 @@ from betty.datas.str import StrDefinition
 from betty.indicator.operator import Attr
 from betty.localizables.plain import Plain
 from betty.portable import Porter
-from betty.portable.error import NotPortable
 from betty.porters.fields import FieldsPorter
 from betty.porters.porter_field import PorterFieldPorter
 
@@ -61,7 +61,7 @@ class TestFieldDefinition:
 
     def test_porter__without_porter_without_data_porter(self) -> None:
         sut = FieldDefinition(DataDefinition(label="-"))
-        with pytest.raises(NotPortable):
+        with pytest.raises(Incapable):
             assert sut.porter
 
     def test_porter__without_porter_with_data_porter(

--- a/betty/tests/datas/test_localizable.py
+++ b/betty/tests/datas/test_localizable.py
@@ -23,7 +23,7 @@ from betty.localizables.static import (
     StaticTranslations,
 )
 from betty.localizer import default_localizer
-from betty.portable.error import NotPortable
+from betty.portable.error import NotDumpable
 from betty.test_utils.locale.localizable import DUMMY_LOCALIZABLE
 
 if TYPE_CHECKING:
@@ -67,7 +67,7 @@ class TestLocalizableDefinition:
         )
 
     def test_dump__with_unsupported_localizable(self) -> None:
-        with pytest.raises(NotPortable):
+        with pytest.raises(NotDumpable):
             LocalizableDefinition().porter.dump(Paragraph("Hello, world!"))
 
 
@@ -137,7 +137,7 @@ class TestCountableLocalizableDefinition:
         }
 
     def test_dump_countable_localizable__with_unsupported_localizable(self) -> None:
-        with pytest.raises(NotPortable):
+        with pytest.raises(NotDumpable):
             CountableLocalizableDefinition().porter.dump(
                 _NotDumpableCountableLocalizable()
             )

--- a/betty/tests/test_capability.py
+++ b/betty/tests/test_capability.py
@@ -1,0 +1,132 @@
+from typing import Self
+
+import pytest
+
+from betty.capability import (
+    Capable,
+    Incapable,
+    NotYetInitialized,
+    ResolvableStagedCapability,
+    Stage,
+    UnsupportedCapability,
+)
+
+
+class _Stage(Stage):
+    pass
+
+
+class _Capability:
+    pass
+
+
+class _Capable(Capable[_Stage]):
+    def __init__(
+        self,
+        my_first_capability: ResolvableStagedCapability[Self, _Capability, _Stage]
+        | None = None,
+        /,
+    ):
+        super().__init__(
+            capabilities={
+                "my_first_capability": (_Capability, my_first_capability),
+            }
+        )
+
+    def init_staged_capabilities(self) -> None:
+        self._init_staged_capabilities(_Stage)
+
+
+class TestUnsupportedCapability:
+    def test(self) -> None:
+        assert (
+            str(UnsupportedCapability(Capable(), "my_first_capability"))
+            == 'betty.capability:Capable does not support the "my_first_capability" capability.'
+        )
+
+
+class TestIncapable:
+    def test(self) -> None:
+        assert (
+            str(Incapable(Capable(), "my_first_capability"))
+            == 'betty.capability:Capable does not have a(n) "my_first_capability" capability.'
+        )
+
+
+class TestNotYetInitialized:
+    def test(self) -> None:
+        assert (
+            str(NotYetInitialized(Capable(), "my_first_capability", _Stage))
+            == 'betty.capability:Capable\'s "my_first_capability" capability was not yet initialized for stage betty.tests.test_capability:_Stage.'
+        )
+
+
+class TestCapable:
+    def test__capability__with_unsupported_capability(self) -> None:
+        sut = Capable()
+        with pytest.raises(UnsupportedCapability):
+            sut._capability("my_first_capability")
+
+    def test__capability__with_incapable(self) -> None:
+        sut = _Capable()
+        with pytest.raises(Incapable):
+            sut._capability("my_first_capability")
+
+    def test__capability__with_uninitialized_staged_capability_manufacturer(
+        self,
+    ) -> None:
+        capability = _Capability()
+        sut = _Capable(_Stage(lambda _: capability))
+        with pytest.raises(NotYetInitialized):
+            sut._capability("my_first_capability")
+
+    def test__capability__with_initialized_staged_capability_manufacturer(self) -> None:
+        capability = _Capability()
+        sut = _Capable(_Stage(lambda _: capability))
+        sut.init_staged_capabilities()
+        assert sut._capability("my_first_capability") is capability
+
+    def test__capability__with_capability_manufacturer(self) -> None:
+        capability = _Capability()
+        sut = _Capable(lambda _: capability)
+        assert sut._capability("my_first_capability") is capability
+
+    def test__capability__with_capability(self) -> None:
+        capability = _Capability()
+        sut = _Capable(capability)
+        assert sut._capability("my_first_capability") is capability
+
+    def test__try_capability__with_unsupported_capability(self) -> None:
+        sut = Capable()
+        with pytest.raises(UnsupportedCapability):
+            sut._try_capability("my_first_capability")
+
+    def test__try_capability__with_incapable(self) -> None:
+        sut = _Capable()
+        assert sut._try_capability("my_first_capability") is None
+
+    def test__try_capability__with_uninitialized_staged_capability_manufacturer(
+        self,
+    ) -> None:
+        capability = _Capability()
+        sut = _Capable(_Stage(lambda _: capability))
+        with pytest.raises(NotYetInitialized):
+            sut._try_capability("my_first_capability")
+
+    def test__try_capability__with_initialized_staged_capability_manufacturer(
+        self,
+    ) -> None:
+        capability = _Capability()
+        sut = _Capable(_Stage(lambda _: capability))
+        sut.init_staged_capabilities()
+        assert sut._try_capability("my_first_capability") is capability
+
+    def test__try_capability__with_capability_manufacturer(self) -> None:
+        capability = _Capability()
+        sut = _Capable(lambda _: capability)
+        assert sut._try_capability("my_first_capability") is capability
+
+    def test__try_capability__with_capability(self) -> None:
+        capability = _Capability()
+        sut = _Capable(capability)
+        assert sut._try_capability("my_first_capability") is capability

--- a/betty/tests/test_data.py
+++ b/betty/tests/test_data.py
@@ -4,8 +4,8 @@ from typing import Self, override
 
 import pytest
 
+from betty.capability import Incapable
 from betty.data import Data, DataDefinition, Sample, resolve_data_definition
-from betty.portable.error import NotPortable
 from betty.porters.callback import CallbackPorter
 from betty.sample import Samplable, Samples
 
@@ -13,7 +13,7 @@ from betty.sample import Samplable, Samples
 class TestDataDefinition:
     def test_porter__without_porter(self) -> None:
         sut = DataDefinition(label="-")
-        with pytest.raises(NotPortable):
+        with pytest.raises(Incapable):
             assert sut.porter
 
     def test_porter__with_porter(self) -> None:


### PR DESCRIPTION
This adds the concept of "capabilities", which are a bit like services, except that they live on otherwise isolated value objects, and only optionally have access to their owning instances.

This also unified `DataDefinition` and `FieldDefinition`, as well as opens both of those up to future and third-party capabilities without having to break BC.