### PR TITLE
Remove the constraint preventing aiohttp 3.14 or newer from being installed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,8 +342,7 @@ setuptools = [
     'wheel ~= 0.48.0',
 ]
 test = [
-    # Work around https://github.com/pnuckowski/aioresponses/issues/289.
-    'aiohttp ~= 3.12, < 3.14',
+    'aiohttp ~= 3.12',
     'aioresponses ~= 0.7.8',
     'coverage ~= 7.6',
     'packaging ~= 26.0',


### PR DESCRIPTION
Consider using https://github.com/j7an/dep-rank/pull/123/changes#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128 as a workaround (that project is MIT-licensed)